### PR TITLE
Hotfix: too many ws connections

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.9.2",
+  "version": "1.9.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@balancer-labs/frontend-v2",
-      "version": "1.9.2",
+      "version": "1.9.3",
       "license": "MIT",
       "dependencies": {
         "@balancer-labs/assets": "github:balancer-labs/assets#master",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.9.2",
+  "version": "1.9.3",
   "engines": {
     "node": "14.x",
     "npm": ">=7"

--- a/src/App.vue
+++ b/src/App.vue
@@ -26,7 +26,7 @@ import AppNav from '@/components/navs/AppNav/AppNav.vue';
 import AppHero from '@/components/heros/AppHero.vue';
 import WalletSelectModal from '@/components/web3/WalletSelectModal.vue';
 import useVueWeb3 from '@/services/web3/useVueWeb3';
-import RpcProviderService from '@/services/rpc-provider/rpc-provider.service';
+import { rpcProviderService } from '@/services/rpc-provider/rpc-provider.service';
 import { DEFAULT_TOKEN_DECIMALS } from './constants/tokens';
 
 BigNumber.config({ DECIMAL_PLACES: DEFAULT_TOKEN_DECIMALS });
@@ -46,9 +46,6 @@ export default defineComponent({
     const store = useStore();
     const route = useRoute();
 
-    // SERVICES
-    const providerService = new RpcProviderService();
-
     // COMPUTED
     const isHomePage = computed(() => route.path === '/');
 
@@ -60,7 +57,7 @@ export default defineComponent({
     // CALLBACKS
     onBeforeMount(() => {
       store.dispatch('app/init');
-      providerService.initBlockListener(setBlockNumber);
+      rpcProviderService.initBlockListener(setBlockNumber);
     });
 
     return {

--- a/src/services/balancer/subgraph/service.ts
+++ b/src/services/balancer/subgraph/service.ts
@@ -1,5 +1,5 @@
 import Client from './client';
-import RpcProviderService from '@/services/rpc-provider/rpc-provider.service';
+import { rpcProviderService as _rpcProviderService } from '@/services/rpc-provider/rpc-provider.service';
 import Pools from './entities/pools';
 import PoolShares from './entities/poolShares';
 import PoolActivities from './entities/poolActivities';
@@ -9,7 +9,6 @@ const NETWORK = process.env.VUE_APP_NETWORK || '1';
 
 export default class Service {
   client: Client;
-  rpcProviderService: RpcProviderService;
   pools: Pools;
   poolShares: PoolShares;
   poolActivities: PoolActivities;
@@ -17,10 +16,9 @@ export default class Service {
 
   constructor(
     client = new Client(),
-    rpcProviderService = new RpcProviderService()
+    readonly rpcProviderService = _rpcProviderService
   ) {
     this.client = client;
-    this.rpcProviderService = rpcProviderService;
 
     // Init entities
     this.pools = new Pools(this);

--- a/src/services/ipfs/ipfs.service.ts
+++ b/src/services/ipfs/ipfs.service.ts
@@ -1,11 +1,11 @@
 import axios from 'axios';
-import ConfigService from '../config/config.service';
+import { configService as _configService } from '../config/config.service';
 
 export default class IpfsService {
   gateway: string;
 
-  constructor(private readonly configService = new ConfigService()) {
-    this.gateway = configService.env.IPFS_NODE;
+  constructor(private readonly configService = _configService) {
+    this.gateway = this.configService.env.IPFS_NODE;
   }
 
   async get(hash: string, protocol = 'ipfs'): Promise<unknown> {
@@ -15,3 +15,5 @@ export default class IpfsService {
     return data;
   }
 }
+
+export const ipfsService = new IpfsService();

--- a/src/services/rpc-provider/rpc-provider.service.ts
+++ b/src/services/rpc-provider/rpc-provider.service.ts
@@ -32,3 +32,5 @@ export default class RpcProviderService {
     return new JsonRpcProvider(rpcUrl);
   }
 }
+
+export const rpcProviderService = new RpcProviderService();

--- a/src/services/token-list/token-list.service.ts
+++ b/src/services/token-list/token-list.service.ts
@@ -2,17 +2,17 @@ import axios from 'axios';
 import { JsonRpcProvider } from '@ethersproject/providers';
 import { TokenList, TokenListDict } from '@/types/TokenList';
 import TOKEN_LISTS from '@/constants/tokenlists';
-import RpcProviderService from '@/services/rpc-provider/rpc-provider.service';
-import IpfsService from '../ipfs/ipfs.service';
+import { rpcProviderService as _rpcProviderService } from '@/services/rpc-provider/rpc-provider.service';
+import { ipfsService as _ipfsService } from '../ipfs/ipfs.service';
 
 export default class TokenListService {
   provider: JsonRpcProvider;
 
   constructor(
-    private readonly rpcProviderService = new RpcProviderService(),
-    private readonly ipfsService = new IpfsService()
+    private readonly rpcProviderService = _rpcProviderService,
+    private readonly ipfsService = _ipfsService
   ) {
-    this.provider = rpcProviderService.jsonProvider;
+    this.provider = this.rpcProviderService.jsonProvider;
   }
 
   async getAll(): Promise<TokenListDict> {

--- a/src/services/token/token.service.ts
+++ b/src/services/token/token.service.ts
@@ -1,6 +1,6 @@
 import { JsonRpcProvider } from '@ethersproject/providers';
-import RpcProviderService from '../rpc-provider/rpc-provider.service';
-import ConfigService from '../config/config.service';
+import { rpcProviderService as _rpcProviderService } from '../rpc-provider/rpc-provider.service';
+import { configService as _configService } from '../config/config.service';
 import MetadataConcern from './concerns/metadata.concern';
 import BalanceConcern from './concerns/balance.concern';
 
@@ -12,10 +12,10 @@ export default class TokenService {
   constructor(
     readonly metadataConcernClass = MetadataConcern,
     readonly balanceConcernClass = BalanceConcern,
-    readonly rpcProviderService = new RpcProviderService(),
-    readonly configService = new ConfigService()
+    readonly rpcProviderService = _rpcProviderService,
+    readonly configService = _configService
   ) {
-    this.provider = rpcProviderService.jsonProvider;
+    this.provider = this.rpcProviderService.jsonProvider;
     this.metadata = new metadataConcernClass(this);
     this.balance = new balanceConcernClass(this);
   }

--- a/src/services/web3/useVueWeb3.ts
+++ b/src/services/web3/useVueWeb3.ts
@@ -5,12 +5,10 @@ import { Web3Plugin, Web3ProviderSymbol } from './web3.plugin';
 import { Web3Provider } from '@ethersproject/providers';
 import QUERY_KEYS from '@/constants/queryKeys';
 import ConfigService from '../config/config.service';
-import RpcProviderService from '../rpc-provider/rpc-provider.service';
 import { isAddress } from '@ethersproject/address';
+import { useStore } from 'vuex';
 
 const isWalletSelectVisible = ref(false);
-const rpcProviderService = new RpcProviderService();
-const blockNumber = ref(0);
 
 export default function useVueWeb3() {
   const {
@@ -28,8 +26,10 @@ export default function useVueWeb3() {
   const isV1Supported = isAddress(
     configService.network.addresses.exchangeProxy
   );
+  const store = useStore();
 
   // COMPUTED REFS + COMPUTED REFS
+  const blockNumber = computed(() => store.state.web3.blockNumber);
   const userNetworkConfig = computed(() => {
     return configService.getNetworkConfig(String(chainId.value));
   });
@@ -58,9 +58,6 @@ export default function useVueWeb3() {
   };
 
   // METHODS
-  rpcProviderService.initBlockListener(
-    _blockNumber => (blockNumber.value = _blockNumber)
-  );
   const getProvider = () => new Web3Provider(provider.value as any);
   const getSigner = () => getProvider().getSigner();
   const toggleWalletSelectModal = (value: boolean) => {


### PR DESCRIPTION
# Description

We were initiating a block number websocket connection every time useVueWeb3 was being imported. This only needs to be done once and was [already happening in the root component](https://github.com/balancer-labs/frontend-v2/blob/develop/src/App.vue#L57-L64) and the blockNumber was being stored and kept up to date in the vuex store.

This fix reverts to fetching the block number from the vuex store.

We could move the state into the composable later. But we need to be careful not to init listeners on every import.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## How should this be tested?

- [x] On mainnet and polygon app check for 'too many ws connection' errors in console.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] My changes generate no new console warnings
- [x] The base of this PR is `master` if hotfix, `develop` if not
