### PR TITLE
Hotfix/1.14.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.14.3",
+  "version": "1.14.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@balancer-labs/frontend-v2",
-      "version": "1.14.3",
+      "version": "1.14.4",
       "license": "MIT",
       "dependencies": {
         "@balancer-labs/assets": "github:balancer-labs/assets#master",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.14.3",
+  "version": "1.14.4",
   "engines": {
     "node": "14.x",
     "npm": ">=7"

--- a/src/components/tables/LMTable/LMTable.vue
+++ b/src/components/tables/LMTable/LMTable.vue
@@ -115,7 +115,7 @@ import useNumbers from '@/composables/useNumbers';
 import { last, sum } from 'lodash';
 import useDarkMode from '@/composables/useDarkMode';
 import { isStableLike } from '@/composables/usePool';
-import { startOfWeek, subWeeks, format } from 'date-fns';
+import { startOfWeek, subWeeks, format, addDays } from 'date-fns';
 
 function getWeekName(week: string) {
   const parts = week.split('_');
@@ -224,9 +224,9 @@ export default defineComponent({
     }
 
     function getWeekStart(howManyWeeksToSubtract: number) {
-      console.log('lmao', howManyWeeksToSubtract);
       return format(
-        startOfWeek(subWeeks(new Date(), howManyWeeksToSubtract)),
+        // startOfWeek is Sunday for date-fns
+        addDays(startOfWeek(subWeeks(new Date(), howManyWeeksToSubtract)), 1),
         'dd/MM/yyyy'
       );
     }

--- a/src/components/tables/LMTable/LMTable.vue
+++ b/src/components/tables/LMTable/LMTable.vue
@@ -31,7 +31,7 @@
       >
         <div class="text-right flex flex-col">
           <span>{{ getWeekName(week.week) }}</span>
-          <span class="text-xs">Starts {{ getWeekStart(i) }}</span>
+          <span class="text-xs">Starts {{ getWeekStart(weeks.length - i - 1) }}</span>
         </div>
       </template>
       <template v-slot:iconColumnCell="pool">
@@ -222,6 +222,7 @@ export default defineComponent({
     }
 
     function getWeekStart(howManyWeeksToSubtract: number) {
+      console.log('lmao', howManyWeeksToSubtract)
       return format(
         startOfWeek(subWeeks(new Date(), howManyWeeksToSubtract)),
         'dd/MM/yyyy'

--- a/src/components/tables/LMTable/LMTable.vue
+++ b/src/components/tables/LMTable/LMTable.vue
@@ -31,7 +31,9 @@
       >
         <div class="text-right flex flex-col">
           <span>{{ getWeekName(week.week) }}</span>
-          <span class="text-xs">Starts {{ getWeekStart(weeks.length - i - 1) }}</span>
+          <span class="text-xs"
+            >Starts {{ getWeekStart(weeks.length - i - 1) }}</span
+          >
         </div>
       </template>
       <template v-slot:iconColumnCell="pool">
@@ -222,7 +224,7 @@ export default defineComponent({
     }
 
     function getWeekStart(howManyWeeksToSubtract: number) {
-      console.log('lmao', howManyWeeksToSubtract)
+      console.log('lmao', howManyWeeksToSubtract);
       return format(
         startOfWeek(subWeeks(new Date(), howManyWeeksToSubtract)),
         'dd/MM/yyyy'


### PR DESCRIPTION
# Description

The week starts shown on the LM Table were reverse ordered. Also need to show that the LM rewards start on Monday rather than Sunday

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## How should this be tested?
Test the LM Table