### PR TITLE
Fix trade interface switch

### DIFF
--- a/src/components/navs/AppNav/AppNavSettings.vue
+++ b/src/components/navs/AppNav/AppNavSettings.vue
@@ -218,12 +218,12 @@ export default defineComponent({
     const {
       explorerLinks,
       account,
-      chainId,
       disconnectWallet,
       connector,
       isV1Supported,
       isEIP1559SupportedNetwork,
-      userNetworkConfig
+      userNetworkConfig,
+      appNetworkConfig
     } = useWeb3();
     const { ethereumTxType, setEthereumTxType } = useEthereumTxType();
 
@@ -250,7 +250,7 @@ export default defineComponent({
     const connectorLogo = computed(() => getConnectorLogo(connector.value?.id));
     const hideDisconnect = computed(() => connector.value?.id == 'gnosis');
     const isGnosisSupportedNetwork = computed(() =>
-      GP_SUPPORTED_NETWORKS.includes(chainId.value)
+      GP_SUPPORTED_NETWORKS.includes(appNetworkConfig.chainId)
     );
 
     // METHODS
@@ -280,7 +280,6 @@ export default defineComponent({
       // computed
       account,
       appTradeLiquidity,
-      chainId,
       appTradeInterface,
       networkName,
       networkColorClass,


### PR DESCRIPTION
# Description

Langer reported strange behavior with the trade switch (being visible on Polygon deployment). This fix replaces the `chainId` check to the app network one instead of the user one.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## How should this be tested?

Please provide instructions so we can test. Please also list any relevant details for your test configuration.

- [x] Network switch should not appear on Polygon deployment regardless of what network the user has selected.
- [x] Ethereum networks should have the switch

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] My changes generate no new console warnings
- [x] The base of this PR is `master` if hotfix, `develop` if not
