### PR TITLE
Update the source of tokens eligible for "BAL for Gas"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.14.3",
+  "version": "1.14.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@balancer-labs/frontend-v2",
-      "version": "1.14.3",
+      "version": "1.14.4",
       "license": "MIT",
       "dependencies": {
         "@balancer-labs/assets": "github:balancer-labs/assets#master",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.14.4",
       "license": "MIT",
       "dependencies": {
-        "@balancer-labs/assets": "github:balancer-labs/assets#master",
+        "@balancer-labs/assets": "github:balancer-labs/assets#922890a",
         "@balancer-labs/sor": "github:balancer-labs/balancer-sor#john/v1-consideringFees-package",
         "@balancer-labs/sor2": "github:balancer-labs/balancer-sor#john/ui-694-sor-lido-add-static-route-refactor",
         "@ensdomains/content-hash": "^2.5.3",
@@ -1417,7 +1417,7 @@
     "node_modules/@balancer-labs/assets": {
       "name": "assets",
       "version": "1.0.0",
-      "resolved": "git+ssh://git@github.com/balancer-labs/assets.git#47ab806dc0f1f350585f589c98cbbda0cc2b8e54",
+      "resolved": "git+ssh://git@github.com/balancer-labs/assets.git#922890a1af06490476eaca7a87ecf463f8765bc4",
       "license": "ISC",
       "dependencies": {
         "dotenv": "^8.2.0"
@@ -31922,8 +31922,8 @@
       }
     },
     "@balancer-labs/assets": {
-      "version": "git+ssh://git@github.com/balancer-labs/assets.git#47ab806dc0f1f350585f589c98cbbda0cc2b8e54",
-      "from": "@balancer-labs/assets@github:balancer-labs/assets#master",
+      "version": "git+ssh://git@github.com/balancer-labs/assets.git#922890a1af06490476eaca7a87ecf463f8765bc4",
+      "from": "@balancer-labs/assets@github:balancer-labs/assets#922890a",
       "requires": {
         "dotenv": "^8.2.0"
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.14.3",
+  "version": "1.14.4",
   "engines": {
     "node": "14.x",
     "npm": ">=7"

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "prepare": "husky install"
   },
   "dependencies": {
-    "@balancer-labs/assets": "github:balancer-labs/assets#master",
+    "@balancer-labs/assets": "github:balancer-labs/assets#922890a",
     "@balancer-labs/sor": "github:balancer-labs/balancer-sor#john/v1-consideringFees-package",
     "@balancer-labs/sor2": "github:balancer-labs/balancer-sor#john/ui-694-sor-lido-add-static-route-refactor",
     "@ensdomains/content-hash": "^2.5.3",

--- a/src/components/cards/TradeCard/GasReimbursement.vue
+++ b/src/components/cards/TradeCard/GasReimbursement.vue
@@ -21,7 +21,7 @@ import { useStore } from 'vuex';
 import BigNumber from 'bignumber.js';
 import { SorReturn } from '@/lib/utils/balancer/helpers/sor/sorManager';
 import { isBudgetLeft } from '@/lib/utils/balancer/bal4gas';
-import eligibleAssetList from '@balancer-labs/assets/lists/eligible.json';
+import eligibleAssetList from '@balancer-labs/assets/generated/bal-for-gas.json';
 import { useI18n } from 'vue-i18n';
 import { EXTERNAL_LINKS } from '@/constants/links';
 import useWeb3 from '@/services/web3/useWeb3';
@@ -54,8 +54,7 @@ export default defineComponent({
 
     const eligibleAssetMeta = eligibleAssetList[appNetworkConfig.network] ?? {};
     const eligibleAssets = Object.fromEntries(
-      Object.entries(eligibleAssetMeta).map(assetEntry => {
-        const [address] = assetEntry;
+      eligibleAssetMeta.map(address => {
         return [address.toLowerCase(), ''];
       })
     );

--- a/src/components/tables/LMTable/LMTable.vue
+++ b/src/components/tables/LMTable/LMTable.vue
@@ -31,7 +31,9 @@
       >
         <div class="text-right flex flex-col">
           <span>{{ getWeekName(week.week) }}</span>
-          <span class="text-xs">Starts {{ getWeekStart(i) }}</span>
+          <span class="text-xs"
+            >Starts {{ getWeekStart(weeks.length - i - 1) }}</span
+          >
         </div>
       </template>
       <template v-slot:iconColumnCell="pool">
@@ -113,7 +115,7 @@ import useNumbers from '@/composables/useNumbers';
 import { last, sum } from 'lodash';
 import useDarkMode from '@/composables/useDarkMode';
 import { isStableLike } from '@/composables/usePool';
-import { startOfWeek, subWeeks, format } from 'date-fns';
+import { startOfWeek, subWeeks, format, addDays } from 'date-fns';
 
 function getWeekName(week: string) {
   const parts = week.split('_');
@@ -223,7 +225,8 @@ export default defineComponent({
 
     function getWeekStart(howManyWeeksToSubtract: number) {
       return format(
-        startOfWeek(subWeeks(new Date(), howManyWeeksToSubtract)),
+        // startOfWeek is Sunday for date-fns
+        addDays(startOfWeek(subWeeks(new Date(), howManyWeeksToSubtract)), 1),
         'dd/MM/yyyy'
       );
     }


### PR DESCRIPTION
# Description

Some users have noticed that the trade UI wasn't showing "BAL for Gas" estimates for USDT trades, when it should.

This conforms the frontend to the new file structure of the `assets` repo, where `eligible.json` is no longer maintained; instead, `bal-for-gas.json` is auto-generated by making a union of `eligible.json`, `ui-not-eligible.json` and `listed.json`. See https://github.com/balancer-labs/assets/pull/369

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## How should this be tested?

- [ ] A swap between ETH and USDT should display the BAL for Gas estimate

## Checklist:

- [X] I have performed a self-review of my own code
- [X] I have commented my code where relevant, particularly in hard-to-understand areas
- [X] My changes generate no new console warnings
- [X] The base of this PR is `master` if hotfix, `develop` if not
