### PR TITLE
refactor: prep tokenlists definitions for multichain

### DIFF
--- a/src/components/cards/TradeCard/TradeCard.vue
+++ b/src/components/cards/TradeCard/TradeCard.vue
@@ -258,10 +258,10 @@ export default defineComponent({
 
     async function populateInitialTokens(): Promise<void> {
       let assetIn = router.currentRoute.value.params.assetIn as string;
-      if (assetIn === ETHER.id) assetIn = ETHER.address;
+      if (assetIn === ETHER.deeplinkId) assetIn = ETHER.address;
       else if (isAddress(assetIn)) assetIn = getAddress(assetIn);
       let assetOut = router.currentRoute.value.params.assetOut as string;
-      if (assetOut === ETHER.id) assetOut = ETHER.address;
+      if (assetOut === ETHER.deeplinkId) assetOut = ETHER.address;
       else if (isAddress(assetOut)) assetOut = getAddress(assetOut);
 
       tokenInAddress.value = assetIn || store.state.trade.inputAsset;

--- a/src/components/cards/TradeCardGP/TradeCardGP.vue
+++ b/src/components/cards/TradeCardGP/TradeCardGP.vue
@@ -251,10 +251,10 @@ export default defineComponent({
 
     async function populateInitialTokens(): Promise<void> {
       let assetIn = router.currentRoute.value.params.assetIn as string;
-      if (assetIn === ETHER.id) assetIn = ETHER.address;
+      if (assetIn === ETHER.deeplinkId) assetIn = ETHER.address;
       else if (isAddress(assetIn)) assetIn = getAddress(assetIn);
       let assetOut = router.currentRoute.value.params.assetOut as string;
-      if (assetOut === ETHER.id) assetOut = ETHER.address;
+      if (assetOut === ETHER.deeplinkId) assetOut = ETHER.address;
       else if (isAddress(assetOut)) assetOut = getAddress(assetOut);
 
       tokenInAddress.value = assetIn || store.state.trade.inputAsset;

--- a/src/components/forms/pool_actions/InvestForm.vue
+++ b/src/components/forms/pool_actions/InvestForm.vue
@@ -442,7 +442,7 @@ export default defineComponent({
       return minusSlippage(bptOut, props.pool.onchain.decimals);
     });
 
-    const nativeAsset = computed(() => appNetwork.nativeAsset);
+    const nativeAsset = computed(() => appNetwork.nativeAsset.symbol);
 
     const isWethPool = computed(() =>
       props.pool.tokenAddresses.includes(TOKENS.AddressMap.WETH)

--- a/src/composables/useTokenLists.ts
+++ b/src/composables/useTokenLists.ts
@@ -6,7 +6,7 @@ import { flatten, keyBy, orderBy, uniqBy } from 'lodash';
 import { getAddress } from '@ethersproject/address';
 
 import QUERY_KEYS from '@/constants/queryKeys';
-import { TOKEN_LISTS } from '@/constants/tokenlists';
+import TOKEN_LISTS from '@/constants/tokenlists';
 
 import { getTokensListURL, loadTokenlist } from '@/lib/utils/tokenlists';
 import { lsGet, lsSet } from '@/lib/utils';
@@ -42,7 +42,7 @@ const loadAllTokenLists = async () => {
   // retrieve what we can
   return (
     await Promise.allSettled(
-      TOKEN_LISTS.map(async listURI => {
+      TOKEN_LISTS.Approved.map(async listURI => {
         const tokenList = (await loadTokenlist(listURI)) as Omit<
           TokenList,
           'tokenListsURL'

--- a/src/composables/useTokens2.ts
+++ b/src/composables/useTokens2.ts
@@ -6,7 +6,6 @@ import useConfig from './useConfig';
 import TokenService from '@/services/token/token.service';
 import useTokenPricesQuery from './queries/useTokenPricesQuery';
 import useAccountBalancesQuery from './queries/useAccountBalancesQuery';
-import { TOKENS } from '@/constants/tokens';
 
 // TYPES
 type TokenDictionary = { [address: string]: TokenInfo };
@@ -59,7 +58,12 @@ export default function useTokens2() {
 
   const ether = computed(
     (): TokenDictionary => {
-      return { [TOKENS.EthMeta.address]: TOKENS.EthMeta };
+      return {
+        [networkConfig.nativeAsset.address]: {
+          ...networkConfig.nativeAsset,
+          chainId: networkConfig.chainId
+        }
+      };
     }
   );
 

--- a/src/constants/tokenlists.ts
+++ b/src/constants/tokenlists.ts
@@ -43,7 +43,9 @@ type TokenLists = {
   All: string[];
   Balancer: {
     All: string[];
+    // Compliant list for exchange
     Default: string;
+    // Extended list to include LBP tokens
     Vetted: string;
   };
   Approved: string[];
@@ -71,13 +73,6 @@ const processTokenLists = (config: TokenListConfig): TokenLists => {
   };
 };
 
-const FULL_TOKEN_LISTS = processTokenLists(TOKEN_LISTS_MAP[env.NETWORK]);
+const TOKEN_LISTS = processTokenLists(TOKEN_LISTS_MAP[env.NETWORK]);
 
-// Compliant list for exchange
-export const TOKEN_LIST_DEFAULT = FULL_TOKEN_LISTS.Balancer.Default;
-// Extended list to include LBP tokens
-export const VETTED_TOKEN_LIST = FULL_TOKEN_LISTS.Balancer.Vetted;
-
-export const TOKEN_LISTS = FULL_TOKEN_LISTS.Approved;
-
-export default FULL_TOKEN_LISTS;
+export default TOKEN_LISTS;

--- a/src/constants/tokenlists.ts
+++ b/src/constants/tokenlists.ts
@@ -2,6 +2,8 @@ import useConfig from '@/composables/useConfig';
 
 const { env, networkConfig } = useConfig();
 
+// TODO replace imports of ETHER throughout the app so we can remove it from here.
+// It doesn't make sense to have this ETHER definition here, this file should be for tokenlist URIs only.
 export const ETHER = networkConfig.nativeAsset;
 
 type TokenListConfig = {

--- a/src/constants/tokenlists.ts
+++ b/src/constants/tokenlists.ts
@@ -2,10 +2,7 @@ import useConfig from '@/composables/useConfig';
 
 const { env, networkConfig } = useConfig();
 
-export const ETHER = {
-  ...networkConfig.nativeAsset,
-  id: 'ether'
-};
+export const ETHER = networkConfig.nativeAsset;
 
 type TokenListConfig = {
   Balancer: {

--- a/src/constants/tokenlists.ts
+++ b/src/constants/tokenlists.ts
@@ -29,6 +29,33 @@ const TOKEN_LISTS_MAP: Record<string, TokenListConfig> = {
       'https://tokens.coingecko.com/uniswap/all.json',
       'https://umaproject.org/uma.tokenlist.json'
     ]
+  },
+  '42': {
+    Balancer: {
+      Default:
+        'https://storageapi.fleek.co/balancer-team-bucket/assets/listed.tokenlist.json',
+      Vetted:
+        'https://storageapi.fleek.co/balancer-team-bucket/assets/vetted.tokenlist.json'
+    },
+    External: [
+      'ipns://tokens.uniswap.org',
+      'tokenlist.zerion.eth',
+      'tokens.1inch.eth',
+      'tokenlist.aave.eth',
+      'https://tokens.coingecko.com/uniswap/all.json',
+      'https://umaproject.org/uma.tokenlist.json'
+    ]
+  },
+  '137': {
+    Balancer: {
+      Default:
+        'https://storageapi.fleek.co/tomafrench-team-bucket/polygon.listed.tokenlist.json',
+      Vetted:
+        'https://storageapi.fleek.co/tomafrench-team-bucket/polygon.vetted.tokenlist.json'
+    },
+    External: [
+      'https://unpkg.com/quickswap-default-token-list@1.0.67/build/quickswap-default.tokenlist.json'
+    ]
   }
 };
 

--- a/src/constants/tokenlists.ts
+++ b/src/constants/tokenlists.ts
@@ -1,49 +1,83 @@
-// Compliant list for exchange
-export const TOKEN_LIST_DEFAULT =
-  'https://storageapi.fleek.co/balancer-team-bucket/assets/listed.tokenlist.json';
+import useConfig from '@/composables/useConfig';
 
-// Extended list to include LBP tokens
-export const VETTED_TOKEN_LIST =
-  'https://storageapi.fleek.co/balancer-team-bucket/assets/vetted.tokenlist.json';
-
-export const TOKEN_LISTS: string[] = [
-  TOKEN_LIST_DEFAULT,
-  'ipns://tokens.uniswap.org',
-  'tokenlist.zerion.eth',
-  'tokens.1inch.eth',
-  'tokenlist.aave.eth',
-  'https://tokens.coingecko.com/uniswap/all.json',
-  'https://umaproject.org/uma.tokenlist.json'
-];
-
+const { env, networkConfig } = useConfig();
 export const ETHER = {
   id: 'ether',
-  name: 'Ether',
+  name: networkConfig.nativeAssetLong,
   address: '0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE',
-  symbol: 'ETH',
+  symbol: networkConfig.nativeAsset,
   decimals: 18,
   logoURI:
     'https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2/logo.png'
 };
 
-export const balancerLists = [VETTED_TOKEN_LIST, TOKEN_LIST_DEFAULT];
-
-export const extLists = [
-  'ipns://tokens.uniswap.org',
-  'tokenlist.zerion.eth',
-  'tokens.1inch.eth',
-  'tokenlist.aave.eth',
-  'https://tokens.coingecko.com/uniswap/all.json',
-  'https://umaproject.org/uma.tokenlist.json'
-];
-
-export default {
-  All: [...balancerLists, ...extLists],
+type TokenListConfig = {
   Balancer: {
-    All: balancerLists,
-    Default: TOKEN_LIST_DEFAULT,
-    Vetted: VETTED_TOKEN_LIST
-  },
-  Approved: [TOKEN_LIST_DEFAULT, ...extLists],
-  External: extLists
+    Default: string;
+    Vetted: string;
+  };
+  External: string[];
 };
+
+// Mapping of the TokenLists used on each network
+const TOKEN_LISTS_MAP: Record<string, TokenListConfig> = {
+  '1': {
+    Balancer: {
+      Default:
+        'https://storageapi.fleek.co/balancer-team-bucket/assets/listed.tokenlist.json',
+      Vetted:
+        'https://storageapi.fleek.co/balancer-team-bucket/assets/vetted.tokenlist.json'
+    },
+    External: [
+      'ipns://tokens.uniswap.org',
+      'tokenlist.zerion.eth',
+      'tokens.1inch.eth',
+      'tokenlist.aave.eth',
+      'https://tokens.coingecko.com/uniswap/all.json',
+      'https://umaproject.org/uma.tokenlist.json'
+    ]
+  }
+};
+
+type TokenLists = {
+  All: string[];
+  Balancer: {
+    All: string[];
+    Default: string;
+    Vetted: string;
+  };
+  Approved: string[];
+  External: string[];
+};
+
+/**
+ * Convert TokenList config into a more usable structure
+ */
+const processTokenLists = (config: TokenListConfig): TokenLists => {
+  const { Balancer, External } = config;
+
+  const balancerLists = [Balancer.Default, Balancer.Vetted];
+  const All = [...balancerLists, ...External];
+  const Approved = [Balancer.Default, ...External];
+
+  return {
+    All,
+    Balancer: {
+      All: balancerLists,
+      ...Balancer
+    },
+    Approved,
+    External
+  };
+};
+
+const FULL_TOKEN_LISTS = processTokenLists(TOKEN_LISTS_MAP[env.NETWORK]);
+
+// Compliant list for exchange
+export const TOKEN_LIST_DEFAULT = FULL_TOKEN_LISTS.Balancer.Default;
+// Extended list to include LBP tokens
+export const VETTED_TOKEN_LIST = FULL_TOKEN_LISTS.Balancer.Vetted;
+
+export const TOKEN_LISTS = FULL_TOKEN_LISTS.Approved;
+
+export default FULL_TOKEN_LISTS;

--- a/src/constants/tokenlists.ts
+++ b/src/constants/tokenlists.ts
@@ -1,14 +1,10 @@
 import useConfig from '@/composables/useConfig';
 
 const { env, networkConfig } = useConfig();
+
 export const ETHER = {
-  id: 'ether',
-  name: networkConfig.nativeAssetLong,
-  address: '0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE',
-  symbol: networkConfig.nativeAsset,
-  decimals: 18,
-  logoURI:
-    'https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2/logo.png'
+  ...networkConfig.nativeAsset,
+  id: 'ether'
 };
 
 type TokenListConfig = {

--- a/src/constants/tokens.ts
+++ b/src/constants/tokens.ts
@@ -7,16 +7,6 @@ export const TOKENS = {
     WETH: '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2',
     BAL: '0xba100000625a3754423978a60c9317c58a424e3d'
   },
-  EthMeta: {
-    id: 'ether',
-    name: 'Ether',
-    address: '0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE',
-    symbol: 'ETH',
-    decimals: 18,
-    chainId: 1,
-    logoURI:
-      'https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2/logo.png'
-  },
   Prices: {
     ChainMap: {
       '42': {

--- a/src/lib/config/docker.json
+++ b/src/lib/config/docker.json
@@ -11,6 +11,13 @@
   "subgraph": "http://localhost:8000/subgraphs/name/balancer-labs/balancer-v2",
   "poolsUrlV1": "",
   "poolsUrlV2": "",
+  "nativeAsset": {
+    "name": "Ether",
+    "address": "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
+    "symbol": "ETH",
+    "decimals": 18,
+    "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2/logo.png"
+  },
   "addresses": {
     "exchangeProxy": "",
     "multicall": "0xfe17B701A8F44D9D18D4f83dB71Bf9442D0003f1",

--- a/src/lib/config/docker.json
+++ b/src/lib/config/docker.json
@@ -16,6 +16,7 @@
     "address": "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
     "symbol": "ETH",
     "decimals": 18,
+    "deeplinkId": "ether",
     "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2/logo.png"
   },
   "addresses": {

--- a/src/lib/config/homestead.json
+++ b/src/lib/config/homestead.json
@@ -5,14 +5,19 @@
   "shortName": "Mainnet",
   "network": "homestead",
   "unknown": false,
-  "nativeAsset": "ETH",
-  "nativeAssetLong": "Ether",
   "rpc": "https://mainnet.infura.io/v3/daaa68ec242643719749dd1caba2fc66",
   "ws": "wss://mainnet.infura.io/ws/v3/daaa68ec242643719749dd1caba2fc66",
   "explorer": "https://etherscan.io",
   "subgraph": "https://api.thegraph.com/subgraphs/name/balancer-labs/balancer-v2",
   "poolsUrlV1": "https://storageapi.fleek.co/balancer-bucket/balancer-exchange/pools",
   "poolsUrlV2": "https://storageapi.fleek.co/johngrantuk-team-bucket/poolsV2.json",
+  "nativeAsset": {
+    "name": "Ether",
+    "address": "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
+    "symbol": "ETH",
+    "decimals": 18,
+    "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2/logo.png"
+  },
   "addresses": {
     "bFactory": "0x9424B1412450D0f8Fc2255FAf6046b98213B76Bd",
     "bActions": "0xde4A25A0b9589689945d842c5ba0CF4f0D4eB3ac",

--- a/src/lib/config/homestead.json
+++ b/src/lib/config/homestead.json
@@ -16,6 +16,7 @@
     "address": "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
     "symbol": "ETH",
     "decimals": 18,
+    "deeplinkId": "ether",
     "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2/logo.png"
   },
   "addresses": {

--- a/src/lib/config/index.ts
+++ b/src/lib/config/index.ts
@@ -11,14 +11,19 @@ export interface Config {
   shortName: string;
   network: string;
   unknown: boolean;
-  nativeAsset: string;
-  nativeAssetLong: string;
   rpc: string;
   ws: string;
   explorer: string;
   subgraph: string;
   poolsUrlV1: string;
   poolsUrlV2: string;
+  nativeAsset: {
+    name: string;
+    address: string;
+    symbol: string;
+    decimals: number;
+    logoURI: string;
+  };
   addresses: {
     exchangeProxy: string;
     merkleRedeem: string;

--- a/src/lib/config/index.ts
+++ b/src/lib/config/index.ts
@@ -22,6 +22,7 @@ export interface Config {
     address: string;
     symbol: string;
     decimals: number;
+    deeplinkId: string;
     logoURI: string;
   };
   addresses: {

--- a/src/lib/config/kovan.json
+++ b/src/lib/config/kovan.json
@@ -5,14 +5,19 @@
   "shortName": "Kovan",
   "network": "kovan",
   "unknown": false,
-  "nativeAsset": "ETH",
-  "nativeAssetLong": "Ether",
   "rpc": "https://eth-kovan.alchemyapi.io/v2/QCsM2iU0bQ49eGDmZ7-Y--Wpu0lVWXSO",
   "ws": "wss://eth-kovan.ws.alchemyapi.io/v2/QCsM2iU0bQ49eGDmZ7-Y--Wpu0lVWXSO",
   "explorer": "https://kovan.etherscan.io",
   "subgraph": "https://api.thegraph.com/subgraphs/name/balancer-labs/balancer-kovan-v2",
   "poolsUrlV1": "https://storageapi.fleek.co/balancer-bucket/balancer-exchange-kovan/pools",
   "poolsUrlV2": "https://storageapi.fleek.co/johngrantuk-team-bucket/poolsRc02.json",
+  "nativeAsset": {
+    "name": "Ether",
+    "address": "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
+    "symbol": "ETH",
+    "decimals": 18,
+    "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2/logo.png"
+  },
   "addresses": {
     "bFactory": "0x8f7F78080219d4066A8036ccD30D588B416a40DB",
     "bActions": "0x02EFDB542B9390ae7C1620B29674e02F9c0d86CC",

--- a/src/lib/config/kovan.json
+++ b/src/lib/config/kovan.json
@@ -16,6 +16,7 @@
     "address": "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
     "symbol": "ETH",
     "decimals": 18,
+    "deeplinkId": "ether",
     "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2/logo.png"
   },
   "addresses": {

--- a/src/lib/config/polygon.json
+++ b/src/lib/config/polygon.json
@@ -5,14 +5,19 @@
   "shortName": "Polygon",
   "network": "polygon",
   "unknown": false,
-  "nativeAsset": "MATIC",
-  "nativeAssetLong": "Matic",
   "rpc": "https://polygon-mainnet.infura.io/v3/daaa68ec242643719749dd1caba2fc66",
   "ws": "wss://rpc-mainnet.maticvigil.com/ws",
   "explorer": "https://polygonscan.com/",
   "subgraph": "https://api.thegraph.com/subgraphs/name/balancer-labs/balancer-polygon-v2",
   "poolsUrlV1": "",
   "poolsUrlV2": "",
+  "nativeAsset": {
+    "name": "Matic",
+    "address": "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
+    "symbol": "MATIC",
+    "decimals": 18,
+    "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x7D1AfA7B718fb893dB30A3aBc0Cfc608AaCfeBB0/logo.png"
+  },
   "addresses": {
     "bFactory": "",
     "bActions": "",

--- a/src/lib/config/polygon.json
+++ b/src/lib/config/polygon.json
@@ -16,6 +16,7 @@
     "address": "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
     "symbol": "MATIC",
     "decimals": 18,
+    "deeplinkId": "matic",
     "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x7D1AfA7B718fb893dB30A3aBc0Cfc608AaCfeBB0/logo.png"
   },
   "addresses": {

--- a/src/lib/config/rinkeby.json
+++ b/src/lib/config/rinkeby.json
@@ -5,14 +5,19 @@
   "shortName": "Rinkeby",
   "network": "rinkeby",
   "unknown": false,
-  "nativeAsset": "ETH",
-  "nativeAssetLong": "Ether",
   "rpc": "https://eth-rinkeby.alchemyapi.io/v2/QCsM2iU0bQ49eGDmZ7-Y--Wpu0lVWXSO",
   "ws": "wss://eth-rinkeby.ws.alchemyapi.io/v2/QCsM2iU0bQ49eGDmZ7-Y--Wpu0lVWXSO",
   "explorer": "https://rinkeby.etherscan.io",
   "subgraph": "https://api.thegraph.com/subgraphs/name/balancer-labs/balancer-rinkeby-v2",
   "poolsUrlV1": "https://storageapi.fleek.co/balancer-bucket/balancer-exchange-rinkeby/pools",
   "poolsUrlV2": "https://storageapi.fleek.co/johngrantuk-team-bucket/poolsRc02.json",
+  "nativeAsset": {
+    "name": "Ether",
+    "address": "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
+    "symbol": "ETH",
+    "decimals": 18,
+    "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2/logo.png"
+  },
   "addresses": {
     "bFactory": "0x8f7F78080219d4066A8036ccD30D588B416a40DB",
     "bActions": "0x02EFDB542B9390ae7C1620B29674e02F9c0d86CC",

--- a/src/lib/config/rinkeby.json
+++ b/src/lib/config/rinkeby.json
@@ -16,6 +16,7 @@
     "address": "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
     "symbol": "ETH",
     "decimals": 18,
+    "deeplinkId": "ether",
     "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2/logo.png"
   },
   "addresses": {


### PR DESCRIPTION
I've added a mapping in `tokenLists.ts` to allow us to choose a set of token lists depending on the network so that we can have a separate choice of tokenlists for Polygon, etc.

I've also added a small function to allow us to deduplicate some of the definitions in there.