### PR TITLE
Revert to setup function

### DIFF
--- a/src/components/_global/icons/IntercomIcon.vue
+++ b/src/components/_global/icons/IntercomIcon.vue
@@ -1,9 +1,3 @@
-<script setup lang="ts">
-import useDarkMode from '@/composables/useDarkMode';
-
-const { darkMode } = useDarkMode();
-</script>
-
 <template>
   <svg
     width="21"
@@ -46,3 +40,16 @@ const { darkMode } = useDarkMode();
     </defs>
   </svg>
 </template>
+
+<script lang="ts">
+import { defineComponent } from 'vue';
+import useDarkMode from '@/composables/useDarkMode';
+
+export default defineComponent({
+  setup() {
+    const { darkMode } = useDarkMode();
+
+    return { darkMode };
+  }
+});
+</script>

--- a/src/components/btns/DarkModeToggle.vue
+++ b/src/components/btns/DarkModeToggle.vue
@@ -3,7 +3,6 @@
     color="white"
     :size="upToLargeBreakpoint ? 'md' : 'sm'"
     @click="toggleDarkMode"
-    class="hidden xs:inline-block"
   >
     <MoonIcon v-if="darkMode" />
     <SunIcon v-else />

--- a/src/components/btns/IntercomToggle.vue
+++ b/src/components/btns/IntercomToggle.vue
@@ -3,7 +3,6 @@
     id="intercom-activator"
     color="white"
     :size="upToLargeBreakpoint ? 'md' : 'sm'"
-    class="hidden xs:inline-block"
   >
     <IntercomIcon />
   </BalBtn>


### PR DESCRIPTION
# Description

New script setup vue syntax doesn't work in production, we'll probably need to update some package versions. For now I'm reverting to the old setup function in the one component where I used the new syntax.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## How should this be tested?

- [ ] Check the intercom icon displays on mobile

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] My changes generate no new console warnings
- [x] The base of this PR is `master` if hotfix, `develop` if not
