### PR TITLE
Fix USDC decimal parsing on balances. Show dust amounts as < 0.0001 if so

### DIFF
--- a/src/components/lists/TokenListItem.vue
+++ b/src/components/lists/TokenListItem.vue
@@ -12,7 +12,12 @@
     </div>
     <span class="text-right">
       <template v-if="token.balance > 0">
-        {{ fNum(token.balance, 'token') }}
+        <template v-if="token.balance >= 0.0001">
+          {{ fNum(token.balance, 'token') }}
+        </template>
+        <template v-else>
+          &#60; 0.0001
+        </template>
       </template>
       <template v-else>-</template>
       <div class="text-gray text-sm">

--- a/src/composables/useAccountBalances.ts
+++ b/src/composables/useAccountBalances.ts
@@ -4,7 +4,7 @@ import useTokens from './useTokens';
 import useWeb3 from './useWeb3';
 import { computed, reactive } from 'vue';
 import { getBalances } from '@/lib/utils/balancer/tokens';
-import { formatEther } from '@ethersproject/units';
+import { formatEther, formatUnits } from '@ethersproject/units';
 import { getAddress } from '@ethersproject/address';
 import QUERY_KEYS from '@/constants/queryKeys';
 import { ETHER } from '@/constants/tokenlists';
@@ -40,7 +40,10 @@ export default function useAccountBalances() {
     if (data.value) {
       const balances = {};
       Object.keys(data.value[0]).forEach((tokenAddress: string) => {
-        const balance = formatEther(data.value[0][tokenAddress]);
+        const balance = formatUnits(
+          data.value[0][tokenAddress],
+          tokens.value[getAddress(tokenAddress)]?.decimals || 18
+        );
         // not concerned with tokens which have a 0 balance
         if (balance === '0.0') return;
         balances[tokenAddress] = {


### PR DESCRIPTION
Changes proposed in this pull request:
- Fixed a problem where USDC and other tokens were not being parsed with the correct decimals
- Changed the token filter modal to show dust amounts as < 0.0001 rather than just 0

**Testing Criteria**
- Make sure to load USDC into your wallet and check that the correct amount is being shown on the token modal. E.g. if you have 5 usdc in your wallet make sure that the modal shows 5 USDC and not 5e-13.
- Load up a token with a dust amount into your wallet, check that it shows < 0.0001 on the modal rather than just 0