### PR TITLE
Hotfix 1.12.13

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.12.12",
+  "version": "1.12.13",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@balancer-labs/frontend-v2",
-      "version": "1.12.12",
+      "version": "1.12.13",
       "license": "MIT",
       "dependencies": {
         "@balancer-labs/assets": "github:balancer-labs/assets#master",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.12.12",
+  "version": "1.12.13",
   "engines": {
     "node": "14.x",
     "npm": ">=7"

--- a/public/index.html
+++ b/public/index.html
@@ -30,15 +30,8 @@
     <script>
       window.dataLayer = window.dataLayer || [];
       function gtag(){dataLayer.push(arguments);}
-
-      // https://developers.google.com/gtagjs/devguide/consent#in-page-code
-      gtag('consent', 'default', {
-        'ad_storage': 'denied',
-        'analytics_storage': 'denied'
-      });
-
       gtag('js', new Date());
-      gtag('config', '<%= VUE_APP_GA_ID %>', { 'anonymize_ip': true });
+      gtag('config', '<%= VUE_APP_GA_ID %>', { 'client_storage': 'none', 'anonymize_ip': true });
     </script>
     <!-- Fathom Analytics -->
     <script src="https://chipmunk.balancer.fi/script.js" data-spa="hash" data-site="<%= VUE_APP_FATHOM_SITE_ID %>" defer></script>


### PR DESCRIPTION
# Description

Using the consent schema prevents and data being reported in the Google Analytics dashboard. Instead, we have to use the old version of GA and pass `client_storage: none` in the google tag config.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code where relevant, particularly in hard-to-understand areas
- [ ] My changes generate no new console warnings
- [ ] The base of this PR is `master` if hotfix, `develop` if not
