### PR TITLE
Hotfix 1.14.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.14.2",
+  "version": "1.14.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@balancer-labs/frontend-v2",
-      "version": "1.14.2",
+      "version": "1.14.3",
       "license": "MIT",
       "dependencies": {
         "@balancer-labs/assets": "github:balancer-labs/assets#master",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.14.2",
+  "version": "1.14.3",
   "engines": {
     "node": "14.x",
     "npm": ">=7"

--- a/src/composables/queries/useTokenPricesQuery.ts
+++ b/src/composables/queries/useTokenPricesQuery.ts
@@ -7,6 +7,7 @@ import { TokenPrices } from '@/services/coingecko/api/price.service';
 import { sleep } from '@/lib/utils';
 import { configService } from '@/services/config/config.service';
 import useUserSettings from '@/composables/useUserSettings';
+import { TOKENS } from '@/constants/tokens';
 
 /**
  * TYPES
@@ -34,7 +35,9 @@ export default function useTokenPricesQuery(
     const wstEthAddress = configService.network.addresses.wstETH;
     if (prices[stEthAddress]) {
       const stETHPrice = prices[stEthAddress][currency.value] || 0;
-      prices[wstEthAddress] = { [currency.value]: 1.0352 * stETHPrice };
+      prices[wstEthAddress] = {
+        [currency.value]: TOKENS.Prices.ExchangeRates.wstETH.stETH * stETHPrice
+      };
     }
 
     return prices;

--- a/src/constants/tokens.ts
+++ b/src/constants/tokens.ts
@@ -38,6 +38,12 @@ export const TOKENS = {
         '0x04df6e4121c27713ed22341e7c7df330f56f289b':
           '0x6b175474e89094c44da98b954eedeac495271d0f'
       }
+    },
+    // TODO - remove once coingecko supports wstETH
+    ExchangeRates: {
+      wstETH: {
+        stETH: 1.0352
+      }
     }
   }
 };

--- a/src/services/coingecko/api/price.service.ts
+++ b/src/services/coingecko/api/price.service.ts
@@ -31,6 +31,7 @@ export class PriceService {
   platformId: string;
   nativeAssetId: string;
   nativeAssetAddress: string;
+  appAddresses: { [key: string]: string };
 
   constructor(
     service: CoingeckoService,
@@ -42,6 +43,7 @@ export class PriceService {
     this.platformId = getPlatformId(this.appNetwork);
     this.nativeAssetId = getNativeAssetId(this.appNetwork);
     this.nativeAssetAddress = this.configService.network.nativeAsset.address;
+    this.appAddresses = this.configService.network.addresses;
   }
 
   async getNativeAssetPrice(): Promise<Price> {
@@ -69,7 +71,7 @@ export class PriceService {
 
       // TODO - remove once wsteth is supported
       addresses = addresses.filter(
-        address => address !== this.configService.network.addresses.wstETH
+        address => address !== this.appAddresses.wstETH
       );
 
       addresses = addresses.map(address => this.addressMapIn(address));
@@ -120,8 +122,7 @@ export class PriceService {
 
     // TODO - remove once wsteth is supported
     addresses = addresses.filter(
-      address =>
-        address !== this.configService.network.addresses.wstETH.toLowerCase()
+      address => address !== this.appAddresses.wstETH
     );
 
     addresses = addresses.map(address => this.addressMapIn(address));
@@ -178,7 +179,11 @@ export class PriceService {
           const value = result[key];
           const [timestamp, price] = value;
           if (timestamp > dayTimestamp * 1000) {
-            prices[dayTimestamp * 1000] = price;
+            // TODO - remove this conditional once coingecko supports wstETH
+            prices[dayTimestamp * 1000] =
+              address === this.appAddresses.stETH
+                ? price * TOKENS.Prices.ExchangeRates.wstETH.stETH
+                : price;
             dayTimestamp += twentyFourHourseInSecs;
           }
         }
@@ -194,7 +199,7 @@ export class PriceService {
         if (!(timestamp in prices)) {
           prices[timestamp] = [];
         }
-        prices[timestamp].push(price);
+        prices[timestamp].unshift(price);
       }
     }
     return prices;


### PR DESCRIPTION
# Description

Some hacks are required to get the chart to work on the wstETH metastable pool page. Should be reverted once Coingecko support wstETH

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## How should this be tested?

- [ ] Test mainnet app metastable pool displays chart
- [ ] Check other pools display chart.

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code where relevant, particularly in hard-to-understand areas
- [ ] My changes generate no new console warnings
- [ ] The base of this PR is `master` if hotfix, `develop` if not
