### PR TITLE
Hotfix 1.12.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.12.5",
+  "version": "1.12.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@balancer-labs/frontend-v2",
-      "version": "1.12.5",
+      "version": "1.12.6",
       "license": "MIT",
       "dependencies": {
         "@balancer-labs/assets": "github:balancer-labs/assets#master",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.12.5",
+  "version": "1.12.6",
   "engines": {
     "node": "14.x",
     "npm": ">=7"

--- a/src/services/coingecko/api/price.service.ts
+++ b/src/services/coingecko/api/price.service.ts
@@ -146,10 +146,9 @@ export class PriceService {
       {}
     );
     const entries = Object.entries(results);
-    const parsedEntries = entries.map(result => [
-      this.addressMapOut(result[0]),
-      result[1]
-    ]);
+    const parsedEntries = entries
+      .filter(result => Object.keys(result[1]).length > 0)
+      .map(result => [this.addressMapOut(result[0]), result[1]]);
     return Object.fromEntries(parsedEntries);
   }
 


### PR DESCRIPTION
# Description

Fixes price fetching when no price information is available from coingecko. The registry refactor introduced a bug where by the prices map would return an empty object for a token it couldn't fetch the price for. Instead it shouldn't inject that token into the prices map at all.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## How should this be tested?

Please provide instructions so we can test. Please also list any relevant details for your test configuration.

- [ ] Check warning is shown on this mainnet pool `0xea39581977325c0833694d51656316ef8a926a62000200000000000000000036`

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] My changes generate no new console warnings
- [x] The base of this PR is `master` if hotfix, `develop` if not
