### PR TITLE
Prevent GasReimbursement component crashing trading page on unreimbursed networks

### DIFF
--- a/src/components/cards/TradeCard/GasReimbursement.vue
+++ b/src/components/cards/TradeCard/GasReimbursement.vue
@@ -51,7 +51,7 @@ export default defineComponent({
     const { t } = useI18n();
     const BAL = '0xba100000625a3754423978a60c9317c58a424e3d';
 
-    const eligibleAssetMeta = eligibleAssetList[appNetwork.networkName];
+    const eligibleAssetMeta = eligibleAssetList[appNetwork.networkName] ?? {};
     const eligibleAssets = Object.fromEntries(
       Object.entries(eligibleAssetMeta).map(assetEntry => {
         const [address] = assetEntry;


### PR DESCRIPTION
Currently on any network where we aren't running the BAL4Gas program the trading page will crash.

I've added graceful failure for getting eligible assets to prevent this.
