### PR TITLE
[Gnosis]: Reset errors/warnings on successful trades

### DIFF
--- a/src/composables/trade/useTrading.ts
+++ b/src/composables/trade/useTrading.ts
@@ -145,9 +145,21 @@ export default function useTrading(
   // METHODS
   function trade(successCallback?: () => void) {
     if (isGnosisTrade.value) {
-      return gnosis.trade(successCallback);
+      return gnosis.trade(() => {
+        if (successCallback) {
+          successCallback();
+        }
+
+        gnosis.resetState();
+      });
     } else {
-      return sor.trade(successCallback);
+      return sor.trade(() => {
+        if (successCallback) {
+          successCallback();
+        }
+
+        sor.resetState();
+      });
     }
   }
 


### PR DESCRIPTION
# Description

This is a quick fix for hiding the errors/warnings after a trade.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## How should this be tested?

Please provide instructions so we can test. Please also list any relevant details for your test configuration.

- [ ] Make a trade that has a warning on Gnosis (usually on low amounts and high fee - you get the 20% fee warning)

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] My changes generate no new console warnings
- [x] The base of this PR is `master` if hotfix, `develop` if not
