### PR TITLE
[Gnosis]: More UI Tweaks

### DIFF
--- a/src/components/modals/TradePreviewModalGP.vue
+++ b/src/components/modals/TradePreviewModalGP.vue
@@ -146,6 +146,21 @@
           </div>
         </template>
       </BalCard>
+      <BalAlert
+        v-if="showPriceUpdateError"
+        class="p-3 mb-4"
+        type="error"
+        size="md"
+        :title="$t('priceUpdatedAlert.title')"
+        :description="
+          $t('priceUpdatedAlert.description', [
+            fNum(PRICE_UPDATE_THRESHOLD, 'percent')
+          ])
+        "
+        :action-label="$t('priceUpdatedAlert.actionLabel')"
+        block
+        @actionClick="cofirmPriceUpdate"
+      />
       <div v-if="trading.requiresApproval.value" class="flex justify-between">
         <BalBtn
           v-if="!isUnlocked || approved"
@@ -175,7 +190,7 @@
           @click.prevent="trade"
           :loading="trading.isConfirming.value"
           :loading-label="$t('confirming')"
-          :disabled="!isUnlocked"
+          :disabled="tradeDisabled"
         >
           <div
             v-if="!isUnlocked || approved"
@@ -190,6 +205,7 @@
         v-else
         color="gradient"
         block
+        :disabled="tradeDisabled"
         @click.prevent="trade"
         :loading="trading.isConfirming.value"
         :loading-label="$t('confirming')"
@@ -211,21 +227,25 @@
 </template>
 
 <script lang="ts">
-import { defineComponent, computed, PropType, ref } from 'vue';
+import { defineComponent, computed, PropType, ref, watch } from 'vue';
 import { useStore } from 'vuex';
 import { formatUnits } from '@ethersproject/units';
+import { useI18n } from 'vue-i18n';
+import { mapValues } from 'lodash';
 
 import { UseTrading } from '@/composables/trade/useTrading';
 import useNumbers from '@/composables/useNumbers';
 import useTokenApprovalGP from '@/composables/trade/useTokenApprovalGP';
+import { TradeQuote } from '@/composables/trade/types';
+import useWeb3 from '@/services/web3/useWeb3';
 
 import TradeRoute from '@/components/cards/TradeCard/TradeRoute.vue';
 
 import { bnum } from '@/lib/utils';
 
 import { FiatCurrency } from '@/constants/currency';
