### PR TITLE
feat: show prices for wstETH

### DIFF
--- a/src/lib/config/homestead.json
+++ b/src/lib/config/homestead.json
@@ -34,8 +34,8 @@
     "stablePoolFactory": "0xc66Ba2B6595D3613CCab350C886aCE23866EDe24",
     "tokenFactory": "",
     "weth": "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
-    "stETH": "0xae7ab96520de3a18e5e111b5eaab095312d7fe84",
-    "wstETH": "0x7f39c581f595b53c5cb19bd0b3f8da6c935e2ca0",
+    "stETH": "0xae7ab96520DE3A18E5e111B5EaAb095312D7fE84",
+    "wstETH": "0x7f39C581F595B53c5cb19bD0b3f8dA6c935E2Ca0",
     "lidoRelayer": "0xdcdbf71A870cc60C6F9B621E28a7D3Ffd6Dd4965",
     "MockFlashLoanReceiver": "",
     "balancerHelpers": "0x5aDDCCa35b7A0D07C74063c48700C8590E87864E"

--- a/src/providers/tokens.provider.ts
+++ b/src/providers/tokens.provider.ts
@@ -327,6 +327,15 @@ export default {
      */
     function priceFor(address: string): number {
       try {
+        // TODO: kill this with fire as soon as Coingecko supports wstETH
+        if (address === configService.network.addresses.wstETH) {
+          // If we're asking for the wstETH price then return 1.03x stETH price
+          const stETHPrice =
+            prices.value[configService.network.addresses.stETH][
+              currency.value
+            ] || 0;
+          return 1.0352 * stETHPrice;
+        }
         return prices.value[address][currency.value] || 0;
       } catch {
         return 0;


### PR DESCRIPTION
Coingecko doesn't support price queries for wstETH so I've made a quick hacky fix to just return a scaled version of the stETH price.

I realise this is ugly as sin.