### PR TITLE
Fix BalTable z-index issue when sticky

### DIFF
--- a/src/components/_global/BalTable/BalTable.vue
+++ b/src/components/_global/BalTable/BalTable.vue
@@ -351,6 +351,7 @@ export default defineComponent({
 
 <style>
 .horizontalSticky {
+  @apply z-10;
   position: sticky;
   left: 0;
 }


### PR DESCRIPTION
I noticed this behaviour on the homepage: (when scrolling mobile / small screen)

<img width="420" alt="Screen Shot 2021-05-13 at 9 00 51 pm" src="https://user-images.githubusercontent.com/254095/118117060-6cb18280-b42e-11eb-8222-84cdd57b4ed7.png">
<img width="864" alt="Screen Shot 2021-05-13 at 8 56 05 pm" src="https://user-images.githubusercontent.com/254095/118117068-6fac7300-b42e-11eb-9e7e-24236a9caf34.png">

This looks like a regression? I added the z-index to the sticky class and it seems to solve it.