### PR TITLE
UI 678 Liquidity mining table

### DIFF
--- a/src/components/_global/BalTable/BalTable.vue
+++ b/src/components/_global/BalTable/BalTable.vue
@@ -25,7 +25,10 @@
               column.className,
               getHorizontalStickyClass(columnIndex),
               isColumnStuck ? 'isSticky' : '',
-              column.sortKey ? 'cursor-pointer' : ''
+              column.sortKey ? 'cursor-pointer' : '',
+              currentSortColumn === column.id && currentSortDirection
+                ? 'text-blue-400'
+                : 'text-gray-800 dark:text-gray-100'
             ]"
             :ref="setHeaderRef(columnIndex)"
             @click="handleSort(column.id)"
@@ -42,7 +45,7 @@
                 :name="column.Header"
               ></slot>
               <div v-else>
-                <h5 class="text-base text-gray-800 dark:text-gray-100">
+                <h5 class="text-base">
                   {{ column.name }}
                 </h5>
               </div>

--- a/src/components/_global/BalTable/BalTable.vue
+++ b/src/components/_global/BalTable/BalTable.vue
@@ -7,6 +7,7 @@
   >
     <div class="overflow-hidden" ref="headerRef">
       <table class="w-full table-fixed whitespace-normal">
+        <!-- header width handled by colgroup  -->
         <colgroup>
           <col
             v-for="column in filteredColumns"
@@ -14,6 +15,7 @@
             :style="{ width: `${column?.width}px` }"
           />
         </colgroup>
+        <!-- header is rendered as a row - seperated by columns -->
         <thead class="bg-white dark:bg-gray-900 z-10">
           <th
             v-for="(column, columnIndex) in filteredColumns"
@@ -169,6 +171,42 @@
               </template>
             </td>
           </tr>
+          <tr
+            :class="[
+              'bg-white z-10 row-bg group',
+              { 'cursor-pointer': onRowClick }
+            ]"
+            v-if="shouldRenderTotals"
+          >
+            <td
+              :class="[
+                getHorizontalStickyClass(0),
+                isColumnStuck ? 'isSticky' : '',
+                'text-left p-6 bg-white dark:bg-gray-850 border-t dark:border-gray-900 align-top'
+              ]"
+            >
+              <span class="font-semibold text-left">
+                Total
+              </span>
+            </td>
+            <td
+              v-for="(column, columnIndex) in tail(filteredColumns)"
+              :key="column.id"
+              :class="[
+                column.align === 'right' ? 'text-left' : 'text-right',
+                getHorizontalStickyClass(columnIndex + 1),
+                isColumnStuck ? 'isSticky' : '',
+                'p-6 bg-white dark:bg-gray-850 border-t dark:border-gray-900'
+              ]"
+            >
+              <slot
+                v-if="column.totalsCell"
+                v-bind="dataItem"
+                :name="column.totalsCell"
+              >
+              </slot>
+            </td>
+          </tr>
         </tbody>
       </table>
     </div>
@@ -194,7 +232,7 @@ import {
   watch,
   computed
 } from 'vue';
-import { sortBy, sumBy } from 'lodash';
+import { sortBy, sumBy, tail } from 'lodash';
 
 type Sticky = 'horizontal' | 'vertical' | 'both';
 type Data = any;
