### PR TITLE
Remove patch for Polygon subgraph not returning pricerates

### DIFF
--- a/src/services/balancer/subgraph/entities/pools/query.ts
+++ b/src/services/balancer/subgraph/entities/pools/query.ts
@@ -1,6 +1,4 @@
-import { Network } from '@/constants/network';
 import { POOLS } from '@/constants/pools';
-import { configService } from '@/services/config/config.service';
 import { merge } from 'lodash';
 
 const defaultArgs = {
@@ -29,13 +27,10 @@ const defaultAttrs = {
   tokens: {
     address: true,
     balance: true,
-    weight: true
+    weight: true,
+    priceRate: true
   }
 };
-
-if (configService.network.chainId !== Network.POLYGON) {
-  defaultAttrs.tokens['priceRate'] = true;
-}
 
 export default (args = {}, attrs = {}) => ({
   pools: {


### PR DESCRIPTION
# Description

This PR removes the patch around the Polygon subgraph not returning `pricesRates` which resulted in the main page blowing up as this issue with the subgraph has been fixed.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other

## How should this be tested?

Check that pools load on main page of Polygon app

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] My changes generate no new console warnings
- [x] The base of this PR is `master` if hotfix, `develop` if not
