### PR TITLE
update: turn off HODL line in pool chart by default

### DIFF
--- a/src/components/_global/BalLineChart/BalLineChart.vue
+++ b/src/components/_global/BalLineChart/BalLineChart.vue
@@ -95,6 +95,9 @@ export default defineComponent({
     },
     showLegend: {
       type: Boolean
+    },
+    legendState: {
+      type: Object
     }
   },
   components: {
@@ -124,7 +127,8 @@ export default defineComponent({
           return `${legendName}: ${fNum(latestValue[1], null, {
             format: props.axisLabelFormatter.yAxis
           })}`;
-        }
+        },
+        selected: props.legendState
       },
       // controlling the display of the X-Axis
       xAxis: {

--- a/src/components/pages/pool/PoolChart.vue
+++ b/src/components/pages/pool/PoolChart.vue
@@ -9,6 +9,7 @@
       :color="chartColors"
       height="96"
       :showLegend="true"
+      :legendState="{ HODL: false }"
     />
   </div>
   <BalBlankSlate v-else class="h-96">


### PR DESCRIPTION
Changes proposed in this pull request:
- Turn off HODL state in pool chart by default

**Testing Criteria**
- Open pool page, check if HODL is off by default. Make sure that you can re-activate it though.