### PR TITLE
UI-509 prevent writing a number into amounts

### DIFF
--- a/src/components/forms/pool_actions/InvestForm.vue
+++ b/src/components/forms/pool_actions/InvestForm.vue
@@ -121,7 +121,7 @@
         <template v-slot:info>
           <div
             class="cursor-pointer"
-            @click.prevent="amounts[i] = tokenBalance(i)"
+            @click.prevent="amounts[i] = tokenBalance(i).toString()"
           >
             {{ $t('balance') }}: {{ formatBalance(i) }}
           </div>
@@ -131,7 +131,7 @@
             <BalBtn
               size="xs"
               color="white"
-              @click.prevent="amounts[i] = tokenBalance(i)"
+              @click.prevent="amounts[i] = tokenBalance(i).toString()"
             >
               {{ $t('max') }}
             </BalBtn>


### PR DESCRIPTION
Here we're writing a number into an array of strings if we click the "max" button on the invest form.

This causes an error when we try to calculate the price impact as we then try and call `parseUnits` (which only accepts strings) on this number. This then causes the InvestForm to disappear.

I've ensured that we convert this number to a string as a quick fix.