### PR TITLE
fix: add guard for infinity or NaN for apr sorting

### DIFF
--- a/src/components/tables/PoolsTable/PoolsTable.vue
+++ b/src/components/tables/PoolsTable/PoolsTable.vue
@@ -182,7 +182,11 @@ export default defineComponent({
         accessor: pool => pool.dynamic.apr.total,
         align: 'right',
         id: 'poolApr',
-        sortKey: pool => Number(pool.dynamic.apr.total),
+        sortKey: pool => {
+          const apr = Number(pool.dynamic.apr.total);
+          if (apr === Infinity || isNaN(apr)) return 0;
+          return apr;
+        },
         width: 150
       }
     ]);

--- a/src/components/tables/PoolsTable/PoolsTable.vue
+++ b/src/components/tables/PoolsTable/PoolsTable.vue
@@ -165,7 +165,11 @@ export default defineComponent({
         accessor: pool => fNum(pool.totalLiquidity, 'usd'),
         align: 'right',
         id: 'poolValue',
-        sortKey: pool => Number(pool.totalLiquidity),
+        sortKey: pool => {
+          const apr = Number(pool.totalLiquidity);
+          if (apr === Infinity || isNaN(apr)) return 0;
+          return apr;
+        },
         width: 150
       },
       {
@@ -173,7 +177,11 @@ export default defineComponent({
         accessor: pool => fNum(pool.dynamic.volume, 'usd'),
         align: 'right',
         id: 'poolVolume',
-        sortKey: pool => Number(pool.dynamic.volume),
+        sortKey: pool => {
+          const apr = Number(pool.dynamic.volume);
+          if (apr === Infinity || isNaN(apr)) return 0;
+          return apr;
+        },
         width: 175
       },
       {


### PR DESCRIPTION
# Description

APR column is sort of borked when values are NaN or Infinity, they get pushed to the top. This makes them get pushed to the bottom since the number cannot be parsed.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## How should this be tested?

Please provide instructions so we can test. Please also list any relevant details for your test configuration.

Sort by APR column on both production polygon and mainnet.

## Checklist:

- [X] I have performed a self-review of my own code
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] My changes generate no new console warnings
- [x] The base of this PR is `master` if hotfix, `develop` if not
