### PR TITLE
Hotfix/1.1.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@balancer-labs/frontend-v2",
-      "version": "1.1.2",
+      "version": "1.1.3",
       "license": "MIT",
       "dependencies": {
         "@balancer-labs/assets": "github:balancer-labs/assets#master",
@@ -33962,6 +33962,7 @@
           "integrity": "sha512-IWnb10ImrzRMT2qw9785p3wYEI6U9gjsg6H2zKcRJQP5dEboqeX3OFjUKfXkaIWii4nz8MtJjBg5t4BdEYqLdw==",
           "dev": true,
           "requires": {
+            "@babel/core": "^7.12.10",
             "@babel/generator": "^7.12.11",
             "@babel/parser": "^7.12.11",
             "@babel/plugin-transform-react-jsx": "^7.12.12",
@@ -37472,6 +37473,7 @@
     "@vue/babel-preset-app": {
       "version": "4.5.12",
       "requires": {
+        "@babel/core": "^7.11.0",
         "@babel/helper-compilation-targets": "^7.9.6",
         "@babel/helper-module-imports": "^7.8.3",
         "@babel/plugin-proposal-class-properties": "^7.8.3",
@@ -37484,6 +37486,7 @@
         "@vue/babel-plugin-jsx": "^1.0.3",
         "@vue/babel-preset-jsx": "^1.2.4",
         "babel-plugin-dynamic-import-node": "^2.3.3",
+        "core-js": "^3.6.5",
         "core-js-compat": "^3.6.5",
         "semver": "^6.1.0"
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "engines": {
     "node": "14.x",
     "npm": ">=7"

--- a/src/composables/useTokenLists.ts
+++ b/src/composables/useTokenLists.ts
@@ -156,14 +156,13 @@ export default function useTokenLists(request?: TokenListRequest) {
   const tokenDictionary = computed(() => keyBy(tokens.value, 'address'));
 
   const toggleActiveTokenList = (name: string) => {
-    // remove from active lists
     if (activeTokenLists.value.includes(name)) {
       activeTokenLists.value = activeTokenLists.value.filter(
         listName => listName !== name
       );
-      return;
+    } else {
+      activeTokenLists.value.push(name);
     }
-    activeTokenLists.value = [...activeTokenLists.value, name];
     lsSet('activeTokenLists', activeTokenLists.value);
   };
 

--- a/src/constants/tokenlists.ts
+++ b/src/constants/tokenlists.ts
@@ -1,6 +1,8 @@
 export const TOKEN_LIST_DEFAULT =
   'https://storageapi.fleek.co/balancer-team-bucket/assets/listed.tokenlist.json';
 
+export const ELIGIBLE_TOKEN_LIST = 'https://storageapi.fleek.co/balancer-team-bucket/assets/vetted.tokenlist.json';
+
 export const TOKEN_LISTS: string[] = [
   TOKEN_LIST_DEFAULT,
   'ipns://tokens.uniswap.org',

--- a/src/constants/tokenlists.ts
+++ b/src/constants/tokenlists.ts
@@ -1,7 +1,8 @@
 export const TOKEN_LIST_DEFAULT =
   'https://storageapi.fleek.co/balancer-team-bucket/assets/listed.tokenlist.json';
 
-export const ELIGIBLE_TOKEN_LIST = 'https://storageapi.fleek.co/balancer-team-bucket/assets/vetted.tokenlist.json';
+export const ELIGIBLE_TOKEN_LIST =
+  'https://storageapi.fleek.co/balancer-team-bucket/assets/vetted.tokenlist.json';
 
 export const TOKEN_LISTS: string[] = [
   TOKEN_LIST_DEFAULT,

--- a/src/store/modules/registry.ts
+++ b/src/store/modules/registry.ts
@@ -2,7 +2,7 @@ import { formatUnits } from '@ethersproject/units';
 import { getAddress, isAddress } from '@ethersproject/address';
 import orderBy from 'lodash/orderBy';
 import { loadTokenlist } from '@/lib/utils/tokenlists';
-import { ETHER, TOKEN_LIST_DEFAULT, TOKEN_LISTS } from '@/constants/tokenlists';
+import { ETHER, TOKEN_LIST_DEFAULT, ELIGIBLE_TOKEN_LIST, TOKEN_LISTS } from '@/constants/tokenlists';
 import { clone, lsGet, lsSet } from '@/lib/utils';
 import injected from '@/constants/injected.json';
 import { TokenList, TokenInfo } from '@/types/TokenList';
@@ -14,6 +14,7 @@ defaultActiveLists[TOKEN_LIST_DEFAULT] = true;
 interface RegistryState {
   activeLists: Record<string, boolean>;
   tokenLists: Record<string, TokenList | {}>;
+  eligibleList: TokenList | {};
   injected: TokenInfo[];
   loading: boolean;
 }
@@ -21,6 +22,7 @@ interface RegistryState {
 const state: RegistryState = {
   activeLists: lsGet('tokenLists', defaultActiveLists),
   tokenLists: Object.fromEntries(TOKEN_LISTS.map(tokenList => [tokenList, {}])),
+  eligibleList: {},
   injected,
   loading: true
 };
@@ -164,26 +166,28 @@ const getters = {
 
 const actions = {
   async get({ dispatch, commit }) {
-    const loadAllLists = TOKEN_LISTS.map(name =>
-      dispatch('loadTokenlist', name)
+    const loadAllLists = TOKEN_LISTS.map(url =>
+      dispatch('loadTokenlist', url)
     );
     const results = await Promise.all(loadAllLists.map(p => p.catch(e => e)));
     const validResults = results.filter(result => !(result instanceof Error));
     if (validResults.length === 0) {
       throw new Error('Failed to load any TokenLists');
     }
+    const eligibleList = await loadTokenlist(ELIGIBLE_TOKEN_LIST)
+    commit('setEligibleList', eligibleList);
     commit('setLoading', false);
   },
 
-  async loadTokenlist({ commit }, name) {
-    name = name || TOKEN_LIST_DEFAULT;
+  async loadTokenlist({ commit }, url) {
+    url = url || TOKEN_LIST_DEFAULT;
     try {
-      const tokenList = await loadTokenlist(name);
+      const tokenList = await loadTokenlist(url);
       const tokenLists = clone(state.tokenLists);
-      tokenLists[name] = tokenList;
+      tokenLists[url] = tokenList;
       commit('setTokenLists', tokenLists);
     } catch (error) {
-      console.error('Failed to load TokenList', name, error);
+      console.error('Failed to load TokenList', url, error);
       throw error;
     }
   },
@@ -193,7 +197,11 @@ const actions = {
       token => token !== ETHER.address && isAddress(token)
     );
     if (tokens.length === 0) return;
-    const tokensMeta = await getTokensMeta(tokens, state.tokenLists);
+    const lists = {
+      ...state.tokenLists,
+      [ELIGIBLE_TOKEN_LIST]: state.eligibleList
+    }
+    const tokensMeta = await getTokensMeta(tokens, lists);
     const injected = clone(state.injected);
     Object.values(tokensMeta).forEach((meta: TokenInfo) => {
       if (meta) injected.push({ ...meta, injected: true });
@@ -239,6 +247,10 @@ const mutations = {
     activeLists: Record<string, boolean>
   ): void {
     _state.activeLists = activeLists;
+  },
+
+  setEligibleList(_state: RegistryState, list: TokenList): void {
+    _state.eligibleList = list;
   }
 };
 

--- a/src/store/modules/registry.ts
+++ b/src/store/modules/registry.ts
@@ -2,7 +2,12 @@ import { formatUnits } from '@ethersproject/units';
 import { getAddress, isAddress } from '@ethersproject/address';
 import orderBy from 'lodash/orderBy';
 import { loadTokenlist } from '@/lib/utils/tokenlists';
-import { ETHER, TOKEN_LIST_DEFAULT, ELIGIBLE_TOKEN_LIST, TOKEN_LISTS } from '@/constants/tokenlists';
+import {
+  ETHER,
+  TOKEN_LIST_DEFAULT,
+  ELIGIBLE_TOKEN_LIST,
+  TOKEN_LISTS
+} from '@/constants/tokenlists';
 import { clone, lsGet, lsSet } from '@/lib/utils';
 import injected from '@/constants/injected.json';
 import { TokenList, TokenInfo } from '@/types/TokenList';
@@ -166,15 +171,13 @@ const getters = {
 
 const actions = {
   async get({ dispatch, commit }) {
-    const loadAllLists = TOKEN_LISTS.map(url =>
-      dispatch('loadTokenlist', url)
-    );
+    const loadAllLists = TOKEN_LISTS.map(url => dispatch('loadTokenlist', url));
     const results = await Promise.all(loadAllLists.map(p => p.catch(e => e)));
     const validResults = results.filter(result => !(result instanceof Error));
     if (validResults.length === 0) {
       throw new Error('Failed to load any TokenLists');
     }
-    const eligibleList = await loadTokenlist(ELIGIBLE_TOKEN_LIST)
+    const eligibleList = await loadTokenlist(ELIGIBLE_TOKEN_LIST);
     commit('setEligibleList', eligibleList);
     commit('setLoading', false);
   },
@@ -200,7 +203,7 @@ const actions = {
     const lists = {
       ...state.tokenLists,
       [ELIGIBLE_TOKEN_LIST]: state.eligibleList
-    }
+    };
     const tokensMeta = await getTokensMeta(tokens, lists);
     const injected = clone(state.injected);
     Object.values(tokensMeta).forEach((meta: TokenInfo) => {


### PR DESCRIPTION
Changes proposed in this pull request:
- Add Balancer's eligible token list for LBP tokens.
- Fix tokenlist toggle state persistance in local storage.

Testing criteria:
- Navigate to `/#/trade/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/0xc67B12049c2D0CF6e476BC64c7F82fc6C63cFFc5` on the PR deployment and check that the LBP token logo is visible.
- Check that there are no repercussions from using the eligible list to find metadata in the injectTokens method.
- Toggle tokelists in the manage tokenlists modal and check that they are persisted on page refresh.