### PR TITLE
Disable/remove claim button on non Mainnet networks

### DIFF
--- a/src/components/navs/AppNav/AppNavActions.vue
+++ b/src/components/navs/AppNav/AppNavActions.vue
@@ -1,7 +1,7 @@
 <template>
   <div>
     <div v-if="$auth.isAuthenticated.value" class="flex items-center">
-      <AppNavClaimBtn />
+      <AppNavClaimBtn v-if="isMainnet" />
       <AppNavAccountBtn />
     </div>
     <BalBtn
@@ -45,7 +45,7 @@ export default defineComponent({
     // COMPOSABLES
     const store = useStore();
     const { bp } = useBreakpoints();
-    const { account, profile, loading: web3Loading } = useWeb3();
+    const { account, profile, loading: web3Loading, isMainnet } = useWeb3();
     const { fNum } = useNumbers();
     const { trackGoal, Goals } = useFathom();
 
@@ -60,6 +60,7 @@ export default defineComponent({
 
     return {
       // computed
+      isMainnet,
       account,
       profile,
       web3Loading,

--- a/src/composables/useWeb3.ts
+++ b/src/composables/useWeb3.ts
@@ -43,7 +43,7 @@ export default function useWeb3() {
   });
 
   const isMainnet = computed(() => {
-    return userNetwork.value.name === 'Mainnet';
+    return appNetwork.name === 'Mainnet';
   });
 
   const unsupportedNetwork = computed(() => {


### PR DESCRIPTION
Claiming only works on Mainnet for now and so other networks shouldn't show it.

For now, it's completely removed - but might get a nicer design from Pon.