### PR TITLE
add polygon blocktime

### DIFF
--- a/src/services/balancer/subgraph/service.ts
+++ b/src/services/balancer/subgraph/service.ts
@@ -33,6 +33,8 @@ export default class Service {
     switch (NETWORK) {
       case '1':
         return 13;
+      case '137':
+        return 2;
       case '42':
         // Should be ~4s but this causes subgraph to return with unindexed block error.
         return 1;


### PR DESCRIPTION
24h volume displayed in the UI is approximate, computed using a timetravel query that relies on the network's blocktime, which is lower on Polygon. Meaning we're currently underestimating volume by a factor of ~6