### PR TITLE
Fix wstEth price injection

### DIFF
--- a/src/lib/utils/balancer/price.ts
+++ b/src/lib/utils/balancer/price.ts
@@ -1,4 +1,4 @@
-import { isStable, isWeighted } from '@/composables/usePool';
+import { isStable, isStableLike, isWeighted } from '@/composables/usePool';
 import { FiatCurrency } from '@/constants/currency';
 import { Pool } from '@/services/balancer/subgraph/types';
 import { TokenPrices } from '@/services/coingecko/api/price.service';
@@ -37,7 +37,7 @@ export function getPoolLiquidity(
     }
   }
   // TODO [improvement]: if price is missing, compute spot price based on balances and amp factor
-  if (isStable(pool)) {
+  if (isStableLike(pool)) {
     let sumBalance = 0;
     let sumValue = 0;
 

--- a/src/lib/utils/balancer/price.ts
+++ b/src/lib/utils/balancer/price.ts
@@ -1,4 +1,4 @@
-import { isStable, isStableLike, isWeighted } from '@/composables/usePool';
+import { isStableLike, isWeighted } from '@/composables/usePool';
 import { FiatCurrency } from '@/constants/currency';
 import { Pool } from '@/services/balancer/subgraph/types';
 import { TokenPrices } from '@/services/coingecko/api/price.service';

--- a/src/providers/tokens.provider.ts
+++ b/src/providers/tokens.provider.ts
@@ -327,15 +327,6 @@ export default {
      */
     function priceFor(address: string): number {
       try {
-        // TODO: kill this with fire as soon as Coingecko supports wstETH
-        if (address === configService.network.addresses.wstETH) {
-          // If we're asking for the wstETH price then return 1.03x stETH price
-          const stETHPrice =
-            prices.value[configService.network.addresses.stETH][
-              currency.value
-            ] || 0;
-          return 1.0352 * stETHPrice;
-        }
         return prices.value[address][currency.value] || 0;
       } catch {
         return 0;


### PR DESCRIPTION
# Description

Inject wstEth price into prices map rather than in the priceFor helper function.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## How should this be tested?

Please provide instructions so we can test. Please also list any relevant details for your test configuration.

- [ ] Check this pool has correct price info and appropriate pool value: `0x32296969ef14eb0c6d29669c550d4a0449130230000200000000000000000080`

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code where relevant, particularly in hard-to-understand areas
- [ ] My changes generate no new console warnings
- [ ] The base of this PR is `master` if hotfix, `develop` if not
