### PR TITLE
fix: add missing ETH keys to AddressMap

### DIFF
--- a/src/constants/tokens.ts
+++ b/src/constants/tokens.ts
@@ -16,10 +16,12 @@ export const TOKENS = {
       BAL: '0x41286Bb1D3E870f3F750eB7E1C25d7E48c8A1Ac7'
     },
     '137': {
+      ETH: '0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE',
       WETH: '0x7ceb23fd6bc0add59e62ac25578270cff1b9f619',
       BAL: '0x9a71012b13ca4d3d0cdc72a177df3ef03b0e76a3'
     },
     '42161': {
+      ETH: '0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE',
       WETH: '0x82aF49447D8a07e3bd95BD0d56f35241523fBab1',
       BAL: '0x040d1EdC9569d4Bab2D15287Dc5A4F10F56a56B8'
     }


### PR DESCRIPTION
# Description

Fixes Arbitrum and Polygon not having a set value for the ETH key in the AddressMap resulting in broken link when clicking "Wrap ETH into WETH" on invest page. (https://arbitrum.balancer.fi/#/trade/undefined/0x82aF49447D8a07e3bd95BD0d56f35241523fBab1)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## How should this be tested?

Click "Wrap ETH into WETH" on invest page and see that ETH is selected in trade card

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] My changes generate no new console warnings
- [x] The base of this PR is `master` if hotfix, `develop` if not