@@ -229,6 +267,8 @@ export type ColumnDefinition<T = Data> = {
   sortKey?: string | ((row: T) => unknown);
 
   width?: number;
+
+  totalsCell?: string;
 };
 
 export default defineComponent({
@@ -380,6 +420,10 @@ export default defineComponent({
       props.columns.filter(column => !column.hidden)
     );
 
+    const shouldRenderTotals = computed(() =>
+      props.columns.some(column => column.totalsCell !== undefined)
+    );
+
     watch(
       () => props.data,
       newData => {
@@ -402,6 +446,7 @@ export default defineComponent({
       getHorizontalStickyClass,
       handleSort,
       handleRowClick,
+      tail,
 
       //data
       isColumnStuck,
@@ -411,7 +456,8 @@ export default defineComponent({
       placeholderBlockWidth,
 
       // computed
-      filteredColumns
+      filteredColumns,
+      shouldRenderTotals
     };
   }
 });

--- a/src/components/tables/LMTable/LMTable.vue
+++ b/src/components/tables/LMTable/LMTable.vue
@@ -1,6 +1,12 @@
 <template>
   <BalCard shadow="lg" class="mt-4" noPad>
-    <BalTable sticky="both" :columns="columns" :data="data" :is-loading="false">
+    <BalTable
+      sticky="both"
+      :columns="columns"
+      :data="data"
+      :is-loading="isLoading"
+      skeleton-class="h-64"
+    >
       <template v-slot:iconColumnHeader>
         <div class="flex items-center">
           <img
@@ -22,7 +28,7 @@
         </div>
       </template>
       <template v-slot:poolNameCell="pool">
-        {{ console.log('steble', pool )}}
+        {{ console.log('steble', pool) }}
         <div class="px-6 py-4">
           <TokenPills
             :tokens="orderedPoolTokens(pool)"
@@ -106,6 +112,9 @@ export default defineComponent({
     poolMetadata: {
       type: Object,
       required: true
+    },
+    isLoading: {
+      type: Boolean
     }
   },
   setup(props) {

--- a/src/components/tables/LMTable/LMTable.vue
+++ b/src/components/tables/LMTable/LMTable.vue
@@ -1,0 +1,230 @@
+<template>
+  <BalCard shadow="lg" class="mt-4" noPad>
+    <BalTable sticky="both" :columns="columns" :data="data" :is-loading="false">
+      <template v-slot:iconColumnHeader>
+        <div class="flex items-center">
+          <img
+            v-if="darkMode"
+            :src="require('@/assets/images/icons/tokens_white.svg')"
+          />
+          <img
+            v-else
+            :src="require('@/assets/images/icons/tokens_black.svg')"
+          />
+        </div>
+      </template>
+      <template v-slot:iconColumnCell="pool">
+        <div class="px-6 py-4">
+          <BalAssetSet
+            :addresses="orderedTokenAddressesFor(pool)"
+            :width="100"
+          />
+        </div>
+      </template>
+      <template v-slot:poolNameCell="pool">
+        <div class="px-6 py-4">
+          <TokenPills
+            :tokens="orderedPoolTokens(pool)"
+            :isStablePool="pool.poolType === 'Stable'"
+          />
+        </div>
+      </template>
+      <template
+        v-for="(week, i) in weeks"
+        v-slot:[week.week]="pool"
+        :key="week.week"
+      >
+        <div class="px-6 py-4 text-right flex flex-col">
+          <span
+            v-for="(tokenDist, tokenIndex) in pool.distributions[i]
+              .distribution"
+            :key="tokenDist.tokenAddress"
+          >
+            <span v-if="tokenIndex !== 0">+</span>&nbsp;
+            {{ fNum(tokenDist.amount, 'token_lg') }}
+            {{ tokens[getAddress(tokenDist.tokenAddress)]?.symbol || 'N/A' }}
+          </span>
+        </div>
+      </template>
+      <template
+        v-for="week in weeks"
+        v-slot:[`totals-${week.week}`]
+        :key="week.week"
+      >
+        <div class="text-right flex flex-col">
+          <span
+            v-for="({ token, total }, i) in totals[week.week]"
+            :key="`totals-${token}`"
+            class="font-semibold text-right"
+          >
+            <span v-if="i !== 0">+</span>&nbsp;
+            {{ fNum(total, 'token_lg') }}
+            {{ tokens[getAddress(token)]?.symbol || 'N/A' }}
+          </span>
+          <span class="mt-2 text-gray-500"
+            >~${{ fNum(calculatePricesFor(totals[week.week])) }}</span
+          >
+        </div>
+      </template>
+    </BalTable>
+  </BalCard>
+</template>
+
+<script lang="ts">
+import { ColumnDefinition } from '@/components/_global/BalTable/BalTable.vue';
+import { WeeklyDistributions } from '@/pages/LiquidityMining.vue';
+import TokenPills from '../PoolsTable/TokenPills/TokenPills.vue';
+import {
+  DecoratedPoolWithShares,
+  PoolToken
+} from '@/services/balancer/subgraph/types';
+import { getAddress } from '@ethersproject/address';
+import { computed, defineComponent, PropType, toRefs } from 'vue';
+import { useI18n } from 'vue-i18n';
+import useTokens from '@/composables/useTokens';
+import useNumbers from '@/composables/useNumbers';
+import { sum } from 'lodash';
+import { useStore } from 'vuex';
+
+function getWeekName(week: string) {
+  const parts = week.split('_');
+  return `Week ${parts[1]}`;
+}
+
+type TokenTotal = { token: string; total: number };
+
+export default defineComponent({
+  components: {
+    TokenPills
+  },
+  props: {
+    weeks: {
+      type: Object as PropType<WeeklyDistributions[]>,
+      required: true
+    },
+    poolMetadata: {
+      type: Object,
+      required: true
+    }
+  },
+  setup(props) {
+    const { t } = useI18n();
+    const { weeks, poolMetadata } = toRefs(props);
+    const { tokens } = useTokens();
+    const { fNum } = useNumbers();
+    const store = useStore();
+
+    const prices = computed(() => store.state.market.prices);
+    const data = computed(() => {
+      if (!poolMetadata.value) return [];
+      return poolMetadata.value[0].pools.map(pool => ({
+        address: pool.address,
+        tokens: pool.tokens,
+        distributions: weeks.value.map(week => ({
+          week: week.week,
+          distribution: week.distributions[pool.id.toLowerCase()]
+        }))
+      }));
+    });
+
+    const columns = computed<ColumnDefinition[]>(() => {
+      return [
+        {
+          name: 'Icons',
+          id: 'icons',
+          accessor: 'uri',
+          Header: 'iconColumnHeader',
+          Cell: 'iconColumnCell',
+          width: 125,
+          noGrow: true
+        },
+        {
+          name: t('composition'),
+          id: 'poolName',
+          accessor: 'id',
+          Cell: 'poolNameCell',
+          width: 350
+        },
+        ...weeks.value.map(({ week }, i) => ({
+          name: getWeekName(week),
+          accessor: week,
+          id: week,
+          Cell: week,
+          width: 135,
+          align: 'right' as any,
+          sortKey: pool => {
+            return sum(
+              (pool.distributions[i].distribution || []).map(d => d.amount)
+            );
+          },
+          totalsCell: `totals-${week}`
+        }))
+      ];
+    });
+
+    const totals = computed(() => {
+      // map tracking a list of token totals for each week
+      const weeklyTotals: Record<string, TokenTotal[]> = {};
+      for (const week of weeks.value) {
+        // map tracking totals for each token
+        const tokenTotals: Record<string, TokenTotal> = {};
+        // this will be an array of pools with their token distributions,
+        // we just want the values, not the pool id
+        const distributions = Object.values(week.distributions);
+        for (const distribution of distributions) {
+          for (const allocation of distribution) {
+            if (!tokenTotals[allocation.tokenAddress]) {
+              tokenTotals[allocation.tokenAddress] = {
+                token: allocation.tokenAddress,
+                total: allocation.amount
+              };
+              continue;
+            } else {
+              tokenTotals[allocation.tokenAddress].total =
+                tokenTotals[allocation.tokenAddress].total + allocation.amount;
+            }
+          }
+        }
+        weeklyTotals[week.week] = Object.values(tokenTotals);
+      }
+      return weeklyTotals;
+    });
+
+    function orderedPoolTokens(pool: DecoratedPoolWithShares): PoolToken[] {
+      if (pool.poolType === 'Stable') return pool.tokens;
+
+      const sortedTokens = pool.tokens.slice();
+      sortedTokens.sort((a, b) => parseFloat(b.weight) - parseFloat(a.weight));
+      return sortedTokens;
+    }
+
+    function orderedTokenAddressesFor(pool: DecoratedPoolWithShares) {
+      const sortedTokens = orderedPoolTokens(pool);
+      return sortedTokens.map(token => getAddress(token.address));
+    }
+
+    function calculatePricesFor(totals: TokenTotal[]) {
+      let totalUsd = 0;
+      for (const total of totals) {
+        const usdValue =
+          prices.value[total.token.toLowerCase()].price * total.total;
+        totalUsd = totalUsd + usdValue;
+      }
+      return totalUsd;
+    }
+
+    return {
+      columns,
+      data,
+      orderedTokenAddressesFor,
+      orderedPoolTokens,
+      fNum,
+      getAddress,
+      totals,
+      tokens,
+      prices,
+      calculatePricesFor
+    };
+  }
+});
+</script>

--- a/src/components/tables/LMTable/LMTable.vue
+++ b/src/components/tables/LMTable/LMTable.vue
@@ -22,6 +22,7 @@
         </div>
       </template>
       <template v-slot:poolNameCell="pool">
+        {{ console.log('steble', pool )}}
         <div class="px-6 py-4">
           <TokenPills
             :tokens="orderedPoolTokens(pool)"
@@ -123,7 +124,8 @@ export default defineComponent({
         distributions: weeks.value.map(week => ({
           week: week.week,
           distribution: week.distributions[pool.id.toLowerCase()]
-        }))
+        })),
+        poolType: pool.poolType
       }));
     });
 
@@ -223,7 +225,8 @@ export default defineComponent({
       totals,
       tokens,
       prices,
-      calculatePricesFor
+      calculatePricesFor,
+      console
     };
   }
 });

