### PR TITLE
Hotfix 1.13.8

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.13.7",
+  "version": "1.13.8",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@balancer-labs/frontend-v2",
-      "version": "1.13.7",
+      "version": "1.13.8",
       "license": "MIT",
       "dependencies": {
         "@balancer-labs/assets": "github:balancer-labs/assets#master",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.13.7",
+  "version": "1.13.8",
   "engines": {
     "node": "14.x",
     "npm": ">=7"


### PR DESCRIPTION
# Description

Fixes price impact calculation for withdrawals in all non-metastable pools. There is an issue with how to scale balance inputs for the SOR. For metastable pools it needs to scale all tokens to 18 decimals, for everything else it needs to be scaled to the token decimals. We will need to refactor how all this works so it's consistent.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## How should this be tested?

- [ ] Check price impact numbers for withdrawals on non-metastable pools.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] My changes generate no new console warnings
- [x] The base of this PR is `master` if hotfix, `develop` if not
