### PR TITLE
[Gnosis]: Add support for error messages

### DIFF
--- a/src/components/modals/TradePreviewModalGP.vue
+++ b/src/components/modals/TradePreviewModalGP.vue
@@ -313,6 +313,17 @@
       >
         {{ labels.confirmTrade }}
       </BalBtn>
+      <BalAlert
+        v-if="trading.submissionError.value != null"
+        class="p-3 mt-4"
+        type="error"
+        size="md"
+        :title="$t('tradeSubmissionError.title')"
+        :description="trading.submissionError.value"
+        block
+        :action-label="$t('tradeSubmissionError.actionLabel')"
+        @actionClick="trading.resetSubmissionError"
+      />
     </div>
     <BalCard shadow="none" class="mt-3" v-if="showTradeRoute">
       <TradeRoute

--- a/src/composables/trade/useGnosis.ts
+++ b/src/composables/trade/useGnosis.ts
@@ -157,7 +157,7 @@ export default function useGnosis({
         kind: exactIn.value ? OrderKind.SELL : OrderKind.BUY,
         receiver: account.value,
         partiallyFillable: false, // Always fill or kill,
-        sellTokenBalance: OrderBalance.INTERNAL
+        sellTokenBalance: OrderBalance.EXTERNAL
       };
 
       const { signature, signingScheme } = await signOrder(

--- a/src/composables/trade/useGnosis.ts
+++ b/src/composables/trade/useGnosis.ts
@@ -22,13 +22,14 @@ import useTokens from '../useTokens';
 const HIGH_FEE_THRESHOLD = 0.2;
 
 const state = reactive({
-  errors: {
+  validationErrors: {
     feeExceedsPrice: false,
     priceExceedsBalance: false
   },
   warnings: {
     highFees: false
-  }
+  },
+  submissionError: null
 });
 
 export type GnosisTransactionDetails = {
@@ -89,8 +90,8 @@ export default function useGnosis({
     () => store.state.app.transactionDeadline
   );
 
-  const hasErrors = computed(() =>
-    Object.values(state.errors).some(hasError => hasError)
+  const hasValidationErrors = computed(() =>
+    Object.values(state.validationErrors).some(hasError => hasError)
   );
 
   // METHODS
@@ -134,6 +135,8 @@ export default function useGnosis({
   async function trade(successCallback?: () => void) {
     try {
       confirming.value = true;
+      state.submissionError = null;
+
       const quote = getQuote();
 
       const unsignedOrder: UnsignedOrder = {
@@ -154,7 +157,7 @@ export default function useGnosis({
         kind: exactIn.value ? OrderKind.SELL : OrderKind.BUY,
         receiver: account.value,
         partiallyFillable: false, // Always fill or kill,
-        sellTokenBalance: OrderBalance.EXTERNAL
+        sellTokenBalance: OrderBalance.INTERNAL
       };
 
       const { signature, signingScheme } = await signOrder(
@@ -221,16 +224,18 @@ export default function useGnosis({
       }
       confirming.value = false;
     } catch (e) {
-      console.log(e);
+      state.submissionError = e.message;
       confirming.value = false;
     }
   }
 
   function resetState(shouldResetFees = true) {
-    state.errors.feeExceedsPrice = false;
-    state.errors.priceExceedsBalance = false;
+    state.validationErrors.feeExceedsPrice = false;
+    state.validationErrors.priceExceedsBalance = false;
 
     state.warnings.highFees = false;
+
+    state.submissionError = null;
 
     if (shouldResetFees) {
       feeQuote.value = null;
@@ -269,11 +274,11 @@ export default function useGnosis({
 
       if (feeQuoteResult != null) {
         if (exactIn.value) {
-          state.errors.feeExceedsPrice = amountToExchange
+          state.validationErrors.feeExceedsPrice = amountToExchange
             .minus(feeQuoteResult.amount)
             .isNegative();
         }
-        if (!state.errors.feeExceedsPrice) {
+        if (!state.validationErrors.feeExceedsPrice) {
           const priceQuoteResult = await gnosisOperator.getPriceQuote(
             queryParams
           );
@@ -302,7 +307,7 @@ export default function useGnosis({
                 .div(amountToExchange)
                 .gt(HIGH_FEE_THRESHOLD);
 
-              state.errors.priceExceedsBalance = bnum(
+              state.validationErrors.priceExceedsBalance = bnum(
                 formatUnits(maximumInAmount, tokenIn.value.decimals)
               ).gt(balanceFor(tokenIn.value.address));
             }
@@ -325,7 +330,7 @@ export default function useGnosis({
     ...toRefs(state),
     feeQuote,
     updatingQuotes,
-    hasErrors,
+    hasValidationErrors,
     confirming,
     getQuote
   };

--- a/src/composables/trade/useSor.ts
+++ b/src/composables/trade/useSor.ts
@@ -49,9 +49,10 @@ const SWAP_COST = process.env.VUE_APP_SWAP_COST || '100000';
 const MIN_PRICE_IMPACT = 0.0001;
 const HIGH_PRICE_IMPACT_THRESHOLD = 0.05;
 const state = reactive({
-  errors: {
+  validationErrors: {
     highPriceImpact: false
-  }
+  },
+  submissionError: null
 });
 
 type Props = {
@@ -159,7 +160,9 @@ export default function useSor({
   }, 30 * 1e3);
 
   function resetState() {
-    state.errors.highPriceImpact = false;
+    state.validationErrors.highPriceImpact = false;
+
+    state.submissionError = null;
   }
 
   async function initSor(): Promise<void> {
@@ -388,7 +391,7 @@ export default function useSor({
 
     pools.value = sorManager.selectedPools;
 
-    state.errors.highPriceImpact =
+    state.validationErrors.highPriceImpact =
       priceImpact.value >= HIGH_PRICE_IMPACT_THRESHOLD;
   }
 
@@ -447,6 +450,7 @@ export default function useSor({
     trackGoal(Goals.ClickSwap);
     trading.value = true;
     confirming.value = true;
+    state.submissionError = null;
 
     const tokenInAddress = tokenInAddressInput.value;
     const tokenOutAddress = tokenOutAddressInput.value;
@@ -472,6 +476,7 @@ export default function useSor({
         }
       } catch (e) {
         console.log(e);
+        state.submissionError = e.message;
         trading.value = false;
         confirming.value = false;
       }
@@ -493,6 +498,7 @@ export default function useSor({
         }
       } catch (e) {
         console.log(e);
+        state.submissionError = e.message;
         trading.value = false;
         confirming.value = false;
       }
@@ -522,6 +528,7 @@ export default function useSor({
         }
       } catch (e) {
         console.log(e);
+        state.submissionError = e.message;
         trading.value = false;
         confirming.value = false;
       }
@@ -551,6 +558,7 @@ export default function useSor({
         }
       } catch (e) {
         console.log(e);
+        state.submissionError = e.message;
         trading.value = false;
         confirming.value = false;
       }

--- a/src/composables/trade/useTrading.ts
+++ b/src/composables/trade/useTrading.ts
@@ -154,6 +154,10 @@ export default function useTrading(
     () => sor.confirming.value || gnosis.confirming.value
   );
 
+  const submissionError = computed(
+    () => sor.submissionError.value || gnosis.submissionError.value
+  );
+
   // METHODS
   function trade(successCallback?: () => void) {
     if (isGnosisTrade.value) {
@@ -174,6 +178,11 @@ export default function useTrading(
         sor.resetState();
       });
     }
+  }
+
+  function resetSubmissionError() {
+    sor.submissionError.value = null;
+    gnosis.submissionError.value = null;
   }
 
   function getQuote() {
@@ -215,7 +224,7 @@ export default function useTrading(
 
   watch(blockNumber, () => {
     if (isGnosisTrade.value) {
-      if (!gnosis.hasErrors.value) {
+      if (!gnosis.hasValidationErrors.value) {
         gnosis.handleAmountChange();
       }
     } else if (isBalancerTrade.value) {
@@ -260,6 +269,8 @@ export default function useTrading(
     tokenOutAmountInput,
     slippageBufferRate,
     isConfirming,
+    submissionError,
+    resetSubmissionError,
 
     // methods
     getQuote,

--- a/src/locales/default.json
+++ b/src/locales/default.json
@@ -327,6 +327,10 @@
     "transactionDeadline": "Transaction deadline",
     "transactionDeadlineTooltip": "Your swap will expire and not execute if it is pending for more than the selected duration. Only executed swaps incur fees for trades between ERC-20 tokens.",
     "transactionType": "Transaction type",
+    "tradeSubmissionError": {
+        "title": "An error has occurred",
+        "actionLabel": "Dismiss"
+    },
     "unavailableOnNetwork": "Sorry! Balancer is not available on this network",
     "unavailableOnNetworkWithName": "Sorry! Balancer is not available on {0}",
     "liquidityProviderCopy": "People who provide liquidity to eligible investment pools or trade on eligible token pairs receive weekly $BAL distributions as incentives. $BAL token holders own the Balancer Protocol and can help shape its future by voting on governance proposals.",

--- a/src/services/gnosis/error.ts
+++ b/src/services/gnosis/error.ts
@@ -1,7 +1,13 @@
-// Conforms to backend API
-
 import { AxiosResponse } from 'axios';
 
+type ApiActionType = 'get' | 'create' | 'delete';
+
+export interface ApiErrorObject {
+  errorType: ApiErrorCodes;
+  description: string;
+}
+
+// Conforms to backend API
 // https://github.com/gnosis/gp-v2-services/blob/0bd5f7743bebaa5acd3be13e35ede2326a096f14/orderbook/openapi.yml#L562
 export enum ApiErrorCodes {
   DuplicateOrder = 'DuplicateOrder',
@@ -11,47 +17,76 @@ export enum ApiErrorCodes {
   InsufficientFunds = 'InsufficientFunds',
   InsufficientFee = 'InsufficientFee',
   UnsupportedToken = 'UnsupportedToken',
-  WrongOwner = 'WrongOwner'
+  WrongOwner = 'WrongOwner',
+  NotFound = 'NotFound',
+  OrderNotFound = 'OrderNotFound',
+  AlreadyCancelled = 'AlreadyCancelled',
+  OrderFullyExecuted = 'OrderFullyExecuted',
+  OrderExpired = 'OrderExpired',
+  UnsupportedSellTokenSource = 'UnsupportedSellTokenSource',
+  UnsupportedBuyTokenSource = 'UnsupportedBuyTokenSource',
+  UNHANDLED_GET_ERROR = 'UNHANDLED_GET_ERROR',
+  UNHANDLED_CREATE_ERROR = 'UNHANDLED_CREATE_ERROR',
+  UNHANDLED_DELETE_ERROR = 'UNHANDLED_DELETE_ERROR'
 }
 
-export interface ApiError {
-  errorType: ApiErrorCodes;
-  description: string;
+export enum ApiErrorCodeDetails {
+  DuplicateOrder = 'There was another identical order already submitted. Please try again.',
+  InsufficientFee = "The signed fee is insufficient. It's possible that is higher now due to a change in the gas price, ether price, or the sell token price. Please try again to get an updated fee quote.",
+  InvalidSignature = 'The order signature is invalid. Check whether your Wallet app supports off-chain signing.',
+  MissingOrderData = 'The order has missing information.',
+  InsufficientValidTo = 'The order you are signing is already expired. This can happen if you set a short expiration in the settings and waited too long before signing the transaction. Please try again.',
+  InsufficientFunds = "The account doesn't have enough funds.",
+  UnsupportedToken = 'One of the tokens you are trading is unsupported.',
+  WrongOwner = "The signature is invalid.\n\nIt's likely that the signing method provided by your wallet doesn't comply with the standards required by Balancer.\n\nCheck whether your Wallet app supports off-chain signing (EIP-712 or ETHSIGN).",
+  NotFound = 'Token pair selected has insufficient liquidity.',
+  OrderNotFound = 'The order you are trying to cancel does not exist.',
+  AlreadyCancelled = 'Order is already cancelled.',
+  OrderFullyExecuted = 'Order is already filled.',
+  OrderExpired = 'Order is expired.',
+  UnsupportedSellTokenSource = 'The sell token source is currently not supported.',
+  UnsupportedBuyTokenSource = 'The buy token source is currently not supported.',
+  UNHANDLED_GET_ERROR = 'Order fetch failed. This may be due to a server or network connectivity issue. Please try again later.',
+  UNHANDLED_CREATE_ERROR = 'The order was not accepted by the network.',
+  UNHANDLED_DELETE_ERROR = 'The order cancellation was not accepted by the network.'
 }
 
-const API_ERROR_CODE_DESCRIPTIONS = {
-  [ApiErrorCodes.DuplicateOrder]:
-    'There was another identical order already submitted. Please try again.',
-  [ApiErrorCodes.InsufficientFee]:
-    "The signed fee is insufficient. It's possible that is higher now due to a change in the gas price, ether price, or the sell token price. Please try again to get an updated fee quote.",
-  [ApiErrorCodes.InvalidSignature]:
-    'The order signature is invalid. Check whether your Wallet app supports off-chain signing.',
-  [ApiErrorCodes.MissingOrderData]: 'The order has missing information',
-  [ApiErrorCodes.InsufficientValidTo]:
-    'The order you are signing is already expired. This can happen if you set a short expiration in the settings and waited too long before signing the transaction. Please try again.',
-  [ApiErrorCodes.InsufficientFunds]: "The account doesn't have enough funds",
-  [ApiErrorCodes.UnsupportedToken]:
-    'One of the tokens you are trading is unsupported. Please read the FAQ for more info.',
-  [ApiErrorCodes.WrongOwner]:
-    "The signature is invalid.\n\nIt's likely that the signing method provided by your wallet doesn't comply with the standards required by CowSwap.\n\nCheck whether your Wallet app supports off-chain signing (EIP-712 or ETHSIGN).",
-  UNHANDLED_ERROR: 'The order was not accepted by the network'
-};
+function _mapActionToErrorDetail(action?: ApiActionType) {
+  switch (action) {
+    case 'get':
+      return ApiErrorCodeDetails.UNHANDLED_GET_ERROR;
+    case 'create':
+      return ApiErrorCodeDetails.UNHANDLED_CREATE_ERROR;
+    case 'delete':
+      return ApiErrorCodeDetails.UNHANDLED_DELETE_ERROR;
+    default:
+      console.error(
+        '[OperatorError::_mapActionToErrorDetails] Uncaught error mapping error action type to server error. Please try again later.'
+      );
+      return 'Something failed. Please try again later.';
+  }
+}
 
 export default class OperatorError extends Error {
   name = 'OperatorError';
   type: ApiErrorCodes;
-  description: ApiError['description'];
+  description: ApiErrorObject['description'];
 
   // Status 400 errors
   // https://github.com/gnosis/gp-v2-services/blob/9014ae55412a356e46343e051aefeb683cc69c41/orderbook/openapi.yml#L563
-  static apiErrorDetails = API_ERROR_CODE_DESCRIPTIONS;
+  static apiErrorDetails = ApiErrorCodeDetails;
 
-  static getErrorMessage(response: AxiosResponse) {
+  public static getErrorMessage(
+    orderPostError: ApiErrorObject,
+    action: ApiActionType
+  ) {
     try {
-      const orderPostError: ApiError = response.data;
-
+      console.log(orderPostError);
       if (orderPostError.errorType) {
-        return OperatorError.apiErrorDetails[orderPostError.errorType];
+        const errorMessage =
+          OperatorError.apiErrorDetails[orderPostError.errorType];
+        // shouldn't fall through as this error constructor expects the error code to exist but just in case
+        return errorMessage || orderPostError.errorType;
       } else {
         console.error(
           'Unknown reason for bad order submission',
@@ -63,30 +98,52 @@ export default class OperatorError extends Error {
       console.error(
         'Error handling a 400 error. Likely a problem deserialising the JSON response'
       );
-      return OperatorError.apiErrorDetails.UNHANDLED_ERROR;
+      return _mapActionToErrorDetail(action);
     }
   }
-  static getErrorForUnsuccessfulPostOrder(response: AxiosResponse) {
+  static getErrorFromStatusCode(
+    response: AxiosResponse,
+    action: 'create' | 'delete'
+  ) {
     switch (response.status) {
       case 400:
-        return this.getErrorMessage(response);
+      case 404:
+        return this.getErrorMessage(response.data, action);
 
       case 403:
-        return 'The order cannot be accepted. Your account is deny-listed.';
+        return `The order cannot be ${
+          action === 'create' ? 'accepted' : 'cancelled'
+        }. Your account is deny-listed.`;
 
       case 429:
-        return 'The order cannot be accepted. Too many order placements. Please, retry in a minute';
+        return `The order cannot be ${
+          action === 'create'
+            ? 'accepted. Too many order placements'
+            : 'cancelled. Too many order cancellations'
+        }. Please, retry in a minute`;
 
       case 500:
       default:
-        return 'Error adding an order';
+        console.error(
+          `[OperatorError::getErrorFromStatusCode] Error ${
+            action === 'create' ? 'creating' : 'cancelling'
+          } the order, status code:`,
+          response.status || 'unknown'
+        );
+        return `Error ${
+          action === 'create' ? 'creating' : 'cancelling'
+        } the order`;
     }
   }
-  constructor(apiError: ApiError) {
+  constructor(apiError: ApiErrorObject) {
     super(apiError.description);
 
     this.type = apiError.errorType;
     this.description = apiError.description;
-    this.message = OperatorError.apiErrorDetails[apiError.errorType];
+    this.message = ApiErrorCodeDetails[apiError.errorType];
   }
+}
+
+export function isValidOperatorError(error: any): error is OperatorError {
+  return error instanceof OperatorError;
 }

--- a/src/services/gnosis/operator.service.ts
+++ b/src/services/gnosis/operator.service.ts
@@ -43,8 +43,9 @@ export default class GnosisOperatorService {
       return response.data as OrderID;
     }
 
-    const errorMessage = OperatorError.getErrorForUnsuccessfulPostOrder(
-      response
+    const errorMessage = OperatorError.getErrorFromStatusCode(
+      response,
+      'create'
     );
 
     throw new Error(errorMessage);


### PR DESCRIPTION
# Description

Adds support for submission errors (could come from MetaMask/SOR/Gnosis API).

Here is an example of a user rejection of a tx:
<img width="570" alt="Screen Shot 2021-08-23 at 11 42 15 am" src="https://user-images.githubusercontent.com/254095/130379778-12cdb73f-c5f4-46af-9c33-655850b92016.png">

EIP 1559 error (using Ledger):
<img width="490" alt="Screen Shot 2021-08-23 at 12 35 11 pm" src="https://user-images.githubusercontent.com/254095/130382261-526b72ac-4392-4496-81dc-e725f09100fe.png">


Note - currently it does not work for approvals.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## How should this be tested?

Please provide instructions so we can test. Please also list any relevant details for your test configuration.

- [ ] Make a trade and try to cancel it (you should see MM user error)
- [ ] Make an ERC20 <> ERC20 trade (this won't work on prod for now and so you should see an error)

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] My changes generate no new console warnings
- [x] The base of this PR is `master` if hotfix, `develop` if not
