### PR TITLE
Hotfix: Properly handle null price rates in stable pool maths

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.17.2",
+  "version": "1.17.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@balancer-labs/frontend-v2",
-      "version": "1.17.2",
+      "version": "1.17.3",
       "license": "MIT",
       "dependencies": {
         "@balancer-labs/assets": "github:balancer-labs/assets#master",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.17.2",
+  "version": "1.17.3",
   "engines": {
     "node": "14.x",
     "npm": ">=7"

--- a/src/services/balancer/subgraph/types.ts
+++ b/src/services/balancer/subgraph/types.ts
@@ -16,7 +16,7 @@ export interface PoolToken {
   address: string;
   balance: string;
   weight: string;
-  priceRate?: string;
+  priceRate: string | null;
 }
 
 export interface Pool {

--- a/src/services/pool/calculator/stable.ts
+++ b/src/services/pool/calculator/stable.ts
@@ -99,7 +99,7 @@ export default class Stable {
       return this.scaleOutput(
         '0',
         this.calc.poolTokenDecimals[tokenIndex],
-        this.calc.pool.tokens[tokenIndex]?.priceRate ?? '1',
+        this.calc.pool.tokens[tokenIndex].priceRate,
         BigNumber.ROUND_DOWN // If OUT given IN, round down
       );
 
@@ -119,7 +119,7 @@ export default class Stable {
     return this.scaleOutput(
       tokenAmountOut.toString(),
       this.calc.poolTokenDecimals[tokenIndex],
-      this.calc.pool.tokens[tokenIndex]?.priceRate ?? '1',
+      this.calc.pool.tokens[tokenIndex].priceRate,
       BigNumber.ROUND_DOWN // If OUT given IN, round down
     );
   }
@@ -220,7 +220,12 @@ export default class Stable {
     return bnum(scaledSupply.toString());
   }
 
-  private scaleInput(normalizedAmount: string, priceRate = '1'): BigNumber {
+  private scaleInput(
+    normalizedAmount: string,
+    priceRate: string | null = null
+  ): BigNumber {
+    if (priceRate === null) priceRate = '1';
+
     const denormAmount = bnum(parseUnits(normalizedAmount, 18).toString())
       .times(priceRate)
       .toFixed(0, BigNumber.ROUND_UP);
@@ -231,9 +236,11 @@ export default class Stable {
   private scaleOutput(
     amount: string,
     decimals: number,
-    priceRate: string,
+    priceRate: string | null,
     rounding: BigNumber.RoundingMode
   ): BigNumber {
+    if (priceRate === null) priceRate = '1';
+
     const amountAfterPriceRate = bnum(amount)
       .div(priceRate)
       .toString();


### PR DESCRIPTION
# Description

The subgraph returns nulls for stable pool price rates however the frontend is expecting to get undefined. This means that null price rates were slipping through and blowing up the maths.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## How should this be tested?

Attempt to join/exit a stable pool. (just being able to add an input is enough)

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] My changes generate no new console warnings
- [x] The base of this PR is `master` if hotfix, `develop` if not
