### PR TITLE
Hotfix: get LM manifest from GitHub

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.16.1",
+  "version": "1.16.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@balancer-labs/frontend-v2",
-      "version": "1.16.1",
+      "version": "1.16.2",
       "license": "MIT",
       "dependencies": {
         "@balancer-labs/assets": "github:balancer-labs/assets#master",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.16.1",
+  "version": "1.16.2",
   "engines": {
     "node": "14.x",
     "npm": ">=7"

--- a/src/services/claim.ts
+++ b/src/services/claim.ts
@@ -23,21 +23,20 @@ type Snapshot = Record<number, string>;
 export const constants: Record<NetworkId, Record<string, string>> = {
   1: {
     merkleRedeem: '0x6d19b2bF3A36A61530909Ae65445a906D98A2Fa8',
-    snapshot: 'balancer-team-bucket.storage.fleek.co/balancer-claim/snapshot'
+    snapshot:
+      'https://raw.githubusercontent.com/balancer-labs/bal-mining-scripts/master/reports/_current.json'
   },
   42: {
     merkleRedeem: '0x3bc73D276EEE8cA9424Ecb922375A0357c1833B3',
     snapshot:
-      'balancer-team-bucket.storage.fleek.co/balancer-claim-kovan/snapshot'
+      'https://raw.githubusercontent.com/balancer-labs/bal-mining-scripts/master/reports-kovan/_current.json'
   }
 };
 
 export async function getSnapshot(network: NetworkId) {
   if (constants[network]?.snapshot) {
-    return (
-      (await ipfsService.get<Snapshot>(constants[network].snapshot, 'ipns')) ||
-      {}
-    );
+    const response = await axios.get<Snapshot>(constants[network].snapshot);
+    return response.data || {};
   }
   return {};
 }


### PR DESCRIPTION
# Description

Fleek has been having stability issues. We now have a copy of the liquidity mining manifest ("snapshot") on GitHub. [claim.balancer.fi](claim.balancer.fi) was updated last week to use that instead of fleek. This does the same for the app's UI.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## How should this be tested?

- [x] "Available to Claim" on the app UI should show the same value as the one displayed at [claim.balancer.fi](claim.balancer.fi)

## Checklist:

- [X] I have performed a self-review of my own code
- [X] I have commented my code where relevant, particularly in hard-to-understand areas
- [X] My changes generate no new console warnings
- [X] The base of this PR is `master` if hotfix, `develop` if not
