### PR TITLE
Allow VueQuery DevTools to be closed

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -71,3 +71,8 @@ export default defineComponent({
   }
 });
 </script>
+<style>
+.VueQueryDevtoolsPanel + button {
+  @apply text-black bg-gray-100 p-2 rounded text-sm;
+}
+</style>


### PR DESCRIPTION
Previously it wasn't possible to actually close the DevTools (unless you knew where the close button was).

Here is how it looks now:
<img width="1392" alt="Screen Shot 2021-05-13 at 12 19 30 pm" src="https://user-images.githubusercontent.com/254095/118068639-0c96ee00-b3e6-11eb-83dc-80285e6ee75d.png">

Game changer 👯 