### PR TITLE
Hotfix/1.11.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.11.0",
+  "version": "1.11.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@balancer-labs/frontend-v2",
-      "version": "1.11.0",
+      "version": "1.11.1",
       "license": "MIT",
       "dependencies": {
         "@balancer-labs/assets": "github:balancer-labs/assets#master",
@@ -34192,6 +34192,7 @@
           "integrity": "sha512-IWnb10ImrzRMT2qw9785p3wYEI6U9gjsg6H2zKcRJQP5dEboqeX3OFjUKfXkaIWii4nz8MtJjBg5t4BdEYqLdw==",
           "dev": true,
           "requires": {
+            "@babel/core": "^7.12.10",
             "@babel/generator": "^7.12.11",
             "@babel/parser": "^7.12.11",
             "@babel/plugin-transform-react-jsx": "^7.12.12",
@@ -37709,6 +37710,7 @@
     "@vue/babel-preset-app": {
       "version": "4.5.12",
       "requires": {
+        "@babel/core": "^7.11.0",
         "@babel/helper-compilation-targets": "^7.9.6",
         "@babel/helper-module-imports": "^7.8.3",
         "@babel/plugin-proposal-class-properties": "^7.8.3",
@@ -37721,6 +37723,7 @@
         "@vue/babel-plugin-jsx": "^1.0.3",
         "@vue/babel-preset-jsx": "^1.2.4",
         "babel-plugin-dynamic-import-node": "^2.3.3",
+        "core-js": "^3.6.5",
         "core-js-compat": "^3.6.5",
         "semver": "^6.1.0"
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.11.0",
+  "version": "1.11.1",
   "engines": {
     "node": "14.x",
     "npm": ">=7"

--- a/src/services/balancer/subgraph/entities/pools/query.ts
+++ b/src/services/balancer/subgraph/entities/pools/query.ts
@@ -7,7 +7,8 @@ const defaultArgs = {
   orderDirection: 'desc',
   where: {
     totalShares_gt: 0.01,
-    id_not_in: POOLS.BlockList
+    id_not_in: POOLS.BlockList,
+    poolType_not: 'Element'
   }
 };
 


### PR DESCRIPTION
# Description

We're pulling all pooltypes from the subgraph however we don't currently support Element pools in the frontend. This results in them not displaying correctly and trying to click on one will kick you back to the homepage.

I've set the subgraph service to not return Element pools by default.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## How should this be tested?

- [x] Check that the main page pool's table is properly populated with Weighted and Stable pools

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] My changes generate no new console warnings
- [x] The base of this PR is `master` if hotfix, `develop` if not
