### PR TITLE
Change to SOR that is filtering Stable pool.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@balancer-labs/assets": "github:balancer-labs/assets#master",
         "@balancer-labs/sor": "github:balancer-labs/balancer-sor#john/v1-consideringFees-package",
-        "@balancer-labs/sor2": "github:balancer-labs/balancer-sor#master-V2",
+        "@balancer-labs/sor2": "github:balancer-labs/balancer-sor#john/temp-stable-pool-subgraph-bug-fix",
         "@ensdomains/content-hash": "^2.5.3",
         "@ethersproject/abi": "^5.0.1",
         "@ethersproject/address": "^5.0.1",
@@ -1479,7 +1479,7 @@
     },
     "node_modules/@balancer-labs/sor2": {
       "version": "2.0.0",
-      "resolved": "git+ssh://git@github.com/balancer-labs/balancer-sor.git#479590f0cd338c7edad4bfa1570c8bb3ce6bcf06",
+      "resolved": "git+ssh://git@github.com/balancer-labs/balancer-sor.git#3865df8e997e144b1aabb3086a6cd311649b5c20",
       "license": "GPL-3.0-only",
       "dependencies": {
         "@ethersproject/address": "^5.0.5",
@@ -32587,8 +32587,8 @@
       }
     },
     "@balancer-labs/sor2": {
-      "version": "git+ssh://git@github.com/balancer-labs/balancer-sor.git#479590f0cd338c7edad4bfa1570c8bb3ce6bcf06",
-      "from": "@balancer-labs/sor2@github:balancer-labs/balancer-sor#master-V2",
+      "version": "git+ssh://git@github.com/balancer-labs/balancer-sor.git#3865df8e997e144b1aabb3086a6cd311649b5c20",
+      "from": "@balancer-labs/sor2@github:balancer-labs/balancer-sor#john/temp-stable-pool-subgraph-bug-fix",
       "requires": {
         "@ethersproject/address": "^5.0.5",
         "@ethersproject/constants": "^5.0.5",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "dependencies": {
     "@balancer-labs/assets": "github:balancer-labs/assets#master",
     "@balancer-labs/sor": "github:balancer-labs/balancer-sor#john/v1-consideringFees-package",
-    "@balancer-labs/sor2": "github:balancer-labs/balancer-sor#master-V2",
+    "@balancer-labs/sor2": "github:balancer-labs/balancer-sor#john/temp-stable-pool-subgraph-bug-fix",
     "@ensdomains/content-hash": "^2.5.3",
     "@ethersproject/abi": "^5.0.1",
     "@ethersproject/address": "^5.0.1",


### PR DESCRIPTION
Fixes # .

Changes proposed in this pull request:
- Temp fix. Subgraph for Kovan has been updated for Stable Pools but it doesn't seem to be handling them correctly as the tokens and tokensList arrays are showing as empty. This is causing the SOR balances multicall to fail. So the Kovan app is currently only returning V1 swaps.
- SOR in this version is filtering Stable pools from multicall.
- 
