### PR TITLE
chore: remove trailing slash from polygonscan url

### DIFF
--- a/src/lib/config/polygon.json
+++ b/src/lib/config/polygon.json
@@ -7,7 +7,7 @@
   "unknown": false,
   "rpc": "https://polygon-mainnet.infura.io/v3/daaa68ec242643719749dd1caba2fc66",
   "ws": "wss://rpc-mainnet.maticvigil.com/ws/v1/0640daf21d413ff9adc73b043d91264e42d92a87",
-  "explorer": "https://polygonscan.com/",
+  "explorer": "https://polygonscan.com",
   "subgraph": "https://api.thegraph.com/subgraphs/name/balancer-labs/balancer-polygon-v2",
   "poolsUrlV1": "",
   "poolsUrlV2": "",


### PR DESCRIPTION
This isn't causing any issues but a double slash in the urls doesn't look great.