### PR TITLE
Hotfix 1.12.7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.12.6",
+  "version": "1.12.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@balancer-labs/frontend-v2",
-      "version": "1.12.6",
+      "version": "1.12.7",
       "license": "MIT",
       "dependencies": {
         "@balancer-labs/assets": "github:balancer-labs/assets#master",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.12.6",
+  "version": "1.12.7",
   "engines": {
     "node": "14.x",
     "npm": ">=7"

--- a/src/lib/config/polygon.json
+++ b/src/lib/config/polygon.json
@@ -7,7 +7,7 @@
   "network": "polygon",
   "unknown": false,
   "rpc": "https://polygon-mainnet.infura.io/v3/daaa68ec242643719749dd1caba2fc66",
-  "ws": "wss://rpc-mainnet.maticvigil.com/ws/v1/0640daf21d413ff9adc73b043d91264e42d92a87",
+  "ws": "wss://polygon-mainnet.g.alchemy.com/v2/ODJ9G5Ipv-Hb2zTWMNbUFIqv9WtqBOc2",
   "publicRpc": "https://rpc-mainnet.matic.network",
   "explorer": "https://polygonscan.com",
   "subgraph": "https://api.thegraph.com/subgraphs/name/balancer-labs/balancer-polygon-v2",


### PR DESCRIPTION
# Description

The current maticvigil websocket rpc doesn't work correctly on polygon and therefore we were unable to track block number updates. This PR replaces maticvigil with an Alchemy websocket rpc for polygon.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## How should this be tested?

- [ ] Check polygon app functionality

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] My changes generate no new console warnings
- [x] The base of this PR is `master` if hotfix, `develop` if not
