### PR TITLE
Hotfix: add Arbitrum public rpc

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.17.1",
+  "version": "1.17.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@balancer-labs/frontend-v2",
-      "version": "1.17.1",
+      "version": "1.17.2",
       "license": "MIT",
       "dependencies": {
         "@balancer-labs/assets": "github:balancer-labs/assets#master",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.17.1",
+  "version": "1.17.2",
   "engines": {
     "node": "14.x",
     "npm": ">=7"

--- a/src/lib/config/arbitrum.json
+++ b/src/lib/config/arbitrum.json
@@ -8,6 +8,7 @@
   "unknown": false,
   "rpc": "https://arbitrum-mainnet.infura.io/v3/daaa68ec242643719749dd1caba2fc66",
   "ws": "wss://arb-mainnet.g.alchemy.com/v2/ODJ9G5Ipv-Hb2zTWMNbUFIqv9WtqBOc2",
+  "publicRpc": "https://arb1.arbitrum.io/rpc",
   "loggingRpc": "https://arb-mainnet.g.alchemy.com/v2/ODJ9G5Ipv-Hb2zTWMNbUFIqv9WtqBOc2",
   "explorer": "https://arbiscan.io",
   "subgraph": "https://api.thegraph.com/subgraphs/name/balancer-labs/balancer-arbitrum-v2",


### PR DESCRIPTION
# Description

Adds a public rpc connection for Arbitrum to allow users to add it to Metamask

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## How should this be tested?

Check that "Switch Network" button in banner works in situations where Metamask doesn't have the Arbitrum network details.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] My changes generate no new console warnings
- [x] The base of this PR is `master` if hotfix, `develop` if not
