### PR TITLE
fix: change initial output token on Polygon to WETH

### DIFF
--- a/src/constants/initialTokens.json
+++ b/src/constants/initialTokens.json
@@ -9,6 +9,6 @@
   },
   "137": {
     "input": "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
-    "output": "0x8f3cf7ad23cd3cadbd9735aff958023239c6a063"
+    "output": "0x7ceB23fD6bC0adD59E62ac25578270cFf1b9f619"
   }
 }


### PR DESCRIPTION
We're currently pushing people towards DAI (a token that we have no liquidity for). This is also a non-checksummed address so we're missing the metadata from the tokenlist.

I've changed this to instead use WETH.