### PR TITLE
Migrate composables to a provider pattern, so watchers and composables register once.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -63,7 +63,7 @@
         "pretty-ms": "^7.0.0",
         "tailwindcss": "npm:@tailwindcss/postcss7-compat@^2.0.4",
         "typescript": "~3.9.3",
-        "vue": "^3.0.0-beta.1",
+        "vue": "^3.1.4",
         "vue-echarts": "^6.0.0-rc.4",
         "vue-i18n": "^9.0.0-rc.1",
         "vue-query": "^1.6.0",
@@ -1692,9 +1692,9 @@
       }
     },
     "node_modules/@ethersproject/abi": {
-      "version": "5.3.1",
-      "resolved": "https://registry.npmjs.org/@ethersproject/abi/-/abi-5.3.1.tgz",
-      "integrity": "sha512-F98FWTJG7nWWAQ4DcV6R0cSlrj67MWK3ylahuFbzkumem5cLWg1p7fZ3vIdRoS1c7TEf55Lvyx0w7ICR47IImw==",
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/abi/-/abi-5.4.0.tgz",
+      "integrity": "sha512-9gU2H+/yK1j2eVMdzm6xvHSnMxk8waIHQGYCZg5uvAyH0rsAzxkModzBSpbAkAuhKFEovC2S9hM4nPuLym8IZw==",
       "funding": [
         {
           "type": "individual",
@@ -1706,21 +1706,21 @@
         }
       ],
       "dependencies": {
-        "@ethersproject/address": "^5.3.0",
-        "@ethersproject/bignumber": "^5.3.0",
-        "@ethersproject/bytes": "^5.3.0",
-        "@ethersproject/constants": "^5.3.0",
-        "@ethersproject/hash": "^5.3.0",
-        "@ethersproject/keccak256": "^5.3.0",
-        "@ethersproject/logger": "^5.3.0",
-        "@ethersproject/properties": "^5.3.0",
-        "@ethersproject/strings": "^5.3.0"
+        "@ethersproject/address": "^5.4.0",
+        "@ethersproject/bignumber": "^5.4.0",
+        "@ethersproject/bytes": "^5.4.0",
+        "@ethersproject/constants": "^5.4.0",
+        "@ethersproject/hash": "^5.4.0",
+        "@ethersproject/keccak256": "^5.4.0",
+        "@ethersproject/logger": "^5.4.0",
+        "@ethersproject/properties": "^5.4.0",
+        "@ethersproject/strings": "^5.4.0"
       }
     },
     "node_modules/@ethersproject/abstract-provider": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/abstract-provider/-/abstract-provider-5.3.0.tgz",
-      "integrity": "sha512-1+MLhGP1GwxBDBNwMWVmhCsvKwh4gK7oIfOrmlmePNeskg1NhIrYssraJBieaFNHUYfKEd/1DjiVZMw8Qu5Cxw==",
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/abstract-provider/-/abstract-provider-5.4.0.tgz",
+      "integrity": "sha512-vPBR7HKUBY0lpdllIn7tLIzNN7DrVnhCLKSzY0l8WAwxz686m/aL7ASDzrVxV93GJtIub6N2t4dfZ29CkPOxgA==",
       "funding": [
         {
           "type": "individual",
@@ -1732,19 +1732,19 @@
         }
       ],
       "dependencies": {
-        "@ethersproject/bignumber": "^5.3.0",
-        "@ethersproject/bytes": "^5.3.0",
-        "@ethersproject/logger": "^5.3.0",
-        "@ethersproject/networks": "^5.3.0",
-        "@ethersproject/properties": "^5.3.0",
-        "@ethersproject/transactions": "^5.3.0",
-        "@ethersproject/web": "^5.3.0"
+        "@ethersproject/bignumber": "^5.4.0",
+        "@ethersproject/bytes": "^5.4.0",
+        "@ethersproject/logger": "^5.4.0",
+        "@ethersproject/networks": "^5.4.0",
+        "@ethersproject/properties": "^5.4.0",
+        "@ethersproject/transactions": "^5.4.0",
+        "@ethersproject/web": "^5.4.0"
       }
     },
     "node_modules/@ethersproject/abstract-signer": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/abstract-signer/-/abstract-signer-5.3.0.tgz",
-      "integrity": "sha512-w8IFwOYqiPrtvosPuArZ3+QPR2nmdVTRrVY8uJYL3NNfMmQfTy3V3l2wbzX47UUlNbPJY+gKvzJAyvK1onZxJg==",
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/abstract-signer/-/abstract-signer-5.4.0.tgz",
+      "integrity": "sha512-AieQAzt05HJZS2bMofpuxMEp81AHufA5D6M4ScKwtolj041nrfIbIi8ciNW7+F59VYxXq+V4c3d568Q6l2m8ew==",
       "funding": [
         {
           "type": "individual",
@@ -1756,17 +1756,17 @@
         }
       ],
       "dependencies": {
-        "@ethersproject/abstract-provider": "^5.3.0",
-        "@ethersproject/bignumber": "^5.3.0",
-        "@ethersproject/bytes": "^5.3.0",
-        "@ethersproject/logger": "^5.3.0",
-        "@ethersproject/properties": "^5.3.0"
+        "@ethersproject/abstract-provider": "^5.4.0",
+        "@ethersproject/bignumber": "^5.4.0",
+        "@ethersproject/bytes": "^5.4.0",
+        "@ethersproject/logger": "^5.4.0",
+        "@ethersproject/properties": "^5.4.0"
       }
     },
     "node_modules/@ethersproject/address": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/address/-/address-5.3.0.tgz",
-      "integrity": "sha512-29TgjzEBK+gUEUAOfWCG7s9IxLNLCqvr+oDSk6L9TXD0VLvZJKhJV479tKQqheVA81OeGxfpdxYtUVH8hqlCvA==",
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/address/-/address-5.4.0.tgz",
+      "integrity": "sha512-SD0VgOEkcACEG/C6xavlU1Hy3m5DGSXW3CUHkaaEHbAPPsgi0coP5oNPsxau8eTlZOk/bpa/hKeCNoK5IzVI2Q==",
       "funding": [
         {
           "type": "individual",
@@ -1778,17 +1778,17 @@
         }
       ],
       "dependencies": {
-        "@ethersproject/bignumber": "^5.3.0",
-        "@ethersproject/bytes": "^5.3.0",
-        "@ethersproject/keccak256": "^5.3.0",
-        "@ethersproject/logger": "^5.3.0",
-        "@ethersproject/rlp": "^5.3.0"
+        "@ethersproject/bignumber": "^5.4.0",
+        "@ethersproject/bytes": "^5.4.0",
+        "@ethersproject/keccak256": "^5.4.0",
+        "@ethersproject/logger": "^5.4.0",
+        "@ethersproject/rlp": "^5.4.0"
       }
     },
     "node_modules/@ethersproject/base64": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/base64/-/base64-5.3.0.tgz",
-      "integrity": "sha512-JIqgtOmgKcbc2sjGWTXyXktqUhvFUDte8fPVsAaOrcPiJf6YotNF+nsrOYGC9pbHBEGSuSBp3QR0varkO8JHEw==",
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/base64/-/base64-5.4.0.tgz",
+      "integrity": "sha512-CjQw6E17QDSSC5jiM9YpF7N1aSCHmYGMt9bWD8PWv6YPMxjsys2/Q8xLrROKI3IWJ7sFfZ8B3flKDTM5wlWuZQ==",
       "funding": [
         {
           "type": "individual",
@@ -1800,13 +1800,13 @@
         }
       ],
       "dependencies": {
-        "@ethersproject/bytes": "^5.3.0"
+        "@ethersproject/bytes": "^5.4.0"
       }
     },
     "node_modules/@ethersproject/basex": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/basex/-/basex-5.3.0.tgz",
-      "integrity": "sha512-8J4nS6t/SOnoCgr3DF5WCSRLC5YwTKYpZWJqeyYQLX+86TwPhtzvHXacODzcDII9tWKhVg6g0Bka8JCBWXsCiQ==",
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/basex/-/basex-5.4.0.tgz",
+      "integrity": "sha512-J07+QCVJ7np2bcpxydFVf/CuYo9mZ7T73Pe7KQY4c1lRlrixMeblauMxHXD0MPwFmUHZIILDNViVkykFBZylbg==",
       "funding": [
         {
           "type": "individual",
@@ -1818,14 +1818,14 @@
         }
       ],
       "dependencies": {
-        "@ethersproject/bytes": "^5.3.0",
-        "@ethersproject/properties": "^5.3.0"
+        "@ethersproject/bytes": "^5.4.0",
+        "@ethersproject/properties": "^5.4.0"
       }
     },
     "node_modules/@ethersproject/bignumber": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.3.0.tgz",
-      "integrity": "sha512-5xguJ+Q1/zRMgHgDCaqAexx/8DwDVLRemw2i6uR8KyGjwGdXI8f32QZZ1cKGucBN6ekJvpUpHy6XAuQnTv0mPA==",
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.4.0.tgz",
+      "integrity": "sha512-OXUu9f9hO3vGRIPxU40cignXZVaYyfx6j9NNMjebKdnaCL3anCLSSy8/b8d03vY6dh7duCC0kW72GEC4tZer2w==",
       "funding": [
         {
           "type": "individual",
@@ -1837,15 +1837,15 @@
         }
       ],
       "dependencies": {
-        "@ethersproject/bytes": "^5.3.0",
-        "@ethersproject/logger": "^5.3.0",
+        "@ethersproject/bytes": "^5.4.0",
+        "@ethersproject/logger": "^5.4.0",
         "bn.js": "^4.11.9"
       }
     },
     "node_modules/@ethersproject/bytes": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.3.0.tgz",
-      "integrity": "sha512-rqLJjdVqCcn7glPer7Fxh87PRqlnRScVAoxcIP3PmOUNApMWJ6yRdOFfo2KvPAdO7Le3yEI1o0YW+Yvr7XCYvw==",
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.4.0.tgz",
+      "integrity": "sha512-H60ceqgTHbhzOj4uRc/83SCN9d+BSUnOkrr2intevqdtEMO1JFVZ1XL84OEZV+QjV36OaZYxtnt4lGmxcGsPfA==",
       "funding": [
         {
           "type": "individual",
@@ -1857,13 +1857,13 @@
         }
       ],
       "dependencies": {
-        "@ethersproject/logger": "^5.3.0"
+        "@ethersproject/logger": "^5.4.0"
       }
     },
     "node_modules/@ethersproject/constants": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/constants/-/constants-5.3.0.tgz",
-      "integrity": "sha512-4y1feNOwEpgjAfiCFWOHznvv6qUF/H6uI0UKp8xdhftb+H+FbKflXg1pOgH5qs4Sr7EYBL+zPyPb+YD5g1aEyw==",
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/constants/-/constants-5.4.0.tgz",
+      "integrity": "sha512-tzjn6S7sj9+DIIeKTJLjK9WGN2Tj0P++Z8ONEIlZjyoTkBuODN+0VfhAyYksKi43l1Sx9tX2VlFfzjfmr5Wl3Q==",
       "funding": [
         {
           "type": "individual",
@@ -1875,13 +1875,13 @@
         }
       ],
       "dependencies": {
-        "@ethersproject/bignumber": "^5.3.0"
+        "@ethersproject/bignumber": "^5.4.0"
       }
     },
     "node_modules/@ethersproject/contracts": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/contracts/-/contracts-5.3.0.tgz",
-      "integrity": "sha512-eDyQ8ltykvyQqnGZxb/c1e0OnEtzqXhNNC4BX8nhYBCaoBrYYuK/1fLmyEvc5+XUMoxNhwpYkoSSwvPLci7/Zg==",
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/contracts/-/contracts-5.4.0.tgz",
+      "integrity": "sha512-hkO3L3IhS1Z3ZtHtaAG/T87nQ7KiPV+/qnvutag35I0IkiQ8G3ZpCQ9NNOpSCzn4pWSW4CfzmtE02FcqnLI+hw==",
       "funding": [
         {
           "type": "individual",
@@ -1893,22 +1893,22 @@
         }
       ],
       "dependencies": {
-        "@ethersproject/abi": "^5.3.0",
-        "@ethersproject/abstract-provider": "^5.3.0",
-        "@ethersproject/abstract-signer": "^5.3.0",
-        "@ethersproject/address": "^5.3.0",
-        "@ethersproject/bignumber": "^5.3.0",
-        "@ethersproject/bytes": "^5.3.0",
-        "@ethersproject/constants": "^5.3.0",
-        "@ethersproject/logger": "^5.3.0",
-        "@ethersproject/properties": "^5.3.0",
-        "@ethersproject/transactions": "^5.3.0"
+        "@ethersproject/abi": "^5.4.0",
+        "@ethersproject/abstract-provider": "^5.4.0",
+        "@ethersproject/abstract-signer": "^5.4.0",
+        "@ethersproject/address": "^5.4.0",
+        "@ethersproject/bignumber": "^5.4.0",
+        "@ethersproject/bytes": "^5.4.0",
+        "@ethersproject/constants": "^5.4.0",
+        "@ethersproject/logger": "^5.4.0",
+        "@ethersproject/properties": "^5.4.0",
+        "@ethersproject/transactions": "^5.4.0"
       }
     },
     "node_modules/@ethersproject/hash": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/hash/-/hash-5.3.0.tgz",
-      "integrity": "sha512-gAFZSjUPQ32CIfoKSMtMEQ+IO0kQxqhwz9fCIFt2DtAq2u4pWt8mL9Z5P0r6KkLcQU8LE9FmuPPyd+JvBzmr1w==",
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/hash/-/hash-5.4.0.tgz",
+      "integrity": "sha512-xymAM9tmikKgbktOCjW60Z5sdouiIIurkZUr9oW5NOex5uwxrbsYG09kb5bMcNjlVeJD3yPivTNzViIs1GCbqA==",
       "funding": [
         {
           "type": "individual",
@@ -1920,20 +1920,20 @@
         }
       ],
       "dependencies": {
-        "@ethersproject/abstract-signer": "^5.3.0",
-        "@ethersproject/address": "^5.3.0",
-        "@ethersproject/bignumber": "^5.3.0",
-        "@ethersproject/bytes": "^5.3.0",
-        "@ethersproject/keccak256": "^5.3.0",
-        "@ethersproject/logger": "^5.3.0",
-        "@ethersproject/properties": "^5.3.0",
-        "@ethersproject/strings": "^5.3.0"
+        "@ethersproject/abstract-signer": "^5.4.0",
+        "@ethersproject/address": "^5.4.0",
+        "@ethersproject/bignumber": "^5.4.0",
+        "@ethersproject/bytes": "^5.4.0",
+        "@ethersproject/keccak256": "^5.4.0",
+        "@ethersproject/logger": "^5.4.0",
+        "@ethersproject/properties": "^5.4.0",
+        "@ethersproject/strings": "^5.4.0"
       }
     },
     "node_modules/@ethersproject/hdnode": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/hdnode/-/hdnode-5.3.0.tgz",
-      "integrity": "sha512-zLmmtLNoDMGoYRdjOab01Zqkvp+TmZyCGDAMQF1Bs3yZyBs/kzTNi1qJjR1jVUcPP5CWGtjFwY8iNG8oNV9J8g==",
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/hdnode/-/hdnode-5.4.0.tgz",
+      "integrity": "sha512-pKxdS0KAaeVGfZPp1KOiDLB0jba11tG6OP1u11QnYfb7pXn6IZx0xceqWRr6ygke8+Kw74IpOoSi7/DwANhy8Q==",
       "funding": [
         {
           "type": "individual",
@@ -1945,24 +1945,24 @@
         }
       ],
       "dependencies": {
-        "@ethersproject/abstract-signer": "^5.3.0",
-        "@ethersproject/basex": "^5.3.0",
-        "@ethersproject/bignumber": "^5.3.0",
-        "@ethersproject/bytes": "^5.3.0",
-        "@ethersproject/logger": "^5.3.0",
-        "@ethersproject/pbkdf2": "^5.3.0",
-        "@ethersproject/properties": "^5.3.0",
-        "@ethersproject/sha2": "^5.3.0",
-        "@ethersproject/signing-key": "^5.3.0",
-        "@ethersproject/strings": "^5.3.0",
-        "@ethersproject/transactions": "^5.3.0",
-        "@ethersproject/wordlists": "^5.3.0"
+        "@ethersproject/abstract-signer": "^5.4.0",
+        "@ethersproject/basex": "^5.4.0",
+        "@ethersproject/bignumber": "^5.4.0",
+        "@ethersproject/bytes": "^5.4.0",
+        "@ethersproject/logger": "^5.4.0",
+        "@ethersproject/pbkdf2": "^5.4.0",
+        "@ethersproject/properties": "^5.4.0",
+        "@ethersproject/sha2": "^5.4.0",
+        "@ethersproject/signing-key": "^5.4.0",
+        "@ethersproject/strings": "^5.4.0",
+        "@ethersproject/transactions": "^5.4.0",
+        "@ethersproject/wordlists": "^5.4.0"
       }
     },
     "node_modules/@ethersproject/json-wallets": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/json-wallets/-/json-wallets-5.3.0.tgz",
