### PR TITLE
Added check for V1 support in sorManager.

### DIFF
--- a/src/composables/trade/useSor.ts
+++ b/src/composables/trade/useSor.ts
@@ -107,7 +107,11 @@ export default function useSor({
 
   // COMPOSABLES
   const store = useStore();
-  const { getProvider: getWeb3Provider, userNetworkConfig } = useVueWeb3();
+  const {
+    getProvider: getWeb3Provider,
+    userNetworkConfig,
+    isV1Supported
+  } = useVueWeb3();
   const provider = computed(() => getWeb3Provider());
   const { refetchBalances } = useAccountBalances();
   const { txListener, supportsBlocknative } = useNotify();
@@ -157,6 +161,7 @@ export default function useSor({
     }
 
     sorManager = new SorManager(
+      isV1Supported,
       rpcProviderService.jsonProvider,
       new BigNumber(GAS_PRICE),
       Number(MAX_POOLS),


### PR DESCRIPTION
# Description

Change sorManager to only use SOR V1 functions when on supported network. Should fix Sentry issue thrown when attempting to fetch V1 supgraph data.
Uses isV1Supported from useVueWeb3() to determine support. 

Fixes #UI-652

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## How should this be tested?

- [ ] Confirm trades look correct on Mainnet + Kovan - should use V1 and V2 liquidity (check console logs)
- [ ] Confirm trades look correct on Polygon - only V2 liquidity, no errors thrown.

## Checklist:

- [X] I have performed a self-review of my own code
- [X] I have commented my code where relevant, particularly in hard-to-understand areas
- [X] My changes generate no new console warnings
- [X] The base of this PR is `master` if hotfix, `develop` if not