--- a/src/constants/queryKeys.ts
+++ b/src/constants/queryKeys.ts
@@ -8,7 +8,11 @@ export const CLAIMS_ROOT_KEY = 'claims';
 
 const QUERY_KEYS = {
   Pools: {
-    All: (tokens: Ref<string[]>) => [POOLS_ROOT_KEY, 'all', { tokens }],
+    All: (tokens: Ref<string[]>, poolIds: Ref<string[]> | undefined) => [
+      POOLS_ROOT_KEY,
+      'all',
+      { tokens, poolIds }
+    ],
     User: (account: Ref<string>) => [POOLS_ROOT_KEY, 'user', { account }],
     Current: (id: string) => [POOLS_ROOT_KEY, 'current', { id }],
     Snapshot: (id: string) => [POOLS_ROOT_KEY, 'snapshot', { id }],

--- a/src/pages/LiquidityMining.vue
+++ b/src/pages/LiquidityMining.vue
@@ -3,7 +3,11 @@
     <div class="px-4">
       <h3>{{ title }}</h3>
       <span class="text-black-600">{{ description }}</span>
-      <LMTable :poolMetadata="pools" :weeks="distributions" />
+      <LMTable
+        :is-loading="isLoadingPools || isLoadingPoolsIdle"
+        :poolMetadata="pools"
+        :weeks="distributions"
+      />
       <div class="mt-20">
         <h4 class="font-bold">About liquidity mining</h4>
         <p class="mt-2">
@@ -91,11 +95,11 @@ export default defineComponent({
 
     // there shouldn't be too many pools for the LM distribution for each chain
     // so we won't need to get a paginated response, just get all
-    const { data: poolsResponse } = usePoolsQuery(
-      undefined,
-      {},
-      { poolIds, pageSize: 1000 }
-    );
+    const {
+      data: poolsResponse,
+      isLoading: isLoadingPools,
+      isIdle: isLoadingPoolsIdle
+    } = usePoolsQuery(undefined, {}, { poolIds, pageSize: 1000 });
 
     const pools = computed(() => poolsResponse.value?.pages);
 
@@ -125,7 +129,9 @@ export default defineComponent({
       distributions,
       pools,
       title,
-      description
+      description,
+      isLoadingPools,
+      isLoadingPoolsIdle
     };
   }
 });

--- a/src/pages/LiquidityMining.vue
+++ b/src/pages/LiquidityMining.vue
@@ -1,0 +1,132 @@
+<template>
+  <div class="lg:container lg:mx-auto pt-10 md:pt-12">
+    <div class="px-4">
+      <h3>{{ title }}</h3>
+      <span class="text-black-600">{{ description }}</span>
+      <LMTable :poolMetadata="pools" :weeks="distributions" />
+      <div class="mt-20">
+        <h4 class="font-bold">About liquidity mining</h4>
+        <p class="mt-2">
+          Liquidity mining is a form of ‘yield farming’ used to align incentives
+          between a protocol and its community. Typically, DeFi protocols
+          distribute tokens to users who perform certain activities which help
+          the network grow.<br /><br />
+          The Balancer protocol via the community Ballers, has allocated BAL
+          tokens to go to liquidity providers in certain eligible pools (as
+          listed in the tables above). Tokens are distributed proportional to
+          the amount of liquidity each address contributed, relative to the
+          total liquidity in eligible Balancer pools. BAL tokens represent an
+          ownership stake in the platform and voting rights in community
+          governance. In addition, other protocols like Polygon are further
+          incentivizing liquidity by also distributing MATIC tokens to Balancer
+          liquidity providers in certain pools on Polygon.
+        </p>
+        <div class="mt-6">
+          <h5>Liquidity mining details</h5>
+          <ul class="mt-2 pl-8 list-disc">
+            <li class="mt-2">
+              You’re eligible to receive token distributions if you add
+              liquidity to any of the eligible pools.
+            </li>
+            <li class="mt-2">
+              Liquidity mining weeks start and end at 00:00 UTC on Mondays.
+            </li>
+            <li class="mt-2">
+              BAL allocations and pool eligibility are determined weekly by the
+              community ‘Ballers’.
+            </li>
+          </ul>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script lang="ts">
+import { computed, defineComponent } from 'vue';
+import LMTable from '@/components/tables/LMTable/LMTable.vue';
+import LiquidityMiningDistributions from '@/lib/utils/liquidityMining/MultiTokenLiquidityMining.json';
+import usePoolsQuery from '@/composables/queries/usePoolsQuery';
+import { flatten, takeRight, uniq } from 'lodash';
+import { Network } from '@/constants/network';
+
+type TokenDistribution = {
+  tokenAddress: string;
+  amount: number;
+}[];
+
+type PoolDistribution = {
+  chainId: number;
+  pools: Record<string, TokenDistribution[]>;
+};
+
+type LiquidityMiningDistribution = Record<string, PoolDistribution[]>;
+
+const NETWORK = process.env.VUE_APP_NETWORK || '1';
+
+export type WeeklyDistributions = {
+  week: string;
+  distributions: TokenDistribution[];
+};
+
+export default defineComponent({
+  components: {
+    LMTable
+  },
+  setup() {
+    // seperate variable to type the JSON
+    const weeks = (LiquidityMiningDistributions as unknown) as LiquidityMiningDistribution;
+
+    // only concerned with past 3 weeks
+    const distributions = takeRight(Object.keys(weeks), 3).map(week => ({
+      week: week,
+      distributions: weeks[week]
+        .filter(d => d.chainId === Number(NETWORK))
+        .map(d => d.pools)[0]
+    }));
+
+    const poolIds = computed(() =>
+      uniq(flatten(distributions.map(d => Object.keys(d.distributions))))
+    );
+
+    // there shouldn't be too many pools for the LM distribution for each chain
+    // so we won't need to get a paginated response, just get all
+    const { data: poolsResponse } = usePoolsQuery(
+      undefined,
+      {},
+      { poolIds, pageSize: 1000 }
+    );
+
+    const pools = computed(() => poolsResponse.value?.pages);
+
+    const title = computed(() => {
+      if (Number(NETWORK) === Network.MAINNET) {
+        return 'Ethereum Network';
+      }
+      if (Number(NETWORK) === Network.POLYGON) {
+        return 'Polygon Network';
+      }
+      return 'Unknown Network';
+    });
+
+    const description = computed(() => {
+      if (Number(NETWORK) === Network.MAINNET) {
+        return `BAL distributions on Ethereum can be claimed weekly by tapping the
+        liquidity mining claim tool in the header.`;
+      }
+      if (Number(NETWORK) === Network.POLYGON) {
+        return `BAL distributions on Polygon are automatically airdropped to eligible
+        addresses weekly.`;
+      }
+      return '';
+    });
+
+    return {
+      distributions,
+      pools,
+      title,
+      description
+    };
+  }
+});
+</script>

--- a/src/plugins/router.ts
+++ b/src/plugins/router.ts
@@ -1,6 +1,7 @@
 import { createRouter, createWebHashHistory, RouteRecordRaw } from 'vue-router';
 import Home from '@/pages/Home.vue';
 import Pool from '@/pages/Pool.vue';
+import LiquidityMining from '@/pages/LiquidityMining.vue';
 import Trade from '@/pages/Trade.vue';
 
 const routes: RouteRecordRaw[] = [
@@ -13,6 +14,11 @@ const routes: RouteRecordRaw[] = [
     }
   },
   { path: '/pool/:id', name: 'pool', component: Pool },
+  {
+    path: '/liquidity-mining',
+    name: 'liquidity-mining',
+    component: LiquidityMining
+  },
   { path: '/:pathMatch(.*)*', name: 'not-found', redirect: '/' }
 ];
 


### PR DESCRIPTION
# Description

This pull request introduces the liquidity mining table under a new route. Shows a breakdown of the distribution of tokens to each pool for that week and well as the totals and the fiat usd value.


## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## How should this be tested?

On both polygon and ethereum environments, navigate to the `/liquidity-mining` route and verify that the table works and shows the correct info in regards to the distributions for that week. Can be found in `MultiTokenLiquidityMining.json`.
Verify the totals.
Verify mobile compatibility.

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code where relevant, particularly in hard-to-understand areas
- [ ] My changes generate no new console warnings
- [ ] The base of this PR is `master` if hotfix, `develop` if not
