### PR TITLE
[Gnosis]: Show a better price estimate on transactions

### DIFF
--- a/src/composables/trade/useGnosis.ts
+++ b/src/composables/trade/useGnosis.ts
@@ -173,16 +173,25 @@ export default function useGnosis({
         owner: account.value
       });
 
+      const sellAmount = exactIn.value
+        ? tokenInAmountInput.value
+        : formatUnits(quote.maximumInAmount, tokenIn.value.decimals).toString();
+
+      const buyAmount = exactIn.value
+        ? formatUnits(
+            quote.minimumOutAmount,
+            tokenOut.value.decimals
+          ).toString()
+        : tokenOutAmountInput.value;
+
       const tokenInAmountEst = exactIn.value ? '' : '~';
       const tokenOutAmountEst = exactIn.value ? '~' : '';
 
-      const summary = `${tokenInAmountEst}${fNum(
-        tokenInAmountInput.value,
-        'token'
-      )} ${tokenIn.value.symbol} -> ${tokenOutAmountEst}${fNum(
-        tokenOutAmountInput.value,
-        'token'
-      )} ${tokenOut.value.symbol}`;
+      const summary = `${tokenInAmountEst}${fNum(sellAmount, 'token')} ${
+        tokenIn.value.symbol
+      } -> ${tokenOutAmountEst}${fNum(buyAmount, 'token')} ${
+        tokenOut.value.symbol
+      }`;
 
       const { validTo, partiallyFillable } = unsignedOrder;
 


### PR DESCRIPTION
# Description

Following Gnosis team feedback, it was noted that the amount estimate shown upon trade confirmation does not include slippage/fees - this PR solves this.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## How should this be tested?

Please provide instructions so we can test. Please also list any relevant details for your test configuration.

- [ ] Make an ERC20 <> ERC20 trade and check the estimated amount

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] My changes generate no new console warnings
- [x] The base of this PR is `master` if hotfix, `develop` if not
