### PR TITLE
Hotfix 1.12.8

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.12.7",
+  "version": "1.12.8",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@balancer-labs/frontend-v2",
-      "version": "1.12.7",
+      "version": "1.12.8",
       "license": "MIT",
       "dependencies": {
         "@balancer-labs/assets": "github:balancer-labs/assets#master",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.12.7",
+  "version": "1.12.8",
   "engines": {
     "node": "14.x",
     "npm": ">=7"

--- a/src/components/cards/TradeCard/TradeCard.vue
+++ b/src/components/cards/TradeCard/TradeCard.vue
@@ -136,7 +136,7 @@ export default defineComponent({
     const { bp } = useBreakpoints();
 
     const { tokens } = useTokens();
-    const { userNetworkConfig } = useWeb3();
+    const { userNetworkConfig, appNetworkConfig } = useWeb3();
     const { darkMode } = useDarkMode();
 
     const exactIn = ref(true);
@@ -170,18 +170,16 @@ export default defineComponent({
     });
 
     const isWrap = computed(() => {
-      const config = userNetworkConfig.value;
       return (
         tokenInAddress.value === nativeAsset.address &&
-        tokenOutAddress.value === config.addresses.weth
+        tokenOutAddress.value === appNetworkConfig.addresses.weth
       );
     });
 
     const isUnwrap = computed(() => {
-      const config = userNetworkConfig.value;
       return (
         tokenOutAddress.value === nativeAsset.address &&
-        tokenInAddress.value === config.addresses.weth
+        tokenInAddress.value === appNetworkConfig.addresses.weth
       );
     });
 

--- a/src/components/cards/TradeCard/TradeRoute.vue
+++ b/src/components/cards/TradeCard/TradeRoute.vue
@@ -186,7 +186,7 @@ export default defineComponent({
     const { fNum } = useNumbers();
     const { t } = useI18n();
 
-    const { userNetworkConfig } = useWeb3();
+    const { userNetworkConfig, appNetworkConfig } = useWeb3();
     const { tokens } = useTokens();
 
     const visible = ref(false);
@@ -431,7 +431,7 @@ export default defineComponent({
     }
 
     function getPoolLink(id: string): string {
-      const chainId = userNetworkConfig.value.chainId;
+      const chainId = appNetworkConfig.chainId;
       const prefixMap = {
         1: 'app.',
         42: 'kovan.',

--- a/src/components/modals/TradePreviewModal.vue
+++ b/src/components/modals/TradePreviewModal.vue
@@ -126,21 +126,19 @@ export default defineComponent({
     const { addressIn, amountIn, addressOut, isV1Swap } = toRefs(props);
 
     const { tokens } = useTokens();
-    const { userNetworkConfig } = useWeb3();
+    const { appNetworkConfig } = useWeb3();
 
     const isWrap = computed(() => {
-      const config = userNetworkConfig.value;
       return (
         addressIn.value === NATIVE_ASSET_ADDRESS &&
-        addressOut.value === config.addresses.weth
+        addressOut.value === appNetworkConfig.addresses.weth
       );
     });
 
     const isUnwrap = computed(() => {
-      const config = userNetworkConfig.value;
       return (
         addressOut.value === NATIVE_ASSET_ADDRESS &&
-        addressIn.value === config.addresses.weth
+        addressIn.value === appNetworkConfig.addresses.weth
       );
     });
 

--- a/src/composables/trade/useSor.ts
+++ b/src/composables/trade/useSor.ts
@@ -121,7 +121,6 @@ export default function useSor({
   const store = useStore();
   const {
     getProvider: getWeb3Provider,
-    userNetworkConfig,
     isV1Supported,
     appNetworkConfig
   } = useWeb3();
@@ -408,7 +407,7 @@ export default function useSor({
     if (isWrap.value) {
       try {
         const tx = await wrap(
-          String(userNetworkConfig.value.chainId),
+          appNetworkConfig.key,
           provider.value as any,
           tokenInAmountScaled
         );
@@ -428,7 +427,7 @@ export default function useSor({
     } else if (isUnwrap.value) {
       try {
         const tx = await unwrap(
-          String(userNetworkConfig.value.chainId),
+          appNetworkConfig.key,
           provider.value as any,
           tokenInAmountScaled
         );
@@ -455,7 +454,7 @@ export default function useSor({
 
       try {
         const tx = await swapIn(
-          String(userNetworkConfig.value.chainId),
+          appNetworkConfig.key,
           provider.value as any,
           sr,
           tokenInAmountScaled,
@@ -484,7 +483,7 @@ export default function useSor({
 
       try {
         const tx = await swapOut(
-          String(userNetworkConfig.value.chainId),
+          appNetworkConfig.key,
           provider.value as any,
           sr,
           tokenInAmountMax,

--- a/src/composables/trade/useSor.ts
+++ b/src/composables/trade/useSor.ts
@@ -523,10 +523,9 @@ export default function useSor({
     tokenDecimals: number,
     sorManager: SorManager
   ): Promise<void> {
-    const chainId = userNetworkConfig.value.chainId;
     // If using Polygon get price of swap using stored market prices
     // If mainnet price retrieved on-chain using SOR
-    if (chainId === 137) {
+    if (appNetworkConfig.chainId === 137) {
       const swapCostToken = calculateSwapCost(tokenOutAddressInput.value);
       await sorManager.setCostOutputToken(
         tokenAddress,

--- a/src/composables/trade/useTrading.ts
+++ b/src/composables/trade/useTrading.ts
@@ -23,7 +23,7 @@ export default function useTrading(
   const store = useStore();
   const { fNum } = useNumbers();
   const { tokens } = useTokens();
-  const { blockNumber, userNetworkConfig } = useWeb3();
+  const { blockNumber, appNetworkConfig } = useWeb3();
 
   // COMPUTED
   const slippageBufferRate = computed(() =>
@@ -35,13 +35,13 @@ export default function useTrading(
   const isWrap = computed(
     () =>
       tokenInAddressInput.value === NATIVE_ASSET_ADDRESS &&
-      tokenOutAddressInput.value === userNetworkConfig.value.addresses.weth
+      tokenOutAddressInput.value === appNetworkConfig.addresses.weth
   );
 
   const isUnwrap = computed(
     () =>
       tokenOutAddressInput.value === NATIVE_ASSET_ADDRESS &&
-      tokenInAddressInput.value === userNetworkConfig.value.addresses.weth
+      tokenInAddressInput.value === appNetworkConfig.addresses.weth
   );
 
   const tokenIn = computed(() => tokens.value[tokenInAddressInput.value]);

--- a/src/constants/tokenlists.ts
+++ b/src/constants/tokenlists.ts
@@ -39,9 +39,6 @@ export const TOKEN_LIST_MAP: TokenListMapByNetwork = {
     },
     External: [
       'ipns://tokens.uniswap.org',
-      'tokenlist.zerion.eth',
-      'tokens.1inch.eth',
-      'tokenlist.aave.eth',
       // 'https://tokens.coingecko.com/uniswap/all.json',
       'https://umaproject.org/uma.tokenlist.json'
     ]

--- a/src/constants/tokens.ts
+++ b/src/constants/tokens.ts
@@ -10,6 +10,11 @@ export const TOKENS = {
       WETH: '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2',
       BAL: '0xba100000625a3754423978a60c9317c58a424e3d'
     },
+    '42': {
+      ETH: '0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE',
+      WETH: '0xdFCeA9088c8A88A76FF74892C1457C17dfeef9C1',
+      BAL: '0x41286Bb1D3E870f3F750eB7E1C25d7E48c8A1Ac7'
+    },
     '137': {
       WETH: '0x7ceb23fd6bc0add59e62ac25578270cff1b9f619',
       BAL: '0x9a71012b13ca4d3d0cdc72a177df3ef03b0e76a3'

--- a/src/lib/utils/liquidityMining/index.ts
+++ b/src/lib/utils/liquidityMining/index.ts
@@ -86,7 +86,7 @@ export function getLiquidityMiningRewards(
     Object.assign(
       miningRewards,
       liquidityMiningWeek.find(
-        pool => pool.chainId === Number(configService.env.NETWORK)
+        pool => pool.chainId === configService.network.chainId
       )?.pools
     );
   }

--- a/src/pages/LiquidityMining.vue
+++ b/src/pages/LiquidityMining.vue
@@ -67,6 +67,7 @@ import { Network } from '@/constants/network';
 import useNumbers from '@/composables/useNumbers';
 import useTokens from '@/composables/useTokens';
 import { getAddress } from '@ethersproject/address';
+import useConfig from '@/composables/useConfig';
 
 type TokenDistribution = {
   tokenAddress: string;
@@ -82,8 +83,6 @@ export type TokenTotal = { token: string; total: number };
 
 type LiquidityMiningDistribution = Record<string, PoolDistribution[]>;
 
-const NETWORK = process.env.VUE_APP_NETWORK || '1';
-
 export type WeeklyDistributions = {
   week: string;
   distributions: TokenDistribution[];
@@ -96,6 +95,7 @@ export default defineComponent({
   setup() {
     const { fNum } = useNumbers();
     const { priceFor } = useTokens();
+    const { networkConfig } = useConfig();
 
     // seperate variable to type the JSON
     const weeksJSON = (LiquidityMiningDistributions as unknown) as LiquidityMiningDistribution;
@@ -144,7 +144,7 @@ export default defineComponent({
     const weeks = takeRight(Object.keys(weeksJSON), 3).map(week => ({
       week: week,
       distributions: weeksJSON[week]
-        .filter(d => d.chainId === Number(NETWORK))
+        .filter(d => d.chainId === networkConfig.chainId)
         .map(d => d.pools)[0]
     }));
 
@@ -163,21 +163,21 @@ export default defineComponent({
     const pools = computed(() => poolsResponse.value?.pages);
 
     const title = computed(() => {
-      if (Number(NETWORK) === Network.MAINNET) {
+      if (networkConfig.chainId === Network.MAINNET) {
         return 'Ethereum Network';
       }
-      if (Number(NETWORK) === Network.POLYGON) {
+      if (networkConfig.chainId === Network.POLYGON) {
         return 'Polygon Network';
       }
       return 'Unknown Network';
     });
 
     const description = computed(() => {
-      if (Number(NETWORK) === Network.MAINNET) {
+      if (networkConfig.chainId === Network.MAINNET) {
         return `BAL distributions on Ethereum can be claimed weekly by tapping the
         liquidity mining claim tool in the header.`;
       }
-      if (Number(NETWORK) === Network.POLYGON) {
+      if (networkConfig.chainId === Network.POLYGON) {
         return `BAL distributions on Polygon are automatically airdropped to eligible
         addresses weekly.`;
       }

--- a/src/services/web3/useWeb3.ts
+++ b/src/services/web3/useWeb3.ts
@@ -50,7 +50,7 @@ export default function useWeb3() {
   const isMismatchedNetwork = computed(() => {
     return (
       isWalletReady.value &&
-      userNetworkConfig.value?.key !== process.env.VUE_APP_NETWORK
+      userNetworkConfig.value?.key !== appNetworkConfig.key
     );
   });
   const isUnsupportedNetwork = computed(() => {

--- a/src/services/web3/web3.plugin.ts
+++ b/src/services/web3/web3.plugin.ts
@@ -89,10 +89,7 @@ export default {
     });
 
     const chainId = computed(() => {
-      if (pluginState.connector) {
-        return pluginState.connector.chainId;
-      }
-      return Number(process.env.VUE_APP_NETWORK);
+      return pluginState.connector?.chainId;
     });
 
     const provider = computed(


### PR DESCRIPTION
# Description

Cleans up references to chainId. We have a few exceptions being thrown in Sentry where chainId is missing. It's not easy to see exactly where this is happening so this PR is cleaning up all references. In particular, we should be using the `appNetworkConfig.chainId` everywhere except where it's a user action that explicitly needs to know the user's current chainId, for example when checking if they're on the wrong network.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## How should this be tested?

- [ ] Test all functionality

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] My changes generate no new console warnings
- [x] The base of this PR is `master` if hotfix, `develop` if not
