### PR TITLE
Lazy network switching (no more millions of Metamask popups)

### DIFF
--- a/src/components/navs/AppNav/AppNavAlert.vue
+++ b/src/components/navs/AppNav/AppNavAlert.vue
@@ -4,6 +4,13 @@
     <div class="flex-1 text-center flex items-center justify-center">
       <BalIcon :name="iconName" class="mr-4" />
       <span>{{ alert.label }}</span>
+      <BalBtn
+        v-if="alert.action && alert.actionLabel"
+        class="ml-4 cursor-pointer"
+        color="white"
+        :label="alert.actionLabel"
+        @click="alert.action"
+      />
     </div>
     <div v-if="!alert.persistant" class="w-8">
       <BalIcon name="x" class="cursor-pointer" @click="handleClose" />

--- a/src/composables/queries/useUserClaimsQuery.ts
+++ b/src/composables/queries/useUserClaimsQuery.ts
@@ -74,7 +74,6 @@ export default function useUserClaimsQuery(
   const queryOptions = reactive({
     enabled: isQueryEnabled,
     refetchOnMount: false,
-    refetchOnWindowFocus: false,
     ...options
   });
 

--- a/src/composables/useWeb3Watchers.ts
+++ b/src/composables/useWeb3Watchers.ts
@@ -19,7 +19,8 @@ export default function useWeb3Watchers() {
     account,
     isMismatchedNetwork,
     isUnsupportedNetwork,
-    blockNumber
+    blockNumber,
+    connectToAppNetwork
   } = useWeb3();
   const { refetchBalances, refetchAllowances } = useTokens();
   const { handlePendingTransactions, updateTransaction } = useTransactions();
@@ -93,7 +94,9 @@ export default function useWeb3Watchers() {
         store.commit('alerts/setCurrent', {
           label: t('networkMismatch', [appNetworkConfig.name]),
           type: 'error',
-          persistant: true
+          persistant: true,
+          action: connectToAppNetwork,
+          actionLabel: t('switchNetwork')
         });
       } else {
         store.commit('alerts/setCurrent', null);

--- a/src/locales/default.json
+++ b/src/locales/default.json
@@ -211,6 +211,7 @@
     "receipt": "Receipt",
     "recentActivityTitle": "Recent activity",
     "noRecentActivity": "Your recent activity will appear here…",
+    "switchNetwork": "Switch Network",
     "transactionAction": {
         "trade": "Trade",
         "approve": "Approve",

--- a/src/services/web3/useWeb3.ts
+++ b/src/services/web3/useWeb3.ts
@@ -7,6 +7,7 @@ import ConfigService from '../config/config.service';
 import { isAddress } from '@ethersproject/address';
 import { web3Service } from './web3.service';
 import { rpcProviderService } from '../rpc-provider/rpc-provider.service';
+import { switchToAppNetwork } from './utils/helpers';
 
 /** STATE */
 const blockNumber = ref(0);
@@ -70,6 +71,7 @@ export default function useWeb3() {
   // METHODS
   const getProvider = () => new Web3Provider(provider.value as any);
   const getSigner = () => getProvider().getSigner();
+  const connectToAppNetwork = () => switchToAppNetwork(provider.value as any);
   const toggleWalletSelectModal = (value: boolean) => {
     if (value !== undefined && typeof value === 'boolean') {
       isWalletSelectVisible.value = value;
@@ -117,6 +119,7 @@ export default function useWeb3() {
 
     // methods
     connectWallet,
+    connectToAppNetwork,
     getProvider,
     getSigner,
     disconnectWallet,

--- a/src/services/web3/web3.plugin.ts
+++ b/src/services/web3/web3.plugin.ts
@@ -13,7 +13,6 @@ import { GnosisSafeConnector } from './connectors/gnosis/gnosis.connector';
 import { WalletLinkConnector } from './connectors/walletlink/walletlink.connector';
 import { PortisConnector } from './connectors/portis/portis.connector';
 import useFathom from '@/composables/useFathom';
-import { configService } from '../config/config.service';
 
 import defaultLogo from '@/assets/images/connectors/default.svg';
 import fortmaticLogo from '@/assets/images/connectors/fortmatic.svg';

--- a/src/services/web3/web3.plugin.ts
+++ b/src/services/web3/web3.plugin.ts
@@ -14,7 +14,6 @@ import { WalletLinkConnector } from './connectors/walletlink/walletlink.connecto
 import { PortisConnector } from './connectors/portis/portis.connector';
 import useFathom from '@/composables/useFathom';
 import { configService } from '../config/config.service';
-import { switchToAppNetwork } from './utils/helpers';
 
 import defaultLogo from '@/assets/images/connectors/default.svg';
 import fortmaticLogo from '@/assets/images/connectors/fortmatic.svg';
@@ -144,19 +143,6 @@ export default {
           lsSet('connectedProvider', wallet);
           pluginState.walletState = 'connected';
 
-          if (
-            configService.env.NETWORK !== chainId.value &&
-            connector.id === 'injected'
-          ) {
-            // this will also as the user to switch to Polygon, if already added
-            const result = await switchToAppNetwork(connector.provider);
-            if (!result) {
-              return;
-            }
-            if (chainId.value !== configService.network.chainId) {
-              await connectWallet(wallet);
-            }
-          }
           trackGoal(Goals.ConnectedWallet);
         }
       } catch (err) {

--- a/src/store/modules/alerts.ts
+++ b/src/store/modules/alerts.ts
@@ -1,7 +1,9 @@
 export interface Alert {
   label: string;
   type: 'error' | 'info';
-  persistant: boolean;
+  actionLabel: string;
+  action?: () => void;
+  persistant?: boolean;
 }
 
 export interface AlertState {


### PR DESCRIPTION
# Description

We're currently immediately requesting that the user switch their network to match whatever the UI is expecting to as soon as they enter the page. This is a massive pain (especially if you have polygon and mainnet open at the same time.) and we've got multiple complaints about it (including @alexvansande).

I've removed the current logic which checks the network on connecting to a wallet and instead added a button to the alert navbar to ask Metamask to switch. 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## How should this be tested?

Load the app with metamask connected to the wrong network. Click button on nav and check that UI behaves as expected afterwards.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] My changes generate no new console warnings
- [x] The base of this PR is `master` if hotfix, `develop` if not
