### PR TITLE
Disable Coingecko list for now

### DIFF
--- a/src/constants/tokenlists.ts
+++ b/src/constants/tokenlists.ts
@@ -26,7 +26,7 @@ export const TOKEN_LIST_MAP: TokenListMapByNetwork = {
       'tokenlist.zerion.eth',
       'tokens.1inch.eth',
       'tokenlist.aave.eth',
-      'https://tokens.coingecko.com/uniswap/all.json',
+      // 'https://tokens.coingecko.com/uniswap/all.json', Breaks balance/allowance fetching
       'https://umaproject.org/uma.tokenlist.json'
     ]
   },
@@ -42,7 +42,7 @@ export const TOKEN_LIST_MAP: TokenListMapByNetwork = {
       'tokenlist.zerion.eth',
       'tokens.1inch.eth',
       'tokenlist.aave.eth',
-      'https://tokens.coingecko.com/uniswap/all.json',
+      // 'https://tokens.coingecko.com/uniswap/all.json',
       'https://umaproject.org/uma.tokenlist.json'
     ]
   },


### PR DESCRIPTION
# Description

Enabling the Coingecko token list atm currently breaks balance/allowance fetching. I believe this is a result of some bad tokens but would take quite a bit of investigation to know for sure. For now, this PR removes that list from the options.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## How should this be tested?

- [ ] Check that you can't see or enable the Coingecko list in the token search modal.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] My changes generate no new console warnings
- [x] The base of this PR is `master` if hotfix, `develop` if not