-      "integrity": "sha512-/xwbqaIb5grUIGNmeEaz8GdcpmDr++X8WT4Jqcclnxow8PXCUHFeDxjf3O+nSuoqOYG/Ds0+BI5xuQKbva6Xkw==",
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/json-wallets/-/json-wallets-5.4.0.tgz",
+      "integrity": "sha512-igWcu3fx4aiczrzEHwG1xJZo9l1cFfQOWzTqwRw/xcvxTk58q4f9M7cjh51EKphMHvrJtcezJ1gf1q1AUOfEQQ==",
       "funding": [
         {
           "type": "individual",
@@ -1974,25 +1974,25 @@
         }
       ],
       "dependencies": {
-        "@ethersproject/abstract-signer": "^5.3.0",
-        "@ethersproject/address": "^5.3.0",
-        "@ethersproject/bytes": "^5.3.0",
-        "@ethersproject/hdnode": "^5.3.0",
-        "@ethersproject/keccak256": "^5.3.0",
-        "@ethersproject/logger": "^5.3.0",
-        "@ethersproject/pbkdf2": "^5.3.0",
-        "@ethersproject/properties": "^5.3.0",
-        "@ethersproject/random": "^5.3.0",
-        "@ethersproject/strings": "^5.3.0",
-        "@ethersproject/transactions": "^5.3.0",
+        "@ethersproject/abstract-signer": "^5.4.0",
+        "@ethersproject/address": "^5.4.0",
+        "@ethersproject/bytes": "^5.4.0",
+        "@ethersproject/hdnode": "^5.4.0",
+        "@ethersproject/keccak256": "^5.4.0",
+        "@ethersproject/logger": "^5.4.0",
+        "@ethersproject/pbkdf2": "^5.4.0",
+        "@ethersproject/properties": "^5.4.0",
+        "@ethersproject/random": "^5.4.0",
+        "@ethersproject/strings": "^5.4.0",
+        "@ethersproject/transactions": "^5.4.0",
         "aes-js": "3.0.0",
         "scrypt-js": "3.0.1"
       }
     },
     "node_modules/@ethersproject/keccak256": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/keccak256/-/keccak256-5.3.0.tgz",
-      "integrity": "sha512-Gv2YqgIUmRbYVNIibafT0qGaeGYLIA/EdWHJ7JcVxVSs2vyxafGxOJ5VpSBHWeOIsE6OOaCelYowhuuTicgdFQ==",
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/keccak256/-/keccak256-5.4.0.tgz",
+      "integrity": "sha512-FBI1plWet+dPUvAzPAeHzRKiPpETQzqSUWR1wXJGHVWi4i8bOSrpC3NwpkPjgeXG7MnugVc1B42VbfnQikyC/A==",
       "funding": [
         {
           "type": "individual",
@@ -2004,14 +2004,14 @@
         }
       ],
       "dependencies": {
-        "@ethersproject/bytes": "^5.3.0",
+        "@ethersproject/bytes": "^5.4.0",
         "js-sha3": "0.5.7"
       }
     },
     "node_modules/@ethersproject/logger": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.3.0.tgz",
-      "integrity": "sha512-8bwJ2gxJGkZZnpQSq5uSiZSJjyVTWmlGft4oH8vxHdvO1Asy4TwVepAhPgxIQIMxXZFUNMych1YjIV4oQ4I7dA==",
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.4.0.tgz",
+      "integrity": "sha512-xYdWGGQ9P2cxBayt64d8LC8aPFJk6yWCawQi/4eJ4+oJdMMjEBMrIcIMZ9AxhwpPVmnBPrsB10PcXGmGAqgUEQ==",
       "funding": [
         {
           "type": "individual",
@@ -2024,9 +2024,9 @@
       ]
     },
     "node_modules/@ethersproject/networks": {
-      "version": "5.3.1",
-      "resolved": "https://registry.npmjs.org/@ethersproject/networks/-/networks-5.3.1.tgz",
-      "integrity": "sha512-6uQKHkYChlsfeiZhQ8IHIqGE/sQsf25o9ZxAYpMxi15dLPzz3IxOEF5KiSD32aHwsjXVBKBSlo+teAXLlYJybw==",
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/@ethersproject/networks/-/networks-5.4.1.tgz",
+      "integrity": "sha512-8SvowCKz9Uf4xC5DTKI8+il8lWqOr78kmiqAVLYT9lzB8aSmJHQMD1GSuJI0CW4hMAnzocpGpZLgiMdzsNSPig==",
       "funding": [
         {
           "type": "individual",
@@ -2038,13 +2038,13 @@
         }
       ],
       "dependencies": {
-        "@ethersproject/logger": "^5.3.0"
+        "@ethersproject/logger": "^5.4.0"
       }
     },
     "node_modules/@ethersproject/pbkdf2": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/pbkdf2/-/pbkdf2-5.3.0.tgz",
-      "integrity": "sha512-Q9ChVU6gBFiex0FSdtzo4b0SAKz3ZYcYVFLrEWHL0FnHvNk3J3WgAtRNtBQGQYn/T5wkoTdZttMbfBkFlaiWcA==",
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/pbkdf2/-/pbkdf2-5.4.0.tgz",
+      "integrity": "sha512-x94aIv6tiA04g6BnazZSLoRXqyusawRyZWlUhKip2jvoLpzJuLb//KtMM6PEovE47pMbW+Qe1uw+68ameJjB7g==",
       "funding": [
         {
           "type": "individual",
@@ -2056,14 +2056,14 @@
         }
       ],
       "dependencies": {
-        "@ethersproject/bytes": "^5.3.0",
-        "@ethersproject/sha2": "^5.3.0"
+        "@ethersproject/bytes": "^5.4.0",
+        "@ethersproject/sha2": "^5.4.0"
       }
     },
     "node_modules/@ethersproject/properties": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/properties/-/properties-5.3.0.tgz",
-      "integrity": "sha512-PaHxJyM5/bfusk6vr3yP//JMnm4UEojpzuWGTmtL5X4uNhNnFNvlYilZLyDr4I9cTkIbipCMsAuIcXWsmdRnEw==",
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/properties/-/properties-5.4.0.tgz",
+      "integrity": "sha512-7jczalGVRAJ+XSRvNA6D5sAwT4gavLq3OXPuV/74o3Rd2wuzSL035IMpIMgei4CYyBdialJMrTqkOnzccLHn4A==",
       "funding": [
         {
           "type": "individual",
@@ -2075,13 +2075,13 @@
         }
       ],
       "dependencies": {
-        "@ethersproject/logger": "^5.3.0"
+        "@ethersproject/logger": "^5.4.0"
       }
     },
     "node_modules/@ethersproject/providers": {
-      "version": "5.3.1",
-      "resolved": "https://registry.npmjs.org/@ethersproject/providers/-/providers-5.3.1.tgz",
-      "integrity": "sha512-HC63vENTrur6/JKEhcQbA8PRDj1FAesdpX98IW+xAAo3EAkf70ou5fMIA3KCGzJDLNTeYA4C2Bonz849tVLekg==",
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/@ethersproject/providers/-/providers-5.4.1.tgz",
+      "integrity": "sha512-p06eiFKz8nu/5Ju0kIX024gzEQIgE5pvvGrBCngpyVjpuLtUIWT3097Agw4mTn9/dEA0FMcfByzFqacBMSgCVg==",
       "funding": [
         {
           "type": "individual",
@@ -2093,23 +2093,23 @@
         }
       ],
       "dependencies": {
-        "@ethersproject/abstract-provider": "^5.3.0",
-        "@ethersproject/abstract-signer": "^5.3.0",
-        "@ethersproject/address": "^5.3.0",
-        "@ethersproject/basex": "^5.3.0",
-        "@ethersproject/bignumber": "^5.3.0",
-        "@ethersproject/bytes": "^5.3.0",
-        "@ethersproject/constants": "^5.3.0",
-        "@ethersproject/hash": "^5.3.0",
-        "@ethersproject/logger": "^5.3.0",
-        "@ethersproject/networks": "^5.3.0",
-        "@ethersproject/properties": "^5.3.0",
-        "@ethersproject/random": "^5.3.0",
-        "@ethersproject/rlp": "^5.3.0",
-        "@ethersproject/sha2": "^5.3.0",
-        "@ethersproject/strings": "^5.3.0",
-        "@ethersproject/transactions": "^5.3.0",
-        "@ethersproject/web": "^5.3.0",
+        "@ethersproject/abstract-provider": "^5.4.0",
+        "@ethersproject/abstract-signer": "^5.4.0",
+        "@ethersproject/address": "^5.4.0",
+        "@ethersproject/basex": "^5.4.0",
+        "@ethersproject/bignumber": "^5.4.0",
+        "@ethersproject/bytes": "^5.4.0",
+        "@ethersproject/constants": "^5.4.0",
+        "@ethersproject/hash": "^5.4.0",
+        "@ethersproject/logger": "^5.4.0",
+        "@ethersproject/networks": "^5.4.0",
+        "@ethersproject/properties": "^5.4.0",
+        "@ethersproject/random": "^5.4.0",
+        "@ethersproject/rlp": "^5.4.0",
+        "@ethersproject/sha2": "^5.4.0",
+        "@ethersproject/strings": "^5.4.0",
+        "@ethersproject/transactions": "^5.4.0",
+        "@ethersproject/web": "^5.4.0",
         "bech32": "1.1.4",
         "ws": "7.4.6"
       }
@@ -2135,9 +2135,9 @@
       }
     },
     "node_modules/@ethersproject/random": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/random/-/random-5.3.0.tgz",
-      "integrity": "sha512-A5SL/4inutSwt3Fh2OD0x2gz+x6GHmuUnIPkR7zAiTidMD2N8F6tZdMF1hlQKWVCcVMWhEQg8mWijhEzm6BBYw==",
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/random/-/random-5.4.0.tgz",
+      "integrity": "sha512-pnpWNQlf0VAZDEOVp1rsYQosmv2o0ITS/PecNw+mS2/btF8eYdspkN0vIXrCMtkX09EAh9bdk8GoXmFXM1eAKw==",
       "funding": [
         {
           "type": "individual",
@@ -2149,14 +2149,14 @@
         }
       ],
       "dependencies": {
-        "@ethersproject/bytes": "^5.3.0",
-        "@ethersproject/logger": "^5.3.0"
+        "@ethersproject/bytes": "^5.4.0",
+        "@ethersproject/logger": "^5.4.0"
       }
     },
     "node_modules/@ethersproject/rlp": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/rlp/-/rlp-5.3.0.tgz",
-      "integrity": "sha512-oI0joYpsRanl9guDubaW+1NbcpK0vJ3F/6Wpcanzcnqq+oaW9O5E98liwkEDPcb16BUTLIJ+ZF8GPIHYxJ/5Pw==",
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/rlp/-/rlp-5.4.0.tgz",
+      "integrity": "sha512-0I7MZKfi+T5+G8atId9QaQKHRvvasM/kqLyAH4XxBCBchAooH2EX5rL9kYZWwcm3awYV+XC7VF6nLhfeQFKVPg==",
       "funding": [
         {
           "type": "individual",
@@ -2168,14 +2168,14 @@
         }
       ],
       "dependencies": {
-        "@ethersproject/bytes": "^5.3.0",
-        "@ethersproject/logger": "^5.3.0"
+        "@ethersproject/bytes": "^5.4.0",
+        "@ethersproject/logger": "^5.4.0"
       }
     },
     "node_modules/@ethersproject/sha2": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/sha2/-/sha2-5.3.0.tgz",
-      "integrity": "sha512-r5ftlwKcocYEuFz2JbeKOT5SAsCV4m1RJDsTOEfQ5L67ZC7NFDK5i7maPdn1bx4nPhylF9VAwxSrQ1esmwzylg==",
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/sha2/-/sha2-5.4.0.tgz",
+      "integrity": "sha512-siheo36r1WD7Cy+bDdE1BJ8y0bDtqXCOxRMzPa4bV1TGt/eTUUt03BHoJNB6reWJD8A30E/pdJ8WFkq+/uz4Gg==",
       "funding": [
         {
           "type": "individual",
@@ -2187,15 +2187,15 @@
         }
       ],
       "dependencies": {
-        "@ethersproject/bytes": "^5.3.0",
-        "@ethersproject/logger": "^5.3.0",
+        "@ethersproject/bytes": "^5.4.0",
+        "@ethersproject/logger": "^5.4.0",
         "hash.js": "1.1.7"
       }
     },
     "node_modules/@ethersproject/signing-key": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/signing-key/-/signing-key-5.3.0.tgz",
-      "integrity": "sha512-+DX/GwHAd0ok1bgedV1cKO0zfK7P/9aEyNoaYiRsGHpCecN7mhLqcdoUiUzE7Uz86LBsxm5ssK0qA1kBB47fbQ==",
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/signing-key/-/signing-key-5.4.0.tgz",
+      "integrity": "sha512-q8POUeywx6AKg2/jX9qBYZIAmKSB4ubGXdQ88l40hmATj29JnG5pp331nAWwwxPn2Qao4JpWHNZsQN+bPiSW9A==",
       "funding": [
         {
           "type": "individual",
@@ -2207,18 +2207,18 @@
         }
       ],
       "dependencies": {
-        "@ethersproject/bytes": "^5.3.0",
-        "@ethersproject/logger": "^5.3.0",
-        "@ethersproject/properties": "^5.3.0",
+        "@ethersproject/bytes": "^5.4.0",
+        "@ethersproject/logger": "^5.4.0",
+        "@ethersproject/properties": "^5.4.0",
         "bn.js": "^4.11.9",
         "elliptic": "6.5.4",
         "hash.js": "1.1.7"
       }
     },
     "node_modules/@ethersproject/solidity": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/solidity/-/solidity-5.3.0.tgz",
-      "integrity": "sha512-uLRBaNUiISHbut94XKewJgQh6UmydWTBp71I7I21pkjVXfZO2dJ5EOo3jCnumJc01M4LOm79dlNNmF3oGIvweQ==",
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/solidity/-/solidity-5.4.0.tgz",
+      "integrity": "sha512-XFQTZ7wFSHOhHcV1DpcWj7VXECEiSrBuv7JErJvB9Uo+KfCdc3QtUZV+Vjh/AAaYgezUEKbCtE6Khjm44seevQ==",
       "funding": [
         {
           "type": "individual",
@@ -2230,17 +2230,17 @@
         }
       ],
       "dependencies": {
-        "@ethersproject/bignumber": "^5.3.0",
-        "@ethersproject/bytes": "^5.3.0",
-        "@ethersproject/keccak256": "^5.3.0",
-        "@ethersproject/sha2": "^5.3.0",
-        "@ethersproject/strings": "^5.3.0"
+        "@ethersproject/bignumber": "^5.4.0",
+        "@ethersproject/bytes": "^5.4.0",
+        "@ethersproject/keccak256": "^5.4.0",
+        "@ethersproject/sha2": "^5.4.0",
+        "@ethersproject/strings": "^5.4.0"
       }
     },
     "node_modules/@ethersproject/strings": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/strings/-/strings-5.3.0.tgz",
-      "integrity": "sha512-j/AzIGZ503cvhuF2ldRSjB0BrKzpsBMtCieDtn4TYMMZMQ9zScJn9wLzTQl/bRNvJbBE6TOspK0r8/Ngae/f2Q==",
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/strings/-/strings-5.4.0.tgz",
+      "integrity": "sha512-k/9DkH5UGDhv7aReXLluFG5ExurwtIpUfnDNhQA29w896Dw3i4uDTz01Quaptbks1Uj9kI8wo9tmW73wcIEaWA==",
       "funding": [
         {
           "type": "individual",
@@ -2252,15 +2252,15 @@
         }
       ],
       "dependencies": {
-        "@ethersproject/bytes": "^5.3.0",
-        "@ethersproject/constants": "^5.3.0",
-        "@ethersproject/logger": "^5.3.0"
+        "@ethersproject/bytes": "^5.4.0",
+        "@ethersproject/constants": "^5.4.0",
+        "@ethersproject/logger": "^5.4.0"
       }
     },
     "node_modules/@ethersproject/transactions": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/transactions/-/transactions-5.3.0.tgz",
