### PR TITLE
[Gnosis]: Fix notifications when using trades via Balancer

### DIFF
--- a/src/composables/trade/useSor.ts
+++ b/src/composables/trade/useSor.ts
@@ -490,7 +490,7 @@ export default function useSor({
         );
         console.log('Swap out tx', tx);
 
-        txHandler(tx);
+        txHandler(tx, 'trade');
 
         if (successCallback != null) {
           successCallback();

--- a/src/composables/trade/useSor.ts
+++ b/src/composables/trade/useSor.ts
@@ -414,10 +414,12 @@ export default function useSor({
           tokenInAmountScaled
         );
         console.log('Wrap tx', tx);
+
+        txHandler(tx, 'wrap');
+
         if (successCallback != null) {
           successCallback();
         }
-        txHandler(tx, 'wrap');
       } catch (e) {
         console.log(e);
         trading.value = false;
@@ -431,10 +433,12 @@ export default function useSor({
           tokenInAmountScaled
         );
         console.log('Unwrap tx', tx);
+
+        txHandler(tx, 'unwrap');
+
         if (successCallback != null) {
           successCallback();
         }
-        txHandler(tx, 'unwrap');
       } catch (e) {
         console.log(e);
         trading.value = false;
@@ -457,10 +461,12 @@ export default function useSor({
           minAmount
         );
         console.log('Swap in tx', tx);
+
+        txHandler(tx, 'trade');
+
         if (successCallback != null) {
           successCallback();
         }
-        txHandler(tx, 'trade');
       } catch (e) {
         console.log(e);
         trading.value = false;
@@ -483,10 +489,12 @@ export default function useSor({
           tokenOutAmountScaled
         );
         console.log('Swap out tx', tx);
+
+        txHandler(tx);
+
         if (successCallback != null) {
           successCallback();
         }
-        txHandler(tx);
       } catch (e) {
         console.log(e);
         trading.value = false;


### PR DESCRIPTION
# Description

The `txHandler` function needs to be called prior to the success callback because the new behaviour after a successful trade is to reset the inputs (which causes the notifications to appear as `0` value). This fixes it.

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## How should this be tested?

Please provide instructions so we can test. Please also list any relevant details for your test configuration.

- [ ] Make ETH -> ERC20 trade.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] My changes generate no new console warnings
- [x] The base of this PR is `master` if hotfix, `develop` if not
