### PR TITLE
Hotfix: dark mode default

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.9.0",
+  "version": "1.9.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@balancer-labs/frontend-v2",
-      "version": "1.9.0",
+      "version": "1.9.1",
       "license": "MIT",
       "dependencies": {
         "@balancer-labs/assets": "github:balancer-labs/assets#master",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.9.0",
+  "version": "1.9.1",
   "engines": {
     "node": "14.x",
     "npm": ">=7"

--- a/src/composables/useDarkMode.ts
+++ b/src/composables/useDarkMode.ts
@@ -4,14 +4,16 @@ import LS_KEYS from '@/constants/local-storage.keys';
 import useBlocknative from './useBlocknative';
 
 const osDarkMode = window.matchMedia('(prefers-color-scheme: dark)').matches;
+const lsDarkMode =
+  lsGet(LS_KEYS.App.DarkMode, osDarkMode.toString()) === 'true';
 
 // STATE
-const darkMode = ref<boolean>(lsGet(LS_KEYS.App.DarkMode, osDarkMode));
+const darkMode = ref<boolean>(lsDarkMode);
 
 // MUTATIONS
 function setDarkMode(val: boolean): void {
   darkMode.value = val;
-  lsSet(LS_KEYS.App.DarkMode, darkMode.value);
+  lsSet(LS_KEYS.App.DarkMode, darkMode.value.toString());
   if (darkMode.value) {
     document.documentElement.classList.add('dark');
   } else {


### PR DESCRIPTION
# Description

Correctly store dark mode boolean as string in local storage so that os default is respected.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## How should this be tested?

- [ ] Clear local storage, set laptop & browser to dark mode and load preview app, it should start in dark mode.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] My changes generate no new console warnings
- [x] The base of this PR is `master` if hotfix, `develop` if not
