### PR TITLE
Liquidity Mining - Switch to using UTC time for time diff

### DIFF
--- a/src/lib/utils/date.ts
+++ b/src/lib/utils/date.ts
@@ -1,0 +1,10 @@
+export function toUtcTime(date: Date) {
+  return Date.UTC(
+    date.getUTCFullYear(),
+    date.getUTCMonth(),
+    date.getUTCDate(),
+    date.getUTCHours(),
+    date.getUTCMinutes(),
+    date.getUTCSeconds()
+  );
+}

--- a/src/lib/utils/liquidityMining/index.ts
+++ b/src/lib/utils/liquidityMining/index.ts
@@ -1,6 +1,8 @@
 import { differenceInWeeks } from 'date-fns';
 import { groupBy, mapValues, mergeWith, add } from 'lodash';
-import { bnum } from '..';
+
+import { bnum } from '@/lib/utils';
+import { toUtcTime } from '@/lib/utils/date';
 
 import LiquidityMiningV2 from './LiquidityMiningV2.json';
 
@@ -19,9 +21,11 @@ type LiquidityMiningWeek = {
 
 type LiquidityMiningRewards = Record<string, number>;
 
-// Liquidity mining started on June 1, 2020
+// Liquidity mining started on June 1, 2020 00:00 UTC
+const liquidityMiningStartTime = Date.UTC(2020, 5, 1, 0, 0);
+
 function getCurrentLiquidityMiningWeek() {
-  return differenceInWeeks(new Date(), new Date(2020, 5, 1)) + 1;
+  return differenceInWeeks(toUtcTime(new Date()), liquidityMiningStartTime) + 1;
 }
 
 function computeRewardsForTier(tier: LiquidityMiningTier) {
@@ -46,7 +50,7 @@ export function getLiquidityMiningRewards(
 ) {
   const miningWeek =
     week === 'current' ? getCurrentLiquidityMiningWeek() : week;
-
+  console.log(miningWeek);
   const miningRewards: LiquidityMiningRewards = {};
 
   const liquidityMiningWeek = LiquidityMiningV2[

--- a/src/lib/utils/liquidityMining/index.ts
+++ b/src/lib/utils/liquidityMining/index.ts
@@ -50,7 +50,7 @@ export function getLiquidityMiningRewards(
 ) {
   const miningWeek =
     week === 'current' ? getCurrentLiquidityMiningWeek() : week;
-  console.log(miningWeek);
+
   const miningRewards: LiquidityMiningRewards = {};
 
   const liquidityMiningWeek = LiquidityMiningV2[


### PR DESCRIPTION
As discussed with @markusbkoch its better to switch to UTC time when computing the diff.