### PR TITLE
Liquidity Mining, week 62

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.11.1",
+  "version": "1.11.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@balancer-labs/frontend-v2",
-      "version": "1.11.1",
+      "version": "1.11.2",
       "license": "MIT",
       "dependencies": {
         "@balancer-labs/assets": "github:balancer-labs/assets#master",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.11.1",
+  "version": "1.11.2",
   "engines": {
     "node": "14.x",
     "npm": ">=7"

--- a/src/lib/utils/liquidityMining/MultiTokenLiquidityMining.json
+++ b/src/lib/utils/liquidityMining/MultiTokenLiquidityMining.json
@@ -1282,5 +1282,234 @@
         ]
       }
     }
+  ],
+  "week_62": [
+    {
+      "chainId": 1,
+      "pools": {
+        "0xa6f548df93de924d73be7d25dc02554c6bd66db500020000000000000000000e": [
+          {
+            "tokenAddress": "0xba100000625a3754423978a60c9317c58a424e3d",
+            "amount": 15000
+          }
+        ],
+        "0x0b09dea16768f0799065c475be02919503cb2a3500020000000000000000001a": [
+          {
+            "tokenAddress": "0xba100000625a3754423978a60c9317c58a424e3d",
+            "amount": 15000
+          }
+        ],
+        "0x5c6ee304399dbdb9c8ef030ab642b10820db8f56000200000000000000000014": [
+          {
+            "tokenAddress": "0xba100000625a3754423978a60c9317c58a424e3d",
+            "amount": 30000
+          }
+        ],
+        "0x06df3b2bbb68adc8b0e302443692037ed9f91b42000000000000000000000063": [
+          {
+            "tokenAddress": "0xba100000625a3754423978a60c9317c58a424e3d",
+            "amount": 15000
+          }
+        ],
+        "0x96646936b91d6b9d7d0c47c496afbf3d6ec7b6f8000200000000000000000019": [
+          {
+            "tokenAddress": "0xba100000625a3754423978a60c9317c58a424e3d",
+            "amount": 5000
+          }
+        ],
+        "0xa1116930326d21fb917d5a27f1e9943a9595fb47": [
+          {
+            "tokenAddress": "0xba100000625a3754423978a60c9317c58a424e3d",
+            "amount": 12500
+          }
+        ],
+        "0x3e5fa9518ea95c3e533eb377c001702a9aacaa32000200000000000000000052": [
+          {
+            "tokenAddress": "0xba100000625a3754423978a60c9317c58a424e3d",
+            "amount": 5000
+          }
+        ],
+        "0xaac98ee71d4f8a156b6abaa6844cdb7789d086ce00020000000000000000001b": [
+          {
+            "tokenAddress": "0xba100000625a3754423978a60c9317c58a424e3d",
+            "amount": 2500
+          }
+        ],
+        "0x186084ff790c65088ba694df11758fae4943ee9e000200000000000000000013": [
+          {
+            "tokenAddress": "0xba100000625a3754423978a60c9317c58a424e3d",
+            "amount": 2500
+          }
+        ],
+        "0x072f14b85add63488ddad88f855fda4a99d6ac9b000200000000000000000027": [
+          {
+            "tokenAddress": "0xba100000625a3754423978a60c9317c58a424e3d",
+            "amount": 2500
+          }
+        ],
+        "0xe99481dc77691d8e2456e5f3f61c1810adfc1503000200000000000000000018": [
+          {
+            "tokenAddress": "0xba100000625a3754423978a60c9317c58a424e3d",
+            "amount": 2500
+          }
+        ],
+        "0xefaa1604e82e1b3af8430b90192c1b9e8197e377000200000000000000000021": [
+          {
+            "tokenAddress": "0xba100000625a3754423978a60c9317c58a424e3d",
+            "amount": 2500
+          }
+        ],
+        "0xfeadd389a5c427952d8fdb8057d6c8ba1156cc56000000000000000000000066": [
+          {
+            "tokenAddress": "0xba100000625a3754423978a60c9317c58a424e3d",
+            "amount": 2500
+          }
+        ],
+        "0x148ce9b50be946a96e94a4f5479b771bab9b1c59000100000000000000000054": [
+          {
+            "tokenAddress": "0xba100000625a3754423978a60c9317c58a424e3d",
+            "amount": 2500
+          }
+        ],
+        "0xec60a5fef79a92c741cb74fdd6bfc340c0279b01000200000000000000000015": [
+          {
+            "tokenAddress": "0xba100000625a3754423978a60c9317c58a424e3d",
+            "amount": 1000
+          }
+        ],
+        "0xa02e4b3d18d4e6b8d18ac421fbc3dfff8933c40a00020000000000000000004b": [
+          {
+            "tokenAddress": "0xba100000625a3754423978a60c9317c58a424e3d",
+            "amount": 1000
+          }
+        ],
+        "0x61d5dc44849c9c87b0856a2a311536205c96c7fd000100000000000000000001": [
+          {
+            "tokenAddress": "0xba100000625a3754423978a60c9317c58a424e3d",
+            "amount": 1000
+          }
+        ],
+        "0xf5aaf7ee8c39b651cebf5f1f50c10631e78e0ef9000200000000000000000069": [
+          {
+            "tokenAddress": "0xba100000625a3754423978a60c9317c58a424e3d",
+            "amount": 1000
+          }
+        ],
+        "0x14462305d211c12a736986f4e8216e28c5ea7ab4000200000000000000000068": [
+          {
+            "tokenAddress": "0xba100000625a3754423978a60c9317c58a424e3d",
+            "amount": 1000
+          }
+        ]
+        
+      }
+    },
+    {
+      "chainId": 137,
+      "pools": {
+        "0x0297e37f1873d2dab4487aa67cd56b58e2f27875000100000000000000000002": [
+          {
+            "tokenAddress": "0x9a71012b13ca4d3d0cdc72a177df3ef03b0e76a3",
+            "amount": 7500
+          },
+          {
+            "tokenAddress": "0x0d500b1d8e8ef31e21c99d1db9a6444d3adf1270",
+            "amount": 112500
+          }
+        ],
+        "0x36128d5436d2d70cab39c9af9cce146c38554ff0000100000000000000000008": [
+          {
+            "tokenAddress": "0x9a71012b13ca4d3d0cdc72a177df3ef03b0e76a3",
+            "amount": 6000
+          },
+          {
+            "tokenAddress": "0x0d500b1d8e8ef31e21c99d1db9a6444d3adf1270",
+            "amount": 90000
+          }
+        ],
+        "0x03cd191f589d12b0582a99808cf19851e468e6b500010000000000000000000a": [
+          {
+            "tokenAddress": "0x9a71012b13ca4d3d0cdc72a177df3ef03b0e76a3",
+            "amount": 2500
+          },
+          {
+            "tokenAddress": "0x0d500b1d8e8ef31e21c99d1db9a6444d3adf1270",
+            "amount": 37500
+          }
+        ],
+        "0xce66904b68f1f070332cbc631de7ee98b650b499000100000000000000000009": [
+          {
+            "tokenAddress": "0x9a71012b13ca4d3d0cdc72a177df3ef03b0e76a3",
+            "amount": 2500
+          },
+          {
+            "tokenAddress": "0x0d500b1d8e8ef31e21c99d1db9a6444d3adf1270",
+            "amount": 37500
+          }
+        ],
+        "0x06df3b2bbb68adc8b0e302443692037ed9f91b42000000000000000000000012": [
+          {
+            "tokenAddress": "0x9a71012b13ca4d3d0cdc72a177df3ef03b0e76a3",
+            "amount": 2500
+          },
+          {
+            "tokenAddress": "0x0d500b1d8e8ef31e21c99d1db9a6444d3adf1270",
+            "amount": 37500
+          },
+          {
+            "tokenAddress": "0x580a84c73811e1839f75d86d75d88cca0c241ff4",
+            "amount": 15000
+          }
+        ],
+        "0xf461f2240b66d55dcf9059e26c022160c06863bf000100000000000000000006": [
+          {
+            "tokenAddress": "0x9a71012b13ca4d3d0cdc72a177df3ef03b0e76a3",
+            "amount": 1000
+          },
+          {
+            "tokenAddress": "0x0d500b1d8e8ef31e21c99d1db9a6444d3adf1270",
+            "amount": 15000
+          },
+          {
+            "tokenAddress": "0x580a84c73811e1839f75d86d75d88cca0c241ff4",
+            "amount": 15000
+          }
+        ],
+        "0x614b5038611729ed49e0ded154d8a5d3af9d1d9e00010000000000000000001d": [
+          {
+            "tokenAddress": "0x9a71012b13ca4d3d0cdc72a177df3ef03b0e76a3",
+            "amount": 1000
+          },
+          {
+            "tokenAddress": "0x0d500b1d8e8ef31e21c99d1db9a6444d3adf1270",
+            "amount": 15000
+          },
+          {
+            "tokenAddress": "0xF501dd45a1198C2E1b5aEF5314A68B9006D842E0",
+            "amount": 15000
+          }
+        ],
+        "0x4e7f40cd37cee710f5e87ad72959d30ef8a01a5d00010000000000000000000b": [
+          {
+            "tokenAddress": "0x9a71012b13ca4d3d0cdc72a177df3ef03b0e76a3",
+            "amount": 1000
+          },
+          {
+            "tokenAddress": "0x0d500b1d8e8ef31e21c99d1db9a6444d3adf1270",
+            "amount": 15000
+          }
+        ],
+        "0xfeadd389a5c427952d8fdb8057d6c8ba1156cc5600020000000000000000001e": [
+          {
+            "tokenAddress": "0x9a71012b13ca4d3d0cdc72a177df3ef03b0e76a3",
+            "amount": 1000
+          },
+          {
+            "tokenAddress": "0x0d500b1d8e8ef31e21c99d1db9a6444d3adf1270",
+            "amount": 15000
+          }
+        ]
+      }
+    }
   ]
 }


### PR DESCRIPTION
Co-authored-by: bakamoto20 <85693860+bakamoto20@users.noreply.github.com>
Ballers vote link: https://snapshot.org/#/ballersvote.eth/proposal/QmTiBKhkWVxJU4v1y8nZhbZeYyf4ghNuCznAx6e8RSvLfW

# ETHEREUM CHANGES #

None.

# POLYGON CHANGES #

WMATIC/USDC/QI/BAL/MAI pool moved from T3 to T4. This now receives 1,000 BAL per week. 
WMATIC/USDC/WETH/BAL pool given an extra T3 slot, had a T4 slot removed. This now receives 7,500 BAL per week.


## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other

## How should this be tested?

- [x]  Set system date to sometime next week; on mainnet the same pools should display the same LM APR in preview and prod
- [x]  Set system date to sometime next week; on polygon,  the same pools should display the same LM APR in preview and prod, except for the changes in the pools mentioned above

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] My changes generate no new console warnings
- [x] The base of this PR is `master` if hotfix, `develop` if not
