### PR TITLE
Purge cloudflare cache after vercel deployment

### DIFF
--- a/.github/workflows/cache.yml
+++ b/.github/workflows/cache.yml
@@ -1,0 +1,26 @@
+name: Purge Cloudflare Cache
+on:
+  push:
+    branches:
+      - master
+jobs:
+  wait-for-vercel-deployment:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: UnlyEd/github-action-await-vercel@v1.1.0
+        id: await-vercel
+        env:
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+        with:
+          deployment-url: pm2.vercel.app
+          timeout: 600 # Wait for 10 minutes before failing
+  purge-cache:
+    runs-on: ubuntu-latest
+    needs: wait-for-vercel-deployment
+    steps:
+    - name: Purge cache
+      uses: jakejarvis/cloudflare-purge-action@master
+      env:
+        # Zone is required by both authentication methods
+        CLOUDFLARE_ZONE: ${{ secrets.CLOUDFLARE_ZONE }}
+        CLOUDFLARE_TOKEN: ${{ secrets.CLOUDFLARE_TOKEN }}


### PR DESCRIPTION
# Description

Users have consistently run into issues where cached versions of the site are loaded and have to hard refresh to fix bugs. This adds a github action that waits on a new vercel deployment and then purges the cloudflare cache.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other

## How should this be tested?

This is hard to test locally

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] My changes generate no new console warnings
- [x] The base of this PR is `master` if hotfix, `develop` if not