-      "integrity": "sha512-cdfK8VVyW2oEBCXhURG0WQ6AICL/r6Gmjh0e4Bvbv6MCn/GBd8FeBH3rtl7ho+AW50csMKeGv3m3K1HSHB2jMQ==",
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/transactions/-/transactions-5.4.0.tgz",
+      "integrity": "sha512-s3EjZZt7xa4BkLknJZ98QGoIza94rVjaEed0rzZ/jB9WrIuu/1+tjvYCWzVrystXtDswy7TPBeIepyXwSYa4WQ==",
       "funding": [
         {
           "type": "individual",
@@ -2272,21 +2272,21 @@
         }
       ],
       "dependencies": {
-        "@ethersproject/address": "^5.3.0",
-        "@ethersproject/bignumber": "^5.3.0",
-        "@ethersproject/bytes": "^5.3.0",
-        "@ethersproject/constants": "^5.3.0",
-        "@ethersproject/keccak256": "^5.3.0",
-        "@ethersproject/logger": "^5.3.0",
-        "@ethersproject/properties": "^5.3.0",
-        "@ethersproject/rlp": "^5.3.0",
-        "@ethersproject/signing-key": "^5.3.0"
+        "@ethersproject/address": "^5.4.0",
+        "@ethersproject/bignumber": "^5.4.0",
+        "@ethersproject/bytes": "^5.4.0",
+        "@ethersproject/constants": "^5.4.0",
+        "@ethersproject/keccak256": "^5.4.0",
+        "@ethersproject/logger": "^5.4.0",
+        "@ethersproject/properties": "^5.4.0",
+        "@ethersproject/rlp": "^5.4.0",
+        "@ethersproject/signing-key": "^5.4.0"
       }
     },
     "node_modules/@ethersproject/units": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/units/-/units-5.3.0.tgz",
-      "integrity": "sha512-BkfccZGwfJ6Ob+AelpIrgAzuNhrN2VLp3AILnkqTOv+yBdsc83V4AYf25XC/u0rHnWl6f4POaietPwlMqP2vUg==",
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/units/-/units-5.4.0.tgz",
+      "integrity": "sha512-Z88krX40KCp+JqPCP5oPv5p750g+uU6gopDYRTBGcDvOASh6qhiEYCRatuM/suC4S2XW9Zz90QI35MfSrTIaFg==",
       "funding": [
         {
           "type": "individual",
@@ -2298,15 +2298,15 @@
         }
       ],
       "dependencies": {
-        "@ethersproject/bignumber": "^5.3.0",
-        "@ethersproject/constants": "^5.3.0",
-        "@ethersproject/logger": "^5.3.0"
+        "@ethersproject/bignumber": "^5.4.0",
+        "@ethersproject/constants": "^5.4.0",
+        "@ethersproject/logger": "^5.4.0"
       }
     },
     "node_modules/@ethersproject/wallet": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/wallet/-/wallet-5.3.0.tgz",
-      "integrity": "sha512-boYBLydG6671p9QoG6EinNnNzbm7DNOjVT20eV8J6HQEq4aUaGiA2CytF2vK+2rOEWbzhZqoNDt6AlkE1LlsTg==",
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/wallet/-/wallet-5.4.0.tgz",
+      "integrity": "sha512-wU29majLjM6AjCjpat21mPPviG+EpK7wY1+jzKD0fg3ui5fgedf2zEu1RDgpfIMsfn8fJHJuzM4zXZ2+hSHaSQ==",
       "funding": [
         {
           "type": "individual",
@@ -2318,27 +2318,27 @@
         }
       ],
       "dependencies": {
-        "@ethersproject/abstract-provider": "^5.3.0",
-        "@ethersproject/abstract-signer": "^5.3.0",
-        "@ethersproject/address": "^5.3.0",
-        "@ethersproject/bignumber": "^5.3.0",
-        "@ethersproject/bytes": "^5.3.0",
-        "@ethersproject/hash": "^5.3.0",
-        "@ethersproject/hdnode": "^5.3.0",
-        "@ethersproject/json-wallets": "^5.3.0",
-        "@ethersproject/keccak256": "^5.3.0",
-        "@ethersproject/logger": "^5.3.0",
-        "@ethersproject/properties": "^5.3.0",
-        "@ethersproject/random": "^5.3.0",
-        "@ethersproject/signing-key": "^5.3.0",
-        "@ethersproject/transactions": "^5.3.0",
-        "@ethersproject/wordlists": "^5.3.0"
+        "@ethersproject/abstract-provider": "^5.4.0",
+        "@ethersproject/abstract-signer": "^5.4.0",
+        "@ethersproject/address": "^5.4.0",
+        "@ethersproject/bignumber": "^5.4.0",
+        "@ethersproject/bytes": "^5.4.0",
+        "@ethersproject/hash": "^5.4.0",
+        "@ethersproject/hdnode": "^5.4.0",
+        "@ethersproject/json-wallets": "^5.4.0",
+        "@ethersproject/keccak256": "^5.4.0",
+        "@ethersproject/logger": "^5.4.0",
+        "@ethersproject/properties": "^5.4.0",
+        "@ethersproject/random": "^5.4.0",
+        "@ethersproject/signing-key": "^5.4.0",
+        "@ethersproject/transactions": "^5.4.0",
+        "@ethersproject/wordlists": "^5.4.0"
       }
     },
     "node_modules/@ethersproject/web": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/web/-/web-5.3.0.tgz",
-      "integrity": "sha512-Ni6/DHnY6k/TD41LEkv0RQDx4jqWz5e/RZvrSecsxGYycF+MFy2z++T/yGc2peRunLOTIFwEksgEGGlbwfYmhQ==",
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/web/-/web-5.4.0.tgz",
+      "integrity": "sha512-1bUusGmcoRLYgMn6c1BLk1tOKUIFuTg8j+6N8lYlbMpDesnle+i3pGSagGNvwjaiLo4Y5gBibwctpPRmjrh4Og==",
       "funding": [
         {
           "type": "individual",
@@ -2350,17 +2350,17 @@
         }
       ],
       "dependencies": {
-        "@ethersproject/base64": "^5.3.0",
-        "@ethersproject/bytes": "^5.3.0",
-        "@ethersproject/logger": "^5.3.0",
-        "@ethersproject/properties": "^5.3.0",
-        "@ethersproject/strings": "^5.3.0"
+        "@ethersproject/base64": "^5.4.0",
+        "@ethersproject/bytes": "^5.4.0",
+        "@ethersproject/logger": "^5.4.0",
+        "@ethersproject/properties": "^5.4.0",
+        "@ethersproject/strings": "^5.4.0"
       }
     },
     "node_modules/@ethersproject/wordlists": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/wordlists/-/wordlists-5.3.0.tgz",
-      "integrity": "sha512-JcwumCZcsUxgWpiFU/BRy6b4KlTRdOmYvOKZcAw/3sdF93/pZyPW5Od2hFkHS8oWp4xS06YQ+qHqQhdcxdHafQ==",
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/wordlists/-/wordlists-5.4.0.tgz",
+      "integrity": "sha512-FemEkf6a+EBKEPxlzeVgUaVSodU7G0Na89jqKjmWMlDB0tomoU8RlEMgUvXyqtrg8N4cwpLh8nyRnm1Nay1isA==",
       "funding": [
         {
           "type": "individual",
@@ -2372,11 +2372,11 @@
         }
       ],
       "dependencies": {
-        "@ethersproject/bytes": "^5.3.0",
-        "@ethersproject/hash": "^5.3.0",
-        "@ethersproject/logger": "^5.3.0",
-        "@ethersproject/properties": "^5.3.0",
-        "@ethersproject/strings": "^5.3.0"
+        "@ethersproject/bytes": "^5.4.0",
+        "@ethersproject/hash": "^5.4.0",
+        "@ethersproject/logger": "^5.4.0",
+        "@ethersproject/properties": "^5.4.0",
+        "@ethersproject/strings": "^5.4.0"
       }
     },
     "node_modules/@fullhuman/postcss-purgecss": {
@@ -8782,6 +8782,7 @@
     },
     "node_modules/@vue/compiler-core": {
       "version": "3.0.11",
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/parser": "^7.12.0",
@@ -8793,6 +8794,7 @@
     },
     "node_modules/@vue/compiler-core/node_modules/source-map": {
       "version": "0.6.1",
+      "devOptional": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
@@ -8800,6 +8802,7 @@
     },
     "node_modules/@vue/compiler-dom": {
       "version": "3.0.11",
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@vue/compiler-core": "3.0.11",
@@ -9043,31 +9046,50 @@
       }
     },
     "node_modules/@vue/reactivity": {
-      "version": "3.0.11",
-      "license": "MIT",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.1.4.tgz",
+      "integrity": "sha512-YDlgii2Cr9yAoKVZFzgY4j0mYlVT73986X3e5SPp6ifqckSEoFSUWXZK2Tb53TB/9qO29BEEbspnKD3m3wAwkA==",
       "dependencies": {
-        "@vue/shared": "3.0.11"
+        "@vue/shared": "3.1.4"
       }
+    },
+    "node_modules/@vue/reactivity/node_modules/@vue/shared": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.1.4.tgz",
+      "integrity": "sha512-6O45kZAmkLvzGLToBxEz4lR2W6kXohCtebV2UxjH9GXjd8X9AhEn68FN9eNanFtWNzvgw1hqd6HkPRVQalqf7Q=="
     },
     "node_modules/@vue/runtime-core": {
-      "version": "3.0.11",
-      "license": "MIT",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.1.4.tgz",
+      "integrity": "sha512-qmVJgJuFxfT7M4qHQ4M6KqhKC66fjuswK+aBivE8dWiZ2rtIGl9gtJGpwqwjQEcKEBTOfvvrtrwBncYArJUO8Q==",
       "dependencies": {
-        "@vue/reactivity": "3.0.11",
-        "@vue/shared": "3.0.11"
+        "@vue/reactivity": "3.1.4",
+        "@vue/shared": "3.1.4"
       }
     },
+    "node_modules/@vue/runtime-core/node_modules/@vue/shared": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.1.4.tgz",
+      "integrity": "sha512-6O45kZAmkLvzGLToBxEz4lR2W6kXohCtebV2UxjH9GXjd8X9AhEn68FN9eNanFtWNzvgw1hqd6HkPRVQalqf7Q=="
+    },
     "node_modules/@vue/runtime-dom": {
-      "version": "3.0.11",
-      "license": "MIT",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.1.4.tgz",
+      "integrity": "sha512-vbmwgTxku1BU87Kw7r29adv0OIrDXCW0PslOPQT0O/9R5SqcXgS94Yj6zsztDjvghegenwIAPNLlDR1Auh5s+w==",
       "dependencies": {
-        "@vue/runtime-core": "3.0.11",
-        "@vue/shared": "3.0.11",
+        "@vue/runtime-core": "3.1.4",
+        "@vue/shared": "3.1.4",
         "csstype": "^2.6.8"
       }
     },
+    "node_modules/@vue/runtime-dom/node_modules/@vue/shared": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.1.4.tgz",
+      "integrity": "sha512-6O45kZAmkLvzGLToBxEz4lR2W6kXohCtebV2UxjH9GXjd8X9AhEn68FN9eNanFtWNzvgw1hqd6HkPRVQalqf7Q=="
+    },
     "node_modules/@vue/shared": {
       "version": "3.0.11",
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@vue/test-utils": {
@@ -15342,9 +15364,9 @@
       }
     },
     "node_modules/ethers": {
-      "version": "5.3.1",
-      "resolved": "https://registry.npmjs.org/ethers/-/ethers-5.3.1.tgz",
-      "integrity": "sha512-xCKmC0gsZ9gks89ZfK3B1y6LlPdvX5fxDtu9SytnpdDJR1M7pmJI+4H0AxQPMgUYr7GtQdmECLR0gWdJQ+lZYw==",
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/ethers/-/ethers-5.4.1.tgz",
+      "integrity": "sha512-SrcddMdCgP1hukDvCPd87Aipbf4NWjQvdfAbZ65XSZGbfyuYPtIrUJPDH5B1SBRsdlfiEgX3eoz28DdBDzMNFg==",
       "funding": [
         {
           "type": "individual",
@@ -15357,36 +15379,36 @@
       ],
       "peer": true,
       "dependencies": {
-        "@ethersproject/abi": "5.3.1",
-        "@ethersproject/abstract-provider": "5.3.0",
-        "@ethersproject/abstract-signer": "5.3.0",
-        "@ethersproject/address": "5.3.0",
-        "@ethersproject/base64": "5.3.0",
-        "@ethersproject/basex": "5.3.0",
-        "@ethersproject/bignumber": "5.3.0",
-        "@ethersproject/bytes": "5.3.0",
-        "@ethersproject/constants": "5.3.0",
-        "@ethersproject/contracts": "5.3.0",
-        "@ethersproject/hash": "5.3.0",
-        "@ethersproject/hdnode": "5.3.0",
-        "@ethersproject/json-wallets": "5.3.0",
-        "@ethersproject/keccak256": "5.3.0",
-        "@ethersproject/logger": "5.3.0",
-        "@ethersproject/networks": "5.3.1",
-        "@ethersproject/pbkdf2": "5.3.0",
-        "@ethersproject/properties": "5.3.0",
-        "@ethersproject/providers": "5.3.1",
-        "@ethersproject/random": "5.3.0",
-        "@ethersproject/rlp": "5.3.0",
-        "@ethersproject/sha2": "5.3.0",
-        "@ethersproject/signing-key": "5.3.0",
-        "@ethersproject/solidity": "5.3.0",
-        "@ethersproject/strings": "5.3.0",
-        "@ethersproject/transactions": "5.3.0",
-        "@ethersproject/units": "5.3.0",
-        "@ethersproject/wallet": "5.3.0",
-        "@ethersproject/web": "5.3.0",
-        "@ethersproject/wordlists": "5.3.0"
+        "@ethersproject/abi": "5.4.0",
+        "@ethersproject/abstract-provider": "5.4.0",
+        "@ethersproject/abstract-signer": "5.4.0",
+        "@ethersproject/address": "5.4.0",
+        "@ethersproject/base64": "5.4.0",
+        "@ethersproject/basex": "5.4.0",
+        "@ethersproject/bignumber": "5.4.0",
+        "@ethersproject/bytes": "5.4.0",
+        "@ethersproject/constants": "5.4.0",
+        "@ethersproject/contracts": "5.4.0",
+        "@ethersproject/hash": "5.4.0",
+        "@ethersproject/hdnode": "5.4.0",
+        "@ethersproject/json-wallets": "5.4.0",
+        "@ethersproject/keccak256": "5.4.0",
+        "@ethersproject/logger": "5.4.0",
+        "@ethersproject/networks": "5.4.1",
+        "@ethersproject/pbkdf2": "5.4.0",
+        "@ethersproject/properties": "5.4.0",
+        "@ethersproject/providers": "5.4.1",
+        "@ethersproject/random": "5.4.0",
+        "@ethersproject/rlp": "5.4.0",
+        "@ethersproject/sha2": "5.4.0",
+        "@ethersproject/signing-key": "5.4.0",
+        "@ethersproject/solidity": "5.4.0",
+        "@ethersproject/strings": "5.4.0",
+        "@ethersproject/transactions": "5.4.0",
+        "@ethersproject/units": "5.4.0",
+        "@ethersproject/wallet": "5.4.0",
+        "@ethersproject/web": "5.4.0",
+        "@ethersproject/wordlists": "5.4.0"
       }
     },
     "node_modules/ethjs-unit": {
@@ -29133,12 +29155,13 @@
       }
     },
     "node_modules/vue": {
-      "version": "3.0.11",
-      "license": "MIT",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/vue/-/vue-3.1.4.tgz",
+      "integrity": "sha512-p8dcdyeCgmaAiZsbLyDkmOLcFGZb/jEVdCLW65V68LRCXTNX8jKsgah2F7OZ/v/Ai2V0Fb1MNO0vz/GFqsPVMA==",
       "dependencies": {
-        "@vue/compiler-dom": "3.0.11",
-        "@vue/runtime-dom": "3.0.11",
-        "@vue/shared": "3.0.11"
+        "@vue/compiler-dom": "3.1.4",
+        "@vue/runtime-dom": "3.1.4",
+        "@vue/shared": "3.1.4"
       }
     },
     "node_modules/vue-cli-plugin-webpack-bundle-analyzer": {
@@ -29630,6 +29653,40 @@
     "node_modules/vue-template-es2015-compiler": {
       "version": "1.9.1",
       "license": "MIT"
+    },
+    "node_modules/vue/node_modules/@vue/compiler-core": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.1.4.tgz",
+      "integrity": "sha512-TnUz+1z0y74O/A4YKAbzsdUfamyHV73MihrEfvettWpm9bQKVoZd1nEmR1cGN9LsXWlwAvVQBetBlWdOjmQO5Q==",
+      "dependencies": {
+        "@babel/parser": "^7.12.0",
+        "@babel/types": "^7.12.0",
+        "@vue/shared": "3.1.4",
+        "estree-walker": "^2.0.1",
+        "source-map": "^0.6.1"
+      }
+    },
+    "node_modules/vue/node_modules/@vue/compiler-dom": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.1.4.tgz",
+      "integrity": "sha512-3tG2ScHkghhUBuFwl9KgyZhrS8CPFZsO7hUDekJgIp5b1OMkROr4AvxHu6rRMl4WkyvYkvidFNBS2VfOnwa6Kw==",
+      "dependencies": {
+        "@vue/compiler-core": "3.1.4",
+        "@vue/shared": "3.1.4"
+      }
+    },
+    "node_modules/vue/node_modules/@vue/shared": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.1.4.tgz",
+      "integrity": "sha512-6O45kZAmkLvzGLToBxEz4lR2W6kXohCtebV2UxjH9GXjd8X9AhEn68FN9eNanFtWNzvgw1hqd6HkPRVQalqf7Q=="
+    },
+    "node_modules/vue/node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/vue3-apexcharts": {
       "version": "1.2.1",
@@ -32879,234 +32936,234 @@
       }
     },
     "@ethersproject/abi": {
-      "version": "5.3.1",
-      "resolved": "https://registry.npmjs.org/@ethersproject/abi/-/abi-5.3.1.tgz",
-      "integrity": "sha512-F98FWTJG7nWWAQ4DcV6R0cSlrj67MWK3ylahuFbzkumem5cLWg1p7fZ3vIdRoS1c7TEf55Lvyx0w7ICR47IImw==",
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/abi/-/abi-5.4.0.tgz",
+      "integrity": "sha512-9gU2H+/yK1j2eVMdzm6xvHSnMxk8waIHQGYCZg5uvAyH0rsAzxkModzBSpbAkAuhKFEovC2S9hM4nPuLym8IZw==",
       "requires": {
-        "@ethersproject/address": "^5.3.0",
-        "@ethersproject/bignumber": "^5.3.0",
-        "@ethersproject/bytes": "^5.3.0",
-        "@ethersproject/constants": "^5.3.0",
-        "@ethersproject/hash": "^5.3.0",
-        "@ethersproject/keccak256": "^5.3.0",
-        "@ethersproject/logger": "^5.3.0",
-        "@ethersproject/properties": "^5.3.0",
-        "@ethersproject/strings": "^5.3.0"
+        "@ethersproject/address": "^5.4.0",
+        "@ethersproject/bignumber": "^5.4.0",
+        "@ethersproject/bytes": "^5.4.0",
+        "@ethersproject/constants": "^5.4.0",
+        "@ethersproject/hash": "^5.4.0",
+        "@ethersproject/keccak256": "^5.4.0",
+        "@ethersproject/logger": "^5.4.0",
+        "@ethersproject/properties": "^5.4.0",
+        "@ethersproject/strings": "^5.4.0"
       }
     },
     "@ethersproject/abstract-provider": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/abstract-provider/-/abstract-provider-5.3.0.tgz",
