### PR TITLE
Handle tx events on polygon

### DIFF
--- a/src/components/forms/pool_actions/InvestForm.vue
+++ b/src/components/forms/pool_actions/InvestForm.vue
@@ -320,10 +320,10 @@ export default defineComponent({
     // COMPOSABLES
     const store = useStore();
     const { isAuthenticated } = useAuth();
-    const { account, appNetwork, userNetwork, isPolygon } = useWeb3();
+    const { account, appNetwork, userNetwork } = useWeb3();
     const { fNum, toFiat } = useNumbers();
     const { t } = useI18n();
-    const { txListener } = useNotify();
+    const { txListener, supportsBlocknative } = useNotify();
     const { minusSlippage } = useSlippage();
     const { allTokens } = useTokens();
     const { trackGoal, Goals } = useFathom();
@@ -600,10 +600,10 @@ export default defineComponent({
           minBptOut.value
         );
         console.log('Receipt', tx);
-        if (isPolygon.value) {
-          ethersTxHandler(tx);
-        } else {
+        if (supportsBlocknative.value) {
           blocknativeTxHandler(tx);
+        } else {
+          ethersTxHandler(tx);
         }
       } catch (error) {
         console.error(error);

--- a/src/components/forms/pool_actions/InvestForm.vue
+++ b/src/components/forms/pool_actions/InvestForm.vue
@@ -270,6 +270,8 @@ import { FullPool } from '@/services/balancer/subgraph/types';
 import useFathom from '@/composables/useFathom';
 
 import { TOKENS } from '@/constants/tokens';
+import { TransactionResponse } from '@ethersproject/abstract-provider';
+import useEthers from '@/composables/useEthers';
 
 export enum FormTypes {
   proportional = 'proportional',
@@ -318,13 +320,14 @@ export default defineComponent({
     // COMPOSABLES
     const store = useStore();
     const { isAuthenticated } = useAuth();
-    const { account, appNetwork, userNetwork } = useWeb3();
+    const { account, appNetwork, userNetwork, isPolygon } = useWeb3();
     const { fNum, toFiat } = useNumbers();
     const { t } = useI18n();
     const { txListener } = useNotify();
     const { minusSlippage } = useSlippage();
     const { allTokens } = useTokens();
     const { trackGoal, Goals } = useFathom();
+    const { txListener: ethersTxListener } = useEthers();
 
     const { amounts } = toRefs(data);
 
@@ -555,6 +558,37 @@ export default defineComponent({
       }
     }
 
+    function blocknativeTxHandler(tx: TransactionResponse): void {
+      txListener(tx.hash, {
+        onTxConfirmed: (tx: TransactionData) => {
+          emit('success', tx);
+          data.amounts = [];
+          data.loading = false;
+          store.dispatch('account/getBalances');
+        },
+        onTxCancel: () => {
+          data.loading = false;
+        },
+        onTxFailed: () => {
+          data.loading = false;
+        }
+      });
+    }
+
+    function ethersTxHandler(tx: TransactionResponse): void {
+      ethersTxListener(tx, {
+        onTxConfirmed: (tx: TransactionResponse) => {
+          emit('success', tx);
+          data.amounts = [];
+          data.loading = false;
+          store.dispatch('account/getBalances');
+        },
+        onTxFailed: () => {
+          data.loading = false;
+        }
+      });
+    }
+
     async function submit(): Promise<void> {
       if (!data.investForm.validate()) return;
       try {
@@ -566,19 +600,11 @@ export default defineComponent({
           minBptOut.value
         );
         console.log('Receipt', tx);
-        txListener(tx.hash, {
-          onTxConfirmed: (tx: TransactionData) => {
-            emit('success', tx);
-            data.amounts = [];
-            data.loading = false;
-          },
-          onTxCancel: () => {
-            data.loading = false;
-          },
-          onTxFailed: () => {
-            data.loading = false;
-          }
-        });
+        if (isPolygon.value) {
+          ethersTxHandler(tx);
+        } else {
+          blocknativeTxHandler(tx);
+        }
       } catch (error) {
         console.error(error);
         data.loading = false;

--- a/src/components/forms/pool_actions/WithdrawForm.vue
+++ b/src/components/forms/pool_actions/WithdrawForm.vue
@@ -204,10 +204,13 @@ import PoolExchange from '@/services/pool/exchange';
 import PoolCalculator from '@/services/pool/calculator';
 import { bnum } from '@/lib/utils';
 import { formatUnits } from '@ethersproject/units';
+import { TransactionResponse } from '@ethersproject/abstract-provider';
 import FormTypeToggle from './shared/FormTypeToggle.vue';
 import useTokens from '@/composables/useTokens';
 import { FullPool } from '@/services/balancer/subgraph/types';
 import useFathom from '@/composables/useFathom';
+import useEthers from '@/composables/useEthers';
+import useWeb3 from '@/composables/useWeb3';
 
 export enum FormTypes {
   proportional = 'proportional',
@@ -242,6 +245,7 @@ export default defineComponent({
 
     // COMPOSABLES
     const store = useStore();
+    const { account, userNetwork, isPolygon } = useWeb3();
     const { txListener } = useNotify();
     const { isAuthenticated } = useAuth();
     const { fNum, toFiat } = useNumbers();
@@ -249,15 +253,11 @@ export default defineComponent({
     const { t } = useI18n();
     const { allTokens } = useTokens();
     const { trackGoal, Goals } = useFathom();
+    const { txListener: ethersTxListener } = useEthers();
 
     // SERVICES
     const poolExchange = computed(
-      () =>
-        new PoolExchange(
-          props.pool,
-          store.state.web3.config.key,
-          allTokens.value
-        )
+      () => new PoolExchange(props.pool, userNetwork.value.key, allTokens.value)
     );
 
     const poolCalculator = new PoolCalculator(
@@ -489,7 +489,7 @@ export default defineComponent({
     // Talk to Fernando to see if still needed
     async function calcBptIn() {
       const { bptIn: queryBptIn } = await poolExchange.value.queryExit(
-        store.state.web3.account,
+        account.value,
         fullAmounts.value,
         bptBalance.value,
         exitTokenIndex.value,
@@ -514,32 +514,55 @@ export default defineComponent({
       }
     }
 
+    function blocknativeTxHandler(tx: TransactionResponse): void {
+      txListener(tx.hash, {
+        onTxConfirmed: (tx: TransactionData) => {
+          emit('success', tx);
+          data.amounts = [];
+          data.loading = false;
+          store.dispatch('account/getBalances');
+        },
+        onTxCancel: () => {
+          data.loading = false;
+        },
+        onTxFailed: () => {
+          data.loading = false;
+        }
+      });
+    }
+
+    function ethersTxHandler(tx: TransactionResponse): void {
+      ethersTxListener(tx, {
+        onTxConfirmed: (tx: TransactionResponse) => {
+          emit('success', tx);
+          data.amounts = [];
+          data.loading = false;
+          store.dispatch('account/getBalances');
+        },
+        onTxFailed: () => {
+          data.loading = false;
+        }
+      });
+    }
+
     async function submit(): Promise<void> {
       if (!data.withdrawForm.validate()) return;
       try {
         data.loading = true;
         await calcBptIn();
         const tx = await poolExchange.value.exit(
-          store.state.web3.account,
+          account.value,
           amountsOut.value,
           `${bptIn.value}`,
           exitTokenIndex.value,
           exactOut.value
         );
         console.log('Receipt', tx);
-        txListener(tx.hash, {
-          onTxConfirmed: (tx: TransactionData) => {
-            emit('success', tx);
-            data.amounts = [];
-            data.loading = false;
-          },
-          onTxCancel: () => {
-            data.loading = false;
-          },
-          onTxFailed: () => {
-            data.loading = false;
-          }
-        });
+        if (isPolygon.value) {
+          ethersTxHandler(tx);
+        } else {
+          blocknativeTxHandler(tx);
+        }
       } catch (error) {
         console.error(error);
         data.loading = false;
@@ -590,6 +613,11 @@ export default defineComponent({
         data.amounts = [];
         data.propMax = [];
       }
+    });
+
+    watch(account, () => {
+      setPropMax();
+      resetSlider();
     });
 
     onMounted(async () => {

--- a/src/components/forms/pool_actions/WithdrawForm.vue
+++ b/src/components/forms/pool_actions/WithdrawForm.vue
@@ -245,8 +245,8 @@ export default defineComponent({
 
     // COMPOSABLES
     const store = useStore();
-    const { account, userNetwork, isPolygon } = useWeb3();
-    const { txListener } = useNotify();
+    const { account, userNetwork } = useWeb3();
+    const { txListener, supportsBlocknative } = useNotify();
     const { isAuthenticated } = useAuth();
     const { fNum, toFiat } = useNumbers();
     const { minusSlippage, addSlippage } = useSlippage();
@@ -558,10 +558,10 @@ export default defineComponent({
           exactOut.value
         );
         console.log('Receipt', tx);
-        if (isPolygon.value) {
-          ethersTxHandler(tx);
-        } else {
+        if (supportsBlocknative.value) {
           blocknativeTxHandler(tx);
+        } else {
+          ethersTxHandler(tx);
         }
       } catch (error) {
         console.error(error);

--- a/src/components/pages/pool/PoolActionsCard/PoolActionsCard.vue
+++ b/src/components/pages/pool/PoolActionsCard/PoolActionsCard.vue
@@ -17,7 +17,7 @@
           :title="$t('investmentSettled')"
           :description="$t('investmentSuccess')"
           :closeLabel="$t('close')"
-          :txHash="txHash"
+          :explorerLink="explorer.txLink(txHash)"
           @close="investmentSuccess = false"
         />
       </template>
@@ -32,7 +32,7 @@
           :title="$t('withdrawalSettled')"
           :description="$t('withdrawalSuccess')"
           :closeLabel="$t('close')"
-          :txHash="txHash"
+          :explorerLink="explorer.txLink(txHash)"
           @close="withdrawalSuccess = false"
         />
       </template>
@@ -50,6 +50,7 @@ import TradeSettingsPopover, {
   TradeSettingsContext
 } from '@/components/popovers/TradeSettingsPopover.vue';
 import useFathom from '@/composables/useFathom';
+import useWeb3 from '@/composables/useWeb3';
 
 export default defineComponent({
   name: 'PoolActionsCard',
@@ -72,6 +73,7 @@ export default defineComponent({
     // COMPOSABLES
     const { t } = useI18n();
     const { trackGoal, Goals } = useFathom();
+    const { explorer } = useWeb3();
 
     // DATA
     const tabs = [
@@ -108,7 +110,8 @@ export default defineComponent({
       TradeSettingsContext,
       // methods
       handleInvestment,
-      handleWithdrawal
+      handleWithdrawal,
+      explorer
     };
   }
 });

--- a/src/composables/pools/useTokenApprovals.ts
+++ b/src/composables/pools/useTokenApprovals.ts
@@ -6,7 +6,6 @@ import { TransactionResponse } from '@ethersproject/providers';
 import useAuth from '@/composables/useAuth';
 import useTokens from '@/composables/useTokens';
 import useNotify from '@/composables/useNotify';
-import useWeb3 from '@/composables/useWeb3';
 import useEthers from '@/composables/useEthers';
 import { sleep } from '@/lib/utils';
 

--- a/src/composables/pools/useTokenApprovals.ts
+++ b/src/composables/pools/useTokenApprovals.ts
@@ -2,9 +2,12 @@ import { ref, computed } from 'vue';
 import { useStore } from 'vuex';
 import { approveTokens } from '@/lib/utils/balancer/tokens';
 import { parseUnits } from '@ethersproject/units';
+import { TransactionResponse } from '@ethersproject/providers';
 import useAuth from '@/composables/useAuth';
 import useTokens from '@/composables/useTokens';
 import useNotify from '@/composables/useNotify';
+import useWeb3 from '@/composables/useWeb3';
+import useEthers from '@/composables/useEthers';
 import { sleep } from '@/lib/utils';
 
 export default function useTokenApprovals(tokens, shortAmounts) {
@@ -14,6 +17,8 @@ export default function useTokenApprovals(tokens, shortAmounts) {
   const approvedAll = ref(false);
   const { allTokens } = useTokens();
   const { txListener } = useNotify();
+  const { isPolygon } = useWeb3();
+  const { txListener: ethersTxListener } = useEthers();
 
   const amounts = computed(() =>
     tokens.map((token, index) => {
@@ -32,6 +37,37 @@ export default function useTokenApprovals(tokens, shortAmounts) {
     return allowances;
   });
 
+  async function blocknativeTxHandler(tx: TransactionResponse): Promise<void> {
+    txListener([tx.hash], {
+      onTxConfirmed: async () => {
+        // REFACTOR: Hack to prevent race condition causing double approvals
+        await tx.wait();
+        await sleep(5000);
+        await store.dispatch('account/getAllowances', { tokens });
+        // END REFACTOR
+        approving.value = false;
+      },
+      onTxCancel: () => {
+        approving.value = false;
+      },
+      onTxFailed: () => {
+        approving.value = false;
+      }
+    });
+  }
+
+  async function ethersTxHandler(tx: TransactionResponse): Promise<void> {
+    await ethersTxListener(tx, {
+      onTxConfirmed: async () => {
+        await store.dispatch('account/getAllowances', { tokens });
+        approving.value = false;
+      },
+      onTxFailed: () => {
+        approving.value = false;
+      }
+    });
+  }
+
   async function approveAllowances(): Promise<void> {
     try {
       approving.value = true;
@@ -40,24 +76,12 @@ export default function useTokenApprovals(tokens, shortAmounts) {
         store.state.web3.config.addresses.vault,
         [requiredAllowances.value[0]]
       );
-      const txHashes = txs.map(tx => tx.hash);
 
-      txListener(txHashes, {
-        onTxConfirmed: async () => {
-          // REFACTOR: Hack to prevent race condition causing double approvals
-          await txs[0].wait();
-          await sleep(5000);
-          await store.dispatch('account/getAllowances', { tokens });
-          // END REFACTOR
-          approving.value = false;
-        },
-        onTxCancel: () => {
-          approving.value = false;
-        },
-        onTxFailed: () => {
-          approving.value = false;
-        }
-      });
+      if (isPolygon.value) {
+        ethersTxHandler(txs[0]);
+      } else {
+        blocknativeTxHandler(txs[0]);
+      }
     } catch (error) {
       approving.value = false;
       console.error(error);

--- a/src/composables/pools/useTokenApprovals.ts
+++ b/src/composables/pools/useTokenApprovals.ts
@@ -36,7 +36,7 @@ export default function useTokenApprovals(tokens, shortAmounts) {
   });
 
   async function blocknativeTxHandler(tx: TransactionResponse): Promise<void> {
-    txListener([tx.hash], {
+    txListener(tx.hash, {
       onTxConfirmed: async () => {
         // REFACTOR: Hack to prevent race condition causing double approvals
         await tx.wait();
@@ -69,6 +69,7 @@ export default function useTokenApprovals(tokens, shortAmounts) {
   async function approveAllowances(): Promise<void> {
     try {
       approving.value = true;
+
       const txs = await approveTokens(
         auth.web3,
         store.state.web3.config.addresses.vault,

--- a/src/composables/pools/useTokenApprovals.ts
+++ b/src/composables/pools/useTokenApprovals.ts
@@ -16,8 +16,7 @@ export default function useTokenApprovals(tokens, shortAmounts) {
   const approving = ref(false);
   const approvedAll = ref(false);
   const { allTokens } = useTokens();
-  const { txListener } = useNotify();
-  const { isPolygon } = useWeb3();
+  const { txListener, supportsBlocknative } = useNotify();
   const { txListener: ethersTxListener } = useEthers();
 
   const amounts = computed(() =>
@@ -77,10 +76,10 @@ export default function useTokenApprovals(tokens, shortAmounts) {
         [requiredAllowances.value[0]]
       );
 
-      if (isPolygon.value) {
-        ethersTxHandler(txs[0]);
-      } else {
+      if (supportsBlocknative.value) {
         blocknativeTxHandler(txs[0]);
+      } else {
+        ethersTxHandler(txs[0]);
       }
     } catch (error) {
       approving.value = false;

--- a/src/composables/trade/useSor.ts
+++ b/src/composables/trade/useSor.ts
@@ -72,9 +72,9 @@ export default function useSor(
   // COMPOSABLES
   const store = useStore();
   const auth = useAuth();
-  const { txListener } = useNotify();
+  const { txListener, supportsBlocknative } = useNotify();
   const { trackGoal, Goals } = useFathom();
-  const { appNetwork, isPolygon } = useWeb3();
+  const { appNetwork } = useWeb3();
   const { txListener: ethersTxListener } = useEthers();
 
   const getConfig = () => store.getters['web3/getConfig']();
@@ -314,10 +314,10 @@ export default function useSor(
   }
 
   function txHandler(tx: TransactionResponse): void {
-    if (isPolygon.value) {
-      ethersTxHandler(tx);
-    } else {
+    if (supportsBlocknative.value) {
       blocknativeTxHandler(tx.hash);
+    } else {
+      ethersTxHandler(tx);
     }
   }
 

--- a/src/composables/trade/useSor.ts
+++ b/src/composables/trade/useSor.ts
@@ -22,6 +22,8 @@ import useNotify from '@/composables/useNotify';
 import useFathom from '../useFathom';
 
 import { ETHER } from '@/constants/tokenlists';
+import { TransactionResponse } from '@ethersproject/providers';
+import useEthers from '../useEthers';
 
 const GAS_PRICE = process.env.VUE_APP_GAS_PRICE || '100000000000';
 const MAX_POOLS = process.env.VUE_APP_MAX_POOLS || '4';
@@ -72,7 +74,8 @@ export default function useSor(
   const auth = useAuth();
   const { txListener } = useNotify();
   const { trackGoal, Goals } = useFathom();
-  const { appNetwork } = useWeb3();
+  const { appNetwork, isPolygon } = useWeb3();
+  const { txListener: ethersTxListener } = useEthers();
 
   const getConfig = () => store.getters['web3/getConfig']();
   const liquiditySelection = computed(() => store.state.app.tradeLiquidity);
@@ -281,7 +284,7 @@ export default function useSor(
     pools.value = sorManager.selectedPools;
   }
 
-  function tradeTxListener(hash: string) {
+  function blocknativeTxHandler(hash: string): void {
     txListener(hash, {
       onTxConfirmed: () => {
         trading.value = false;
@@ -295,6 +298,27 @@ export default function useSor(
         trading.value = false;
       }
     });
+  }
+
+  function ethersTxHandler(tx: TransactionResponse): void {
+    ethersTxListener(tx, {
+      onTxConfirmed: () => {
+        trading.value = false;
+        latestTxHash.value = tx.hash;
+        trackGoal(Goals.Swapped);
+      },
+      onTxFailed: () => {
+        trading.value = false;
+      }
+    });
+  }
+
+  function txHandler(tx: TransactionResponse): void {
+    if (isPolygon.value) {
+      ethersTxHandler(tx);
+    } else {
+      blocknativeTxHandler(tx.hash);
+    }
   }
 
   async function trade() {
@@ -314,7 +338,7 @@ export default function useSor(
       try {
         const tx = await wrap(chainId, auth.web3, tokenInAmountScaled);
         console.log('Wrap tx', tx);
-        tradeTxListener(tx.hash);
+        txHandler(tx);
       } catch (e) {
         console.log(e);
         trading.value = false;
@@ -324,7 +348,7 @@ export default function useSor(
       try {
         const tx = await unwrap(chainId, auth.web3, tokenInAmountScaled);
         console.log('Unwrap tx', tx);
-        tradeTxListener(tx.hash);
+        txHandler(tx);
       } catch (e) {
         console.log(e);
         trading.value = false;
@@ -349,7 +373,7 @@ export default function useSor(
           minAmount
         );
         console.log('Swap in tx', tx);
-        tradeTxListener(tx.hash);
+        txHandler(tx);
       } catch (e) {
         console.log(e);
         trading.value = false;
@@ -374,7 +398,7 @@ export default function useSor(
           tokenOutAmountScaled
         );
         console.log('Swap out tx', tx);
-        tradeTxListener(tx.hash);
+        txHandler(tx);
       } catch (e) {
         console.log(e);
         trading.value = false;

--- a/src/composables/trade/useTokenApproval.ts
+++ b/src/composables/trade/useTokenApproval.ts
@@ -16,8 +16,7 @@ export default function useTokenApproval(tokenInAddress, amount, tokens) {
   // COMPOSABLES
   const store = useStore();
   const auth = useAuth();
-  const { txListener } = useNotify();
-  const { isPolygon } = useWeb3();
+  const { txListener, supportsBlocknative } = useNotify();
   const { txListener: ethersTxListener } = useEthers();
 
   const { config } = store.state.web3;
@@ -103,10 +102,10 @@ export default function useTokenApproval(tokenInAddress, amount, tokens) {
   }
 
   function txHandler(tx: TransactionResponse): void {
-    if (isPolygon.value) {
-      ethersTxHandler(tx);
-    } else {
+    if (supportsBlocknative.value) {
       blocknativeTxHandler(tx.hash);
+    } else {
+      ethersTxHandler(tx);
     }
   }
 

--- a/src/composables/trade/useTokenApproval.ts
+++ b/src/composables/trade/useTokenApproval.ts
@@ -5,7 +5,6 @@ import { parseUnits } from '@ethersproject/units';
 import { approveTokens } from '@/lib/utils/balancer/tokens';
 import useNotify from '@/composables/useNotify';
 import { ETHER } from '@/constants/tokenlists';
-import useWeb3 from '../useWeb3';
 import { TransactionResponse } from '@ethersproject/providers';
 import useEthers from '../useEthers';
 

--- a/src/composables/trade/useTokenApproval.ts
+++ b/src/composables/trade/useTokenApproval.ts
@@ -102,14 +102,14 @@ export default function useTokenApproval(tokenInAddress, amount, tokens) {
 
   function txHandler(tx: TransactionResponse): void {
     if (supportsBlocknative.value) {
-      blocknativeTxHandler(tx.hash);
+      blocknativeTxHandler(tx);
     } else {
       ethersTxHandler(tx);
     }
   }
 
-  function blocknativeTxHandler(hash: string): void {
-    txListener(hash, {
+  function blocknativeTxHandler(tx: TransactionResponse): void {
+    txListener(tx.hash, {
       onTxConfirmed: () => {
         approving.value = false;
         approved.value = true;

--- a/src/composables/useBlocknative.ts
+++ b/src/composables/useBlocknative.ts
@@ -1,6 +1,5 @@
-import { computed } from 'vue';
+import { computed, inject } from 'vue';
 import Notify from 'bnc-notify';
-import { inject } from 'vue';
 import { bnNotifySymbol } from '@/plugins/blocknative';
 import useWeb3 from './useWeb3';
 

--- a/src/composables/useBlocknative.ts
+++ b/src/composables/useBlocknative.ts
@@ -1,12 +1,23 @@
+import { computed } from 'vue';
 import Notify from 'bnc-notify';
 import { inject } from 'vue';
 import { bnNotifySymbol } from '@/plugins/blocknative';
+import useWeb3 from './useWeb3';
+
+const SUPPORTED_NETWORKS = [1, 42];
 
 export default function useBlocknative() {
+  const { appNetwork } = useWeb3();
+
   const notify = inject(bnNotifySymbol) as ReturnType<typeof Notify>;
   if (!notify) throw new Error('Blocknative Notify missing!');
 
+  const supportsBlocknative = computed(() => {
+    return SUPPORTED_NETWORKS.includes(appNetwork.id);
+  });
+
   return {
-    notify
+    notify,
+    supportsBlocknative
   };
 }

--- a/src/composables/useEthers.ts
+++ b/src/composables/useEthers.ts
@@ -1,0 +1,23 @@
+import { TransactionResponse } from '@ethersproject/providers';
+
+type TxCallback = (txData: TransactionResponse) => void;
+
+export default function useEthers() {
+  async function txListener(
+    tx: TransactionResponse,
+    callbacks: {
+      onTxConfirmed: TxCallback;
+      onTxFailed: TxCallback;
+    }
+  ) {
+    try {
+      await tx.wait();
+      callbacks.onTxConfirmed(tx);
+    } catch (error) {
+      console.error(error);
+      callbacks.onTxFailed(tx);
+    }
+  }
+
+  return { txListener };
+}

--- a/src/composables/useNotify.ts
+++ b/src/composables/useNotify.ts
@@ -8,7 +8,7 @@ import useWeb3 from './useWeb3';
 type TxCallback = (txData: TransactionData) => void;
 
 export default function useNotify() {
-  const { notify } = useBlocknative();
+  const { notify, supportsBlocknative } = useBlocknative();
   const { explorer } = useWeb3();
 
   function txListener(
@@ -76,5 +76,5 @@ export default function useNotify() {
     });
   }
 
-  return { txListener };
+  return { txListener, supportsBlocknative };
 }

--- a/src/composables/useWeb3.ts
+++ b/src/composables/useWeb3.ts
@@ -43,7 +43,6 @@ export default function useWeb3() {
   });
 
   const isMainnet = computed(() => appNetwork.id === 1);
-  const isPolygon = computed(() => appNetwork.id === 137);
 
   const unsupportedNetwork = computed(() => {
     return store.state.web3.config.unknown;
@@ -81,7 +80,6 @@ export default function useWeb3() {
     loading,
     blockNumber,
     isMainnet,
-    isPolygon,
     unsupportedNetwork,
     networkMismatch,
     isConnected,

--- a/src/composables/useWeb3.ts
+++ b/src/composables/useWeb3.ts
@@ -42,9 +42,8 @@ export default function useWeb3() {
     return getProvider(userNetwork.value.key);
   });
 
-  const isMainnet = computed(() => {
-    return appNetwork.name === 'Mainnet';
-  });
+  const isMainnet = computed(() => appNetwork.id === 1);
+  const isPolygon = computed(() => appNetwork.id === 137);
 
   const unsupportedNetwork = computed(() => {
     return store.state.web3.config.unknown;
@@ -82,6 +81,7 @@ export default function useWeb3() {
     loading,
     blockNumber,
     isMainnet,
+    isPolygon,
     unsupportedNetwork,
     networkMismatch,
     isConnected,


### PR DESCRIPTION
Changes proposed in this pull request:
- Add a useEthers composable with simple tx listener function similar to our blocknative equivalent.
- If network is polygon handle tx confirmations with ethers tx listener.

This is a stop-gap solution until we role our own tx handler which is also needed to support the Gnosis integration.
