### PR TITLE
Only recalculate balances and allowances on txConfirmed events

### DIFF
--- a/src/composables/useWeb3Watchers.ts
+++ b/src/composables/useWeb3Watchers.ts
@@ -26,11 +26,9 @@ export default function useWeb3Watchers() {
       if (!newAccount) return;
 
       const { emitter } = notify.account(newAccount);
-      emitter.on('all', transaction => {
-        if (transaction.status === 'confirmed') {
-          store.dispatch('account/getBalances');
-          store.dispatch('account/getAllowances');
-        }
+      emitter.on('txConfirmed', () => {
+        store.dispatch('account/getBalances');
+        store.dispatch('account/getAllowances');
         return false;
       });
     }


### PR DESCRIPTION

Changes proposed in this pull request:
- Instead of re-calculating allowances and balances on all blocknative notify events, only do it on `txConfirmed` events
