### PR TITLE
pk Fixes the fully transparent sticky column bug

### DIFF
--- a/src/components/_global/BalTable/BalTable.vue
+++ b/src/components/_global/BalTable/BalTable.vue
@@ -412,9 +412,11 @@ export default defineComponent({
 
 <style>
 .horizontalSticky {
-  @apply z-10 bg-white dark:bg-gray-850;
+  @apply z-10 bg-white dark:bg-gray-850 group-hover:bg-gray-50 dark:group-hover:bg-gray-800 opacity-90;
   position: sticky;
   left: 0;
+  width: 100%;
+  backdrop-filter: blur(2px);
 }
 
 .horizontalSticky::after {

--- a/src/components/_global/BalTable/BalTable.vue
+++ b/src/components/_global/BalTable/BalTable.vue
@@ -412,7 +412,7 @@ export default defineComponent({
 
 <style>
 .horizontalSticky {
-  @apply z-10 bg-white dark:bg-gray-850 group-hover:bg-gray-50 dark:group-hover:bg-gray-800 opacity-90;
+  @apply z-10 bg-white dark:bg-gray-850 group-hover:bg-gray-50 dark:group-hover:bg-gray-800 opacity-95 xs:opacity-90;
   position: sticky;
   left: 0;
   width: 100%;

--- a/src/components/_global/BalTable/BalTable.vue
+++ b/src/components/_global/BalTable/BalTable.vue
@@ -412,7 +412,7 @@ export default defineComponent({
 
 <style>
 .horizontalSticky {
-  @apply z-10;
+  @apply z-10 bg-white dark:bg-gray-850;
   position: sticky;
   left: 0;
 }


### PR DESCRIPTION
This fixes a bug where the sticky column has lost it's background on horizontal scroll.

![Screen Shot 2021-07-12 at 9 17 45 PM](https://user-images.githubusercontent.com/1121139/125389787-9ddb0000-e356-11eb-80da-8a6e62092f14.png)

This also introduces some subtle translucency behind the sticky column. 