-      "integrity": "sha512-1+MLhGP1GwxBDBNwMWVmhCsvKwh4gK7oIfOrmlmePNeskg1NhIrYssraJBieaFNHUYfKEd/1DjiVZMw8Qu5Cxw==",
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/abstract-provider/-/abstract-provider-5.4.0.tgz",
+      "integrity": "sha512-vPBR7HKUBY0lpdllIn7tLIzNN7DrVnhCLKSzY0l8WAwxz686m/aL7ASDzrVxV93GJtIub6N2t4dfZ29CkPOxgA==",
       "requires": {
-        "@ethersproject/bignumber": "^5.3.0",
-        "@ethersproject/bytes": "^5.3.0",
-        "@ethersproject/logger": "^5.3.0",
-        "@ethersproject/networks": "^5.3.0",
-        "@ethersproject/properties": "^5.3.0",
-        "@ethersproject/transactions": "^5.3.0",
-        "@ethersproject/web": "^5.3.0"
+        "@ethersproject/bignumber": "^5.4.0",
+        "@ethersproject/bytes": "^5.4.0",
+        "@ethersproject/logger": "^5.4.0",
+        "@ethersproject/networks": "^5.4.0",
+        "@ethersproject/properties": "^5.4.0",
+        "@ethersproject/transactions": "^5.4.0",
+        "@ethersproject/web": "^5.4.0"
       }
     },
     "@ethersproject/abstract-signer": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/abstract-signer/-/abstract-signer-5.3.0.tgz",
-      "integrity": "sha512-w8IFwOYqiPrtvosPuArZ3+QPR2nmdVTRrVY8uJYL3NNfMmQfTy3V3l2wbzX47UUlNbPJY+gKvzJAyvK1onZxJg==",
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/abstract-signer/-/abstract-signer-5.4.0.tgz",
+      "integrity": "sha512-AieQAzt05HJZS2bMofpuxMEp81AHufA5D6M4ScKwtolj041nrfIbIi8ciNW7+F59VYxXq+V4c3d568Q6l2m8ew==",
       "requires": {
-        "@ethersproject/abstract-provider": "^5.3.0",
-        "@ethersproject/bignumber": "^5.3.0",
-        "@ethersproject/bytes": "^5.3.0",
-        "@ethersproject/logger": "^5.3.0",
-        "@ethersproject/properties": "^5.3.0"
+        "@ethersproject/abstract-provider": "^5.4.0",
+        "@ethersproject/bignumber": "^5.4.0",
+        "@ethersproject/bytes": "^5.4.0",
+        "@ethersproject/logger": "^5.4.0",
+        "@ethersproject/properties": "^5.4.0"
       }
     },
     "@ethersproject/address": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/address/-/address-5.3.0.tgz",
-      "integrity": "sha512-29TgjzEBK+gUEUAOfWCG7s9IxLNLCqvr+oDSk6L9TXD0VLvZJKhJV479tKQqheVA81OeGxfpdxYtUVH8hqlCvA==",
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/address/-/address-5.4.0.tgz",
+      "integrity": "sha512-SD0VgOEkcACEG/C6xavlU1Hy3m5DGSXW3CUHkaaEHbAPPsgi0coP5oNPsxau8eTlZOk/bpa/hKeCNoK5IzVI2Q==",
       "requires": {
-        "@ethersproject/bignumber": "^5.3.0",
-        "@ethersproject/bytes": "^5.3.0",
-        "@ethersproject/keccak256": "^5.3.0",
-        "@ethersproject/logger": "^5.3.0",
-        "@ethersproject/rlp": "^5.3.0"
+        "@ethersproject/bignumber": "^5.4.0",
+        "@ethersproject/bytes": "^5.4.0",
+        "@ethersproject/keccak256": "^5.4.0",
+        "@ethersproject/logger": "^5.4.0",
+        "@ethersproject/rlp": "^5.4.0"
       }
     },
     "@ethersproject/base64": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/base64/-/base64-5.3.0.tgz",
-      "integrity": "sha512-JIqgtOmgKcbc2sjGWTXyXktqUhvFUDte8fPVsAaOrcPiJf6YotNF+nsrOYGC9pbHBEGSuSBp3QR0varkO8JHEw==",
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/base64/-/base64-5.4.0.tgz",
+      "integrity": "sha512-CjQw6E17QDSSC5jiM9YpF7N1aSCHmYGMt9bWD8PWv6YPMxjsys2/Q8xLrROKI3IWJ7sFfZ8B3flKDTM5wlWuZQ==",
       "requires": {
-        "@ethersproject/bytes": "^5.3.0"
+        "@ethersproject/bytes": "^5.4.0"
       }
     },
     "@ethersproject/basex": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/basex/-/basex-5.3.0.tgz",
-      "integrity": "sha512-8J4nS6t/SOnoCgr3DF5WCSRLC5YwTKYpZWJqeyYQLX+86TwPhtzvHXacODzcDII9tWKhVg6g0Bka8JCBWXsCiQ==",
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/basex/-/basex-5.4.0.tgz",
+      "integrity": "sha512-J07+QCVJ7np2bcpxydFVf/CuYo9mZ7T73Pe7KQY4c1lRlrixMeblauMxHXD0MPwFmUHZIILDNViVkykFBZylbg==",
       "requires": {
-        "@ethersproject/bytes": "^5.3.0",
-        "@ethersproject/properties": "^5.3.0"
+        "@ethersproject/bytes": "^5.4.0",
+        "@ethersproject/properties": "^5.4.0"
       }
     },
     "@ethersproject/bignumber": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.3.0.tgz",
-      "integrity": "sha512-5xguJ+Q1/zRMgHgDCaqAexx/8DwDVLRemw2i6uR8KyGjwGdXI8f32QZZ1cKGucBN6ekJvpUpHy6XAuQnTv0mPA==",
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.4.0.tgz",
+      "integrity": "sha512-OXUu9f9hO3vGRIPxU40cignXZVaYyfx6j9NNMjebKdnaCL3anCLSSy8/b8d03vY6dh7duCC0kW72GEC4tZer2w==",
       "requires": {
-        "@ethersproject/bytes": "^5.3.0",
-        "@ethersproject/logger": "^5.3.0",
+        "@ethersproject/bytes": "^5.4.0",
+        "@ethersproject/logger": "^5.4.0",
         "bn.js": "^4.11.9"
       }
     },
     "@ethersproject/bytes": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.3.0.tgz",
-      "integrity": "sha512-rqLJjdVqCcn7glPer7Fxh87PRqlnRScVAoxcIP3PmOUNApMWJ6yRdOFfo2KvPAdO7Le3yEI1o0YW+Yvr7XCYvw==",
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.4.0.tgz",
+      "integrity": "sha512-H60ceqgTHbhzOj4uRc/83SCN9d+BSUnOkrr2intevqdtEMO1JFVZ1XL84OEZV+QjV36OaZYxtnt4lGmxcGsPfA==",
       "requires": {
-        "@ethersproject/logger": "^5.3.0"
+        "@ethersproject/logger": "^5.4.0"
       }
     },
     "@ethersproject/constants": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/constants/-/constants-5.3.0.tgz",
-      "integrity": "sha512-4y1feNOwEpgjAfiCFWOHznvv6qUF/H6uI0UKp8xdhftb+H+FbKflXg1pOgH5qs4Sr7EYBL+zPyPb+YD5g1aEyw==",
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/constants/-/constants-5.4.0.tgz",
+      "integrity": "sha512-tzjn6S7sj9+DIIeKTJLjK9WGN2Tj0P++Z8ONEIlZjyoTkBuODN+0VfhAyYksKi43l1Sx9tX2VlFfzjfmr5Wl3Q==",
       "requires": {
-        "@ethersproject/bignumber": "^5.3.0"
+        "@ethersproject/bignumber": "^5.4.0"
       }
     },
     "@ethersproject/contracts": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/contracts/-/contracts-5.3.0.tgz",
-      "integrity": "sha512-eDyQ8ltykvyQqnGZxb/c1e0OnEtzqXhNNC4BX8nhYBCaoBrYYuK/1fLmyEvc5+XUMoxNhwpYkoSSwvPLci7/Zg==",
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/contracts/-/contracts-5.4.0.tgz",
+      "integrity": "sha512-hkO3L3IhS1Z3ZtHtaAG/T87nQ7KiPV+/qnvutag35I0IkiQ8G3ZpCQ9NNOpSCzn4pWSW4CfzmtE02FcqnLI+hw==",
       "requires": {
-        "@ethersproject/abi": "^5.3.0",
-        "@ethersproject/abstract-provider": "^5.3.0",
-        "@ethersproject/abstract-signer": "^5.3.0",
-        "@ethersproject/address": "^5.3.0",
-        "@ethersproject/bignumber": "^5.3.0",
-        "@ethersproject/bytes": "^5.3.0",
-        "@ethersproject/constants": "^5.3.0",
-        "@ethersproject/logger": "^5.3.0",
-        "@ethersproject/properties": "^5.3.0",
-        "@ethersproject/transactions": "^5.3.0"
+        "@ethersproject/abi": "^5.4.0",
+        "@ethersproject/abstract-provider": "^5.4.0",
+        "@ethersproject/abstract-signer": "^5.4.0",
+        "@ethersproject/address": "^5.4.0",
+        "@ethersproject/bignumber": "^5.4.0",
+        "@ethersproject/bytes": "^5.4.0",
+        "@ethersproject/constants": "^5.4.0",
+        "@ethersproject/logger": "^5.4.0",
+        "@ethersproject/properties": "^5.4.0",
+        "@ethersproject/transactions": "^5.4.0"
       }
     },
     "@ethersproject/hash": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/hash/-/hash-5.3.0.tgz",
-      "integrity": "sha512-gAFZSjUPQ32CIfoKSMtMEQ+IO0kQxqhwz9fCIFt2DtAq2u4pWt8mL9Z5P0r6KkLcQU8LE9FmuPPyd+JvBzmr1w==",
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/hash/-/hash-5.4.0.tgz",
+      "integrity": "sha512-xymAM9tmikKgbktOCjW60Z5sdouiIIurkZUr9oW5NOex5uwxrbsYG09kb5bMcNjlVeJD3yPivTNzViIs1GCbqA==",
       "requires": {
-        "@ethersproject/abstract-signer": "^5.3.0",
-        "@ethersproject/address": "^5.3.0",
-        "@ethersproject/bignumber": "^5.3.0",
-        "@ethersproject/bytes": "^5.3.0",
-        "@ethersproject/keccak256": "^5.3.0",
-        "@ethersproject/logger": "^5.3.0",
-        "@ethersproject/properties": "^5.3.0",
-        "@ethersproject/strings": "^5.3.0"
+        "@ethersproject/abstract-signer": "^5.4.0",
+        "@ethersproject/address": "^5.4.0",
+        "@ethersproject/bignumber": "^5.4.0",
+        "@ethersproject/bytes": "^5.4.0",
+        "@ethersproject/keccak256": "^5.4.0",
+        "@ethersproject/logger": "^5.4.0",
+        "@ethersproject/properties": "^5.4.0",
+        "@ethersproject/strings": "^5.4.0"
       }
     },
     "@ethersproject/hdnode": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/hdnode/-/hdnode-5.3.0.tgz",
-      "integrity": "sha512-zLmmtLNoDMGoYRdjOab01Zqkvp+TmZyCGDAMQF1Bs3yZyBs/kzTNi1qJjR1jVUcPP5CWGtjFwY8iNG8oNV9J8g==",
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/hdnode/-/hdnode-5.4.0.tgz",
+      "integrity": "sha512-pKxdS0KAaeVGfZPp1KOiDLB0jba11tG6OP1u11QnYfb7pXn6IZx0xceqWRr6ygke8+Kw74IpOoSi7/DwANhy8Q==",
       "requires": {
-        "@ethersproject/abstract-signer": "^5.3.0",
-        "@ethersproject/basex": "^5.3.0",
-        "@ethersproject/bignumber": "^5.3.0",
-        "@ethersproject/bytes": "^5.3.0",
-        "@ethersproject/logger": "^5.3.0",
-        "@ethersproject/pbkdf2": "^5.3.0",
-        "@ethersproject/properties": "^5.3.0",
-        "@ethersproject/sha2": "^5.3.0",
-        "@ethersproject/signing-key": "^5.3.0",
-        "@ethersproject/strings": "^5.3.0",
-        "@ethersproject/transactions": "^5.3.0",
-        "@ethersproject/wordlists": "^5.3.0"
+        "@ethersproject/abstract-signer": "^5.4.0",
+        "@ethersproject/basex": "^5.4.0",
+        "@ethersproject/bignumber": "^5.4.0",
+        "@ethersproject/bytes": "^5.4.0",
+        "@ethersproject/logger": "^5.4.0",
+        "@ethersproject/pbkdf2": "^5.4.0",
+        "@ethersproject/properties": "^5.4.0",
+        "@ethersproject/sha2": "^5.4.0",
+        "@ethersproject/signing-key": "^5.4.0",
+        "@ethersproject/strings": "^5.4.0",
+        "@ethersproject/transactions": "^5.4.0",
+        "@ethersproject/wordlists": "^5.4.0"
       }
     },
     "@ethersproject/json-wallets": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/json-wallets/-/json-wallets-5.3.0.tgz",
