### PR TITLE
When changing the account via metamask, the navbar does not reflect this change

### DIFF
--- a/src/store/modules/web3.ts
+++ b/src/store/modules/web3.ts
@@ -83,20 +83,26 @@ const actions = {
         auth.provider.value.removeAllListeners();
       if (auth.provider.value.on) {
         auth.provider.value.on('chainChanged', async chainId => {
+          commit('setLoading', true);
+
           await dispatch('account/resetAccount', null, { root: true });
           auth.web3 = new Web3Provider(auth.provider.value);
+
           commit('setNetwork', parseInt(formatUnits(chainId, 0)));
           dispatch('account/getBalances', null, { root: true });
           dispatch('account/getAllowances', null, { root: true });
+          commit('setLoading', false);
         });
         auth.provider.value.on('accountsChanged', async accounts => {
           if (accounts.length !== 0) {
+            commit('setLoading', true);
+
             await dispatch('account/resetAccount', null, { root: true });
             auth.web3 = new Web3Provider(auth.provider.value);
             commit('setAccount', accounts[0]);
-            await dispatch('loadProvider');
             dispatch('account/getBalances', null, { root: true });
             dispatch('account/getAllowances', null, { root: true });
+            commit('setLoading', false);
           }
         });
         auth.provider.value.on('disconnect', async () => {


### PR DESCRIPTION


Changes proposed in this pull request:
- Commit the web3 loading state to true when changing chain or account so dependents can change without undefined errors

**Testing Criteria**
- Change between accounts and chains on metamask, the navbar should update to reflect changes (does the address change?)