### PR TITLE
Show Gnosis toggle on staging apps

### DIFF
--- a/src/components/navs/AppNav/AppNavSettings.vue
+++ b/src/components/navs/AppNav/AppNavSettings.vue
@@ -140,7 +140,7 @@
       />
     </div>
     <!-- Hide Gnosis interface switch for now -->
-    <div v-if="!isPolygon && false" class="px-4 mt-6">
+    <div v-if="!isPolygon && APP_ENV === 'staging'" class="px-4 mt-6">
       <div class="flex items-baseline">
         <span v-text="$t('tradeInterface')" class="font-medium mb-2" />
         <BalTooltip>
@@ -190,6 +190,7 @@ import {
 } from '@/constants/options';
 import { TradeInterface } from '@/store/modules/app';
 import useEthereumTxType from '@/composables/useEthereumTxType';
+import useConfig from '@/composables/useConfig';
 
 const locales = {
   'en-US': 'English',
@@ -226,6 +227,9 @@ export default defineComponent({
       userNetworkConfig
     } = useWeb3();
     const { ethereumTxType, setEthereumTxType } = useEthereumTxType();
+    const {
+      env: { APP_ENV }
+    } = useConfig();
 
     // DATA
     const data = reactive({
@@ -273,6 +277,7 @@ export default defineComponent({
       ...toRefs(data),
       // constants
       APP,
+      APP_ENV,
       TradeInterface,
       // computed
       account,


### PR DESCRIPTION
# Description

Initial hotfix hid the Gnosis toggle everywhere, including the staging apps. This PR allows it on apps with APP_ENV set to `staging`

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## How should this be tested?

- [ ] Check for Gnosis toggle in account settings.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] My changes generate no new console warnings
- [x] The base of this PR is `master` if hotfix, `develop` if not