-      "integrity": "sha512-/xwbqaIb5grUIGNmeEaz8GdcpmDr++X8WT4Jqcclnxow8PXCUHFeDxjf3O+nSuoqOYG/Ds0+BI5xuQKbva6Xkw==",
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/json-wallets/-/json-wallets-5.4.0.tgz",
+      "integrity": "sha512-igWcu3fx4aiczrzEHwG1xJZo9l1cFfQOWzTqwRw/xcvxTk58q4f9M7cjh51EKphMHvrJtcezJ1gf1q1AUOfEQQ==",
       "requires": {
-        "@ethersproject/abstract-signer": "^5.3.0",
-        "@ethersproject/address": "^5.3.0",
-        "@ethersproject/bytes": "^5.3.0",
-        "@ethersproject/hdnode": "^5.3.0",
-        "@ethersproject/keccak256": "^5.3.0",
-        "@ethersproject/logger": "^5.3.0",
-        "@ethersproject/pbkdf2": "^5.3.0",
-        "@ethersproject/properties": "^5.3.0",
-        "@ethersproject/random": "^5.3.0",
-        "@ethersproject/strings": "^5.3.0",
-        "@ethersproject/transactions": "^5.3.0",
+        "@ethersproject/abstract-signer": "^5.4.0",
+        "@ethersproject/address": "^5.4.0",
+        "@ethersproject/bytes": "^5.4.0",
+        "@ethersproject/hdnode": "^5.4.0",
+        "@ethersproject/keccak256": "^5.4.0",
+        "@ethersproject/logger": "^5.4.0",
+        "@ethersproject/pbkdf2": "^5.4.0",
+        "@ethersproject/properties": "^5.4.0",
+        "@ethersproject/random": "^5.4.0",
+        "@ethersproject/strings": "^5.4.0",
+        "@ethersproject/transactions": "^5.4.0",
         "aes-js": "3.0.0",
         "scrypt-js": "3.0.1"
       }
     },
     "@ethersproject/keccak256": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/keccak256/-/keccak256-5.3.0.tgz",
-      "integrity": "sha512-Gv2YqgIUmRbYVNIibafT0qGaeGYLIA/EdWHJ7JcVxVSs2vyxafGxOJ5VpSBHWeOIsE6OOaCelYowhuuTicgdFQ==",
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/keccak256/-/keccak256-5.4.0.tgz",
+      "integrity": "sha512-FBI1plWet+dPUvAzPAeHzRKiPpETQzqSUWR1wXJGHVWi4i8bOSrpC3NwpkPjgeXG7MnugVc1B42VbfnQikyC/A==",
       "requires": {
-        "@ethersproject/bytes": "^5.3.0",
+        "@ethersproject/bytes": "^5.4.0",
         "js-sha3": "0.5.7"
       }
     },
     "@ethersproject/logger": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.3.0.tgz",
-      "integrity": "sha512-8bwJ2gxJGkZZnpQSq5uSiZSJjyVTWmlGft4oH8vxHdvO1Asy4TwVepAhPgxIQIMxXZFUNMych1YjIV4oQ4I7dA=="
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.4.0.tgz",
+      "integrity": "sha512-xYdWGGQ9P2cxBayt64d8LC8aPFJk6yWCawQi/4eJ4+oJdMMjEBMrIcIMZ9AxhwpPVmnBPrsB10PcXGmGAqgUEQ=="
     },
     "@ethersproject/networks": {
-      "version": "5.3.1",
-      "resolved": "https://registry.npmjs.org/@ethersproject/networks/-/networks-5.3.1.tgz",
-      "integrity": "sha512-6uQKHkYChlsfeiZhQ8IHIqGE/sQsf25o9ZxAYpMxi15dLPzz3IxOEF5KiSD32aHwsjXVBKBSlo+teAXLlYJybw==",
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/@ethersproject/networks/-/networks-5.4.1.tgz",
+      "integrity": "sha512-8SvowCKz9Uf4xC5DTKI8+il8lWqOr78kmiqAVLYT9lzB8aSmJHQMD1GSuJI0CW4hMAnzocpGpZLgiMdzsNSPig==",
       "requires": {
-        "@ethersproject/logger": "^5.3.0"
+        "@ethersproject/logger": "^5.4.0"
       }
     },
     "@ethersproject/pbkdf2": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/pbkdf2/-/pbkdf2-5.3.0.tgz",
-      "integrity": "sha512-Q9ChVU6gBFiex0FSdtzo4b0SAKz3ZYcYVFLrEWHL0FnHvNk3J3WgAtRNtBQGQYn/T5wkoTdZttMbfBkFlaiWcA==",
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/pbkdf2/-/pbkdf2-5.4.0.tgz",
+      "integrity": "sha512-x94aIv6tiA04g6BnazZSLoRXqyusawRyZWlUhKip2jvoLpzJuLb//KtMM6PEovE47pMbW+Qe1uw+68ameJjB7g==",
       "requires": {
-        "@ethersproject/bytes": "^5.3.0",
-        "@ethersproject/sha2": "^5.3.0"
+        "@ethersproject/bytes": "^5.4.0",
+        "@ethersproject/sha2": "^5.4.0"
       }
     },
     "@ethersproject/properties": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/properties/-/properties-5.3.0.tgz",
-      "integrity": "sha512-PaHxJyM5/bfusk6vr3yP//JMnm4UEojpzuWGTmtL5X4uNhNnFNvlYilZLyDr4I9cTkIbipCMsAuIcXWsmdRnEw==",
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/properties/-/properties-5.4.0.tgz",
+      "integrity": "sha512-7jczalGVRAJ+XSRvNA6D5sAwT4gavLq3OXPuV/74o3Rd2wuzSL035IMpIMgei4CYyBdialJMrTqkOnzccLHn4A==",
       "requires": {
-        "@ethersproject/logger": "^5.3.0"
+        "@ethersproject/logger": "^5.4.0"
       }
     },
     "@ethersproject/providers": {
-      "version": "5.3.1",
-      "resolved": "https://registry.npmjs.org/@ethersproject/providers/-/providers-5.3.1.tgz",
-      "integrity": "sha512-HC63vENTrur6/JKEhcQbA8PRDj1FAesdpX98IW+xAAo3EAkf70ou5fMIA3KCGzJDLNTeYA4C2Bonz849tVLekg==",
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/@ethersproject/providers/-/providers-5.4.1.tgz",
+      "integrity": "sha512-p06eiFKz8nu/5Ju0kIX024gzEQIgE5pvvGrBCngpyVjpuLtUIWT3097Agw4mTn9/dEA0FMcfByzFqacBMSgCVg==",
       "requires": {
-        "@ethersproject/abstract-provider": "^5.3.0",
-        "@ethersproject/abstract-signer": "^5.3.0",
-        "@ethersproject/address": "^5.3.0",
-        "@ethersproject/basex": "^5.3.0",
-        "@ethersproject/bignumber": "^5.3.0",
-        "@ethersproject/bytes": "^5.3.0",
-        "@ethersproject/constants": "^5.3.0",
-        "@ethersproject/hash": "^5.3.0",
-        "@ethersproject/logger": "^5.3.0",
-        "@ethersproject/networks": "^5.3.0",
-        "@ethersproject/properties": "^5.3.0",
-        "@ethersproject/random": "^5.3.0",
-        "@ethersproject/rlp": "^5.3.0",
-        "@ethersproject/sha2": "^5.3.0",
-        "@ethersproject/strings": "^5.3.0",
-        "@ethersproject/transactions": "^5.3.0",
-        "@ethersproject/web": "^5.3.0",
+        "@ethersproject/abstract-provider": "^5.4.0",
+        "@ethersproject/abstract-signer": "^5.4.0",
+        "@ethersproject/address": "^5.4.0",
+        "@ethersproject/basex": "^5.4.0",
+        "@ethersproject/bignumber": "^5.4.0",
+        "@ethersproject/bytes": "^5.4.0",
+        "@ethersproject/constants": "^5.4.0",
+        "@ethersproject/hash": "^5.4.0",
+        "@ethersproject/logger": "^5.4.0",
+        "@ethersproject/networks": "^5.4.0",
+        "@ethersproject/properties": "^5.4.0",
+        "@ethersproject/random": "^5.4.0",
+        "@ethersproject/rlp": "^5.4.0",
+        "@ethersproject/sha2": "^5.4.0",
+        "@ethersproject/strings": "^5.4.0",
+        "@ethersproject/transactions": "^5.4.0",
+        "@ethersproject/web": "^5.4.0",
         "bech32": "1.1.4",
         "ws": "7.4.6"
       },
@@ -33120,138 +33177,138 @@
       }
     },
     "@ethersproject/random": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/random/-/random-5.3.0.tgz",
-      "integrity": "sha512-A5SL/4inutSwt3Fh2OD0x2gz+x6GHmuUnIPkR7zAiTidMD2N8F6tZdMF1hlQKWVCcVMWhEQg8mWijhEzm6BBYw==",
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/random/-/random-5.4.0.tgz",
+      "integrity": "sha512-pnpWNQlf0VAZDEOVp1rsYQosmv2o0ITS/PecNw+mS2/btF8eYdspkN0vIXrCMtkX09EAh9bdk8GoXmFXM1eAKw==",
       "requires": {
-        "@ethersproject/bytes": "^5.3.0",
-        "@ethersproject/logger": "^5.3.0"
+        "@ethersproject/bytes": "^5.4.0",
+        "@ethersproject/logger": "^5.4.0"
       }
     },
     "@ethersproject/rlp": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/rlp/-/rlp-5.3.0.tgz",
-      "integrity": "sha512-oI0joYpsRanl9guDubaW+1NbcpK0vJ3F/6Wpcanzcnqq+oaW9O5E98liwkEDPcb16BUTLIJ+ZF8GPIHYxJ/5Pw==",
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/rlp/-/rlp-5.4.0.tgz",
+      "integrity": "sha512-0I7MZKfi+T5+G8atId9QaQKHRvvasM/kqLyAH4XxBCBchAooH2EX5rL9kYZWwcm3awYV+XC7VF6nLhfeQFKVPg==",
       "requires": {
-        "@ethersproject/bytes": "^5.3.0",
-        "@ethersproject/logger": "^5.3.0"
+        "@ethersproject/bytes": "^5.4.0",
+        "@ethersproject/logger": "^5.4.0"
       }
     },
     "@ethersproject/sha2": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/sha2/-/sha2-5.3.0.tgz",
-      "integrity": "sha512-r5ftlwKcocYEuFz2JbeKOT5SAsCV4m1RJDsTOEfQ5L67ZC7NFDK5i7maPdn1bx4nPhylF9VAwxSrQ1esmwzylg==",
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/sha2/-/sha2-5.4.0.tgz",
+      "integrity": "sha512-siheo36r1WD7Cy+bDdE1BJ8y0bDtqXCOxRMzPa4bV1TGt/eTUUt03BHoJNB6reWJD8A30E/pdJ8WFkq+/uz4Gg==",
       "requires": {
-        "@ethersproject/bytes": "^5.3.0",
-        "@ethersproject/logger": "^5.3.0",
+        "@ethersproject/bytes": "^5.4.0",
+        "@ethersproject/logger": "^5.4.0",
         "hash.js": "1.1.7"
       }
     },
     "@ethersproject/signing-key": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/signing-key/-/signing-key-5.3.0.tgz",
-      "integrity": "sha512-+DX/GwHAd0ok1bgedV1cKO0zfK7P/9aEyNoaYiRsGHpCecN7mhLqcdoUiUzE7Uz86LBsxm5ssK0qA1kBB47fbQ==",
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/signing-key/-/signing-key-5.4.0.tgz",
+      "integrity": "sha512-q8POUeywx6AKg2/jX9qBYZIAmKSB4ubGXdQ88l40hmATj29JnG5pp331nAWwwxPn2Qao4JpWHNZsQN+bPiSW9A==",
       "requires": {
-        "@ethersproject/bytes": "^5.3.0",
-        "@ethersproject/logger": "^5.3.0",
-        "@ethersproject/properties": "^5.3.0",
+        "@ethersproject/bytes": "^5.4.0",
+        "@ethersproject/logger": "^5.4.0",
+        "@ethersproject/properties": "^5.4.0",
         "bn.js": "^4.11.9",
         "elliptic": "6.5.4",
         "hash.js": "1.1.7"
       }
     },
     "@ethersproject/solidity": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/solidity/-/solidity-5.3.0.tgz",
-      "integrity": "sha512-uLRBaNUiISHbut94XKewJgQh6UmydWTBp71I7I21pkjVXfZO2dJ5EOo3jCnumJc01M4LOm79dlNNmF3oGIvweQ==",
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/solidity/-/solidity-5.4.0.tgz",
+      "integrity": "sha512-XFQTZ7wFSHOhHcV1DpcWj7VXECEiSrBuv7JErJvB9Uo+KfCdc3QtUZV+Vjh/AAaYgezUEKbCtE6Khjm44seevQ==",
       "requires": {
-        "@ethersproject/bignumber": "^5.3.0",
-        "@ethersproject/bytes": "^5.3.0",
-        "@ethersproject/keccak256": "^5.3.0",
-        "@ethersproject/sha2": "^5.3.0",
-        "@ethersproject/strings": "^5.3.0"
+        "@ethersproject/bignumber": "^5.4.0",
+        "@ethersproject/bytes": "^5.4.0",
+        "@ethersproject/keccak256": "^5.4.0",
+        "@ethersproject/sha2": "^5.4.0",
+        "@ethersproject/strings": "^5.4.0"
       }
     },
     "@ethersproject/strings": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/strings/-/strings-5.3.0.tgz",
-      "integrity": "sha512-j/AzIGZ503cvhuF2ldRSjB0BrKzpsBMtCieDtn4TYMMZMQ9zScJn9wLzTQl/bRNvJbBE6TOspK0r8/Ngae/f2Q==",
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/strings/-/strings-5.4.0.tgz",
+      "integrity": "sha512-k/9DkH5UGDhv7aReXLluFG5ExurwtIpUfnDNhQA29w896Dw3i4uDTz01Quaptbks1Uj9kI8wo9tmW73wcIEaWA==",
       "requires": {
-        "@ethersproject/bytes": "^5.3.0",
-        "@ethersproject/constants": "^5.3.0",
-        "@ethersproject/logger": "^5.3.0"
+        "@ethersproject/bytes": "^5.4.0",
+        "@ethersproject/constants": "^5.4.0",
+        "@ethersproject/logger": "^5.4.0"
       }
     },
     "@ethersproject/transactions": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/transactions/-/transactions-5.3.0.tgz",
-      "integrity": "sha512-cdfK8VVyW2oEBCXhURG0WQ6AICL/r6Gmjh0e4Bvbv6MCn/GBd8FeBH3rtl7ho+AW50csMKeGv3m3K1HSHB2jMQ==",
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/transactions/-/transactions-5.4.0.tgz",
+      "integrity": "sha512-s3EjZZt7xa4BkLknJZ98QGoIza94rVjaEed0rzZ/jB9WrIuu/1+tjvYCWzVrystXtDswy7TPBeIepyXwSYa4WQ==",
       "requires": {
-        "@ethersproject/address": "^5.3.0",
-        "@ethersproject/bignumber": "^5.3.0",
-        "@ethersproject/bytes": "^5.3.0",
-        "@ethersproject/constants": "^5.3.0",
-        "@ethersproject/keccak256": "^5.3.0",
-        "@ethersproject/logger": "^5.3.0",
-        "@ethersproject/properties": "^5.3.0",
-        "@ethersproject/rlp": "^5.3.0",
-        "@ethersproject/signing-key": "^5.3.0"
+        "@ethersproject/address": "^5.4.0",
+        "@ethersproject/bignumber": "^5.4.0",
+        "@ethersproject/bytes": "^5.4.0",
+        "@ethersproject/constants": "^5.4.0",
+        "@ethersproject/keccak256": "^5.4.0",
+        "@ethersproject/logger": "^5.4.0",
+        "@ethersproject/properties": "^5.4.0",
+        "@ethersproject/rlp": "^5.4.0",
+        "@ethersproject/signing-key": "^5.4.0"
       }
     },
     "@ethersproject/units": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/units/-/units-5.3.0.tgz",
-      "integrity": "sha512-BkfccZGwfJ6Ob+AelpIrgAzuNhrN2VLp3AILnkqTOv+yBdsc83V4AYf25XC/u0rHnWl6f4POaietPwlMqP2vUg==",
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/units/-/units-5.4.0.tgz",
+      "integrity": "sha512-Z88krX40KCp+JqPCP5oPv5p750g+uU6gopDYRTBGcDvOASh6qhiEYCRatuM/suC4S2XW9Zz90QI35MfSrTIaFg==",
       "requires": {
-        "@ethersproject/bignumber": "^5.3.0",
-        "@ethersproject/constants": "^5.3.0",
-        "@ethersproject/logger": "^5.3.0"
+        "@ethersproject/bignumber": "^5.4.0",
+        "@ethersproject/constants": "^5.4.0",
+        "@ethersproject/logger": "^5.4.0"
       }
     },
     "@ethersproject/wallet": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/wallet/-/wallet-5.3.0.tgz",
