### PR TITLE
fix: remove cursor pointer from hovering over line in chart

### DIFF
--- a/src/components/_global/BalLineChart/BalLineChart.vue
+++ b/src/components/_global/BalLineChart/BalLineChart.vue
@@ -204,6 +204,7 @@ export default defineComponent({
         smooth: false,
         symbol: 'none',
         name: d.name,
+        silent: true,
         animationEasing: function(k) {
           return k === 1 ? 1 : 1 - Math.pow(2, -10 * k);
         },
@@ -216,7 +217,6 @@ export default defineComponent({
         markLine: {
           symbol: 'roundRect',
           symbolSize: 0,
-          // silent: true,
           lineStyle: {
             color: 'rgba(0, 0, 0, 0)'
           },

--- a/src/components/_global/BalLineChart/BalLineChart.vue
+++ b/src/components/_global/BalLineChart/BalLineChart.vue
@@ -202,7 +202,7 @@ export default defineComponent({
         data: d.values,
         type: 'line',
         smooth: false,
-        symbol: 'none',
+        showSymbol: false,
         name: d.name,
         silent: true,
         animationEasing: function(k) {


### PR DESCRIPTION
**Testing Critera**
- No hand pointer should be visible when hovering over a line in the chart on desktop