-import { mapValues } from 'lodash';
-import { useI18n } from 'vue-i18n';
+
+const PRICE_UPDATE_THRESHOLD = 0.02;
 
 export default defineComponent({
   components: {
@@ -243,6 +263,12 @@ export default defineComponent({
     const store = useStore();
     const { t } = useI18n();
     const { fNum, toFiat } = useNumbers();
+    const { blockNumber } = useWeb3();
+    const lastQuote = ref<TradeQuote | null>(
+      props.trading.isWrapOrUnwrap.value ? null : props.trading.getQuote()
+    );
+    const priceUpdated = ref(false);
+    const priceUpdateAccepted = ref(false);
 
     // DATA
     const showSummaryInFiat = ref(false);
@@ -282,6 +308,16 @@ export default defineComponent({
 
     const zeroFee = computed(() =>
       showSummaryInFiat.value ? fNum('0', 'usd') : '0.0 ETH'
+    );
+
+    const showPriceUpdateError = computed(
+      () => priceUpdated.value && !priceUpdateAccepted.value
+    );
+
+    const tradeDisabled = computed(
+      () =>
+        (props.trading.requiresApproval.value && !isUnlocked.value) ||
+        showPriceUpdateError.value
     );
 
     const summary = computed(() => {
@@ -435,6 +471,41 @@ export default defineComponent({
       emit('close');
     }
 
+    function cofirmPriceUpdate() {
+      priceUpdated.value = false;
+      priceUpdateAccepted.value = true;
+      lastQuote.value = props.trading.getQuote();
+    }
+
+    function handlePriceUpdate() {
+      if (lastQuote.value != null) {
+        const newQuote = props.trading.getQuote();
+
+        if (props.trading.exactIn.value) {
+          priceUpdated.value = bnum(lastQuote.value.minimumOutAmount)
+            .minus(newQuote.minimumOutAmount)
+            .abs()
+            .div(lastQuote.value.minimumOutAmount)
+            .gt(PRICE_UPDATE_THRESHOLD);
+        } else {
+          priceUpdated.value = bnum(lastQuote.value.maximumInAmount)
+            .minus(newQuote.maximumInAmount)
+            .abs()
+            .div(lastQuote.value.maximumInAmount)
+            .gt(PRICE_UPDATE_THRESHOLD);
+        }
+
+        if (priceUpdated.value) {
+          priceUpdateAccepted.value = false;
+        }
+      }
+    }
+
+    // WATCHERS
+    watch(blockNumber, () => {
+      handlePriceUpdate();
+    });
+
     return {
       // constants
       FiatCurrency,
@@ -444,6 +515,7 @@ export default defineComponent({
       onClose,
       approve,
       trade,
+      cofirmPriceUpdate,
 
       // computed
       isUnlocked,
@@ -456,7 +528,13 @@ export default defineComponent({
       slippageRatePercent,
       showTradeRoute,
       labels,
-      zeroFee
+      zeroFee,
+      priceUpdated,
+      tradeDisabled,
+      showPriceUpdateError,
+
+      // consants
+      PRICE_UPDATE_THRESHOLD
     };
   }
 });

--- a/src/components/modals/TradePreviewModalGP.vue
+++ b/src/components/modals/TradePreviewModalGP.vue
@@ -173,7 +173,7 @@
           color="gradient"
           block
           @click.prevent="trade"
-          :loading="trading.isTrading.value"
+          :loading="trading.isConfirming.value"
           :loading-label="$t('confirming')"
           :disabled="!isUnlocked"
         >
@@ -191,7 +191,7 @@
         color="gradient"
         block
         @click.prevent="trade"
-        :loading="trading.isTrading.value"
+        :loading="trading.isConfirming.value"
         :loading-label="$t('confirming')"
       >
         {{ labels.confirmTrade }}

--- a/src/composables/trade/useGnosis.ts
+++ b/src/composables/trade/useGnosis.ts
@@ -86,7 +86,7 @@ export default function useGnosis({
   // DATA
   const feeQuote = ref<FeeInformation | null>(null);
   const updatingQuotes = ref(false);
-  const trading = ref(false);
+  const confirming = ref(false);
 
   // COMPUTED
   const appTransactionDeadline = computed<number>(
@@ -137,7 +137,7 @@ export default function useGnosis({
 
   async function trade(successCallback?: () => void) {
     try {
-      trading.value = true;
+      confirming.value = true;
       const quote = getQuote();
 
       const unsignedOrder: UnsignedOrder = {
@@ -212,10 +212,10 @@ export default function useGnosis({
       if (successCallback != null) {
         successCallback();
       }
-      trading.value = false;
+      confirming.value = false;
     } catch (e) {
       console.log(e);
-      trading.value = false;
+      confirming.value = false;
     }
   }
 
@@ -319,7 +319,7 @@ export default function useGnosis({
     feeQuote,
     updatingQuotes,
     hasErrors,
-    trading,
+    confirming,
     getQuote
   };
 }

--- a/src/composables/trade/useGnosis.ts
+++ b/src/composables/trade/useGnosis.ts
@@ -209,8 +209,6 @@ export default function useGnosis({
         }
       });
 
-      resetState();
-
       if (successCallback != null) {
         successCallback();
       }

--- a/src/composables/trade/useSor.ts
+++ b/src/composables/trade/useSor.ts
@@ -114,6 +114,7 @@ export default function useSor({
     }
   });
   const trading = ref(false);
+  const confirming = ref(false);
   const priceImpact = ref(0);
   const latestTxHash = ref('');
   const poolsLoading = ref(true);
@@ -350,6 +351,8 @@ export default function useSor({
     tx: TransactionResponse,
     action?: 'wrap' | 'unwrap' | 'trade'
   ): void {
+    confirming.value = false;
+
     let summary = '';
     const tokenInAmountFormatted = fNum(tokenInAmountInput.value, 'token');
     const tokenOutAmountFormatted = fNum(tokenOutAmountInput.value, 'token');
@@ -396,6 +399,7 @@ export default function useSor({
   async function trade(successCallback?: () => void) {
     trackGoal(Goals.ClickSwap);
     trading.value = true;
+    confirming.value = true;
 
     const tokenInAddress = tokenInAddressInput.value;
     const tokenOutAddress = tokenOutAddressInput.value;
@@ -421,6 +425,7 @@ export default function useSor({
       } catch (e) {
         console.log(e);
         trading.value = false;
+        confirming.value = false;
       }
       return;
     } else if (isUnwrap.value) {
@@ -440,6 +445,7 @@ export default function useSor({
       } catch (e) {
         console.log(e);
         trading.value = false;
+        confirming.value = false;
       }
       return;
     }
@@ -468,6 +474,7 @@ export default function useSor({
       } catch (e) {
         console.log(e);
         trading.value = false;
+        confirming.value = false;
       }
     } else {
       const tokenInAmountMax = getMaxIn(tokenInAmountScaled);
@@ -496,6 +503,7 @@ export default function useSor({
       } catch (e) {
         console.log(e);
         trading.value = false;
+        confirming.value = false;
       }
     }
   }
@@ -581,6 +589,7 @@ export default function useSor({
     fetchPools,
     poolsLoading,
     getQuote,
-    resetState
+    resetState,
+    confirming
   };
 }

--- a/src/composables/trade/useSor.ts
+++ b/src/composables/trade/useSor.ts
@@ -61,7 +61,6 @@ type Props = {
   sorConfig?: {
     refetchPools: boolean;
     handleAmountsOnFetchPools: boolean;
-    enableTxHandler: boolean;
   };
   tokenIn?: ComputedRef<Token>;
   tokenOut?: ComputedRef<Token>;
@@ -83,8 +82,7 @@ export default function useSor({
   tokenOutAmountScaled,
   sorConfig = {
     refetchPools: true,
-    handleAmountsOnFetchPools: true,
-    enableTxHandler: true
+    handleAmountsOnFetchPools: true
   },
   tokenIn,
   tokenOut,

--- a/src/composables/trade/useSor.ts
+++ b/src/composables/trade/useSor.ts
@@ -202,8 +202,6 @@ export default function useSor({
   }
 
   async function handleAmountChange(): Promise<void> {
-    resetState();
-
     const amount = exactIn.value
       ? tokenInAmountInput.value
       : tokenOutAmountInput.value;
@@ -582,6 +580,7 @@ export default function useSor({
     latestTxHash,
     fetchPools,
     poolsLoading,
-    getQuote
+    getQuote,
+    resetState
   };
 }

--- a/src/composables/trade/useTrading.ts
+++ b/src/composables/trade/useTrading.ts
@@ -116,8 +116,7 @@ export default function useTrading(
     tokenOutAmountScaled,
     sorConfig: {
       handleAmountsOnFetchPools: false,
-      refetchPools: isBalancerTrade.value,
-      enableTxHandler: isBalancerTrade.value
+      refetchPools: false
     },
     tokenIn,
     tokenOut,
@@ -193,8 +192,13 @@ export default function useTrading(
   });
 
   watch(blockNumber, () => {
-    if (isGnosisTrade.value && !gnosis.hasErrors.value) {
-      gnosis.handleAmountChange();
+    if (isGnosisTrade.value) {
+      if (!gnosis.hasErrors.value) {
+        gnosis.handleAmountChange();
+      }
+    } else if (!isWrapOrUnwrap.value) {
+      // only fetch for ETH -> ERC20 trades
+      sor.fetchPools();
     }
   });
 

--- a/src/composables/trade/useTrading.ts
+++ b/src/composables/trade/useTrading.ts
@@ -142,7 +142,9 @@ export default function useTrading(
     isBalancerTrade.value ? sor.poolsLoading.value : gnosis.updatingQuotes.value
   );
 
-  const isTrading = computed(() => sor.trading.value || gnosis.trading.value);
+  const isConfirming = computed(
+    () => sor.confirming.value || gnosis.confirming.value
+  );
 
   // METHODS
   function trade(successCallback?: () => void) {
@@ -225,7 +227,7 @@ export default function useTrading(
     tokenOutAddressInput,
     tokenOutAmountInput,
     slippageBufferRate,
-    isTrading,
+    isConfirming,
 
     // methods
     getQuote,

--- a/src/composables/trade/useTrading.ts
+++ b/src/composables/trade/useTrading.ts
@@ -172,13 +172,8 @@ export default function useTrading(
       gnosis.resetState(false);
       gnosis.handleAmountChange();
     } else {
+      sor.resetState();
       sor.handleAmountChange();
-    }
-  }
-
-  function handleAssetChange() {
-    if (isGnosisTrade.value) {
-      gnosis.resetState();
     }
   }
 
@@ -186,14 +181,12 @@ export default function useTrading(
   watch(tokenInAddressInput, async () => {
     store.commit('trade/setInputAsset', tokenInAddressInput.value);
 
-    handleAssetChange();
     handleAmountChange();
   });
 
   watch(tokenOutAddressInput, () => {
     store.commit('trade/setOutputAsset', tokenOutAddressInput.value);
 
-    handleAssetChange();
     handleAmountChange();
   });
 

--- a/src/locales/default.json
+++ b/src/locales/default.json
@@ -255,6 +255,11 @@
         },
         "gasCosts": "Gas costs"
     },
+    "priceUpdatedAlert": {
+        "title": "Price updated",
+        "description": "The trade price has updated by more than {0}",
+        "actionLabel": "Accept"
+    },
     "searchBy": "Name, symbol or address",
     "searchByName": "Search by Name",
     "seeMore": "See more",


### PR DESCRIPTION
# Description

1. Show price update alert error if it shifts by 2% in the trade preview.
2. Fix a bug related to using the `trading` prop, added a new `confirming` prop (its used to wait for user wallet approval of the trade)
3. Fetch SOR pools on every block (the interval wasn't actually working properly) - thinking that every block is a better approach. This is just for Balancer trades.
4. Some cleanups relating to state reset (cleaning up errors/warnings)

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## How should this be tested?

Please provide instructions so we can test. Please also list any relevant details for your test configuration.

- [ ] The main thing to test is the price update - but for that, there needs to happen a 2% price shift, might take some time to wait on the trade preview modal.


## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] My changes generate no new console warnings
- [x] The base of this PR is `master` if hotfix, `develop` if not
