### PR TITLE
fix: remove times sign rendering of "x" in PoolBalanceCard

### DIFF
--- a/src/assets/css/global/typography.css
+++ b/src/assets/css/global/typography.css
@@ -12,3 +12,7 @@ h2 { @apply text-3xl font-bold; }
 h3 { @apply text-2xl font-semibold; }
 h4 { @apply text-xl font-medium;; }
 h5 { @apply text-lg font-medium;; }
+
+.eth-address {
+  font-variant-ligatures: no-contextual;
+}

--- a/src/components/navs/AppNav/AppNavAccountBtn.vue
+++ b/src/components/navs/AppNav/AppNavAccountBtn.vue
@@ -19,7 +19,7 @@
         <span
           v-else
           v-text="_shorten(account)"
-          class="pl-2 hidden lg:inline-block address"
+          class="pl-2 hidden lg:inline-block eth-address"
         />
         <BalIcon
           name="chevron-down"
@@ -72,9 +72,3 @@ export default defineComponent({
   }
 });
 </script>
-
-<style scoped>
-.address {
-  font-variant-ligatures: no-contextual;
-}
-</style>

--- a/src/components/pages/pool/PoolBalancesCard.vue
+++ b/src/components/pages/pool/PoolBalancesCard.vue
@@ -20,7 +20,7 @@
             class="flex items-center"
           >
             <BalAsset :address="token.address" :size="36" />
-            <span class="pl-4 font-medium">
+            <span class="pl-4 font-medium eth-address">
               {{ symbolFor(token.address) }}
             </span>
             <BalIcon


### PR DESCRIPTION
Applies fix from #310 to `PoolBalancesCard`
