### PR TITLE
Notification system tweaks

### DIFF
--- a/src/components/forms/pool_actions/InvestForm.vue
+++ b/src/components/forms/pool_actions/InvestForm.vue
@@ -280,6 +280,8 @@ import { TransactionResponse } from '@ethersproject/abstract-provider';
 import useEthers from '@/composables/useEthers';
 import useTransactions from '@/composables/useTransactions';
 
+import { getPoolWeights } from './utils';
+
 export enum FormTypes {
   proportional = 'proportional',
   custom = 'custom'
@@ -575,7 +577,10 @@ export default defineComponent({
           id: tx.hash,
           type: 'tx',
           action: 'invest',
-          summary: `${total.value} to pool`,
+          summary: t('transactionSummary.investInPool', [
+            total.value,
+            getPoolWeights(props.pool)
+          ]),
           details: {
             total,
             pool: props.pool

--- a/src/components/forms/pool_actions/InvestForm.vue
+++ b/src/components/forms/pool_actions/InvestForm.vue
@@ -268,6 +268,7 @@ import useSlippage from '@/composables/useSlippage';
 
 import PoolExchange from '@/services/pool/exchange';
 import PoolCalculator from '@/services/pool/calculator/calculator.sevice';
+import { getPoolWeights } from '@/services/pool/pool.helper';
 import { bnum } from '@/lib/utils';
 import FormTypeToggle from './shared/FormTypeToggle.vue';
 import { FullPool } from '@/services/balancer/subgraph/types';
@@ -279,8 +280,6 @@ import useTokens from '@/composables/useTokens';
 import { TransactionResponse } from '@ethersproject/abstract-provider';
 import useEthers from '@/composables/useEthers';
 import useTransactions from '@/composables/useTransactions';
-
-import { getPoolWeights } from './utils';
 
 export enum FormTypes {
   proportional = 'proportional',

--- a/src/components/forms/pool_actions/WithdrawForm.vue
+++ b/src/components/forms/pool_actions/WithdrawForm.vue
@@ -201,6 +201,7 @@ import useSlippage from '@/composables/useSlippage';
 
 import PoolExchange from '@/services/pool/exchange';
 import PoolCalculator from '@/services/pool/calculator/calculator.sevice';
+import { getPoolWeights } from '@/services/pool/pool.helper';
 import { bnum } from '@/lib/utils';
 import { formatUnits } from '@ethersproject/units';
 import { TransactionResponse } from '@ethersproject/abstract-provider';
@@ -211,7 +212,6 @@ import useWeb3 from '@/services/web3/useWeb3';
 import useTokens from '@/composables/useTokens';
 import useEthers from '@/composables/useEthers';
 import useTransactions from '@/composables/useTransactions';
-import { getPoolWeights } from './utils';
 
 export enum FormTypes {
   proportional = 'proportional',

--- a/src/components/forms/pool_actions/WithdrawForm.vue
+++ b/src/components/forms/pool_actions/WithdrawForm.vue
@@ -211,6 +211,7 @@ import useWeb3 from '@/services/web3/useWeb3';
 import useTokens from '@/composables/useTokens';
 import useEthers from '@/composables/useEthers';
 import useTransactions from '@/composables/useTransactions';
+import { getPoolWeights } from './utils';
 
 export enum FormTypes {
   proportional = 'proportional',
@@ -523,7 +524,10 @@ export default defineComponent({
           id: tx.hash,
           type: 'tx',
           action: 'withdraw',
-          summary: `${total.value} from pool`,
+          summary: t('transactionSummary.withdrawFromPool', [
+            total.value,
+            getPoolWeights(props.pool)
+          ]),
           details: {
             total,
             pool: props.pool

--- a/src/components/forms/pool_actions/utils.ts
+++ b/src/components/forms/pool_actions/utils.ts
@@ -1,0 +1,7 @@
+import { FullPool } from '@/services/balancer/subgraph/types';
+
+export function getPoolWeights(pool: FullPool) {
+  return Object.values(pool.onchain.tokens)
+    .map(token => `${token.weight * 100} ${token.symbol}`)
+    .join(', ');
+}

--- a/src/components/navs/AppNav/AppNavActivityBtn/ActivityRows.vue
+++ b/src/components/navs/AppNav/AppNavActivityBtn/ActivityRows.vue
@@ -16,7 +16,7 @@
           />
         </div>
         <div
-          class="text-sm text-gray-500 dark:text-gray-400 group-hover:text-gray-900 dark:group-hover:text-white transition-colors"
+          class="text-sm text-gray-500 dark:text-gray-400 group-hover:text-gray-900 dark:group-hover:text-white transition-colors summary"
         >
           {{ transaction.summary }}
         </div>
@@ -67,5 +67,11 @@ export default defineComponent({
 }
 .row:last-child {
   @apply mb-0;
+}
+.summary {
+  @apply overflow-hidden;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
 }
 </style>

--- a/src/components/navs/AppNav/AppNavActivityBtn/AppNavActivityBtn.vue
+++ b/src/components/navs/AppNav/AppNavActivityBtn/AppNavActivityBtn.vue
@@ -52,7 +52,7 @@
       <template v-if="transactions.length > 0" v-slot:footer>
         <div class="w-full p-3 rounded-b-lg bg-white dark:bg-gray-800 text-sm">
           <a @click="clearAllTransactions()" class="text-blue-500">
-            {{ $t('clearAllTransactions') }}
+            {{ $t('clearTransactions') }}
           </a>
         </div>
       </template>

--- a/src/components/navs/AppNav/AppNavActivityBtn/AppNavActivityBtn.vue
+++ b/src/components/navs/AppNav/AppNavActivityBtn/AppNavActivityBtn.vue
@@ -47,13 +47,13 @@
         </template>
         <template v-else>{{ $t('noRecentActivity') }}</template>
       </div>
-      <template v-if="transactions.length > 0" v-slot:footer>
+      <!-- <template v-if="transactions.length > 0" v-slot:footer>
         <div class="w-full p-3 rounded-b-lg bg-white dark:bg-gray-800 text-sm">
           <a @click="clearAllTransactions()" class="text-blue-500">
             {{ $t('clearTransactions') }}
           </a>
         </div>
-      </template>
+      </template> -->
     </BalCard>
   </BalPopover>
 </template>

--- a/src/components/navs/AppNav/AppNavActivityBtn/AppNavActivityBtn.vue
+++ b/src/components/navs/AppNav/AppNavActivityBtn/AppNavActivityBtn.vue
@@ -1,5 +1,5 @@
 <template>
-  <BalPopover no-pad @show="popoverOpened = true" @hide="popoverOpened = false">
+  <BalPopover no-pad>
     <template v-slot:activator>
       <BalBtn
         color="gray"
@@ -9,9 +9,7 @@
         circle
         class="mr-2 p-1 relative"
       >
-        <ActivityIcon
-          v-if="pendingTransactions.length === 0 || popoverOpened"
-        />
+        <ActivityIcon v-if="pendingTransactions.length === 0" />
         <ActivityCounter v-else :count="pendingTransactions.length" />
       </BalBtn>
     </template>
@@ -61,7 +59,7 @@
 </template>
 
 <script lang="ts">
-import { computed, defineComponent, ref } from 'vue';
+import { computed, defineComponent } from 'vue';
 import useBreakpoints from '@/composables/useBreakpoints';
 import useWeb3 from '@/services/web3/useWeb3';
 import useTransactions from '@/composables/useTransactions';
@@ -78,9 +76,6 @@ export default defineComponent({
   },
 
   setup() {
-    // DATA
-    const popoverOpened = ref(false);
-
     // COMPOSABLES
     const { upToLargeBreakpoint } = useBreakpoints();
     const { isLoadingProfile, profile, account } = useWeb3();
@@ -102,9 +97,6 @@ export default defineComponent({
     );
 
     return {
-      // data
-      popoverOpened,
-
       // methods
       clearAllTransactions,
       getExplorerLink,

--- a/src/components/navs/AppNav/AppNavClaimBtn.vue
+++ b/src/components/navs/AppNav/AppNavClaimBtn.vue
@@ -98,6 +98,7 @@ import { computed, defineComponent, ref, watch } from 'vue';
 import { useStore } from 'vuex';
 import { differenceInSeconds } from 'date-fns';
 import { useIntervalFn } from '@vueuse/core';
+import { useI18n } from 'vue-i18n';
 
 import useNumbers from '@/composables/useNumbers';
 import useUserClaimsQuery from '@/composables/queries/useUserClaimsQuery';
@@ -135,6 +136,7 @@ export default defineComponent({
     } = useWeb3();
     const { txListener } = useEthers();
     const { addTransaction } = useTransactions();
+    const { t } = useI18n();
 
     const balPrice = computed(
       () =>
@@ -225,10 +227,9 @@ export default defineComponent({
             id: tx.hash,
             type: 'tx',
             action: 'claim',
-            summary: `${fNum(
-              userClaims.value.availableToClaim,
-              'token_fixed'
-            )} BAL`
+            summary: t('transactionSummary.claimBAL', [
+              fNum(userClaims.value.availableToClaim, 'token_fixed')
+            ])
           });
 
           txListener(tx, {

--- a/src/components/notifications/Notification.vue
+++ b/src/components/notifications/Notification.vue
@@ -10,7 +10,7 @@
         noStyle
       >
         <div v-if="notification.title" class="font-semibold flex items-center">
-          {{ notification.title }}
+          <span class="title">{{ notification.title }}</span>
           <BalIcon
             name="arrow-up-right"
             size="sm"
@@ -20,25 +20,32 @@
         <div>{{ notification.message }}</div>
       </BalLink>
       <div v-else>
-        <div v-if="notification.title" class="font-semibold">
+        <div v-if="notification.title" class="font-semibold title">
           {{ notification.title }}
         </div>
         <div>{{ notification.message }}</div>
       </div>
       <BalCloseIcon
-        class="cursor-pointer text-black dark:text-white"
+        class="cursor-pointer text-black dark:text-white ml-2"
         @click="closeNotification()"
       />
     </div>
     <div
-      class="absolute bottom-0 left-0 opacity-80 w-0 transition duration-300 ease-linear h-1 bg-yellow-600 dark:bg-yellow-500"
+      :class="progressClasses"
       :style="{ width: `${(progress * 100).toFixed(0)}%` }"
     />
   </div>
 </template>
 
 <script lang="ts">
-import { defineComponent, onMounted, onUnmounted, PropType, ref } from 'vue';
+import {
+  computed,
+  defineComponent,
+  onMounted,
+  onUnmounted,
+  PropType,
+  ref
+} from 'vue';
 import { TransitionPresets, useTransition } from '@vueuse/core';
 
 import useNotifications, { Notification } from '@/composables/useNotifications';
@@ -87,14 +94,37 @@ export default defineComponent({
       }
     });
 
+    // COMPUTED
+    const progressClasses = computed(() => {
+      let bgClasses = 'bg-yellow-600 dark:bg-yellow-500';
+      if (props.notification.transactionMetadata?.status === 'confirmed') {
+        bgClasses = props.notification.transactionMetadata.isSuccess
+          ? 'bg-green-500 dark:bg-green-500'
+          : 'bg-red-500 dark:bg-red-500';
+      }
+
+      return `
+          absolute bottom-0 left-0 opacity-80 w-0 transition duration-300 ease-linear h-1 ${bgClasses}
+        `;
+    });
+
     return {
       // methods
       closeNotification,
 
       // computed
       notifications,
+      progressClasses,
       progress
     };
   }
 });
 </script>
+<style scoped>
+.title {
+  text-transform: lowercase;
+}
+.title::first-letter {
+  text-transform: uppercase;
+}
+</style>

--- a/src/components/notifications/Notification.vue
+++ b/src/components/notifications/Notification.vue
@@ -17,13 +17,13 @@
             class="ml-1 text-gray-400 dark:text-gray-600 group-hover:text-pink-500 transition-colors"
           />
         </div>
-        <div>{{ notification.message }}</div>
+        <div class="message">{{ notification.message }}</div>
       </BalLink>
       <div v-else>
         <div class="font-semibold title mb-1">
           {{ notification.title }}
         </div>
-        <div>{{ notification.message }}</div>
+        <div class="message">{{ notification.message }}</div>
       </div>
       <BalCloseIcon
         class="cursor-pointer text-black dark:text-white flex-shrink-0 absolute top-3 right-2"
@@ -126,5 +126,11 @@ export default defineComponent({
 }
 .title::first-letter {
   @apply uppercase;
+}
+.message {
+  @apply overflow-hidden;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
 }
 </style>

--- a/src/components/notifications/Notification.vue
+++ b/src/components/notifications/Notification.vue
@@ -1,15 +1,15 @@
 <template>
   <div
-    class="relative p-3 border rounded bg-white dark:bg-gray-800 shadow-lg text-sm dark:text-white dark:border-gray-850"
+    class="relative p-3 border rounded bg-white dark:bg-gray-800 shadow-lg text-sm dark:text-white dark:border-gray-850 w-64"
   >
-    <div class="flex justify-between group">
+    <div class="justify-between group">
       <BalLink
         v-if="notification.transactionMetadata"
         :href="notification.transactionMetadata.explorerLink"
         external
         noStyle
       >
-        <div v-if="notification.title" class="font-semibold flex items-center">
+        <div class="font-semibold flex items-center mb-1">
           <span class="title">{{ notification.title }}</span>
           <BalIcon
             name="arrow-up-right"
@@ -20,13 +20,13 @@
         <div>{{ notification.message }}</div>
       </BalLink>
       <div v-else>
-        <div v-if="notification.title" class="font-semibold title">
+        <div class="font-semibold title mb-1">
           {{ notification.title }}
         </div>
         <div>{{ notification.message }}</div>
       </div>
       <BalCloseIcon
-        class="cursor-pointer text-black dark:text-white ml-2"
+        class="cursor-pointer text-black dark:text-white flex-shrink-0 absolute top-3 right-2"
         @click="closeNotification()"
       />
     </div>
@@ -122,9 +122,9 @@ export default defineComponent({
 </script>
 <style scoped>
 .title {
-  text-transform: lowercase;
+  @apply lowercase;
 }
 .title::first-letter {
-  text-transform: uppercase;
+  @apply uppercase;
 }
 </style>

--- a/src/composables/pools/useTokenApprovals.ts
+++ b/src/composables/pools/useTokenApprovals.ts
@@ -1,4 +1,5 @@
 import { ref, computed, Ref } from 'vue';
+import { useI18n } from 'vue-i18n';
 import { parseUnits } from '@ethersproject/units';
 
 import { approveTokens } from '@/lib/utils/balancer/tokens';
@@ -24,6 +25,7 @@ export default function useTokenApprovals(
   const { getRequiredAllowances, refetchAllowances } = useAllowances();
   const { txListener } = useEthers();
   const { addTransaction } = useTransactions();
+  const { t } = useI18n();
 
   // COMPUTED
   const amounts = computed(() =>
@@ -59,7 +61,9 @@ export default function useTokenApprovals(
         id: txs[0].hash,
         type: 'tx',
         action: 'approve',
-        summary: `${tokens.value[tokenAddress]?.symbol} for investing`,
+        summary: t('transactionSummary.approveForInvesting', [
+          tokens.value[tokenAddress]?.symbol
+        ]),
         details: {
           tokenAddress,
           spender: appNetworkConfig.addresses.vault

--- a/src/composables/trade/useGnosis.ts
+++ b/src/composables/trade/useGnosis.ts
@@ -7,7 +7,7 @@ import { OrderKind } from '@gnosis.pm/gp-v2-contracts';
 import { bnum } from '@/lib/utils';
 
 import useWeb3 from '@/services/web3/useWeb3';
-import { FeeInformation } from '@/services/gnosis/types';
+import { FeeInformation, OrderMetaData } from '@/services/gnosis/types';
 import {
   calculateValidTo,
   signOrder,
@@ -24,6 +24,22 @@ import useNumbers from '../useNumbers';
 // TODO: get correct app id
 const GNOSIS_APP_ID = 2;
 const appData = '0x' + GNOSIS_APP_ID.toString(16).padStart(64, '0');
+
+export type GnosisTransactionDetails = {
+  tokenIn: Token;
+  tokenOut: Token;
+  tokenInAddress: string;
+  tokenOutAddress: string;
+  tokenInAmount: string;
+  tokenOutAmount: string;
+  exactIn: boolean;
+  quote: TradeQuote;
+  slippageBufferRate: number;
+  order: {
+    validTo: OrderMetaData['validTo'];
+    partiallyFillable: OrderMetaData['partiallyFillable'];
+  };
+};
 
 type Props = {
   exactIn: Ref<boolean>;
@@ -172,6 +188,8 @@ export default function useGnosis({
         action: 'trade',
         summary,
         details: {
+          tokenIn: tokenIn.value,
+          tokenOut: tokenOut.value,
           tokenInAddress: tokenInAddressInput.value,
           tokenOutAddress: tokenOutAddressInput.value,
           tokenInAmount: tokenInAmountInput.value,

--- a/src/composables/trade/useSor.ts
+++ b/src/composables/trade/useSor.ts
@@ -4,6 +4,7 @@ import { useIntervalFn } from '@vueuse/core';
 import { BigNumber } from 'bignumber.js';
 import { Pool } from '@balancer-labs/sor/dist/types';
 import { SubgraphPoolBase } from '@balancer-labs/sor2';
+import { useI18n } from 'vue-i18n';
 
 import { scale, bnum } from '@/lib/utils';
 import { unwrap, wrap } from '@/lib/utils/balancer/wrapper';
@@ -113,6 +114,7 @@ export default function useSor({
   const { txListener } = useEthers();
   const { addTransaction } = useTransactions();
   const { fNum } = useNumbers();
+  const { t } = useI18n();
 
   const liquiditySelection = computed(() => store.state.app.tradeLiquidity);
 
@@ -334,9 +336,9 @@ export default function useSor({
     const tokenOutAmountFormatted = fNum(tokenOutAmountInput.value, 'token');
 
     if (action === 'wrap') {
-      summary = `Wrap ${tokenInAmountFormatted} WETH to ETH`;
+      summary = t('transactionSummary.wrapETH', [tokenInAmountFormatted]);
     } else if (action === 'unwrap') {
-      summary = `Unwrap ${tokenInAmountFormatted} ETH to WETH`;
+      summary = t('transactionSummary.unwrapETH', [tokenInAmountFormatted]);
     } else {
       summary = `${tokenInAmountFormatted} ${tokenIn?.value.symbol} -> ${tokenOutAmountFormatted} ${tokenOut?.value.symbol}`;
     }

--- a/src/composables/trade/useSor.ts
+++ b/src/composables/trade/useSor.ts
@@ -349,6 +349,8 @@ export default function useSor({
       action: 'trade',
       summary,
       details: {
+        tokenIn: tokenIn?.value,
+        tokenOut: tokenOut?.value,
         tokenInAddress: tokenInAddressInput.value,
         tokenOutAddress: tokenOutAddressInput.value,
         tokenInAmount: tokenInAmountInput.value,

--- a/src/composables/trade/useTokenApproval.ts
+++ b/src/composables/trade/useTokenApproval.ts
@@ -1,15 +1,19 @@
 import { computed, ComputedRef, Ref, ref, watch } from 'vue';
+import { useI18n } from 'vue-i18n';
 import { parseUnits } from '@ethersproject/units';
+import { TransactionResponse } from '@ethersproject/providers';
+
 import { approveTokens } from '@/lib/utils/balancer/tokens';
 import { ETHER } from '@/constants/tokenlists';
-import useWeb3 from '@/services/web3/useWeb3';
-import useAllowances from '../useAllowances';
-import { TransactionResponse } from '@ethersproject/providers';
-import useEthers from '../useEthers';
-import { TokenMap } from '@/types';
-import useTransactions from '../useTransactions';
 
+import useWeb3 from '@/services/web3/useWeb3';
 import { configService } from '@/services/config/config.service';
+
+import useAllowances from '../useAllowances';
+import useTransactions from '../useTransactions';
+import useEthers from '../useEthers';
+
+import { TokenMap } from '@/types';
 
 export default function useTokenApproval(
   tokenInAddress: Ref<string>,
@@ -19,6 +23,7 @@ export default function useTokenApproval(
   const approving = ref(false);
   const approved = ref(false);
   const { addTransaction } = useTransactions();
+  const { t } = useI18n();
 
   // COMPOSABLES
   const { getProvider } = useWeb3();
@@ -108,7 +113,9 @@ export default function useTokenApproval(
       id: tx.hash,
       type: 'tx',
       action: 'approve',
-      summary: `${tokens.value[tokenInAddress.value].symbol} for trading`,
+      summary: t('transactionSummary.approveForTrading', [
+        tokens.value[tokenInAddress.value].symbol
+      ]),
       details: {
         tokenAddress: tokenInAddress.value,
         spender

--- a/src/composables/trade/useTokenApprovalGP.ts
+++ b/src/composables/trade/useTokenApprovalGP.ts
@@ -1,5 +1,6 @@
 import { computed, Ref, ref } from 'vue';
 import { parseUnits } from '@ethersproject/units';
+import { useI18n } from 'vue-i18n';
 
 import { approveTokens } from '@/lib/utils/balancer/tokens';
 
@@ -21,6 +22,7 @@ export default function useTokenApprovalGP(
   const { tokens } = useTokens();
   const { txListener } = useEthers();
   const { addTransaction } = useTransactions();
+  const { t } = useI18n();
 
   // DATA
   const approving = ref(false);
@@ -73,7 +75,7 @@ export default function useTokenApprovalGP(
         id: tx.hash,
         type: 'tx',
         action: 'approve',
-        summary: `${tokenInSymbol} for trading`,
+        summary: t('transactionSummary.approveForTrading', [tokenInSymbol]),
         details: {
           tokenAddress: tokenInAddress.value,
           spender: GP_ALLOWANCE_MANAGER_CONTRACT_ADDRESS

--- a/src/composables/useNotifications.ts
+++ b/src/composables/useNotifications.ts
@@ -14,7 +14,7 @@ export type Notification = {
     isSuccess: boolean;
     explorerLink: string;
   };
-  title?: string;
+  title: string;
   message: string;
   autoCloseAfterMs?: number; // set 0 to disable
   addedTime?: number;

--- a/src/composables/useNumbers.ts
+++ b/src/composables/useNumbers.ts
@@ -29,29 +29,30 @@ enum PresetFormats {
   percent_lg = '0%'
 }
 
+export function fNum(
+  number: number | string,
+  preset: Preset | null = 'default',
+  options: Options = {}
+): string {
+  if (options.format) return numeral(number).format(options.format);
+
+  let adjustedPreset;
+  if (number >= 10_000 && !options.forcePreset) {
+    adjustedPreset = `${preset}_lg`;
+  }
+  if (number < 1e-6) {
+    // Numeral returns NaN in this case so just set to zero.
+    // https://github.com/adamwdraper/Numeral-js/issues/596
+    number = 0;
+  }
+
+  return numeral(number).format(
+    PresetFormats[adjustedPreset || preset || 'default']
+  );
+}
+
 export default function useNumbers() {
   const store = useStore();
-  function fNum(
-    number: number | string,
-    preset: Preset | null = 'default',
-    options: Options = {}
-  ): string {
-    if (options.format) return numeral(number).format(options.format);
-
-    let adjustedPreset;
-    if (number >= 10_000 && !options.forcePreset) {
-      adjustedPreset = `${preset}_lg`;
-    }
-    if (number < 1e-6) {
-      // Numeral returns NaN in this case so just set to zero.
-      // https://github.com/adamwdraper/Numeral-js/issues/596
-      number = 0;
-    }
-
-    return numeral(number).format(
-      PresetFormats[adjustedPreset || preset || 'default']
-    );
-  }
 
   function toFiat(amount: number | string, tokenAddress: string): number {
     const rate =

--- a/src/composables/useTransactions.ts
+++ b/src/composables/useTransactions.ts
@@ -285,7 +285,7 @@ export default function useTransactions() {
   ) {
     if (receipt != null) {
       const transaction = getTransaction(id, type);
-      console.log(receipt);
+
       const updateSuccessful = updateTransaction(id, type, {
         receipt:
           type === 'tx'

--- a/src/composables/useTransactions.ts
+++ b/src/composables/useTransactions.ts
@@ -1,6 +1,7 @@
 import { computed, ref } from 'vue';
 import { merge, orderBy } from 'lodash';
 import { TransactionReceipt } from '@ethersproject/providers';
+import { formatUnits } from '@ethersproject/units';
 import { useI18n } from 'vue-i18n';
 
 import LS_KEYS from '@/constants/local-storage.keys';
@@ -15,10 +16,9 @@ import { lsGet, lsSet } from '@/lib/utils';
 
 import useNotifications from './useNotifications';
 import { processedTxs } from './useEthers';
+import useNumbers from './useNumbers';
 
 import { GnosisTransactionDetails } from './trade/useGnosis';
-import useNumbers from './useNumbers';
-import { formatUnits } from '@ethersproject/units';
 
 const WEEK_MS = 86_400_000 * 7;
 
@@ -285,7 +285,7 @@ export default function useTransactions() {
   ) {
     if (receipt != null) {
       const transaction = getTransaction(id, type);
-
+      console.log(receipt);
       const updateSuccessful = updateTransaction(id, type, {
         receipt:
           type === 'tx'

--- a/src/composables/useTransactions.ts
+++ b/src/composables/useTransactions.ts
@@ -16,7 +16,7 @@ import { lsGet, lsSet } from '@/lib/utils';
 import useNotifications from './useNotifications';
 import { processedTxs } from './useEthers';
 
-const DAY_MS = 86_400_000;
+const WEEK_MS = 86_400_000 * 7;
 
 export type TransactionStatus =
   | 'pending'
@@ -116,7 +116,7 @@ function normalizeTxReceipt(receipt: TransactionReceipt) {
 }
 
 function isTransactionRecent(transaction: Transaction): boolean {
-  return Date.now() - transaction.addedTime < DAY_MS;
+  return Date.now() - transaction.addedTime < WEEK_MS;
 }
 
 function clearAllTransactions() {

--- a/src/locales/default.json
+++ b/src/locales/default.json
@@ -216,6 +216,15 @@
         "cancelling": "Cancelling",
         "Cancelled": "Cancelled"
     },
+    "transactionSummary": {
+        "investInPool": "{0} in {1}",
+        "withdrawFromPool": "{0} from {1}",
+        "claimBAL": "{0} BAL",
+        "approveForInvesting": "Approve {0} for investing",
+        "approveForTrading": "Approve {0} for trading",
+        "wrapETH": "Wrap {0} WETH to ETH",
+        "unwrapETH": "Unwrap {0} ETH to WETH"
+    },
     "searchBy": "Name, symbol or address",
     "searchByName": "Search by Name",
     "seeMore": "See more",

--- a/src/locales/default.json
+++ b/src/locales/default.json
@@ -36,7 +36,7 @@
     "claiming": "Claiming...",
     "classic": "Classic",
     "close": "Close",
-    "clearAllTransactions": "Clear all transactions",
+    "clearTransactions": "Clear transactions",
     "communitySwapFeeLabel": "Delegated swap fees; currently fixed: <b>{0}</b>",
     "configuration": "Configuration",
     "confirmTrade": "Confirm trade",

--- a/src/locales/default.json
+++ b/src/locales/default.json
@@ -201,7 +201,7 @@
     "requiresTransactions": "Requires 1 transaction | Requires {txCount} transactions",
     "receipt": "Receipt",
     "recentActivityTitle": "Recent activity",
-    "noRecentActivity": "Your activity will appear here...",
+    "noRecentActivity": "Your session activity will appear here…",
     "transactionAction": {
         "trade": "Trade",
         "approve": "Approve",

--- a/src/services/pool/pool.helper.ts
+++ b/src/services/pool/pool.helper.ts
@@ -1,7 +1,9 @@
+import { fNum } from '@/composables/useNumbers';
+
 import { FullPool } from '../balancer/subgraph/types';
 
 export function getPoolWeights(pool: FullPool) {
   return Object.values(pool.onchain.tokens)
-    .map(token => `${token.weight * 100} ${token.symbol}`)
+    .map(token => `${fNum(token.weight, 'percent_lg')} ${token.symbol}`)
     .join(', ');
 }

--- a/src/services/pool/pool.helper.ts
+++ b/src/services/pool/pool.helper.ts
@@ -1,4 +1,4 @@
-import { FullPool } from '@/services/balancer/subgraph/types';
+import { FullPool } from '../balancer/subgraph/types';
 
 export function getPoolWeights(pool: FullPool) {
   return Object.values(pool.onchain.tokens)


### PR DESCRIPTION
# Description

Notification tweaks as requested by @pkattera 

1. "Clear all transactions" => "Clear all"
2. Recent transactions time limit - 7 days instead of 1 day.
3. Capitalize only the first letter for notifications.
4. Notification progress bar - green for success, red for failure, and yellow for pending.
5. Increase the size of the notification widget and the spacing between the close button.
6. For invest/withdraw - include pool weights.
7. Activity indicator stays as a spinning circle even when its the popover is opened.
8. Show final values on trades (currently works for Gnosis)

Others:
1. "Clear all" footer is hidden for now.
2. Added translations.

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other

## How should this be tested?

Please provide instructions so we can test. Please also list any relevant details for your test configuration.

- [ ] Invest/withdraw from various pools.
- [ ] Make trades on the Gnosis branch (ERC20<>ERC20 and ETH->ERC20)

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] My changes generate no new console warnings
- [x] The base of this PR is `master` if hotfix, `develop` if not
