### PR TITLE
Hotfix: slow page hack

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.9.1",
+  "version": "1.9.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@balancer-labs/frontend-v2",
-      "version": "1.9.1",
+      "version": "1.9.2",
       "license": "MIT",
       "dependencies": {
         "@balancer-labs/assets": "github:balancer-labs/assets#master",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.9.1",
+  "version": "1.9.2",
   "engines": {
     "node": "14.x",
     "npm": ">=7"

--- a/src/composables/useTokensStore.ts
+++ b/src/composables/useTokensStore.ts
@@ -7,7 +7,7 @@ import QUERY_KEYS from '@/constants/queryKeys';
 import TOKEN_LISTS from '@/constants/tokenlists';
 
 import { getTokensListURL, loadTokenlist } from '@/lib/utils/tokenlists';
-import { lsGet, lsSet } from '@/lib/utils';
+import { lsSet } from '@/lib/utils';
 
 import { Token } from '@/types';
 
@@ -65,9 +65,7 @@ const loadAllTokenLists = async () => {
 // for other composables to build upon
 export default function useTokenStore() {
   const store = useStore();
-  const activeTokenLists = ref<string[]>(
-    lsGet('activeTokenLists', ['Balancer'])
-  );
+  const activeTokenLists = ref<string[]>(['Balancer']);
   const queryKey = QUERY_KEYS.TokenLists;
   const queryFn = loadAllTokenLists;
 


### PR DESCRIPTION
# Description

Having large / multiple tokenlists toggled is causing extremely slow page interaction speeds and freezing. This PR removes the setting of active lists via local storage so that anyone who refreshes the app will revert back to just the default list which  doesn't cause any page speed issues.

This is temporary fix whilst we work on a broader refactor that should fix this.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## How should this be tested?

Please provide instructions so we can test. Please also list any relevant details for your test configuration.

- [ ] Open the select token modal, select some large lists, try to click around the app, when it slows down, refresh and try to click around the app again, it should speed up.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] My changes generate no new console warnings
- [x] The base of this PR is `master` if hotfix, `develop` if not
