### PR TITLE
Make priceRate conditional on network

### DIFF
--- a/src/services/balancer/subgraph/entities/pools/query.ts
+++ b/src/services/balancer/subgraph/entities/pools/query.ts
@@ -1,4 +1,6 @@
+import { Network } from '@/constants/network';
 import { POOLS } from '@/constants/pools';
+import { configService } from '@/services/config/config.service';
 import { merge } from 'lodash';
 
 const defaultArgs = {
@@ -27,10 +29,13 @@ const defaultAttrs = {
   tokens: {
     address: true,
     balance: true,
-    weight: true,
-    priceRate: true
+    weight: true
   }
 };
+
+if (configService.network.chainId !== Network.POLYGON) {
+  defaultAttrs.tokens['priceRate'] = true;
+}
 
 export default (args = {}, attrs = {}) => ({
   pools: {

--- a/src/services/balancer/subgraph/types.ts
+++ b/src/services/balancer/subgraph/types.ts
@@ -16,7 +16,7 @@ export interface PoolToken {
   address: string;
   balance: string;
   weight: string;
-  priceRate: string;
+  priceRate?: string;
 }
 
 export interface Pool {


### PR DESCRIPTION
# Description

The priceRate attribute is breaking polygon subgraph requests. This PR conditionally includes that attribute in requests based on supported networks.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## How should this be tested?

- [ ] Test polygon app loads pools.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] My changes generate no new console warnings
- [x] The base of this PR is `master` if hotfix, `develop` if not
