### PR TITLE
Add Investment pool support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1693,7 +1693,7 @@
     },
     "node_modules/@balancer-labs/sor2": {
       "version": "2.0.1",
-      "resolved": "git+ssh://git@github.com/balancer-labs/balancer-sor.git#5c60aadb76ff9d9263373699e3899246e0805df8",
+      "resolved": "git+ssh://git@github.com/balancer-labs/balancer-sor.git#4f0cf4dab4111c04b39a1281191613a164bbe6bc",
       "license": "GPL-3.0-only",
       "dependencies": {
         "@ethersproject/address": "^5.0.5",
@@ -32475,7 +32475,7 @@
       }
     },
     "@balancer-labs/sor2": {
-      "version": "git+ssh://git@github.com/balancer-labs/balancer-sor.git#5c60aadb76ff9d9263373699e3899246e0805df8",
+      "version": "git+ssh://git@github.com/balancer-labs/balancer-sor.git#4f0cf4dab4111c04b39a1281191613a164bbe6bc",
       "from": "@balancer-labs/sor2@github:balancer-labs/balancer-sor#john/ui-694-sor-lido-add-static-route-refactor",
       "requires": {
         "@ethersproject/address": "^5.0.5",

--- a/src/composables/usePool.ts
+++ b/src/composables/usePool.ts
@@ -28,6 +28,14 @@ export function isWeighted(pool: AnyPool): boolean {
   return pool.poolType === PoolType.Weighted;
 }
 
+export function isInvestment(pool: AnyPool): boolean {
+  return pool.poolType === PoolType.Investment;
+}
+
+export function isWeightedLike(pool: AnyPool): boolean {
+  return isWeighted(pool) || isInvestment(pool);
+}
+
 export function isWeth(pool: AnyPool, networkId: string): boolean {
   return pool.tokenAddresses.includes(TOKENS.AddressMap[networkId].WETH);
 }
@@ -50,6 +58,10 @@ export function usePool(pool: Ref<AnyPool> | Ref<undefined>) {
     () => pool.value && isStableLike(pool.value)
   );
   const isWeightedPool = computed(() => pool.value && isWeighted(pool.value));
+  const isWeightedLikePool = computed(
+    () => pool.value && isWeightedLike(pool.value)
+  );
+
   const isWethPool = computed(
     () => pool.value && isWeth(pool.value, appNetworkConfig.key)
   );
@@ -61,6 +73,7 @@ export function usePool(pool: Ref<AnyPool> | Ref<undefined>) {
     isMetaStablePool,
     isStableLikePool,
     isWeightedPool,
+    isWeightedLikePool,
     isWethPool,
     isWstETHPool,
     // methods
@@ -68,6 +81,7 @@ export function usePool(pool: Ref<AnyPool> | Ref<undefined>) {
     isMetaStable,
     isStableLike,
     isWeighted,
+    isWeightedLike,
     isWeth
   };
 }

--- a/src/constants/pools.ts
+++ b/src/constants/pools.ts
@@ -63,7 +63,7 @@ export const POOLS = {
     '0x67d27634e44793fe63c467035e31ea8635117cd4': 'stablePool', // Metastable
     '0x751dfdace1ad995ff13c927f6f761c6604532c79': 'stablePool', // Kovan
     '0x590e544e7ca956bb878f8c873e82e65550d67d2f': 'stablePool', // Kovan Metastable
-    '0xb08E16cFc07C684dAA2f93C70323BAdb2A6CBFd2': 'investmentPool', // Kovan Investment
+    '0xb08e16cfc07c684daa2f93c70323badb2a6cbfd2': 'investmentPool', // Kovan Investment
     '0x7dfdef5f355096603419239ce743bfaf1120312b': 'weightedPool', // Arbitrum Weighted
     '0xcf0a32bbef8f064969f21f7e02328fb577382018': 'weightedPool', // Arbitrum WeightedOracle
     '0x2433477a10fc5d31b9513c638f19ee85caed53fd': 'stablePool', // Arbitrum Stable

--- a/src/constants/pools.ts
+++ b/src/constants/pools.ts
@@ -52,7 +52,8 @@ export const POOLS = {
       '0x06df3b2bbb68adc8b0e302443692037ed9f91b42000000000000000000000012', // polygon
       '0xfeadd389a5c427952d8fdb8057d6c8ba1156cc5600020000000000000000001e', // polgon
       '0x6b15a01b5d46a5321b627bd7deef1af57bc629070000000000000000000000d4', // kovan
-      '0xe08590bde837eb9b2d42aa1196469d6e08fe96ec000200000000000000000101' //kovan
+      '0xe08590bde837eb9b2d42aa1196469d6e08fe96ec000200000000000000000101', //kovan
+      '0x4fd63966879300cafafbb35d157dc5229278ed23000100000000000000000169' //kovan Investment
     ]
   },
   Factories: {
@@ -62,6 +63,7 @@ export const POOLS = {
     '0x67d27634e44793fe63c467035e31ea8635117cd4': 'stablePool', // Metastable
     '0x751dfdace1ad995ff13c927f6f761c6604532c79': 'stablePool', // Kovan
     '0x590e544e7ca956bb878f8c873e82e65550d67d2f': 'stablePool', // Kovan Metastable
+    '0xb08E16cFc07C684dAA2f93C70323BAdb2A6CBFd2': 'investmentPool', // Kovan Investment
     '0x7dfdef5f355096603419239ce743bfaf1120312b': 'weightedPool', // Arbitrum Weighted
     '0xcf0a32bbef8f064969f21f7e02328fb577382018': 'weightedPool', // Arbitrum WeightedOracle
     '0x2433477a10fc5d31b9513c638f19ee85caed53fd': 'stablePool', // Arbitrum Stable

--- a/src/lib/utils/balancer/price.ts
+++ b/src/lib/utils/balancer/price.ts
@@ -1,4 +1,4 @@
-import { isStableLike, isWeighted } from '@/composables/usePool';
+import { isStableLike, isWeightedLike } from '@/composables/usePool';
 import { FiatCurrency } from '@/constants/currency';
 import { Pool } from '@/services/balancer/subgraph/types';
 import { TokenPrices } from '@/services/coingecko/api/price.service';
@@ -8,7 +8,7 @@ export function getPoolLiquidity(
   prices: TokenPrices,
   currency: FiatCurrency
 ) {
-  if (isWeighted(pool)) {
+  if (isWeightedLike(pool)) {
     const totalWeight = pool.tokens.reduce(
       (total, token) => total + parseFloat(token.weight),
       0

--- a/src/locales/default.json
+++ b/src/locales/default.json
@@ -129,6 +129,7 @@
     "thirdPartyAPR": {
         "steth": "stETH staking rewards APR"
     },
+    "investmentPool": "Investment pool",
     "investmentPools": "Investment pools",
     "investmentSettled": "Your investment has settled",
     "investmentSuccess": "Your tokens have been added to this pool, and you have received a new LP token representing this investment.",

--- a/src/services/balancer/contracts/contracts/vault.ts
+++ b/src/services/balancer/contracts/contracts/vault.ts
@@ -39,7 +39,7 @@ export default class Vault {
     tokenMultiCaller.call('decimals', poolAddress, 'decimals');
     tokenMultiCaller.call('swapFee', poolAddress, 'getSwapFeePercentage');
 
-    if (type === 'Weighted') {
+    if (type === 'Weighted' || type === 'Investment') {
       tokenMultiCaller.call('weights', poolAddress, 'getNormalizedWeights', []);
     } else if (type === 'Stable' || type === 'MetaStable') {
       tokenMultiCaller.call('amp', poolAddress, 'getAmplificationParameter');
@@ -90,7 +90,7 @@ export default class Vault {
     type: PoolType,
     tokens: TokenInfoMap
   ) {
-    if (type == 'Weighted') {
+    if (type == 'Weighted' || type === 'Investment') {
       const totalWeight = weights.reduce((a, b) => a.add(b), BigNumber.from(0));
       return weights.map(
         w =>

--- a/src/services/balancer/contracts/contracts/vault.ts
+++ b/src/services/balancer/contracts/contracts/vault.ts
@@ -98,7 +98,7 @@ export default class Vault {
             Number(formatUnits(w, 10))) /
           100
       );
-    } else if (type === 'Stable') {
+    } else if (type === 'Stable' || type === 'MetaStable') {
       const tokensList = Object.values(tokens);
       return tokensList.map(() => 1 / tokensList.length);
     } else {

--- a/src/services/balancer/subgraph/types.ts
+++ b/src/services/balancer/subgraph/types.ts
@@ -7,6 +7,7 @@ export type QueryBuilder = (
 
 export enum PoolType {
   Weighted = 'Weighted',
+  Investment = 'Investment',
   Stable = 'Stable',
   MetaStable = 'MetaStable'
 }


### PR DESCRIPTION
# Description

Adds a whitelisted InvestmentPool to the UI + updates relevant checks to treat `InvestmentPools` as `WeightedPools` as they use the same underlying maths.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## How should this be tested?

Check that you can access the pool `0x4fd63966879300cafafbb35d157dc5229278ed23000100000000000000000169` on Kovan.

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code where relevant, particularly in hard-to-understand areas
- [ ] My changes generate no new console warnings
- [ ] The base of this PR is `master` if hotfix, `develop` if not
