### PR TITLE
refactor: store subgraph urls in network config json files

### DIFF
--- a/src/composables/trade/useSor.ts
+++ b/src/composables/trade/useSor.ts
@@ -13,7 +13,7 @@ import {
   SorReturn
 } from '@/lib/utils/balancer/helpers/sor/sorManager';
 import { swapIn, swapOut } from '@/lib/utils/balancer/swapper';
-import { urlMap as subgraphUrlMap } from '@/services/balancer/subgraph/client';
+import ConfigService from '@/services/config/config.service';
 
 import useAuth from '@/composables/useAuth';
 import useNotify from '@/composables/useNotify';
@@ -99,7 +99,7 @@ export default function useSor(
     const config = getConfig();
     const poolsUrlV1 = `${config.poolsUrlV1}?timestamp=${Date.now()}`;
     const poolsUrlV2 = `${config.poolsUrlV2}?timestamp=${Date.now()}`;
-    const subgraphUrl = subgraphUrlMap[config.chainId];
+    const subgraphUrl = new ConfigService().network.subgraph;
 
     sorManager = new SorManager(
       getProvider(config.chainId),

--- a/src/lib/config/docker.json
+++ b/src/lib/config/docker.json
@@ -8,6 +8,7 @@
   "rpc": "http://localhost:8545",
   "ws": "ws://localhost:8546",
   "explorer": "",
+  "subgraph": "http://localhost:8000/subgraphs/name/balancer-labs/balancer-v2",
   "poolsUrlV1": "",
   "poolsUrlV2": "",
   "addresses": {

--- a/src/lib/config/homestead.json
+++ b/src/lib/config/homestead.json
@@ -10,6 +10,7 @@
   "rpc": "https://mainnet.infura.io/v3/daaa68ec242643719749dd1caba2fc66",
   "ws": "wss://mainnet.infura.io/ws/v3/daaa68ec242643719749dd1caba2fc66",
   "explorer": "https://etherscan.io",
+  "subgraph": "https://api.thegraph.com/subgraphs/name/balancer-labs/balancer-v2",
   "poolsUrlV1": "https://storageapi.fleek.co/balancer-bucket/balancer-exchange/pools",
   "poolsUrlV2": "https://storageapi.fleek.co/johngrantuk-team-bucket/poolsV2.json",
   "addresses": {

--- a/src/lib/config/index.ts
+++ b/src/lib/config/index.ts
@@ -16,6 +16,7 @@ export interface Config {
   rpc: string;
   ws: string;
   explorer: string;
+  subgraph: string;
   poolsUrlV1: string;
   poolsUrlV2: string;
   addresses: {

--- a/src/lib/config/kovan.json
+++ b/src/lib/config/kovan.json
@@ -10,6 +10,7 @@
   "rpc": "https://eth-kovan.alchemyapi.io/v2/QCsM2iU0bQ49eGDmZ7-Y--Wpu0lVWXSO",
   "ws": "wss://eth-kovan.ws.alchemyapi.io/v2/QCsM2iU0bQ49eGDmZ7-Y--Wpu0lVWXSO",
   "explorer": "https://kovan.etherscan.io",
+  "subgraph": "https://api.thegraph.com/subgraphs/name/balancer-labs/balancer-kovan-v2",
   "poolsUrlV1": "https://storageapi.fleek.co/balancer-bucket/balancer-exchange-kovan/pools",
   "poolsUrlV2": "https://storageapi.fleek.co/johngrantuk-team-bucket/poolsRc02.json",
   "addresses": {

--- a/src/lib/config/polygon.json
+++ b/src/lib/config/polygon.json
@@ -10,6 +10,7 @@
   "rpc": "https://polygon-mainnet.infura.io/v3/daaa68ec242643719749dd1caba2fc66",
   "ws": "wss://rpc-mainnet.maticvigil.com/ws",
   "explorer": "https://polygonscan.com/",
+  "subgraph": "https://api.thegraph.com/subgraphs/name/balancer-labs/balancer-polygon-v2",
   "poolsUrlV1": "",
   "poolsUrlV2": "",
   "addresses": {

--- a/src/lib/config/rinkeby.json
+++ b/src/lib/config/rinkeby.json
@@ -10,7 +10,7 @@
   "rpc": "https://eth-rinkeby.alchemyapi.io/v2/QCsM2iU0bQ49eGDmZ7-Y--Wpu0lVWXSO",
   "ws": "wss://eth-rinkeby.ws.alchemyapi.io/v2/QCsM2iU0bQ49eGDmZ7-Y--Wpu0lVWXSO",
   "explorer": "https://rinkeby.etherscan.io",
-  "subgraph": "http://localhost:8000/subgraphs/name/balancer-labs/balancer-rinkeby-v2",
+  "subgraph": "https://api.thegraph.com/subgraphs/name/balancer-labs/balancer-rinkeby-v2",
   "poolsUrlV1": "https://storageapi.fleek.co/balancer-bucket/balancer-exchange-rinkeby/pools",
   "poolsUrlV2": "https://storageapi.fleek.co/johngrantuk-team-bucket/poolsRc02.json",
   "addresses": {

--- a/src/lib/config/rinkeby.json
+++ b/src/lib/config/rinkeby.json
@@ -10,6 +10,7 @@
   "rpc": "https://eth-rinkeby.alchemyapi.io/v2/QCsM2iU0bQ49eGDmZ7-Y--Wpu0lVWXSO",
   "ws": "wss://eth-rinkeby.ws.alchemyapi.io/v2/QCsM2iU0bQ49eGDmZ7-Y--Wpu0lVWXSO",
   "explorer": "https://rinkeby.etherscan.io",
+  "subgraph": "http://localhost:8000/subgraphs/name/balancer-labs/balancer-rinkeby-v2",
   "poolsUrlV1": "https://storageapi.fleek.co/balancer-bucket/balancer-exchange-rinkeby/pools",
   "poolsUrlV2": "https://storageapi.fleek.co/johngrantuk-team-bucket/poolsRc02.json",
   "addresses": {

--- a/src/services/balancer/subgraph/client.ts
+++ b/src/services/balancer/subgraph/client.ts
@@ -1,21 +1,12 @@
 import axios from 'axios';
 import { jsonToGraphQLQuery } from 'json-to-graphql-query';
-
-const NETWORK = process.env.VUE_APP_NETWORK || '1';
-export const urlMap = {
-  '1': 'https://api.thegraph.com/subgraphs/name/balancer-labs/balancer-v2',
-  '17': 'http://localhost:8000/subgraphs/name/balancer-labs/balancer-v2',
-  '42':
-    'https://api.thegraph.com/subgraphs/name/balancer-labs/balancer-kovan-v2',
-  '137':
-    'https://api.thegraph.com/subgraphs/name/balancer-labs/balancer-matic-v2'
-};
+import ConfigService from '@/services/config/config.service';
 
 export default class Client {
   url: string;
 
-  constructor() {
-    this.url = urlMap[NETWORK];
+  constructor(private readonly configService = new ConfigService()) {
+    this.url = configService.network.subgraph;
   }
 
   public async get(query) {


### PR DESCRIPTION
I've consolidated the subgraph urls so that they live in the relevant network config. The subgraph service can then pull them through the `ConfigService`.

As an aside, do we want to make the methods on the `ConfigService` static?