### PR TITLE
Allow pulling token prices from chains other than Ethereum from CoinGecko

### DIFF
--- a/src/services/coingecko.ts
+++ b/src/services/coingecko.ts
@@ -1,5 +1,5 @@
 import useConfig from '@/composables/useConfig';
-import { getNativeAssetId, getPlatformId } from './coingecko/api/price.service';
+import { getNativeAssetId, getPlatformId } from './coingecko/coingecko.service';
 
 function getChainAddress(chainId: number, address: string) {
   if (!address) {

--- a/src/services/coingecko.ts
+++ b/src/services/coingecko.ts
@@ -71,8 +71,8 @@ export type Prices = Record<string, Price>;
 export type HistoricalPrices = Record<string, Prices>;
 
 export async function getEtherPrice(): Promise<Price> {
-  const { networkConfig } = useConfig();
-  const nativeAssetId = getNativeAssetId(networkConfig.chainId);
+  const { env } = useConfig();
+  const nativeAssetId = getNativeAssetId(env.NETWORK);
   const uri = `https://api.coingecko.com/api/v3/simple/price?ids=${nativeAssetId}&vs_currencies=usd&include_24hr_change=true`;
   const result = await fetch(uri).then(res => res.json());
   return {
@@ -85,7 +85,7 @@ export async function getTokensPrice(
   chainId: number,
   addresses: string[]
 ): Promise<Prices> {
-  const { networkConfig } = useConfig();
+  const { env } = useConfig();
 
   const max = 175;
   const pages = Math.ceil(addresses.length / max);
@@ -95,7 +95,7 @@ export async function getTokensPrice(
       .slice(max * i, max * (i + 1))
       .map(address => getChainAddress(chainId, address));
     const uri = `https://api.coingecko.com/api/v3/simple/token_price/${getPlatformId(
-      networkConfig.chainId
+      env.NETWORK
     )}?contract_addresses=${addressString}&vs_currencies=usd&include_24hr_change=true`;
     // @ts-ignore
     promises.push(fetch(uri).then(res => res.json()));
@@ -121,7 +121,7 @@ export async function getTokensHistoricalPrice(
   addresses: string[],
   days: number
 ): Promise<HistoricalPrices> {
-  const { networkConfig } = useConfig();
+  const { env } = useConfig();
 
   const DAY = 60 * 60 * 24;
   const now = Math.floor(Date.now() / 1000);
@@ -130,7 +130,7 @@ export async function getTokensHistoricalPrice(
   const priceRequests = addresses.map(address => {
     const chainAddress = getChainAddress(chainId, address);
     const url = `https://api.coingecko.com/api/v3/coins/${getPlatformId(
-      networkConfig.chainId
+      env.NETWORK
     )}/contract/${chainAddress}/market_chart/range?vs_currency=usd&from=${start}&to=${end}`;
     const request = fetch(url).then(res => res.json());
     return request;

--- a/src/services/coingecko.ts
+++ b/src/services/coingecko.ts
@@ -121,13 +121,17 @@ export async function getTokensHistoricalPrice(
   addresses: string[],
   days: number
 ): Promise<HistoricalPrices> {
+  const { networkConfig } = useConfig();
+
   const DAY = 60 * 60 * 24;
   const now = Math.floor(Date.now() / 1000);
   const end = now - (now % DAY);
   const start = end - days * DAY;
   const priceRequests = addresses.map(address => {
     const chainAddress = getChainAddress(chainId, address);
-    const url = `https://api.coingecko.com/api/v3/coins/ethereum/contract/${chainAddress}/market_chart/range?vs_currency=usd&from=${start}&to=${end}`;
+    const url = `https://api.coingecko.com/api/v3/coins/${getPlatformId(
+      networkConfig.chainId
+    )}/contract/${chainAddress}/market_chart/range?vs_currency=usd&from=${start}&to=${end}`;
     const request = fetch(url).then(res => res.json());
     return request;
   });

--- a/src/services/coingecko/api/price.service.ts
+++ b/src/services/coingecko/api/price.service.ts
@@ -1,5 +1,9 @@
 import { CoingeckoClient } from '../coingecko.client';
-import { CoingeckoService } from '../coingecko.service';
+import {
+  CoingeckoService,
+  getNativeAssetId,
+  getPlatformId
+} from '../coingecko.service';
 import { TOKENS } from '@/constants/tokens';
 import ConfigService from '@/services/config/config.service';
 import { invert } from 'lodash';
@@ -9,18 +13,6 @@ import { returnChecksum } from '@/lib/decorators/return-checksum.decorator';
 export type Price = { [fiat: string]: number };
 export type PriceResponse = { [id: string]: Price };
 export type TokenPrices = { [address: string]: Price };
-
-const nativeAssetIdMap = {
-  '1': 'ethereum',
-  '42': 'ethereum',
-  '137': 'matic-network'
-};
-
-const platformIdMap = {
-  '1': 'ethereum',
-  '42': 'ethereum',
-  '137': 'polygon-pos'
-};
 
 export class PriceService {
   client: CoingeckoClient;
@@ -38,8 +30,8 @@ export class PriceService {
     this.fiatParam = service.supportedFiat;
     this.baseEndpoint = '/simple';
     this.appNetwork = configService.network.key;
-    this.platformId = platformIdMap[this.appNetwork];
-    this.nativeAssetId = nativeAssetIdMap[this.appNetwork];
+    this.platformId = getPlatformId(this.appNetwork);
+    this.nativeAssetId = getNativeAssetId(this.appNetwork);
   }
 
   async getEther(): Promise<Price> {

--- a/src/services/coingecko/coingecko.service.ts
+++ b/src/services/coingecko/coingecko.service.ts
@@ -3,6 +3,26 @@ import { CoingeckoClient } from './coingecko.client';
 
 const SUPPORTED_FIAT = ['usd'];
 
+export const getNativeAssetId = (chainId: string): string => {
+  const mapping = {
+    '1': 'ethereum',
+    '42': 'ethereum',
+    '137': 'matic-network'
+  };
+
+  return mapping[chainId] || 'ethereum';
+};
+
+export const getPlatformId = (chainId: string): string => {
+  const mapping = {
+    '1': 'ethereum',
+    '42': 'ethereum',
+    '137': 'polygon-pos'
+  };
+
+  return mapping[chainId] || 'ethereum';
+};
+
 export class CoingeckoService {
   supportedFiat: string;
   prices: PriceService;


### PR DESCRIPTION
We now query prices for tokens on Coingecko for whichever network we are connected to.
