### PR TITLE
Show only ENS reverse record

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -48,6 +48,7 @@
         "date-fns": "^2.21.1",
         "echarts": "^5.1.0",
         "eslint": "^6.7.2",
+        "eth-ens-namehash": "^2.0.8",
         "ethereumjs-util": "^7.0.7",
         "feather-icons": "^4.28.0",
         "fortmatic": "^2.0.6",
@@ -14905,6 +14906,15 @@
         "node": ">=4"
       }
     },
+    "node_modules/eth-ens-namehash": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/eth-ens-namehash/-/eth-ens-namehash-2.0.8.tgz",
+      "integrity": "sha1-IprEbsqG1S4MmR58sq74P/D2i88=",
+      "dependencies": {
+        "idna-uts46-hx": "^2.3.1",
+        "js-sha3": "^0.5.7"
+      }
+    },
     "node_modules/eth-json-rpc-filters": {
       "version": "4.2.2",
       "license": "ISC",
@@ -17626,6 +17636,25 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/idna-uts46-hx": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/idna-uts46-hx/-/idna-uts46-hx-2.3.1.tgz",
+      "integrity": "sha512-PWoF9Keq6laYdIRwwCdhTPl60xRqAloYNMQLiyUnG42VjT53oW07BXIRM+NK7eQjzXjAk2gUvX9caRxlnF9TAA==",
+      "dependencies": {
+        "punycode": "2.1.0"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/idna-uts46-hx/node_modules/punycode": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.0.tgz",
+      "integrity": "sha1-X4Y+3Im5bbCQdLrXlHvwkFbKTn0=",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/ieee754": {
@@ -42185,6 +42214,15 @@
         }
       }
     },
+    "eth-ens-namehash": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/eth-ens-namehash/-/eth-ens-namehash-2.0.8.tgz",
+      "integrity": "sha1-IprEbsqG1S4MmR58sq74P/D2i88=",
+      "requires": {
+        "idna-uts46-hx": "^2.3.1",
+        "js-sha3": "^0.5.7"
+      }
+    },
     "eth-json-rpc-filters": {
       "version": "4.2.2",
       "requires": {
@@ -44205,6 +44243,21 @@
       "version": "4.1.1",
       "requires": {
         "postcss": "^7.0.14"
+      }
+    },
+    "idna-uts46-hx": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/idna-uts46-hx/-/idna-uts46-hx-2.3.1.tgz",
+      "integrity": "sha512-PWoF9Keq6laYdIRwwCdhTPl60xRqAloYNMQLiyUnG42VjT53oW07BXIRM+NK7eQjzXjAk2gUvX9caRxlnF9TAA==",
+      "requires": {
+        "punycode": "2.1.0"
+      },
+      "dependencies": {
+        "punycode": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.0.tgz",
+          "integrity": "sha1-X4Y+3Im5bbCQdLrXlHvwkFbKTn0="
+        }
       }
     },
     "ieee754": {

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "date-fns": "^2.21.1",
     "echarts": "^5.1.0",
     "eslint": "^6.7.2",
+    "eth-ens-namehash": "^2.0.8",
     "ethereumjs-util": "^7.0.7",
     "feather-icons": "^4.28.0",
     "fortmatic": "^2.0.6",


### PR DESCRIPTION
Currently the ENS domain visible on the top nav is taken from ENS subgraph, but the subgraph don't give information on what domain should be the default one for the user. On this PR i remove the call to the ENS subgraph to use a smart contract that was recently released to query for reverse records.