### PR TITLE
[hotfix] require-valid-default-prop compilation

### DIFF
--- a/src/components/_global/BalTable/BalTable.vue
+++ b/src/components/_global/BalTable/BalTable.vue
@@ -234,10 +234,10 @@ export default defineComponent({
     },
     initialState: {
       type: Object as PropType<InitialState>,
-      default: {
+      default: () => ({
         sortColumn: null,
         sortDirection: null
-      }
+      })
     }
   },
   setup(props) {


### PR DESCRIPTION
Fixes the following compilation error:
> frontend-v2/src/components/_global/BalTable/BalTable.vue
>  237:16  error  Type of the default value for 'initialState' prop must be a function  vue/require-valid-default-prop