### PR TITLE
Chore: update vue-query dep to latest

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -63,7 +63,7 @@
         "vue": "^3.0.0-beta.1",
         "vue-echarts": "^6.0.0-rc.4",
         "vue-i18n": "^9.0.0-rc.1",
-        "vue-query": "^1.1.1",
+        "vue-query": "^1.4.0",
         "vue-router": "^4.0.0-alpha.6",
         "vue-slider-component": "^4.0.0-beta.3",
         "vue3-apexcharts": "^1.2.1",
@@ -24808,9 +24808,9 @@
       }
     },
     "node_modules/react-query": {
-      "version": "3.13.12",
-      "resolved": "https://registry.npmjs.org/react-query/-/react-query-3.13.12.tgz",
-      "integrity": "sha512-RZYvepBdDG4Xgz64vUHjIkUqXX6giw3xJsgdRjWx+vLkOB1vbIQE8F82CNlVbYW3JjZobl4YzmOuLx0wMhLX4Q==",
+      "version": "3.16.0",
+      "resolved": "https://registry.npmjs.org/react-query/-/react-query-3.16.0.tgz",
+      "integrity": "sha512-YOvI8mO9WG+r4XsyJinjlDMiV5IewUWUcTv2J7z6bIP3KOFvgT6k6HM8vQouz4hPnme7Ktq9j5e7LarUqgJXFQ==",
       "dependencies": {
         "@babel/runtime": "^7.5.5",
         "broadcast-channel": "^3.4.1",
@@ -29476,14 +29476,13 @@
       }
     },
     "node_modules/vue-query": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/vue-query/-/vue-query-1.1.1.tgz",
-      "integrity": "sha512-gMJT/5TSIf/V0bPdhPlFP6b2o1Yo/ccPn8KA2ZGkbbtW5SBa1yULTml/KJh2OGat1YkYeM/lXxpwnwCvEouKBg==",
-      "license": "MIT",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/vue-query/-/vue-query-1.4.0.tgz",
+      "integrity": "sha512-m7dzxXGRbeXn8VzRW30RIrwvprsC6Cvv1nOq/Gd/MmKWKXEeJu107o3uUmQuiHXW9C2HsZ4BzfoK8tkfUiaMCw==",
       "dependencies": {
         "match-sorter": "^6.3.0",
-        "react-query": "^3.13.9",
-        "vue-demi": "^0.7.4"
+        "react-query": "^3.15.2",
+        "vue-demi": "^0.9.0"
       },
       "peerDependencies": {
         "@vue/composition-api": "^1.0.0-rc.1",
@@ -29496,9 +29495,9 @@
       }
     },
     "node_modules/vue-query/node_modules/vue-demi": {
-      "version": "0.7.5",
-      "resolved": "https://registry.npmjs.org/vue-demi/-/vue-demi-0.7.5.tgz",
-      "integrity": "sha512-eFSQSvbQdY7C9ujOzvM6tn7XxwLjn0VQDXQsiYBLBwf28Na+2nTQR4BBBcomhmdP6mmHlBKAwarq6a0BPG87hQ==",
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/vue-demi/-/vue-demi-0.9.0.tgz",
+      "integrity": "sha512-f8vVUpC726YXv99fF/3zHaw5CUYbP5H/DVWBN+pncXM8P2Uz88kkffwj9yD7MukuVzPICDHNrgS3VC2ursaP7g==",
       "hasInstallScript": true,
       "bin": {
         "vue-demi-fix": "bin/vue-demi-fix.js",
@@ -49316,9 +49315,9 @@
       }
     },
     "react-query": {
-      "version": "3.13.12",
-      "resolved": "https://registry.npmjs.org/react-query/-/react-query-3.13.12.tgz",
-      "integrity": "sha512-RZYvepBdDG4Xgz64vUHjIkUqXX6giw3xJsgdRjWx+vLkOB1vbIQE8F82CNlVbYW3JjZobl4YzmOuLx0wMhLX4Q==",
+      "version": "3.16.0",
+      "resolved": "https://registry.npmjs.org/react-query/-/react-query-3.16.0.tgz",
+      "integrity": "sha512-YOvI8mO9WG+r4XsyJinjlDMiV5IewUWUcTv2J7z6bIP3KOFvgT6k6HM8vQouz4hPnme7Ktq9j5e7LarUqgJXFQ==",
       "requires": {
         "@babel/runtime": "^7.5.5",
         "broadcast-channel": "^3.4.1",
@@ -52551,19 +52550,19 @@
       }
     },
     "vue-query": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/vue-query/-/vue-query-1.1.1.tgz",
-      "integrity": "sha512-gMJT/5TSIf/V0bPdhPlFP6b2o1Yo/ccPn8KA2ZGkbbtW5SBa1yULTml/KJh2OGat1YkYeM/lXxpwnwCvEouKBg==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/vue-query/-/vue-query-1.4.0.tgz",
+      "integrity": "sha512-m7dzxXGRbeXn8VzRW30RIrwvprsC6Cvv1nOq/Gd/MmKWKXEeJu107o3uUmQuiHXW9C2HsZ4BzfoK8tkfUiaMCw==",
       "requires": {
         "match-sorter": "^6.3.0",
-        "react-query": "^3.13.9",
-        "vue-demi": "^0.7.4"
+        "react-query": "^3.15.2",
+        "vue-demi": "^0.9.0"
       },
       "dependencies": {
         "vue-demi": {
-          "version": "0.7.5",
-          "resolved": "https://registry.npmjs.org/vue-demi/-/vue-demi-0.7.5.tgz",
-          "integrity": "sha512-eFSQSvbQdY7C9ujOzvM6tn7XxwLjn0VQDXQsiYBLBwf28Na+2nTQR4BBBcomhmdP6mmHlBKAwarq6a0BPG87hQ==",
+          "version": "0.9.0",
+          "resolved": "https://registry.npmjs.org/vue-demi/-/vue-demi-0.9.0.tgz",
+          "integrity": "sha512-f8vVUpC726YXv99fF/3zHaw5CUYbP5H/DVWBN+pncXM8P2Uz88kkffwj9yD7MukuVzPICDHNrgS3VC2ursaP7g==",
           "requires": {}
         }
       }

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "vue": "^3.0.0-beta.1",
     "vue-echarts": "^6.0.0-rc.4",
     "vue-i18n": "^9.0.0-rc.1",
-    "vue-query": "^1.1.1",
+    "vue-query": "^1.4.0",
     "vue-router": "^4.0.0-alpha.6",
     "vue-slider-component": "^4.0.0-beta.3",
     "vue3-apexcharts": "^1.2.1",


### PR DESCRIPTION
This version has a bunch of non breaking changes and a fix for devtools resizing (great to have this working now)