### PR TITLE
Polygon MVP

### DIFF
--- a/src/constants/initialTokens.json
+++ b/src/constants/initialTokens.json
@@ -6,5 +6,9 @@
   "42": {
     "input": "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
     "output": "0x04DF6e4121c27713ED22341E7c7Df330F56f289B"
+  },
+  "137": {
+    "input": "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
+    "output": "0x8f3cf7ad23cd3cadbd9735aff958023239c6a063"
   }
 }

--- a/src/constants/injected.json
+++ b/src/constants/injected.json
@@ -5,8 +5,7 @@
     "name": "Dai Stablecoin",
     "symbol": "DAI",
     "decimals": 18,
-    "logoURI":
-    "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x6B175474E89094C44Da98b954EedeAC495271d0F/logo.png"
+    "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x6B175474E89094C44Da98b954EedeAC495271d0F/logo.png"
   },
   {
     "address": "0x59935f19d720aD935beCdC34c4F367397a28DaED",
@@ -14,7 +13,14 @@
     "name": "Dai Stablecoin",
     "symbol": "DAI",
     "decimals": 18,
-    "logoURI":
-    "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x6B175474E89094C44Da98b954EedeAC495271d0F/logo.png"
+    "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x6B175474E89094C44Da98b954EedeAC495271d0F/logo.png"
+  },
+  {
+    "address": "0x8f3cf7ad23cd3cadbd9735aff958023239c6a063",
+    "chainId": 137,
+    "name": "Dai Stablecoin",
+    "symbol": "DAI",
+    "decimals": 18,
+    "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x6B175474E89094C44Da98b954EedeAC495271d0F/logo.png"
   }
 ]

--- a/src/lib/config/polygon.json
+++ b/src/lib/config/polygon.json
@@ -20,20 +20,15 @@
     "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x7D1AfA7B718fb893dB30A3aBc0Cfc608AaCfeBB0/logo.png"
   },
   "addresses": {
-    "bFactory": "",
-    "bActions": "",
-    "dsProxyRegistry": "",
     "exchangeProxy": "",
     "merkleRedeem": "",
     "multicall": "0xa1B2b503959aedD81512C37e9dce48164ec6a94d",
-    "authorizer": "",
-    "vault": "",
-    "weightedPoolFactory": "",
+    "authorizer": "0xa331d84ec860bf466b4cdccfb4ac09a1b43f3ae6",
+    "vault": "0xBA12222222228d8Ba445958a75a0704d566BF2C8",
+    "weightedPoolFactory": "0x8E9aa87E45e92bad84D5F8DD1bff34Fb92637dE9",
     "stablePoolFactory": "",
-    "tokenFactory": "",
     "weth": "0x0d500B1d8E8eF31E21C99d1Db9A6444d3ADf1270",
-    "MockFlashLoanReceiver": "",
-    "balancerHelpers": ""
+    "balancerHelpers": "0x94905e703fead7f0fd0eee355d267ee909784e6d"
   },
   "strategies": {
     "0": {

--- a/src/lib/config/polygon.json
+++ b/src/lib/config/polygon.json
@@ -6,7 +6,7 @@
   "network": "polygon",
   "unknown": false,
   "rpc": "https://polygon-mainnet.infura.io/v3/daaa68ec242643719749dd1caba2fc66",
-  "ws": "wss://rpc-mainnet.maticvigil.com/ws",
+  "ws": "wss://ws-matic-mainnet.chainstacklabs.com",
   "explorer": "https://polygonscan.com/",
   "subgraph": "https://api.thegraph.com/subgraphs/name/balancer-labs/balancer-polygon-v2",
   "poolsUrlV1": "",


### PR DESCRIPTION
I'm trying to flush out any possible bugs and get a rough version of the frontend which allows trading on Polygon. We have contracts + subgraph deployed so all the tasks from here is frontend related.

Todo:
- [x] deploy a set of initial pools and set `poolsUrlV2` in `polygon.json` so that we can test trading.
- [x] Add Polygon assets to a Balancer tokenlist. (We can use the Quickswap tokenlist as a starting point)
- [x] ~~add mappings for Polygon assets to translate to mainnet addresses to query CoinGecko with. (We can query the Matic bridge for these rather than maintaining a huge mapping)~~ Luckily, CoinGecko allows us to query with the Polygon addresses

Bugs:
- [x] Balancer tokenlist doesn't include Polygon assets and we can't easily override the default tokenlist for Polygon which causes `GasReimbursement` to crash as it doesn't receive addreses.