### PR TITLE
Call handleSwitchTokens if tokenIn/Out === tokenIn/Out on selection.

### DIFF
--- a/src/components/cards/TradeCard/TradePair.vue
+++ b/src/components/cards/TradeCard/TradePair.vue
@@ -263,9 +263,15 @@ export default defineComponent({
 
     function handleSelectToken(address: string): void {
       if (modalSelectTokenType.value === 'input') {
-        emit('tokenInAddressChange', address);
+        if (address === tokenOutAddressInput.value) {
+          handleSwitchTokens();
+          return;
+        } else emit('tokenInAddressChange', address);
       } else {
-        emit('tokenOutAddressChange', address);
+        if (address === tokenInAddressInput.value) {
+          handleSwitchTokens();
+          return;
+        } else emit('tokenOutAddressChange', address);
       }
       store.dispatch('registry/injectTokens', [address]);
     }


### PR DESCRIPTION
Fixes #UI-469.

Changes proposed in this pull request:
- On selection check if tokenIn/Out === tokenIn/Out (i.e. same token>token trade)
- If it does call handleSwitchTokens to flip tokenIn/Out
- 