-      "integrity": "sha512-boYBLydG6671p9QoG6EinNnNzbm7DNOjVT20eV8J6HQEq4aUaGiA2CytF2vK+2rOEWbzhZqoNDt6AlkE1LlsTg==",
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/wallet/-/wallet-5.4.0.tgz",
+      "integrity": "sha512-wU29majLjM6AjCjpat21mPPviG+EpK7wY1+jzKD0fg3ui5fgedf2zEu1RDgpfIMsfn8fJHJuzM4zXZ2+hSHaSQ==",
       "requires": {
-        "@ethersproject/abstract-provider": "^5.3.0",
-        "@ethersproject/abstract-signer": "^5.3.0",
-        "@ethersproject/address": "^5.3.0",
-        "@ethersproject/bignumber": "^5.3.0",
-        "@ethersproject/bytes": "^5.3.0",
-        "@ethersproject/hash": "^5.3.0",
-        "@ethersproject/hdnode": "^5.3.0",
-        "@ethersproject/json-wallets": "^5.3.0",
-        "@ethersproject/keccak256": "^5.3.0",
-        "@ethersproject/logger": "^5.3.0",
-        "@ethersproject/properties": "^5.3.0",
-        "@ethersproject/random": "^5.3.0",
-        "@ethersproject/signing-key": "^5.3.0",
-        "@ethersproject/transactions": "^5.3.0",
-        "@ethersproject/wordlists": "^5.3.0"
+        "@ethersproject/abstract-provider": "^5.4.0",
+        "@ethersproject/abstract-signer": "^5.4.0",
+        "@ethersproject/address": "^5.4.0",
+        "@ethersproject/bignumber": "^5.4.0",
+        "@ethersproject/bytes": "^5.4.0",
+        "@ethersproject/hash": "^5.4.0",
+        "@ethersproject/hdnode": "^5.4.0",
+        "@ethersproject/json-wallets": "^5.4.0",
+        "@ethersproject/keccak256": "^5.4.0",
+        "@ethersproject/logger": "^5.4.0",
+        "@ethersproject/properties": "^5.4.0",
+        "@ethersproject/random": "^5.4.0",
+        "@ethersproject/signing-key": "^5.4.0",
+        "@ethersproject/transactions": "^5.4.0",
+        "@ethersproject/wordlists": "^5.4.0"
       }
     },
     "@ethersproject/web": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/web/-/web-5.3.0.tgz",
-      "integrity": "sha512-Ni6/DHnY6k/TD41LEkv0RQDx4jqWz5e/RZvrSecsxGYycF+MFy2z++T/yGc2peRunLOTIFwEksgEGGlbwfYmhQ==",
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/web/-/web-5.4.0.tgz",
+      "integrity": "sha512-1bUusGmcoRLYgMn6c1BLk1tOKUIFuTg8j+6N8lYlbMpDesnle+i3pGSagGNvwjaiLo4Y5gBibwctpPRmjrh4Og==",
       "requires": {
-        "@ethersproject/base64": "^5.3.0",
-        "@ethersproject/bytes": "^5.3.0",
-        "@ethersproject/logger": "^5.3.0",
-        "@ethersproject/properties": "^5.3.0",
-        "@ethersproject/strings": "^5.3.0"
+        "@ethersproject/base64": "^5.4.0",
+        "@ethersproject/bytes": "^5.4.0",
+        "@ethersproject/logger": "^5.4.0",
+        "@ethersproject/properties": "^5.4.0",
+        "@ethersproject/strings": "^5.4.0"
       }
     },
     "@ethersproject/wordlists": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/wordlists/-/wordlists-5.3.0.tgz",
