### PR TITLE
Hide trade liquidity UI on networks where V1 isn't deployed

### DIFF
--- a/src/components/navs/AppNav/AppNavSettings.vue
+++ b/src/components/navs/AppNav/AppNavSettings.vue
@@ -103,7 +103,7 @@
       </div>
       <AppSlippageForm class="mt-1" />
     </div>
-    <div class="px-4 mt-6">
+    <div v-if="!hideLiquidity" class="px-4 mt-6">
       <div class="flex items-baseline">
         <span v-text="$t('tradeLiquidity')" class="font-medium mb-2" />
         <BalTooltip>
@@ -175,7 +175,7 @@ export default defineComponent({
   setup() {
     // COMPOSABLES
     const store = useStore();
-    const { explorer } = useWeb3();
+    const { appNetwork, explorer } = useWeb3();
 
     // DATA
     const data = reactive({
@@ -210,6 +210,7 @@ export default defineComponent({
     const appDarkMode = computed(() => store.state.app.darkMode);
     const appTradeLiquidity = computed(() => store.state.app.tradeLiquidity);
     const appTradeInterface = computed(() => store.state.app.tradeInterface);
+    const hideLiquidity = computed(() => !appNetwork.supportsV1);
 
     const connectorName = computed(() =>
       getConnectorName(store.state.web3.connector)
@@ -254,6 +255,7 @@ export default defineComponent({
       appDarkMode,
       connectorName,
       connectorLogo,
+      hideLiquidity,
       // methods
       logout,
       setDarkMode,

--- a/src/components/popovers/TradeSettingsPopover.vue
+++ b/src/components/popovers/TradeSettingsPopover.vue
@@ -91,7 +91,7 @@ export default defineComponent({
     // COMPOSABLES
     const store = useStore();
     const { fNum } = useNumbers();
-    const { explorer } = useWeb3();
+    const { appNetwork, explorer } = useWeb3();
     const { trackGoal, Goals } = useFathom();
 
     // DATA
@@ -104,7 +104,8 @@ export default defineComponent({
     // COMPUTED
     const appTradeLiquidity = computed(() => store.state.app.tradeLiquidity);
     const hideLiquidity = computed(
-      () => context.value === TradeSettingsContext.invest
+      () =>
+        !appNetwork.supportsV1 || context.value === TradeSettingsContext.invest
     );
 
     // METHODS

--- a/src/composables/useWeb3.ts
+++ b/src/composables/useWeb3.ts
@@ -1,14 +1,11 @@
 import { computed } from 'vue';
 import { useStore } from 'vuex';
 
-import configs, { Config } from '@/lib/config';
 import getProvider from '@/lib/utils/provider';
 import useAuth from '@/composables/useAuth';
 import { NetworkId } from '@/constants/network';
 import { isAddress } from '@ethersproject/address';
-
-const appConfig: Config | undefined =
-  configs[Number(process.env.VUE_APP_NETWORK)];
+import ConfigService from '@/services/config/config.service';
 
 export default function useWeb3() {
   const store = useStore();
@@ -20,14 +17,16 @@ export default function useWeb3() {
   const loading = computed(() => store.state.web3.loading);
   const isConnected = computed(() => isAuthenticated.value && !loading.value);
 
+  const configService = new ConfigService();
+
   // App Network vars (static)
   const appNetwork = {
-    key: process.env.VUE_APP_NETWORK || '1',
-    id: (Number(process.env.VUE_APP_NETWORK) || 1) as NetworkId,
-    name: appConfig?.shortName || 'Mainnet',
-    networkName: appConfig?.network || 'homestead',
-    nativeAsset: appConfig?.nativeAsset || 'ETH',
-    supportsV1: isAddress(appConfig?.addresses.exchangeProxy || '')
+    key: configService.env.NETWORK,
+    id: Number(configService.env.NETWORK) as NetworkId,
+    name: configService.network.shortName,
+    networkName: configService.network.network,
+    nativeAsset: configService.network.nativeAsset,
+    supportsV1: isAddress(configService.network.addresses.exchangeProxy)
   };
 
   // User network vars (dynamic)
@@ -58,7 +57,7 @@ export default function useWeb3() {
     );
   });
 
-  const explorerBaseURL = configs[appNetwork.id].explorer;
+  const explorerBaseURL = configService.network.explorer;
 
   // assumes etherscan.io
   const explorer = {

--- a/src/composables/useWeb3.ts
+++ b/src/composables/useWeb3.ts
@@ -5,6 +5,7 @@ import configs, { Config } from '@/lib/config';
 import getProvider from '@/lib/utils/provider';
 import useAuth from '@/composables/useAuth';
 import { NetworkId } from '@/constants/network';
+import { isAddress } from '@ethersproject/address';
 
 const appConfig: Config | undefined =
   configs[Number(process.env.VUE_APP_NETWORK)];
@@ -25,7 +26,8 @@ export default function useWeb3() {
     id: (Number(process.env.VUE_APP_NETWORK) || 1) as NetworkId,
     name: appConfig?.shortName || 'Mainnet',
     networkName: appConfig?.network || 'homestead',
-    nativeAsset: appConfig?.nativeAsset || 'ETH'
+    nativeAsset: appConfig?.nativeAsset || 'ETH',
+    supportsV1: isAddress(appConfig?.addresses.exchangeProxy || '')
   };
 
   // User network vars (dynamic)


### PR DESCRIPTION
The "trade liquidity" UI is now hidden on any network where no address is provided for `ExchangeProxy`.

`useWeb3` has been refactored to use the `ConfigService`.
