### PR TITLE
update: persist invest/withdraw form state across tab changes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -33972,7 +33972,6 @@
           "integrity": "sha512-IWnb10ImrzRMT2qw9785p3wYEI6U9gjsg6H2zKcRJQP5dEboqeX3OFjUKfXkaIWii4nz8MtJjBg5t4BdEYqLdw==",
           "dev": true,
           "requires": {
-            "@babel/core": "^7.12.10",
             "@babel/generator": "^7.12.11",
             "@babel/parser": "^7.12.11",
             "@babel/plugin-transform-react-jsx": "^7.12.12",
@@ -37483,7 +37482,6 @@
     "@vue/babel-preset-app": {
       "version": "4.5.12",
       "requires": {
-        "@babel/core": "^7.11.0",
         "@babel/helper-compilation-targets": "^7.9.6",
         "@babel/helper-module-imports": "^7.8.3",
         "@babel/plugin-proposal-class-properties": "^7.8.3",
@@ -37496,7 +37494,6 @@
         "@vue/babel-plugin-jsx": "^1.0.3",
         "@vue/babel-preset-jsx": "^1.2.4",
         "babel-plugin-dynamic-import-node": "^2.3.3",
-        "core-js": "^3.6.5",
         "core-js-compat": "^3.6.5",
         "semver": "^6.1.0"
       }

--- a/src/components/forms/pool_actions/InvestForm.vue
+++ b/src/components/forms/pool_actions/InvestForm.vue
@@ -583,7 +583,7 @@ export default defineComponent({
     watch(allTokens, newTokens => poolCalculator.setAllTokens(newTokens));
 
     watch(data, newData => {
-      emit('update:modelValue', newData);
+      // emit('update:modelValue', newData);
     });
 
     watch(

--- a/src/components/forms/pool_actions/InvestForm.vue
+++ b/src/components/forms/pool_actions/InvestForm.vue
@@ -120,20 +120,13 @@
           </div>
         </template>
         <template v-slot:info>
-          <div
-            class="cursor-pointer"
-            @click.prevent="amounts[i] = tokenBalance(i).toString()"
-          >
+          <div class="cursor-pointer" @click.prevent="setMaxInput">
             {{ $t('balance') }}: {{ formatBalance(i) }}
           </div>
         </template>
         <template v-slot:append>
           <div class="p-2">
-            <BalBtn
-              size="xs"
-              color="white"
-              @click.prevent="amounts[i] = tokenBalance(i).toString()"
-            >
+            <BalBtn size="xs" color="white" @click.prevent="setMaxInput">
               {{ $t('max') }}
             </BalBtn>
           </div>
@@ -271,6 +264,7 @@ import { FullPool } from '@/services/balancer/subgraph/types';
 import useFathom from '@/composables/useFathom';
 
 import { TOKENS } from '@/constants/tokens';
+import { reset } from 'numeral';
 
 export enum FormTypes {
   proportional = 'proportional',
@@ -561,6 +555,11 @@ export default defineComponent({
       }
     }
 
+    function setMaxInput(index: number) {
+      amounts[index] = tokenBalance(index).toString();
+      resetSlider();
+    }
+
     async function submit(): Promise<void> {
       if (!data.investForm.validate()) return;
       try {
@@ -698,7 +697,8 @@ export default defineComponent({
       approveAllowances,
       fNum,
       preventOverflow,
-      trackGoal
+      trackGoal,
+      setMaxInput
     };
   }
 });

--- a/src/components/forms/pool_actions/InvestForm.vue
+++ b/src/components/forms/pool_actions/InvestForm.vue
@@ -300,7 +300,7 @@ export default defineComponent({
 
   props: {
     pool: { type: Object as PropType<FullPool>, required: true },
-    missingPrices: { type: Boolean, default: false },
+    missingPrices: { type: Boolean, default: false }
     // initialState: { type: Object as PropType<DataProps>, default: () => ({}) }
   },
 
@@ -644,7 +644,7 @@ export default defineComponent({
       } else {
         setPropMax();
         // if (props.initialState.range === undefined) {
-          resetSlider();
+        resetSlider();
         // }
       }
     });

--- a/src/components/forms/pool_actions/InvestForm.vue
+++ b/src/components/forms/pool_actions/InvestForm.vue
@@ -582,9 +582,9 @@ export default defineComponent({
 
     watch(allTokens, newTokens => poolCalculator.setAllTokens(newTokens));
 
-    watch(data, newData => {
+    // watch(data, newData => {
       // emit('update:modelValue', newData);
-    });
+    // });
 
     watch(
       () => props.pool.onchain.tokens,

--- a/src/components/forms/pool_actions/InvestForm.vue
+++ b/src/components/forms/pool_actions/InvestForm.vue
@@ -301,19 +301,19 @@ export default defineComponent({
   props: {
     pool: { type: Object as PropType<FullPool>, required: true },
     missingPrices: { type: Boolean, default: false },
-    initialState: { type: Object as PropType<DataProps>, default: () => ({}) }
+    // initialState: { type: Object as PropType<DataProps>, default: () => ({}) }
   },
 
-  setup(props: { pool: FullPool; initialState }, { emit }) {
+  setup(props: { pool: FullPool }, { emit }) {
     const data = reactive<DataProps>({
       investForm: {} as FormRef,
-      investType: props.initialState.investType || FormTypes.proportional,
+      investType: FormTypes.proportional,
       loading: false,
-      amounts: props.initialState?.amounts || [],
+      amounts: [],
       propMax: [],
       validInputs: [],
       propToken: 0,
-      range: props.initialState.range || 1000,
+      range: 1000,
       highPiAccepted: false
     });
 
@@ -643,9 +643,9 @@ export default defineComponent({
         data.investType = FormTypes.custom;
       } else {
         setPropMax();
-        if (props.initialState.range === undefined) {
+        // if (props.initialState.range === undefined) {
           resetSlider();
-        }
+        // }
       }
     });
 

--- a/src/components/forms/pool_actions/InvestForm.vue
+++ b/src/components/forms/pool_actions/InvestForm.vue
@@ -241,8 +241,7 @@ import {
   reactive,
   toRefs,
   ref,
-  PropType,
-  toRef
+  PropType
 } from 'vue';
 import { FormRef } from '@/types';
 import {

--- a/src/components/forms/pool_actions/InvestForm.vue
+++ b/src/components/forms/pool_actions/InvestForm.vue
@@ -289,6 +289,11 @@ type DataProps = {
   highPiAccepted: boolean;
 };
 
+type InvestFormInitialState = Pick<
+  DataProps,
+  'investType' | 'range' | 'amounts'
+>;
+
 export default defineComponent({
   name: 'InvestForm',
 
@@ -302,14 +307,15 @@ export default defineComponent({
     pool: { type: Object as PropType<FullPool>, required: true },
     missingPrices: { type: Boolean, default: false },
     initialState: {
-      type: Object as PropType<
-        Pick<DataProps, 'investType' | 'range' | 'amounts'>
-      >,
+      type: Object as PropType<InvestFormInitialState>,
       default: () => ({})
     }
   },
 
-  setup(props: { pool: FullPool; initialState }, { emit }) {
+  setup(
+    props: { pool: FullPool; initialState: InvestFormInitialState },
+    { emit }
+  ) {
     const data = reactive<DataProps>({
       investForm: {} as FormRef,
       investType: props.initialState.investType || FormTypes.proportional,

--- a/src/components/forms/pool_actions/InvestForm.vue
+++ b/src/components/forms/pool_actions/InvestForm.vue
@@ -582,9 +582,10 @@ export default defineComponent({
 
     watch(allTokens, newTokens => poolCalculator.setAllTokens(newTokens));
 
-    // watch(data, newData => {
-      // emit('update:modelValue', newData);
-    // });
+    watch(data, () => {
+      console.log('p', data);
+    // emit('update:modelValue', newData);
+    });
 
     watch(
       () => props.pool.onchain.tokens,

--- a/src/components/forms/pool_actions/InvestForm.vue
+++ b/src/components/forms/pool_actions/InvestForm.vue
@@ -301,7 +301,7 @@ export default defineComponent({
   props: {
     pool: { type: Object as PropType<FullPool>, required: true },
     missingPrices: { type: Boolean, default: false },
-    initialState: { type: Object, default: () => ({}) }
+    initialState: { type: Object as PropType<DataProps>, default: () => ({}) }
   },
 
   setup(props: { pool: FullPool; initialState }, { emit }) {

--- a/src/components/forms/pool_actions/WithdrawForm.vue
+++ b/src/components/forms/pool_actions/WithdrawForm.vue
@@ -560,9 +560,10 @@ export default defineComponent({
       }
     }
 
-    // watch(data, newData => {
-      // emit('update:modelValue', newData);
-    // });
+    watch(data, () => {
+      console.log('d', data);
+    // emit('update:modelValue', newData);
+    });
 
     watch(
       () => props.pool.onchain.tokens,

--- a/src/components/forms/pool_actions/WithdrawForm.vue
+++ b/src/components/forms/pool_actions/WithdrawForm.vue
@@ -560,9 +560,9 @@ export default defineComponent({
       }
     }
 
-    watch(data, newData => {
+    // watch(data, newData => {
       // emit('update:modelValue', newData);
-    });
+    // });
 
     watch(
       () => props.pool.onchain.tokens,
@@ -610,10 +610,10 @@ export default defineComponent({
     onMounted(async () => {
       if (bptBalance.value) {
         // if (props.initialState.amounts === undefined) {
-          setPropMax();
+        setPropMax();
         // }
         // if (props.initialState.range === undefined) {
-          resetSlider();
+        resetSlider();
         // }
       }
     });

--- a/src/components/forms/pool_actions/WithdrawForm.vue
+++ b/src/components/forms/pool_actions/WithdrawForm.vue
@@ -230,7 +230,6 @@ export default defineComponent({
   },
 
   setup(props: { pool: FullPool; initialState }, { emit }) {
-    console.log('lel', props.initialState);
     const data = reactive({
       withdrawForm: {} as FormRef,
       loading: false,
@@ -552,7 +551,6 @@ export default defineComponent({
     }
 
     watch(data, newData => {
-      console.log('reee', data, newData);
       emit('update:modelValue', newData);
     });
 

--- a/src/components/forms/pool_actions/WithdrawForm.vue
+++ b/src/components/forms/pool_actions/WithdrawForm.vue
@@ -215,6 +215,18 @@ export enum FormTypes {
   single = 'single'
 }
 
+type DataProps = {
+  withdrawForm: FormRef;
+  withdrawType: FormTypes;
+  loading: boolean;
+  amounts: string[];
+  propMax: string[];
+  range: number;
+  bptIn: string;
+  singleAsset: number;
+  highPiAccepted: boolean;
+};
+
 export default defineComponent({
   name: 'WithdrawalForm',
 
@@ -226,7 +238,7 @@ export default defineComponent({
 
   props: {
     pool: { type: Object as PropType<FullPool>, required: true },
-    initialState: { type: Object, default: () => ({}) }
+    initialState: { type: Object as PropType<DataProps>, default: () => ({}) }
   },
 
   setup(props: { pool: FullPool; initialState }, { emit }) {

--- a/src/components/forms/pool_actions/WithdrawForm.vue
+++ b/src/components/forms/pool_actions/WithdrawForm.vue
@@ -227,6 +227,11 @@ type DataProps = {
   highPiAccepted: boolean;
 };
 
+type WithdrawFormInitialState = Pick<
+  DataProps,
+  'bptIn' | 'withdrawType' | 'range' | 'amounts'
+>;
+
 export default defineComponent({
   name: 'WithdrawalForm',
 
@@ -239,14 +244,15 @@ export default defineComponent({
   props: {
     pool: { type: Object as PropType<FullPool>, required: true },
     initialState: {
-      type: Object as PropType<
-        Pick<DataProps, 'bptIn' | 'withdrawType' | 'range' | 'amounts'>
-      >,
+      type: Object as PropType<WithdrawFormInitialState>,
       default: () => ({})
     }
   },
 
-  setup(props: { pool: FullPool; initialState }, { emit }) {
+  setup(
+    props: { pool: FullPool; initialState: WithdrawFormInitialState },
+    { emit }
+  ) {
     const data = reactive({
       withdrawForm: {} as FormRef,
       loading: false,

--- a/src/components/forms/pool_actions/WithdrawForm.vue
+++ b/src/components/forms/pool_actions/WithdrawForm.vue
@@ -624,9 +624,7 @@ export default defineComponent({
 
     onMounted(async () => {
       if (bptBalance.value) {
-        if (props.initialState.amounts === undefined) {
-          setPropMax();
-        }
+        setPropMax();
         if (props.initialState.range === undefined) {
           resetSlider();
         }

--- a/src/components/forms/pool_actions/WithdrawForm.vue
+++ b/src/components/forms/pool_actions/WithdrawForm.vue
@@ -237,20 +237,27 @@ export default defineComponent({
   emits: ['success', 'update:modelValue'],
 
   props: {
-    pool: { type: Object as PropType<FullPool>, required: true }
-    // initialState: { type: Object as PropType<DataProps>, default: () => ({}) }
+    pool: { type: Object as PropType<FullPool>, required: true },
+    initialState: {
+      type: Object as PropType<
+        Pick<DataProps, 'bptIn' | 'withdrawType' | 'range' | 'amounts'>
+      >,
+      default: () => ({})
+    }
   },
 
-  setup(props: { pool: FullPool }, { emit }) {
+  setup(props: { pool: FullPool; initialState }, { emit }) {
     const data = reactive({
       withdrawForm: {} as FormRef,
       loading: false,
-      amounts: [] as string[],
+      amounts: props.initialState?.amounts || ([] as string[]),
       propMax: [] as string[],
-      bptIn: '',
-      withdrawType: FormTypes.proportional as FormTypes,
+      bptIn: props.initialState.bptIn || '',
+      withdrawType:
+        props.initialState.withdrawType ||
+        (FormTypes.proportional as FormTypes),
       singleAsset: 0,
-      range: 1000,
+      range: props.initialState.range || 1000,
       highPiAccepted: false
     });
 
@@ -560,10 +567,17 @@ export default defineComponent({
       }
     }
 
-    watch(data, () => {
-      console.log('d', data);
-    // emit('update:modelValue', newData);
-    });
+    watch(
+      () => ({
+        amounts: data.amounts,
+        withdrawType: data.withdrawType,
+        range: data.range,
+        bptIn: data.bptIn
+      }),
+      newData => {
+        emit('update:modelValue', newData);
+      }
+    );
 
     watch(
       () => props.pool.onchain.tokens,
@@ -610,12 +624,12 @@ export default defineComponent({
 
     onMounted(async () => {
       if (bptBalance.value) {
-        // if (props.initialState.amounts === undefined) {
-        setPropMax();
-        // }
-        // if (props.initialState.range === undefined) {
-        resetSlider();
-        // }
+        if (props.initialState.amounts === undefined) {
+          setPropMax();
+        }
+        if (props.initialState.range === undefined) {
+          resetSlider();
+        }
       }
     });
 

--- a/src/components/forms/pool_actions/WithdrawForm.vue
+++ b/src/components/forms/pool_actions/WithdrawForm.vue
@@ -237,22 +237,20 @@ export default defineComponent({
   emits: ['success', 'update:modelValue'],
 
   props: {
-    pool: { type: Object as PropType<FullPool>, required: true },
-    initialState: { type: Object as PropType<DataProps>, default: () => ({}) }
+    pool: { type: Object as PropType<FullPool>, required: true }
+    // initialState: { type: Object as PropType<DataProps>, default: () => ({}) }
   },
 
-  setup(props: { pool: FullPool; initialState }, { emit }) {
+  setup(props: { pool: FullPool }, { emit }) {
     const data = reactive({
       withdrawForm: {} as FormRef,
       loading: false,
-      amounts: props.initialState?.amounts || ([] as string[]),
+      amounts: [] as string[],
       propMax: [] as string[],
-      bptIn: props.initialState.bptIn || '',
-      withdrawType:
-        props.initialState.withdrawType ||
-        (FormTypes.proportional as FormTypes),
+      bptIn: '',
+      withdrawType: FormTypes.proportional as FormTypes,
       singleAsset: 0,
-      range: props.initialState.range || 1000,
+      range: 1000,
       highPiAccepted: false
     });
 
@@ -563,7 +561,7 @@ export default defineComponent({
     }
 
     watch(data, newData => {
-      emit('update:modelValue', newData);
+      // emit('update:modelValue', newData);
     });
 
     watch(
@@ -611,12 +609,12 @@ export default defineComponent({
 
     onMounted(async () => {
       if (bptBalance.value) {
-        if (props.initialState.amounts === undefined) {
+        // if (props.initialState.amounts === undefined) {
           setPropMax();
-        }
-        if (props.initialState.range === undefined) {
+        // }
+        // if (props.initialState.range === undefined) {
           resetSlider();
-        }
+        // }
       }
     });
 

--- a/src/components/forms/pool_actions/shared/FormTypeToggle.vue
+++ b/src/components/forms/pool_actions/shared/FormTypeToggle.vue
@@ -51,11 +51,12 @@ export default defineComponent({
     modelValue: { type: String, required: true },
     loading: { type: Boolean, default: false },
     hasZeroBalance: { type: Boolean, default: false },
-    missingPrices: { type: Boolean, default: false }
+    missingPrices: { type: Boolean, default: false },
+    initialValue: { type: String as PropType<FormTypes> }
   },
 
   setup(props, { emit }) {
-    const selected = ref(props.formTypes[0].value);
+    const selected = ref(props.initialValue || props.formTypes[0].value);
 
     watch(selected, newVal => {
       emit('update:modelValue', newVal);

--- a/src/components/pages/pool/PoolActionsCard/PoolActionsCard.vue
+++ b/src/components/pages/pool/PoolActionsCard/PoolActionsCard.vue
@@ -11,6 +11,8 @@
           :pool="pool"
           :missing-prices="missingPrices"
           @success="handleInvestment($event)"
+          v-model="investFormState"
+          :initialState="investFormState"
         />
         <SuccessOverlay
           v-if="investmentSuccess"
@@ -26,6 +28,8 @@
           :pool="pool"
           :missing-prices="missingPrices"
           @success="handleWithdrawal($event)"
+          v-model="withdrawFormState"
+          :initialState="withdrawFormState"
         />
         <SuccessOverlay
           v-if="withdrawalSuccess"

--- a/src/components/pages/pool/PoolActionsCard/PoolActionsCard.vue
+++ b/src/components/pages/pool/PoolActionsCard/PoolActionsCard.vue
@@ -11,8 +11,6 @@
           :pool="pool"
           :missing-prices="missingPrices"
           @success="handleInvestment($event)"
-          v-model="investFormState"
-          :initialState="investFormState"
         />
         <SuccessOverlay
           v-if="investmentSuccess"

--- a/src/components/pages/pool/PoolActionsCard/PoolActionsCard.vue
+++ b/src/components/pages/pool/PoolActionsCard/PoolActionsCard.vue
@@ -11,6 +11,8 @@
           :pool="pool"
           :missing-prices="missingPrices"
           @success="handleInvestment($event)"
+          v-model="investFormState"
+          :initialState="investFormState"
         />
         <SuccessOverlay
           v-if="investmentSuccess"
@@ -26,6 +28,8 @@
           :pool="pool"
           :missing-prices="missingPrices"
           @success="handleWithdrawal($event)"
+          v-model="withdrawFormState"
+          :initialState="withdrawFormState"
         />
         <SuccessOverlay
           v-if="withdrawalSuccess"
@@ -82,6 +86,8 @@ export default defineComponent({
     const investmentSuccess = ref(false);
     const withdrawalSuccess = ref(false);
     const txHash = ref('');
+    const investFormState = ref({});
+    const withdrawFormState = ref({});
 
     // METHODS
     function handleInvestment(txReceipt): void {
@@ -108,7 +114,10 @@ export default defineComponent({
       TradeSettingsContext,
       // methods
       handleInvestment,
-      handleWithdrawal
+      handleWithdrawal,
+      //refs
+      investFormState,
+      withdrawFormState
     };
   }
 });

--- a/src/components/pages/pool/PoolActionsCard/PoolActionsCard.vue
+++ b/src/components/pages/pool/PoolActionsCard/PoolActionsCard.vue
@@ -26,8 +26,6 @@
           :pool="pool"
           :missing-prices="missingPrices"
           @success="handleWithdrawal($event)"
-          v-model="withdrawFormState"
-          :initialState="withdrawFormState"
         />
         <SuccessOverlay
           v-if="withdrawalSuccess"


### PR DESCRIPTION
Fixes # .

Changes proposed in this pull request:
- Persist persist/withdraw form state across tab changes

**Testing Criteria**
- When adjusting the inputs on the invest and withdraw form, switch between tabs. Upon returning to each respective tab the inputs that were previously modified should persist.

**Questions**
- I've adjusted the behaviour to also persist the input changes when switching between sub-types in each form. (proportional vs custom), is this something that we want or not?