### PR TITLE
Pool returns charts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.14.4",
+  "version": "1.14.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@balancer-labs/frontend-v2",
-      "version": "1.14.4",
+      "version": "1.14.5",
       "license": "MIT",
       "dependencies": {
         "@balancer-labs/assets": "github:balancer-labs/assets#master",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.14.4",
+  "version": "1.14.5",
   "engines": {
     "node": "14.x",
     "npm": ">=7"

--- a/src/services/coingecko/api/price.service.ts
+++ b/src/services/coingecko/api/price.service.ts
@@ -199,7 +199,7 @@ export class PriceService {
         if (!(timestamp in prices)) {
           prices[timestamp] = [];
         }
-        prices[timestamp].unshift(price);
+        prices[timestamp].push(price);
       }
     }
     return prices;


### PR DESCRIPTION
# Description

There have been reports on Discord of the pool returns charts looking off. Seems to have originated in 1.14.3

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## How should this be tested?

- [ ] HODL returns on the USDC/ETH pool should be close to 23%

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] My changes generate no new console warnings
- [x] The base of this PR is `master` if hotfix, `develop` if not
