### PR TITLE
WIP: Ensure that we pull token icons from larger TokenLists

### DIFF
--- a/src/composables/useTokenLists.ts
+++ b/src/composables/useTokenLists.ts
@@ -3,8 +3,6 @@ import { useStore } from 'vuex';
 import { useQuery } from 'vue-query';
 import { flatten, keyBy, orderBy, uniqBy } from 'lodash';
 
-import { getAddress } from '@ethersproject/address';
-
 import QUERY_KEYS from '@/constants/queryKeys';
 import { TOKEN_LISTS } from '@/constants/tokenlists';
 
@@ -116,7 +114,6 @@ export default function useTokenLists(request?: TokenListRequest) {
               const value24HChange = (value / 100) * price24HChange;
               return {
                 ...token,
-                address: getAddress(token.address), // Enforce that we use checksummed addresses
                 value,
                 price,
                 price24HChange,

--- a/src/lib/utils/balancer/tokens.ts
+++ b/src/lib/utils/balancer/tokens.ts
@@ -1,3 +1,4 @@
+import { getAddress } from '@ethersproject/address';
 import { Web3Provider, TransactionResponse } from '@ethersproject/providers';
 import { MaxUint256 } from '@ethersproject/constants';
 import { multicall, Multicaller } from '@/lib/utils/balancer/contract';
@@ -92,7 +93,9 @@ export async function getTokensMeta(
 
   const meta = {};
   tokenAddresses.forEach(async address => {
-    const tokenMeta = allTokens.find(token => token.address == address);
+    const tokenMeta = allTokens.find(
+      token => token.address == getAddress(address)
+    );
     meta[address] = tokenMeta;
   });
   const unknownAddresses = Object.keys(meta).filter(address => !meta[address]);

--- a/src/store/modules/registry.ts
+++ b/src/store/modules/registry.ts
@@ -197,9 +197,9 @@ const actions = {
   },
 
   async injectTokens({ commit, dispatch, state }, tokens: string[]) {
-    tokens = tokens.filter(
-      token => token !== ETHER.address && isAddress(token)
-    );
+    tokens = tokens
+      .filter(token => token !== ETHER.address && isAddress(token))
+      .map(token => getAddress(token));
     if (tokens.length === 0) return;
     const tokensMeta = await getTokensMeta(tokens, state.tokenLists);
     const injected = clone(state.injected);

--- a/src/store/modules/registry.ts
+++ b/src/store/modules/registry.ts
@@ -179,8 +179,16 @@ const actions = {
     name = name || TOKEN_LIST_DEFAULT;
     try {
       const tokenList = await loadTokenlist(name);
+      // Convert all token addresses to checksum addresses to make searching easier
+      const checksummedTokenList = {
+        tokenList,
+        tokens: tokenList.tokens.map(token => ({
+          ...token,
+          address: getAddress(token.address)
+        }))
+      };
       const tokenLists = clone(state.tokenLists);
-      tokenLists[name] = tokenList;
+      tokenLists[name] = checksummedTokenList;
       commit('setTokenLists', tokenLists);
     } catch (error) {
       console.error('Failed to load TokenList', name, error);


### PR DESCRIPTION
(WIP as the new icons aren't picked up until we re-open the token menu atm)

Zerion and Coingecko both don't use checksummed addresses in their tokenlists and this is causing issues when trying to search for token icons as we miss these entries and fall back to checking trustwallet. This is an issue as the tokens which aren't listed on trust wallet are the exact tokens which we rely on these two lists for.

I've updated `loadTokenlist` to automatically convert all addresses to checksum addresses to avoid this.