### PR TITLE
Missing past pools

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@balancer-labs/frontend-v2",
-      "version": "1.4.0",
+      "version": "1.4.1",
       "license": "MIT",
       "dependencies": {
         "@balancer-labs/assets": "github:balancer-labs/assets#master",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "engines": {
     "node": "14.x",
     "npm": ">=7"

--- a/src/services/balancer/subgraph/entities/pools/index.ts
+++ b/src/services/balancer/subgraph/entities/pools/index.ts
@@ -49,7 +49,7 @@ export default class Pools {
     const block = { number: await this.timeTravelBlock(period) };
     const isCurrentPool = { id_in: currentPools.map(pool => pool.id) };
     const pastPoolsQuery = this.query(
-      { ...args, where: isCurrentPool, block },
+      { where: isCurrentPool, block },
       attrs
     );
     const { pools: pastPools } = await this.service.client.get(pastPoolsQuery);

--- a/src/services/balancer/subgraph/entities/pools/index.ts
+++ b/src/services/balancer/subgraph/entities/pools/index.ts
@@ -48,10 +48,7 @@ export default class Pools {
     // Get past state of current pools
     const block = { number: await this.timeTravelBlock(period) };
     const isCurrentPool = { id_in: currentPools.map(pool => pool.id) };
-    const pastPoolsQuery = this.query(
-      { where: isCurrentPool, block },
-      attrs
-    );
+    const pastPoolsQuery = this.query({ where: isCurrentPool, block }, attrs);
     const { pools: pastPools } = await this.service.client.get(pastPoolsQuery);
 
     return this.serialize(currentPools, pastPools, period, prices);

--- a/src/services/balancer/subgraph/entities/pools/index.ts
+++ b/src/services/balancer/subgraph/entities/pools/index.ts
@@ -39,18 +39,20 @@ export default class Pools {
     args = {},
     attrs = {}
   ): Promise<DecoratedPool[]> {
-    attrs = { ...attrs, __aliasFor: 'pools' };
-    const currentPoolsQuery = {
-      currentPools: this.query(args, attrs).pools
-    };
-    const { currentPools } = await this.service.client.get(currentPoolsQuery);
+    // Get current pools
+    const currentPoolsQuery = this.query(args, attrs);
+    const { pools: currentPools } = await this.service.client.get(
+      currentPoolsQuery
+    );
 
+    // Get past state of current pools
     const block = { number: await this.timeTravelBlock(period) };
-    const pools_of_interest = { id_in: currentPools.map(pool => pool.id) };
-    const pastPoolsQuery = {
-      pastPools: this.query({ where: pools_of_interest, block }, attrs).pools
-    };
-    const { pastPools } = await this.service.client.get(pastPoolsQuery);
+    const isCurrentPool = { id_in: currentPools.map(pool => pool.id) };
+    const pastPoolsQuery = this.query(
+      { ...args, where: isCurrentPool, block },
+      attrs
+    );
+    const { pools: pastPools } = await this.service.client.get(pastPoolsQuery);
 
     return this.serialize(currentPools, pastPools, period, prices);
   }

--- a/src/services/balancer/subgraph/entities/pools/index.ts
+++ b/src/services/balancer/subgraph/entities/pools/index.ts
@@ -41,12 +41,13 @@ export default class Pools {
   ): Promise<DecoratedPool[]> {
     // Get current pools
     const currentPoolsQuery = this.query(args, attrs);
-    const { pools: currentPools } = await this.service.client.get(
-      currentPoolsQuery
-    );
+    const [{ pools: currentPools }, blockNumber] = await Promise.all([
+      this.service.client.get(currentPoolsQuery),
+      this.timeTravelBlock(period)
+    ]);
 
     // Get past state of current pools
-    const block = { number: await this.timeTravelBlock(period) };
+    const block = { number: blockNumber };
     const isCurrentPool = { id_in: currentPools.map(pool => pool.id) };
     const pastPoolsQuery = this.query({ where: isCurrentPool, block }, attrs);
     const { pools: pastPools } = await this.service.client.get(pastPoolsQuery);


### PR DESCRIPTION
Fixes an issue where the Nth to Mth pools in the time travel query are not the same Nth to Mth in the current state query, in which case 24h volume is incorrectly returned.