-      "integrity": "sha512-JcwumCZcsUxgWpiFU/BRy6b4KlTRdOmYvOKZcAw/3sdF93/pZyPW5Od2hFkHS8oWp4xS06YQ+qHqQhdcxdHafQ==",
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/wordlists/-/wordlists-5.4.0.tgz",
+      "integrity": "sha512-FemEkf6a+EBKEPxlzeVgUaVSodU7G0Na89jqKjmWMlDB0tomoU8RlEMgUvXyqtrg8N4cwpLh8nyRnm1Nay1isA==",
       "requires": {
-        "@ethersproject/bytes": "^5.3.0",
-        "@ethersproject/hash": "^5.3.0",
-        "@ethersproject/logger": "^5.3.0",
-        "@ethersproject/properties": "^5.3.0",
-        "@ethersproject/strings": "^5.3.0"
+        "@ethersproject/bytes": "^5.4.0",
+        "@ethersproject/hash": "^5.4.0",
+        "@ethersproject/logger": "^5.4.0",
+        "@ethersproject/properties": "^5.4.0",
+        "@ethersproject/strings": "^5.4.0"
       }
     },
     "@fullhuman/postcss-purgecss": {
@@ -37964,6 +38021,7 @@
     },
     "@vue/compiler-core": {
       "version": "3.0.11",
+      "devOptional": true,
       "requires": {
         "@babel/parser": "^7.12.0",
         "@babel/types": "^7.12.0",
@@ -37973,12 +38031,14 @@
       },
       "dependencies": {
         "source-map": {
-          "version": "0.6.1"
+          "version": "0.6.1",
+          "devOptional": true
         }
       }
     },
     "@vue/compiler-dom": {
       "version": "3.0.11",
+      "devOptional": true,
       "requires": {
         "@vue/compiler-core": "3.0.11",
         "@vue/shared": "3.0.11"
@@ -38136,28 +38196,56 @@
       "requires": {}
     },
     "@vue/reactivity": {
-      "version": "3.0.11",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.1.4.tgz",
+      "integrity": "sha512-YDlgii2Cr9yAoKVZFzgY4j0mYlVT73986X3e5SPp6ifqckSEoFSUWXZK2Tb53TB/9qO29BEEbspnKD3m3wAwkA==",
       "requires": {
-        "@vue/shared": "3.0.11"
+        "@vue/shared": "3.1.4"
+      },
+      "dependencies": {
+        "@vue/shared": {
+          "version": "3.1.4",
+          "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.1.4.tgz",
+          "integrity": "sha512-6O45kZAmkLvzGLToBxEz4lR2W6kXohCtebV2UxjH9GXjd8X9AhEn68FN9eNanFtWNzvgw1hqd6HkPRVQalqf7Q=="
+        }
       }
     },
     "@vue/runtime-core": {
-      "version": "3.0.11",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.1.4.tgz",
+      "integrity": "sha512-qmVJgJuFxfT7M4qHQ4M6KqhKC66fjuswK+aBivE8dWiZ2rtIGl9gtJGpwqwjQEcKEBTOfvvrtrwBncYArJUO8Q==",
       "requires": {
-        "@vue/reactivity": "3.0.11",
-        "@vue/shared": "3.0.11"
+        "@vue/reactivity": "3.1.4",
+        "@vue/shared": "3.1.4"
+      },
+      "dependencies": {
+        "@vue/shared": {
+          "version": "3.1.4",
+          "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.1.4.tgz",
+          "integrity": "sha512-6O45kZAmkLvzGLToBxEz4lR2W6kXohCtebV2UxjH9GXjd8X9AhEn68FN9eNanFtWNzvgw1hqd6HkPRVQalqf7Q=="
+        }
       }
     },
     "@vue/runtime-dom": {
-      "version": "3.0.11",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.1.4.tgz",
+      "integrity": "sha512-vbmwgTxku1BU87Kw7r29adv0OIrDXCW0PslOPQT0O/9R5SqcXgS94Yj6zsztDjvghegenwIAPNLlDR1Auh5s+w==",
       "requires": {
-        "@vue/runtime-core": "3.0.11",
-        "@vue/shared": "3.0.11",
+        "@vue/runtime-core": "3.1.4",
+        "@vue/shared": "3.1.4",
         "csstype": "^2.6.8"
+      },
+      "dependencies": {
+        "@vue/shared": {
+          "version": "3.1.4",
+          "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.1.4.tgz",
+          "integrity": "sha512-6O45kZAmkLvzGLToBxEz4lR2W6kXohCtebV2UxjH9GXjd8X9AhEn68FN9eNanFtWNzvgw1hqd6HkPRVQalqf7Q=="
+        }
       }
     },
     "@vue/shared": {
-      "version": "3.0.11"
+      "version": "3.0.11",
+      "devOptional": true
     },
     "@vue/test-utils": {
       "version": "2.0.0-rc.4",
@@ -42744,40 +42832,40 @@
       }
     },
     "ethers": {
-      "version": "https://registry.npmjs.org/ethers/-/ethers-5.3.1.tgz",
-      "integrity": "sha512-xCKmC0gsZ9gks89ZfK3B1y6LlPdvX5fxDtu9SytnpdDJR1M7pmJI+4H0AxQPMgUYr7GtQdmECLR0gWdJQ+lZYw==",
+      "version": "https://registry.npmjs.org/ethers/-/ethers-5.4.1.tgz",
+      "integrity": "sha512-SrcddMdCgP1hukDvCPd87Aipbf4NWjQvdfAbZ65XSZGbfyuYPtIrUJPDH5B1SBRsdlfiEgX3eoz28DdBDzMNFg==",
       "peer": true,
       "requires": {
-        "@ethersproject/abi": "5.3.1",
-        "@ethersproject/abstract-provider": "5.3.0",
-        "@ethersproject/abstract-signer": "5.3.0",
-        "@ethersproject/address": "5.3.0",
-        "@ethersproject/base64": "5.3.0",
-        "@ethersproject/basex": "5.3.0",
-        "@ethersproject/bignumber": "5.3.0",
-        "@ethersproject/bytes": "5.3.0",
-        "@ethersproject/constants": "5.3.0",
-        "@ethersproject/contracts": "5.3.0",
-        "@ethersproject/hash": "5.3.0",
-        "@ethersproject/hdnode": "5.3.0",
-        "@ethersproject/json-wallets": "5.3.0",
-        "@ethersproject/keccak256": "5.3.0",
-        "@ethersproject/logger": "5.3.0",
-        "@ethersproject/networks": "5.3.1",
-        "@ethersproject/pbkdf2": "5.3.0",
-        "@ethersproject/properties": "5.3.0",
-        "@ethersproject/providers": "5.3.1",
-        "@ethersproject/random": "5.3.0",
-        "@ethersproject/rlp": "5.3.0",
-        "@ethersproject/sha2": "5.3.0",
-        "@ethersproject/signing-key": "5.3.0",
-        "@ethersproject/solidity": "5.3.0",
-        "@ethersproject/strings": "5.3.0",
-        "@ethersproject/transactions": "5.3.0",
-        "@ethersproject/units": "5.3.0",
-        "@ethersproject/wallet": "5.3.0",
-        "@ethersproject/web": "5.3.0",
-        "@ethersproject/wordlists": "5.3.0"
+        "@ethersproject/abi": "5.4.0",
+        "@ethersproject/abstract-provider": "5.4.0",
+        "@ethersproject/abstract-signer": "5.4.0",
+        "@ethersproject/address": "5.4.0",
+        "@ethersproject/base64": "5.4.0",
+        "@ethersproject/basex": "5.4.0",
+        "@ethersproject/bignumber": "5.4.0",
+        "@ethersproject/bytes": "5.4.0",
+        "@ethersproject/constants": "5.4.0",
+        "@ethersproject/contracts": "5.4.0",
+        "@ethersproject/hash": "5.4.0",
+        "@ethersproject/hdnode": "5.4.0",
+        "@ethersproject/json-wallets": "5.4.0",
+        "@ethersproject/keccak256": "5.4.0",
+        "@ethersproject/logger": "5.4.0",
+        "@ethersproject/networks": "5.4.1",
+        "@ethersproject/pbkdf2": "5.4.0",
+        "@ethersproject/properties": "5.4.0",
+        "@ethersproject/providers": "5.4.1",
+        "@ethersproject/random": "5.4.0",
+        "@ethersproject/rlp": "5.4.0",
+        "@ethersproject/sha2": "5.4.0",
+        "@ethersproject/signing-key": "5.4.0",
+        "@ethersproject/solidity": "5.4.0",
+        "@ethersproject/strings": "5.4.0",
+        "@ethersproject/transactions": "5.4.0",
+        "@ethersproject/units": "5.4.0",
+        "@ethersproject/wallet": "5.4.0",
+        "@ethersproject/web": "5.4.0",
+        "@ethersproject/wordlists": "5.4.0"
       }
     },
     "ethjs-unit": {
@@ -52502,11 +52590,46 @@
       "dev": true
     },
     "vue": {
-      "version": "3.0.11",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/vue/-/vue-3.1.4.tgz",
+      "integrity": "sha512-p8dcdyeCgmaAiZsbLyDkmOLcFGZb/jEVdCLW65V68LRCXTNX8jKsgah2F7OZ/v/Ai2V0Fb1MNO0vz/GFqsPVMA==",
       "requires": {
-        "@vue/compiler-dom": "3.0.11",
-        "@vue/runtime-dom": "3.0.11",
-        "@vue/shared": "3.0.11"
+        "@vue/compiler-dom": "3.1.4",
+        "@vue/runtime-dom": "3.1.4",
+        "@vue/shared": "3.1.4"
+      },
+      "dependencies": {
+        "@vue/compiler-core": {
+          "version": "3.1.4",
+          "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.1.4.tgz",
+          "integrity": "sha512-TnUz+1z0y74O/A4YKAbzsdUfamyHV73MihrEfvettWpm9bQKVoZd1nEmR1cGN9LsXWlwAvVQBetBlWdOjmQO5Q==",
+          "requires": {
+            "@babel/parser": "^7.12.0",
+            "@babel/types": "^7.12.0",
+            "@vue/shared": "3.1.4",
+            "estree-walker": "^2.0.1",
+            "source-map": "^0.6.1"
+          }
+        },
+        "@vue/compiler-dom": {
+          "version": "3.1.4",
+          "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.1.4.tgz",
+          "integrity": "sha512-3tG2ScHkghhUBuFwl9KgyZhrS8CPFZsO7hUDekJgIp5b1OMkROr4AvxHu6rRMl4WkyvYkvidFNBS2VfOnwa6Kw==",
+          "requires": {
+            "@vue/compiler-core": "3.1.4",
+            "@vue/shared": "3.1.4"
+          }
+        },
+        "@vue/shared": {
+          "version": "3.1.4",
+          "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.1.4.tgz",
+          "integrity": "sha512-6O45kZAmkLvzGLToBxEz4lR2W6kXohCtebV2UxjH9GXjd8X9AhEn68FN9eNanFtWNzvgw1hqd6HkPRVQalqf7Q=="
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+        }
       }
     },
     "vue-cli-plugin-webpack-bundle-analyzer": {

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "pretty-ms": "^7.0.0",
     "tailwindcss": "npm:@tailwindcss/postcss7-compat@^2.0.4",
     "typescript": "~3.9.3",
-    "vue": "^3.0.0-beta.1",
+    "vue": "^3.1.4",
     "vue-echarts": "^6.0.0-rc.4",
     "vue-i18n": "^9.0.0-rc.1",
     "vue-query": "^1.6.0",

--- a/src/App.vue
+++ b/src/App.vue
@@ -55,7 +55,7 @@ export default defineComponent({
 
     // CALLBACKS
     onBeforeMount(() => {
-      // registerProviders();  
+      // registerProviders();
       store.dispatch('app/init');
       providerService.initBlockListener(setBlockNumber);
     });

--- a/src/App.vue
+++ b/src/App.vue
@@ -25,6 +25,7 @@ import WalletSelectModal from '@/components/web3/WalletSelectModal.vue';
 import useVueWeb3 from './services/web3/useVueWeb3';
 import RpcProviderService from '@/services/rpc-provider/rpc-provider.service';
 import { useRoute } from 'vue-router';
+// import registerProviders from '@/plugins/providers/registerProviders';
 
 export default defineComponent({
   components: {
@@ -54,6 +55,7 @@ export default defineComponent({
 
     // CALLBACKS
     onBeforeMount(() => {
+      // registerProviders();  
       store.dispatch('app/init');
       providerService.initBlockListener(setBlockNumber);
     });

--- a/src/AppProviders.vue
+++ b/src/AppProviders.vue
@@ -1,0 +1,42 @@
+<script lang="ts">
+import { defineComponent, h } from 'vue';
+
+import Provider from '@/plugins/providers/Provider.vue';
+import provideTokenStore from '@/plugins/providers/tokenstore.provider';
+import provideTokens from '@/plugins/providers/tokens.provider';
+import provideAccountBalances from '@/plugins/providers/balances.provider';
+import provideAccountAllowances from '@/plugins/providers/allowances.provider';
+
+const providers = [
+  provideTokenStore,
+  provideAccountBalances,
+  provideTokens,
+  provideAccountAllowances
+];
+
+import App from './App.vue';
+export default defineComponent({
+  components: {
+    App,
+    Provider
+  },
+  render() {
+    const renderProvider = (providerFunctions: Function[]) => {
+      if (!providerFunctions.length) {
+        return h(App, {});
+      }
+      const [providerFunction, ...remainder] = providerFunctions;
+      return h(
+        Provider,
+        { providerFunction: providerFunction as Function },
+        {
+          default() {
+            return [renderProvider(remainder)];
+          }
+        }
+      );
+    };
+    return renderProvider(providers);
+  }
+});
+</script>

--- a/src/components/modals/SelectTokenModal/SelectTokenModal.vue
+++ b/src/components/modals/SelectTokenModal/SelectTokenModal.vue
@@ -104,11 +104,11 @@
 </template>
 
 <script lang="ts">
-import { defineComponent, reactive, toRefs, computed } from 'vue';
+import { defineComponent, reactive, toRefs, computed, watch } from 'vue';
 import { useStore } from 'vuex';
 import { useI18n } from 'vue-i18n';
 import { isAddress, getAddress } from '@ethersproject/address';
-import useTokenLists from '@/composables/useTokensStore';
+import useTokenStore from '@/composables/useTokensStore';
 // import useTokenLists2 from '@/composables/useTokenLists2';
 import TokenListItem from '@/components/lists/TokenListItem.vue';
 import TokenListsListItem from '@/components/lists/TokenListsListItem.vue';
@@ -147,15 +147,18 @@ export default defineComponent({
       isActiveList,
       listMap,
       activeTokenLists
-    } = useTokenLists();
-    const { tokens: tokenMap } = useTokens(data);
-    const tokens = computed(() => Object.values(tokenMap.value));
+    } = useTokenStore();
+
+    const { tokens: tokenMap } = useTokens(toRefs(data));
+    const tokens = computed(() => {
+      return Object.values(tokenMap.value);
+    });
     // const {
     //   approvedTokenLists,
     //   toggleList,
     //   toggled: toggledTokenLists,
     //   isToggled: isToggledList
-    // } = useTokenLists2();
+    // } = useTokenStore2();
 
     // COMPOSABLES
     const store = useStore();

--- a/src/composables/useAccountBalances.ts
+++ b/src/composables/useAccountBalances.ts
@@ -1,90 +1,21 @@
-import getProvider from '@/lib/utils/provider';
-import { useQuery } from 'vue-query';
-import { computed, reactive } from 'vue';
-import { getBalances } from '@/lib/utils/balancer/tokens';
-import { formatEther, formatUnits } from '@ethersproject/units';
-import { getAddress } from '@ethersproject/address';
-import QUERY_KEYS from '@/constants/queryKeys';
-import { ETHER } from '@/constants/tokenlists';
-import useVueWeb3 from '@/services/web3/useVueWeb3';
-import useTokenStore from './useTokensStore';
+import {
+  BalancesProviderPayload,
+  BalancesProviderSymbol
+} from '@/plugins/providers/balances.provider';
+import { inject } from 'vue';
 
 // THE CONTENTS OF THIS WILL BE REPLACED/ALTERED WITH THE REGISTRY REFACTOR
 export default function useAccountBalances() {
-  const { account, userNetworkConfig, isWalletReady } = useVueWeb3();
-  const { allTokens: tokens, isLoading: isLoadingTokens } = useTokenStore();
-
-  const isQueryEnabled = computed(
-    () =>
-      account.value !== null &&
-      Object.keys(tokens).length !== 0 &&
-      isWalletReady.value &&
-      !isLoadingTokens.value
-  );
-
   const {
-    data,
+    balances,
+    hasBalance,
     error,
     isLoading,
     isIdle,
     isError,
     isFetching,
-    refetch: refetchBalances
-  } = useQuery(
-    reactive(QUERY_KEYS.Balances.All(account, userNetworkConfig, tokens)),
-    () => {
-      return Promise.all([
-        getBalances(
-          String(userNetworkConfig.value?.chainId),
-          getProvider(userNetworkConfig.value?.key),
-          account.value,
-          Object.values(tokens.value)
-            .map(token => token.address)
-            .filter(token => token !== ETHER.address)
-        ),
-        getProvider(userNetworkConfig.value?.key).getBalance(
-          account.value.toLowerCase()
-        )
-      ]);
-    },
-    reactive({
-      enabled: isQueryEnabled,
-      keepPreviousData: isWalletReady
-    })
-  );
-
-  const balances = computed(() => {
-    if (data.value) {
-      const balances = {};
-      Object.keys(data.value[0]).forEach((tokenAddress: string) => {
-        const balance = formatUnits(
-          data.value[0][tokenAddress],
-          tokens.value[getAddress(tokenAddress)]?.decimals || 18
-        );
-        // not concerned with tokens which have a 0 balance
-        if (balance === '0.0') return;
-        balances[tokenAddress] = {
-          balance,
-          symbol: tokens.value[getAddress(tokenAddress)].symbol,
-          address: getAddress(tokenAddress)
-        };
-      });
-
-      // separate case for native ether
-      balances[ETHER.address.toLowerCase()] = {
-        balance: formatEther(data.value[1] || 0),
-        symbol: ETHER.symbol,
-        address: ETHER.address
-      };
-      return balances;
-    }
-    return null;
-  });
-
-  function hasBalance(address: string): boolean {
-    return (balances.value || {})[address];
-  }
-
+    refetchBalances
+  } = inject(BalancesProviderSymbol) as BalancesProviderPayload;
   return {
     balances,
     hasBalance,

--- a/src/composables/useAllowances.ts
+++ b/src/composables/useAllowances.ts
@@ -1,88 +1,29 @@
-import useVueWeb3 from '@/services/web3/useVueWeb3';
-import { useQuery } from 'vue-query';
-import { getAllowances } from '@/lib/utils/balancer/tokens';
-import getProvider from '@/lib/utils/provider';
-import { computed, reactive, Ref, ref } from 'vue';
-import { ETHER } from '@/constants/tokenlists';
-import { isAddress } from 'web3-utils';
-import QUERY_KEYS from '@/constants/queryKeys';
-import useTokens from './useTokens';
+import { inject, onBeforeMount, Ref, watch } from 'vue';
+import {
+  AllowancesProviderSymbol,
+  AllowancesProviderPayload
+} from '@/plugins/providers/allowances.provider';
 
 type UseAccountPayload = {
   tokens?: Ref<string[]>;
   dstList?: Ref<string[]>;
 };
 
-const dstAllowanceMap = ref({});
-
 // THE CONTENTS OF THIS WILL BE REPLACED/ALTERED WITH THE REGISTRY REFACTOR
 export default function useAllowances(payload?: UseAccountPayload) {
-  const { userNetworkConfig, account } = useVueWeb3();
-  const { tokens: allTokens } = useTokens();
-  const provider = getProvider(String(userNetworkConfig.value?.chainId));
-  // filter out ether and any bad addresses
-  const tokens = computed(() =>
-    (payload?.tokens?.value || Object.keys(allTokens.value)).filter(
-      t => t !== ETHER.address && isAddress(t)
-    )
-  );
-  const dstList = computed(() => [
-    ...(payload?.dstList?.value || []),
-    userNetworkConfig.value?.addresses.vault
-  ]);
-
-  const isQueryEnabled = computed(
-    () => account.value != '' && tokens.value.length > 0
-  );
   const {
-    data: allowances,
-    isLoading,
-    isFetching,
-    refetch: refetchAllowances
-  } = useQuery(
-    QUERY_KEYS.Account.Allowances(userNetworkConfig, account, dstList, tokens),
-    () =>
-      Promise.all(
-        dstList.value.map(async dst =>
-          getAllowances(
-            String(userNetworkConfig.value?.chainId),
-            provider,
-            account.value,
-            dst,
-            tokens.value
-          )
-        )
-      ),
-    reactive({
-      enabled: isQueryEnabled,
-      onSuccess: allowances => {
-        allowances.forEach((allowance, i) => {
-          dstAllowanceMap.value[dstList.value[i]] = allowance;
-        });
-      }
-    })
-  );
+    allowances,
+    getRequiredAllowances,
+    isLoading: isLoadingOrFetching,
+    refetchAllowances,
+    updateAllowanceRequest
+  } = inject(AllowancesProviderSymbol) as AllowancesProviderPayload;
 
-  const isLoadingOrFetching = computed(
-    () => isLoading.value || isFetching.value
-  );
-
-  const getRequiredAllowances = query => {
-    const tokens = query.tokens;
-    const amounts = query.amounts;
-    const dst = query.dst || userNetworkConfig.value?.addresses.vault;
-
-    const requiredAllowances = tokens.filter((token, index) => {
-      const amount = amounts[index];
-      if (parseFloat(amount) == 0) return false;
-      if (!dstAllowanceMap.value) return false;
-      if (!dstAllowanceMap.value[dst]) return true;
-      if (!dstAllowanceMap.value[dst][token.toLowerCase()]) return true;
-      return dstAllowanceMap.value[dst][token.toLowerCase()].lt(amount);
-    });
-
-    return requiredAllowances;
-  };
+  onBeforeMount(() => {
+    if (payload) {
+      updateAllowanceRequest(payload);
+    }
+  });
 
   return {
     allowances,

--- a/src/composables/useTokens.ts
+++ b/src/composables/useTokens.ts
@@ -1,73 +1,22 @@
-import { Token, TokenMap } from '@/types';
-import { getAddress } from '@ethersproject/address';
-import { keyBy, orderBy, uniqBy } from 'lodash';
-import { computed } from 'vue';
-import { useStore } from 'vuex';
-import useAccountBalances from './useAccountBalances';
-import useTokenStore from './useTokensStore';
-
-type TokenRequest = {
-  query?: string;
-  queryAddress?: string;
-};
+import {
+  TokenRequest,
+  TokensProviderPayload,
+  TokensProviderSymbol
+} from '@/plugins/providers/tokens.provider';
+import { inject, onBeforeMount } from 'vue';
 
 export default function useTokens(request?: TokenRequest) {
-  const store = useStore();
-  const prices = computed(() => store.state.market.prices);
-  const { allTokens: _allTokens } = useTokenStore();
-  const { balances } = useAccountBalances();
+  const { tokens, updateTokenRequest } = inject(
+    TokensProviderSymbol
+  ) as TokensProviderPayload;
 
-  const tokensList = computed(() => {
-    const _tokens = uniqBy<Token>(
-      orderBy(
-        // populate token data into list of tokens
-        Object.values(_allTokens.value).map(token => {
-          const balance =
-            (balances.value || {})[token.address.toLowerCase()]?.balance || '0';
-          const price = prices.value[token.address.toLowerCase()]?.price || 0;
-          const value = balance * price;
-          const price24HChange =
-            prices.value[token.address.toLowerCase()]?.price24HChange || 0;
-          const value24HChange = (value / 100) * price24HChange;
-          return {
-            ...token,
-            address: getAddress(token.address), // Enforce that we use checksummed addresses
-            value,
-            price,
-            price24HChange,
-            balance,
-            value24HChange
-          };
-        }),
-        ['value', 'balance'],
-        ['desc', 'desc']
-      ),
-      'address'
-    );
-
-    if (request?.queryAddress) {
-      const queryAddressLC = request?.queryAddress?.toLowerCase();
-
-      return _tokens.filter(
-        token => token.address?.toLowerCase() === queryAddressLC
-      );
+  onBeforeMount(() => {
+    if (request) {
+      updateTokenRequest(request);
     }
-
-    // search functionality, this can be better
-    if (request?.query) {
-      const queryLC = request?.query?.toLowerCase();
-
-      return _tokens.filter(
-        token =>
-          token.name.toLowerCase().includes(queryLC) ||
-          token.symbol.toLowerCase().includes(queryLC)
-      );
-    }
-
-    return _tokens;
   });
 
-  const tokens = computed(() => keyBy(tokensList.value, 'address') as TokenMap);
-
-  return { tokens };
+  return {
+    tokens
+  };
 }

--- a/src/composables/useTokensStore.ts
+++ b/src/composables/useTokensStore.ts
@@ -1,15 +1,8 @@
-import { computed, ref } from 'vue';
-import { useStore } from 'vuex';
-import { useQuery } from 'vue-query';
-import { flatten, keyBy } from 'lodash';
-
-import QUERY_KEYS from '@/constants/queryKeys';
-import TOKEN_LISTS from '@/constants/tokenlists';
-
-import { getTokensListURL, loadTokenlist } from '@/lib/utils/tokenlists';
-import { lsGet, lsSet } from '@/lib/utils';
-
-import { Token } from '@/types';
+import { computed, inject, ref, watch } from 'vue';
+import {
+  TokenStoreProviderPayload,
+  TokenStoreProviderSymbol
+} from '@/plugins/providers/tokenstore.provider';
 
 export type TokenListItem = {
   address: string;
@@ -35,93 +28,31 @@ type TokenList = {
   tokenListsURL: string;
 };
 
-const loadAllTokenLists = async () => {
-  // since a request to retrieve the list can fail
-  // it is best to use allSettled as we still want to
-  // retrieve what we can
-  return (
-    await Promise.allSettled(
-      TOKEN_LISTS.Approved.map(async listURI => {
-        const tokenList = (await loadTokenlist(listURI)) as Omit<
-          TokenList,
-          'tokenListsURL'
-        >;
-
-        return {
-          ...tokenList,
-          tokenListsURL: getTokensListURL(listURI)
-        };
-      })
-    )
-  )
-    .filter(result => result.status === 'fulfilled')
-    .map(result => (result as PromiseFulfilledResult<TokenList>).value);
-};
-
 // THE CONTENTS OF THIS WILL BE REPLACED/ALTERED WITH THE REGISTRY REFACTOR
 
 // This composable retrieves all the tokens from active token lists,
 // all the injected tokens from the store and the ETHER token
 // for other composables to build upon
 export default function useTokenStore() {
-  const store = useStore();
-  const activeTokenLists = ref<string[]>(
-    lsGet('activeTokenLists', ['Balancer'])
-  );
-  const queryKey = QUERY_KEYS.TokenLists;
-  const queryFn = loadAllTokenLists;
-
-  const { data: lists, isLoading, refetch: refreshTokenLists } = useQuery<
-    TokenList[]
-  >(queryKey, queryFn, {
-    refetchOnMount: false,
-    refetchOnWindowFocus: false
-  });
-
-  const listMap = computed(() => keyBy(lists.value, 'name'));
-  const injectedTokens = computed(() => store.state.registry.injected);
-
-  const allTokens = computed(() => {
-    // get all the tokens from all the active lists
-    // get all tokens that are injected
-    // get the ETHER token ALWAYS
-    return keyBy(
-      flatten([
-        ...Object.values(injectedTokens.value).map((t: any) => ({ ...t })),
-        ...activeTokenLists.value.map(name => listMap.value[name]?.tokens),
-        store.getters['registry/getEther']()
-      ])
-        // invalid network tokens get filtered out
-        .filter(
-          token => token?.chainId === Number(process.env.VUE_APP_NETWORK || 1)
-        ) as Token[],
-      'address'
-    );
-  });
-
-  const toggleActiveTokenList = (name: string) => {
-    if (activeTokenLists.value.includes(name)) {
-      activeTokenLists.value = activeTokenLists.value.filter(
-        listName => listName !== name
-      );
-    } else {
-      activeTokenLists.value.push(name);
-    }
-    lsSet('activeTokenLists', activeTokenLists.value);
-  };
-
-  const isActiveList = (name: string) => {
-    return activeTokenLists.value.includes(name);
-  };
+  const {
+    isLoading,
+    lists,
+    allTokens,
+    listMap,
+    activeTokenLists,
+    refreshTokenLists,
+    toggleActiveTokenList,
+    isActiveList
+  } = inject(TokenStoreProviderSymbol) as TokenStoreProviderPayload;
 
   return {
     isLoading,
     lists,
-    toggleActiveTokenList,
-    isActiveList,
-    refreshTokenLists,
     allTokens,
     listMap,
-    activeTokenLists
+    activeTokenLists,
+    refreshTokenLists,
+    toggleActiveTokenList,
+    isActiveList
   };
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,5 +1,5 @@
 import { createApp } from 'vue';
-import App from '@/App.vue';
+import AppProviders from '@/AppProviders.vue';
 import store from '@/store';
 import router from '@/plugins/router';
 import mixins from '@/plugins/mixins';
@@ -41,16 +41,16 @@ use([
   MarkLineComponent
 ]);
 
-const app = createApp(App)
+const app = createApp(AppProviders)
   .use(i18n)
   .use(router)
   .use(store)
   .use(blocknative)
   .use(VueApexCharts)
   .use(vueQuery)
-  .use(VueVirtualScroller)
   .use(Web3Plugin, Web3Provider)
-  .mixin(mixins);
+  .mixin(mixins)
+  .use(VueVirtualScroller);
 
 registerDirectives(app);
 registerGlobalComponents(app);

--- a/src/pages/Trade.vue
+++ b/src/pages/Trade.vue
@@ -16,7 +16,7 @@ import { useStore } from 'vuex';
 
 import TradeCard from '@/components/cards/TradeCard/TradeCard.vue';
 import TradeCardGP from '@/components/cards/TradeCardGP/TradeCardGP.vue';
-import useTokenLists from '@/composables/useTokensStore';
+import useTokenStore from '@/composables/useTokensStore';
 import { TradeInterface } from '@/store/modules/app';
 import usePoolFilters from '@/composables/pools/usePoolFilters';
 
@@ -29,7 +29,7 @@ export default defineComponent({
   setup() {
     // COMPOSABLES
     const store = useStore();
-    const { isLoading: isLoadingTokens } = useTokenLists();
+    const { isLoading: isLoadingTokens } = useTokenStore();
     const { setSelectedTokens } = usePoolFilters();
 
     // COMPUTED

--- a/src/plugins/providers/Provider.vue
+++ b/src/plugins/providers/Provider.vue
@@ -1,0 +1,19 @@
+<template>
+  <slot />
+</template>
+
+<script lang="ts">
+import { defineComponent } from 'vue';
+
+export default defineComponent({
+  props: {
+    providerFunction: {
+      type: Function,
+      required: true
+    }
+  },
+  setup(props) {
+    props.providerFunction();
+  }
+});
+</script>

--- a/src/plugins/providers/allowances.provider.ts
+++ b/src/plugins/providers/allowances.provider.ts
@@ -1,0 +1,109 @@
+import useVueWeb3 from '@/services/web3/useVueWeb3';
+import { useQuery } from 'vue-query';
+import { getAllowances } from '@/lib/utils/balancer/tokens';
+import getProvider from '@/lib/utils/provider';
+import { computed, provide, reactive, Ref, ref } from 'vue';
+import { ETHER } from '@/constants/tokenlists';
+import { isAddress } from 'web3-utils';
+import QUERY_KEYS from '@/constants/queryKeys';
+import useTokens from '@/composables/useTokens';
+
+type UseAccountPayload = {
+  tokens?: Ref<string[]>;
+  dstList?: Ref<string[]>;
+};
+
+export type AllowancesProviderPayload = {
+  allowances: Ref<any>;
+  getRequiredAllowances: (query: any) => any;
+  isLoading: Ref<boolean>;
+  refetchAllowances: Ref<Function>;
+  updateAllowanceRequest: (payload: UseAccountPayload) => void;
+};
+
+export const AllowancesProviderSymbol = Symbol('ALLOWANCES_PROVIDER');
+
+const dstAllowanceMap = ref({});
+
+// THE CONTENTS OF THIS WILL BE REPLACED/ALTERED WITH THE REGISTRY REFACTOR
+export default function() {
+  const requestPayload = ref<UseAccountPayload>();
+  const { userNetworkConfig, account } = useVueWeb3();
+  const { tokens: allTokens } = useTokens();
+  const provider = getProvider(String(userNetworkConfig.value?.chainId));
+  // filter out ether and any bad addresses
+  const tokens = computed(() =>
+    (
+      requestPayload?.value?.tokens?.value || Object.keys(allTokens.value)
+    ).filter(t => t !== ETHER.address && isAddress(t))
+  );
+  const dstList = computed(() => [
+    ...(requestPayload?.value?.dstList?.value || []),
+    userNetworkConfig.value?.addresses.vault
+  ]);
+
+  const isQueryEnabled = computed(
+    () => account.value != '' && tokens.value.length > 0
+  );
+  const {
+    data: allowances,
+    isLoading,
+    isFetching,
+    refetch: refetchAllowances
+  } = useQuery(
+    QUERY_KEYS.Account.Allowances(userNetworkConfig, account, dstList, tokens),
+    () =>
+      Promise.all(
+        dstList.value.map(async dst =>
+          getAllowances(
+            String(userNetworkConfig.value?.chainId),
+            provider,
+            account.value,
+            dst,
+            tokens.value
+          )
+        )
+      ),
+    reactive({
+      enabled: isQueryEnabled,
+      onSuccess: allowances => {
+        allowances.forEach((allowance, i) => {
+          dstAllowanceMap.value[dstList.value[i]] = allowance;
+        });
+      }
+    })
+  );
+
+  const isLoadingOrFetching = computed(
+    () => isLoading.value || isFetching.value
+  );
+
+  const getRequiredAllowances = query => {
+    const tokens = query.tokens;
+    const amounts = query.amounts;
+    const dst = query.dst || userNetworkConfig.value?.addresses.vault;
+
+    const requiredAllowances = tokens.filter((token, index) => {
+      const amount = amounts[index];
+      if (parseFloat(amount) == 0) return false;
+      if (!dstAllowanceMap.value) return false;
+      if (!dstAllowanceMap.value[dst]) return true;
+      if (!dstAllowanceMap.value[dst][token.toLowerCase()]) return true;
+      return dstAllowanceMap.value[dst][token.toLowerCase()].lt(amount);
+    });
+
+    return requiredAllowances;
+  };
+
+  const updateAllowanceRequest = (payload: UseAccountPayload) => {
+    requestPayload.value = payload;
+  };
+
+  provide(AllowancesProviderSymbol, {
+    allowances,
+    getRequiredAllowances,
+    isLoading: isLoadingOrFetching,
+    refetchAllowances,
+    updateAllowanceRequest
+  });
+}

--- a/src/plugins/providers/balances.provider.ts
+++ b/src/plugins/providers/balances.provider.ts
@@ -1,0 +1,111 @@
+import getProvider from '@/lib/utils/provider';
+import { useQuery } from 'vue-query';
+import { computed, provide, reactive, Ref } from 'vue';
+import { getBalances } from '@/lib/utils/balancer/tokens';
+import { formatEther, formatUnits } from '@ethersproject/units';
+import { getAddress } from '@ethersproject/address';
+import QUERY_KEYS from '@/constants/queryKeys';
+import { ETHER } from '@/constants/tokenlists';
+import useVueWeb3 from '@/services/web3/useVueWeb3';
+import useTokenStore from '@/composables/useTokensStore';
+
+export const BalancesProviderSymbol = Symbol('BALANCES_PROVIDER');
+
+export type BalancesProviderPayload = {
+  balances: Ref<Record<string, { balance: string }>>;
+  hasBalance: (address: string) => boolean;
+  error: Ref<unknown> | Ref<null>;
+  isLoading: Ref<boolean>;
+  isIdle: Ref<boolean>;
+  isError: Ref<boolean>;
+  isFetching: Ref<boolean>;
+  refetchBalances: Ref<Function>;
+};
+
+// THE CONTENTS OF THIS WILL BE REPLACED/ALTERED WITH THE REGISTRY REFACTOR
+export default function() {
+  const { account, userNetworkConfig, isWalletReady } = useVueWeb3();
+  const { allTokens: tokens, isLoading: isLoadingTokens } = useTokenStore();
+
+  const isQueryEnabled = computed(
+    () =>
+      account.value !== null &&
+      Object.keys(tokens).length !== 0 &&
+      isWalletReady.value &&
+      !isLoadingTokens.value
+  );
+
+  const {
+    data,
+    error,
+    isLoading,
+    isIdle,
+    isError,
+    isFetching,
+    refetch: refetchBalances
+  } = useQuery(
+    reactive(QUERY_KEYS.Balances.All(account, userNetworkConfig, tokens)),
+    () => {
+      return Promise.all([
+        getBalances(
+          String(userNetworkConfig.value?.chainId),
+          getProvider(userNetworkConfig.value?.key),
+          account.value,
+          Object.values(tokens.value)
+            .map(token => token.address)
+            .filter(token => token !== ETHER.address)
+        ),
+        getProvider(userNetworkConfig.value?.key).getBalance(
+          account.value.toLowerCase()
+        )
+      ]);
+    },
+    reactive({
+      enabled: isQueryEnabled,
+      keepPreviousData: isWalletReady
+    })
+  );
+
+  const balances = computed(() => {
+    if (data.value) {
+      const balances = {};
+      Object.keys(data.value[0]).forEach((tokenAddress: string) => {
+        const balance = formatUnits(
+          data.value[0][tokenAddress],
+          tokens.value[getAddress(tokenAddress)]?.decimals || 18
+        );
+        // not concerned with tokens which have a 0 balance
+        if (balance === '0.0') return;
+        balances[tokenAddress] = {
+          balance,
+          symbol: tokens.value[getAddress(tokenAddress)].symbol,
+          address: getAddress(tokenAddress)
+        };
+      });
+
+      // separate case for native ether
+      balances[ETHER.address.toLowerCase()] = {
+        balance: formatEther(data.value[1] || 0),
+        symbol: ETHER.symbol,
+        address: ETHER.address
+      };
+      return balances;
+    }
+    return null;
+  });
+
+  function hasBalance(address: string): boolean {
+    return (balances.value || {})[address];
+  }
+
+  provide(BalancesProviderSymbol, {
+    balances,
+    hasBalance,
+    error,
+    isLoading,
+    isIdle,
+    isError,
+    isFetching,
+    refetchBalances
+  });
+}

--- a/src/plugins/providers/tokens.provider.ts
+++ b/src/plugins/providers/tokens.provider.ts
@@ -1,0 +1,85 @@
+import { Token, TokenMap } from '@/types';
+import { getAddress } from '@ethersproject/address';
+import { keyBy, orderBy, uniqBy } from 'lodash';
+import { computed, provide, Ref, ref } from 'vue';
+import { useStore } from 'vuex';
+import useAccountBalances from '@/composables/useAccountBalances';
+import useTokenStore from '@/composables/useTokensStore';
+
+export type TokenRequest = {
+  query?: Ref<string>;
+  queryAddress?: Ref<string>;
+};
+
+export const TokensProviderSymbol = Symbol('TOKENS_PROVIDER');
+
+export type TokensProviderPayload = {
+  tokens: Ref<TokenMap>;
+  updateTokenRequest: (request: TokenRequest) => void;
+};
+
+export default function() {
+  const request = ref<TokenRequest>();
+  const store = useStore();
+  const prices = computed(() => store.state.market.prices);
+  const { allTokens: _allTokens } = useTokenStore();
+  const { balances } = useAccountBalances();
+
+  const updateTokenRequest = (_request: TokenRequest) => {
+    request.value = _request;
+  };
+
+  const tokensList = computed(() => {
+    const _tokens = uniqBy<Token>(
+      orderBy(
+        // populate token data into list of tokens
+        Object.values(_allTokens.value).map(token => {
+          const balance =
+            (balances.value || {})[token.address.toLowerCase()]?.balance || '0';
+          const price = prices.value[token.address.toLowerCase()]?.price || 0;
+          const value = Number(balance) * price;
+          const price24HChange =
+            prices.value[token.address.toLowerCase()]?.price24HChange || 0;
+          const value24HChange = (value / 100) * price24HChange;
+          return {
+            ...token,
+            address: getAddress(token.address), // Enforce that we use checksummed addresses
+            value,
+            price,
+            price24HChange,
+            balance,
+            value24HChange
+          };
+        }),
+        ['value', 'balance'],
+        ['desc', 'desc']
+      ),
+      'address'
+    );
+
+    if (request.value?.queryAddress) {
+      const queryAddressLC = request?.value.queryAddress?.value.toLowerCase();
+
+      return _tokens.filter(
+        token => token.address?.toLowerCase() === queryAddressLC
+      );
+    }
+
+    // search functionality, this can be better
+    if (request?.value?.query) {
+      const queryLC = request?.value.query?.value.toLowerCase();
+
+      return _tokens.filter(
+        token =>
+          token.name.toLowerCase().includes(queryLC) ||
+          token.symbol.toLowerCase().includes(queryLC)
+      );
+    }
+
+    return _tokens;
+  });
+  const tokens = computed(() => keyBy(tokensList.value, 'address') as TokenMap);
+
+  const payload = { tokens, updateTokenRequest };
+  provide(TokensProviderSymbol, payload);
+}

--- a/src/plugins/providers/tokenstore.provider.ts
+++ b/src/plugins/providers/tokenstore.provider.ts
@@ -1,0 +1,112 @@
+import QUERY_KEYS from '@/constants/queryKeys';
+import TOKEN_LISTS from '@/constants/tokenlists';
+import { lsGet, lsSet } from '@/lib/utils';
+import { getTokensListURL, loadTokenlist } from '@/lib/utils/tokenlists';
+import { Token, TokenMap } from '@/types';
+import { TokenList } from '@/types/TokenList';
+import { flatten, keyBy } from 'lodash';
+import { computed, provide, Ref, ref } from 'vue';
+import { useQuery } from 'vue-query';
+import { useStore } from 'vuex';
+
+export const TokenStoreProviderSymbol = Symbol('TOKENSTORE_PROVIDER');
+
+export type TokenStoreProviderPayload = {
+  isLoading: Ref<boolean>;
+  lists: Ref<TokenList[]> | Ref<undefined>;
+  listMap: Ref<Record<string, TokenList>>;
+  activeTokenLists: Ref<string[]>;
+  allTokens: Ref<TokenMap>;
+  toggleActiveTokenList: (name: string) => void;
+  isActiveList: (name: string) => boolean;
+  refreshTokenLists: Ref<any>;
+};
+
+const loadAllTokenLists = async () => {
+  // since a request to retrieve the list can fail
+  // it is best to use allSettled as we still want to
+  // retrieve what we can
+  return (
+    await Promise.allSettled(
+      TOKEN_LISTS.Approved.map(async listURI => {
+        const tokenList = (await loadTokenlist(listURI)) as Omit<
+          TokenList,
+          'tokenListsURL'
+        >;
+
+        return {
+          ...tokenList,
+          tokenListsURL: getTokensListURL(listURI)
+        };
+      })
+    )
+  )
+    .filter(result => result.status === 'fulfilled')
+    .map(result => (result as PromiseFulfilledResult<TokenList>).value);
+};
+
+export default function() {
+  const store = useStore();
+  const activeTokenLists = ref<string[]>(
+    lsGet('activeTokenLists', ['Balancer'])
+  );
+  const queryKey = QUERY_KEYS.TokenLists;
+  const queryFn = loadAllTokenLists;
+
+  const { data: lists, isLoading, refetch: refreshTokenLists } = useQuery<
+    TokenList[]
+  >(queryKey, queryFn, {
+    refetchOnMount: false,
+    refetchOnWindowFocus: false
+  });
+
+  const listMap = computed(() => keyBy(lists.value, 'name'));
+  const injectedTokens = computed(() => store.state.registry.injected);
+
+  const allTokens = computed(() => {
+    // get all the tokens from all the active lists
+    // get all tokens that are injected
+    // get the ETHER token ALWAYS
+    // activeTokenLists;
+    return keyBy(
+      flatten([
+        ...Object.values(injectedTokens.value).map((t: any) => ({ ...t })),
+        ...activeTokenLists.value.map(name => listMap.value[name]?.tokens),
+        store.getters['registry/getEther']()
+      ])
+        // invalid network tokens get filtered out
+        .filter(
+          token => token?.chainId === Number(process.env.VUE_APP_NETWORK || 1)
+        ) as Token[],
+      'address'
+    );
+  });
+
+  const toggleActiveTokenList = (name: string) => {
+    if (activeTokenLists.value.includes(name)) {
+      activeTokenLists.value = activeTokenLists.value.filter(
+        listName => listName !== name
+      );
+    } else {
+      activeTokenLists.value = [...activeTokenLists.value, name];
+    }
+    lsSet('activeTokenLists', activeTokenLists.value);
+  };
+
+  const isActiveList = (name: string) => {
+    return activeTokenLists.value.includes(name);
+  };
+
+  const payload: TokenStoreProviderPayload = {
+    isLoading,
+    lists,
+    allTokens,
+    listMap,
+    activeTokenLists,
+    refreshTokenLists,
+    toggleActiveTokenList,
+    isActiveList
+  };
+
+  provide(TokenStoreProviderSymbol, payload);
+}


### PR DESCRIPTION
# Description
The current issue with a lot of token list lag was the fact that our composables were called many times. Given the fact that these composable instances are isolated, they would register their own watchers and computed properties multiple times as well. 
Some of of these watchers and composables are quite hefty in the compute they perform, so it would essentially become a very expensive render every tim.
This PR aims to refactor that logic and move the more used composable contents to a provider pattern, so they are provided once (watchers and computables) registered once and a much needed speed improvement is introduced.

Fixes #TokenListsLagging

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Other

## How should this be tested?
Entire app, make sure invest works, withdraw works (balances update when so). Trading works (balances update)

## Checklist:

- [ WIP] I have performed a self-review of my own code
- [X ] I have commented my code where relevant, particularly in hard-to-understand areas
- [ X] My changes generate no new console warnings
- [ ] The base of this PR is `master` if hotfix, `develop` if not
