### PR TITLE
Add initial state prop to BalTable

### DIFF
--- a/src/components/_global/BalTable/BalTable.vue
+++ b/src/components/_global/BalTable/BalTable.vue
@@ -155,6 +155,12 @@ import { sortBy, sumBy } from 'lodash';
 
 type Sticky = 'horizontal' | 'vertical' | 'both';
 type Data = any;
+type SortDirection = 'asc' | 'desc' | null;
+
+type InitialState = {
+  sortDirection: SortDirection;
+  sortColumn: string | null;
+};
 
 export type ColumnDefinition<T = Data> = {
   // Column Header Label
@@ -219,6 +225,13 @@ export default defineComponent({
     },
     noResultsLabel: {
       type: String
+    },
+    initialState: {
+      type: Object as PropType<InitialState>,
+      default: {
+        currentSortColumn: null,
+        sortDirection: null
+      }
     }
   },
   setup(props) {
@@ -226,8 +239,10 @@ export default defineComponent({
     const tableRef = ref<HTMLElement>();
     const isColumnStuck = ref(false);
     const tableData = ref(props.data);
-    const currentSortDirection = ref<'asc' | 'desc' | null>(null);
-    const currentSortColumn = ref<string | null>(null);
+    const currentSortDirection = ref<SortDirection>(
+      props.initialState.sortDirection
+    );
+    const currentSortColumn = ref<string | null>(props.initialState.sortColumn);
     const headerRef = ref<HTMLElement>();
     const bodyRef = ref<HTMLElement>();
 

--- a/src/components/_global/BalTable/BalTable.vue
+++ b/src/components/_global/BalTable/BalTable.vue
@@ -155,10 +155,9 @@ import { sortBy, sumBy } from 'lodash';
 
 type Sticky = 'horizontal' | 'vertical' | 'both';
 type Data = any;
-type SortDirection = 'asc' | 'desc' | null;
 
 type InitialState = {
-  sortDirection: SortDirection;
+  sortDirection: 'asc' | 'desc' | null;
   sortColumn: string | null;
 };
 
@@ -239,10 +238,12 @@ export default defineComponent({
     const tableRef = ref<HTMLElement>();
     const isColumnStuck = ref(false);
     const tableData = ref(props.data);
-    const currentSortDirection = ref<SortDirection>(
+    const currentSortDirection = ref<InitialState['sortDirection']>(
       props.initialState.sortDirection
     );
-    const currentSortColumn = ref<string | null>(props.initialState.sortColumn);
+    const currentSortColumn = ref<InitialState['sortColumn']>(
+      props.initialState.sortColumn
+    );
     const headerRef = ref<HTMLElement>();
     const bodyRef = ref<HTMLElement>();
 

--- a/src/components/_global/BalTable/BalTable.vue
+++ b/src/components/_global/BalTable/BalTable.vue
@@ -229,7 +229,7 @@ export default defineComponent({
     initialState: {
       type: Object as PropType<InitialState>,
       default: {
-        currentSortColumn: null,
+        sortColumn: null,
         sortDirection: null
       }
     }

--- a/src/components/pages/pool/PoolActivitiesCard/Table.vue
+++ b/src/components/pages/pool/PoolActivitiesCard/Table.vue
@@ -10,6 +10,10 @@
       skeleton-class="h-64"
       sticky="both"
       :no-results-label="noResultsLabel"
+      :initial-state="{
+        sortColumn: 'timeAgo',
+        sortDirection: 'desc'
+      }"
     >
       <template v-slot:actionCell="action">
         <div class="px-6 py-2">

--- a/src/components/pages/pool/PoolBalancesCard.vue
+++ b/src/components/pages/pool/PoolBalancesCard.vue
@@ -6,6 +6,10 @@
       :is-loading="loading"
       skeleton-class="h-64"
       sticky="both"
+      :initial-state="{
+        sortColumn: 'weight',
+        sortDirection: 'desc'
+      }"
     >
       <template v-slot:tokenColumnCell="token">
         <div class="px-6 py-4 flex flex-row w-52">

--- a/src/components/tables/PoolsTable.vue
+++ b/src/components/tables/PoolsTable.vue
@@ -3,13 +3,17 @@
     <BalTable
       :columns="columns"
       :data="data"
-      :isLoading="isLoading || isLoadingBalances"
-      :isLoadingMore="isLoadingMore"
-      skeletonClass="h-64"
+      :is-loading="isLoading || isLoadingBalances"
+      :is-loading-more="isLoadingMore"
+      skeleton-class="h-64"
       sticky="both"
-      :onRowClick="handleRowClick"
-      :isPaginated="isPaginated"
-      @loadMore="$emit('loadMore')"
+      :on-row-click="handleRowClick"
+      :is-paginated="isPaginated"
+      @load-more="$emit('loadMore')"
+      :initial-state="{
+        sortColumn: 'poolValue',
+        sortDirection: 'desc'
+      }"
     >
       <template v-slot:iconColumnHeader>
         <div class="flex items-center">


### PR DESCRIPTION
Adds an initialState to BalTable so that we can set things like sortColumn/sortDirection when the table loads initially.