### PR TITLE
Trade route fix

### DIFF
--- a/src/components/cards/TradeCard/TradeRoute.vue
+++ b/src/components/cards/TradeCard/TradeRoute.vue
@@ -94,7 +94,11 @@
                   :key="hop?.pool?.address"
                   class="ml-4 first:ml-0 flex bg-white hover:bg-gray-50 dark:bg-gray-900 dark:hover:bg-gray-800 border border-gray-100 hover:border-gray-300 dark:border-gray-600 dark:hover:border-gray-400 rounded-xl shadow transition-colors"
                 >
-                  <a class="flex p-1.5" :href="getPoolLink(hop.pool.id)" target="_blank" >
+                  <a
+                    class="flex p-1.5"
+                    :href="getPoolLink(hop.pool.id)"
+                    target="_blank"
+                  >
                     <BalAsset
                       class="ml-1.5 first:ml-0"
                       v-for="token in hop.pool.tokens"

--- a/src/components/cards/TradeCard/TradeRoute.vue
+++ b/src/components/cards/TradeCard/TradeRoute.vue
@@ -68,7 +68,7 @@
             v-for="(route, index) in routes"
             :key="index"
             :style="{
-              height: `${19 + 72 * index}px`,
+              height: `${18 + 70 * index}px`,
               width: `calc(100% - ${4 * (routes.length - index - 1)}px + 1px)`,
               margin: `0 ${2 * (routes.length - index - 1) - 1}px`
             }"
@@ -92,9 +92,9 @@
                 <div
                   v-for="hop in route.hops"
                   :key="hop?.pool?.address"
-                  class="p-1.5 ml-4 first:ml-0 flex bg-white dark:bg-gray-900 dark:border dark:border-gray-500 rounded shadow"
+                  class="ml-4 first:ml-0 flex bg-white hover:bg-gray-50 dark:bg-gray-900 dark:hover:bg-gray-800 border border-gray-100 hover:border-gray-300 dark:border-gray-600 dark:hover:border-gray-400 rounded-xl shadow transition-colors"
                 >
-                  <a :href="getPoolLink(hop.pool.id)" target="_blank">
+                  <a class="flex p-1.5" :href="getPoolLink(hop.pool.id)" target="_blank" >
                     <BalAsset
                       class="ml-1.5 first:ml-0"
                       v-for="token in hop.pool.tokens"


### PR DESCRIPTION
Original work by @pkattera in #654

## Description

Fixes Trade Route layout issue.

Fixes #UI-654

While here, I also fixed a new layout issue introduced in dark mode where the triangles on each hop was becoming misaligned by 2px on each hop, because there's border on dark mode (but not in light mode).

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## How should this be tested?

Go to the Trade UI page and trade between two tokens (like WETH -> WBTC) and put in a super high amount, like 1000 WETH. This should display the trade route with multiple hops. Open the 'Uses V2 liquidity' accordion.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] My changes generate no new console warnings
- [x] The base of this PR is `master` if hotfix, `develop` if not


From this:

![Screen Shot 2021-07-16 at 5 18 59 PM](https://user-images.githubusercontent.com/1121139/126019531-377bf5a7-c89d-4f73-8ba2-0cb43ca2aca4.png)

and this when no previous layout issue:

![Screen Shot 2021-07-16 at 5 20 00 PM](https://user-images.githubusercontent.com/1121139/126019541-259f99dd-6a6d-40ec-896a-c15e5266065c.png)

To this:

![Screen Shot 2021-07-16 at 5 21 04 PM](https://user-images.githubusercontent.com/1121139/126019564-e065522c-dee8-46cd-a84e-dd3698ab2430.png)




