### PR TITLE
feat: add `font-numeric` to all numeric usages

### DIFF
--- a/src/assets/css/global/typography.css
+++ b/src/assets/css/global/typography.css
@@ -1,30 +1,37 @@
-h1, h2 {
+h1,
+h2 {
   @apply font-display;
   font-weight: 600;
 }
-h1 { @apply text-5xl; }
-h2 { @apply text-3xl font-bold; }
+h1 {
+  @apply text-5xl;
+}
+h2 {
+  @apply text-3xl font-bold;
+}
 
-
-h3, h4, h5, h6 {
+h3,
+h4,
+h5,
+h6 {
   @apply font-body;
 }
-h3 { 
-  @apply text-2xl tracking-tight;   
+h3 {
+  @apply text-2xl tracking-tight;
   font-variation-settings: 'wght' 600;
 }
-h4 { 
-  @apply text-xl tracking-tight; 
+h4 {
+  @apply text-xl tracking-tight;
   font-variation-settings: 'wght' 600;
 }
-h5 { 
+h5 {
   @apply text-lg;
   font-weight: unset;
   font-variation-settings: 'wght' 600;
- }
- h6 {
+}
+h6 {
   font-variation-settings: 'wght' 600;
- }
+}
 
 .eth-address {
   font-variant-ligatures: no-contextual;
@@ -32,7 +39,16 @@ h5 {
 
 /* Using font-variation-settings instead of font-weight for the Inter variable font */
 
-th, .font-thin, .font-extralight, .font-light, .font-normal, .font-medium, .font-semibold, .font-bold, .font-extrabold, .font-black {
+th,
+.font-thin,
+.font-extralight,
+.font-light,
+.font-normal,
+.font-medium,
+.font-semibold,
+.font-bold,
+.font-extrabold,
+.font-black {
   font-weight: unset;
 }
 
@@ -66,4 +82,9 @@ th {
 }
 .font-black {
   font-variation-settings: 'wght' 900;
+}
+
+.font-numeric {
+  font-feature-settings: 'tnum';
+  letter-spacing: -0.5px;
 }

--- a/src/components/_global/BalTable/BalTable.vue
+++ b/src/components/_global/BalTable/BalTable.vue
@@ -140,10 +140,13 @@
                 ></slot>
                 <div
                   v-else
-                  :class="[
-                    'px-6 py-4',
-                    column.align === 'right' ? 'text-right' : 'text-left'
-                  ]"
+                  :class="
+                    compact([
+                      'px-6 py-4',
+                      column.align === 'right' ? 'text-right' : 'text-left',
+                      column.cellClassName
+                    ])
+                  "
                 >
                   {{
                     typeof column.accessor === 'string'
@@ -160,10 +163,13 @@
                 ></slot>
                 <div
                   v-else
-                  :class="[
-                    'px-6 py-4',
-                    column.align === 'right' ? 'text-right' : 'text-left'
-                  ]"
+                  :class="
+                    compact([
+                      'px-6 py-4',
+                      column.align === 'right' ? 'text-right' : 'text-left',
+                      column.cellClassName
+                    ])
+                  "
                 >
                   {{
                     typeof column.accessor === 'string'
@@ -230,7 +236,7 @@ import {
   watch,
   computed
 } from 'vue';
-import { sortBy, sumBy, tail } from 'lodash';
+import { sortBy, sumBy, tail, compact } from 'lodash';
 
 type Sticky = 'horizontal' | 'vertical' | 'both';
 type Data = any;
@@ -267,6 +273,8 @@ export type ColumnDefinition<T = Data> = {
   width?: number;
 
   totalsCell?: string;
+
+  cellClassName?: string;
 };
 
 export default defineComponent({
@@ -445,6 +453,7 @@ export default defineComponent({
       handleSort,
       handleRowClick,
       tail,
+      compact,
 
       //data
       isColumnStuck,

--- a/src/components/_global/BalTextInput/BalTextInput.vue
+++ b/src/components/_global/BalTextInput/BalTextInput.vue
@@ -216,7 +216,8 @@ export default defineComponent({
     const inputClasses = computed(() => {
       return {
         [textSizeClasses()]: true,
-        'text-right': props.textRight
+        'text-right': props.textRight,
+        'font-numeric': props.type === 'number'
       };
     });
 

--- a/src/components/cards/TradeCard/GasReimbursement.vue
+++ b/src/components/cards/TradeCard/GasReimbursement.vue
@@ -7,9 +7,7 @@
     <div v-if="isActive()" class="message relative px-2 py-3">
       <div class="ml-12">
         <h6 v-text="$t('highGasFees')" class="relative text-sm" />
-        <div class="relative text-sm text-gray-500">
-          {{ text }}
-        </div>
+        <div class="relative text-sm text-gray-500" v-html="text" />
       </div>
     </div>
   </BalLink>
@@ -152,10 +150,14 @@ export default defineComponent({
         reimburseAmount.value && reimburseAmount.value.usd.gt(0);
 
       return isEligible
-        ? `${t('tradeEarns')} ~${reimburseAmount.value.bal.toFixed(
+        ? `${t(
+            'tradeEarns'
+          )} <span class="font-numeric">~${reimburseAmount.value.bal.toFixed(
             1,
             BigNumber.ROUND_DOWN
-          )} BAL (${formatUSD(reimburseAmount.value.usd)})`
+          )}</span> BAL (<span class="font-numeric">${formatUSD(
+            reimburseAmount.value.usd
+          )}</span>)`
         : t('earnBAL');
     });
 

--- a/src/components/cards/TradeCard/TradePair.vue
+++ b/src/components/cards/TradeCard/TradePair.vue
@@ -5,7 +5,7 @@
         class="p-2 flex justify-between text-sm rounded-t-lg dark:bg-gray-900 border dark:border-gray-900 w-full border-b-0"
       >
         <div>{{ $t('send') }}</div>
-        <div v-if="tokenInValue > 0" class="text-gray-500">
+        <div v-if="tokenInValue > 0" class="text-gray-500 font-numeric">
           {{ fNum(tokenInValue, 'usd') }}
         </div>
       </div>
@@ -57,7 +57,8 @@
       </template>
       <template v-slot:info>
         <div class="cursor-pointer" @click="handleMax">
-          {{ $t('balance') }}: {{ fNum(balanceLabel, 'token') }}
+          {{ $t('balance') }}:
+          <span class="font-numeric">{{ fNum(balanceLabel, 'token') }}</span>
         </div>
       </template>
       <template v-slot:append>
@@ -74,7 +75,7 @@
         <span
           class="text-sm text-gray-500 cursor-pointer"
           @click="toggleRate"
-          v-text="rateMessage"
+          v-html="rateMessage"
         />
       </div>
     </div>
@@ -83,7 +84,7 @@
         class="p-2 flex justify-between text-sm rounded-t-lg dark:bg-gray-900 border dark:border-gray-900 w-full border-b-0"
       >
         <div>{{ $t('receive') }}</div>
-        <div v-if="tokenOutValue > 0" class="text-gray-500">
+        <div v-if="tokenOutValue > 0" class="text-gray-500 font-numeric">
           {{ fNum(tokenOutValue, 'usd') }}
         </div>
       </div>
@@ -136,7 +137,7 @@
       <template v-slot:info>
         <div>
           {{ $t('priceImpact') }}:
-          {{ fNum(priceImpact, 'percent') }}
+          <span class="font-numeric">{{ fNum(priceImpact, 'percent') }}</span>
         </div>
       </template>
     </BalTextInput>
@@ -313,13 +314,17 @@ export default defineComponent({
       }
       if (isInRate.value) {
         const rate = tokenOutAmount / tokenInAmount;
-        const message = `1 ${tokenIn.symbol} = ${fNum(rate, 'token')} ${
+        const message = `<span class="font-numeric">1</span> ${
+          tokenIn.symbol
+        } = <span class="font-numeric">${fNum(rate, 'token')}</span> ${
           tokenOut.symbol
         }`;
         return message;
       } else {
         const rate = tokenInAmount / tokenOutAmount;
-        const message = `1 ${tokenOut.symbol} = ${fNum(rate, 'token')} ${
+        const message = `<span class="font-numeric">1</span> ${
+          tokenOut.symbol
+        } = <span class="font-numeric">${fNum(rate, 'token')}</span> ${
           tokenIn.symbol
         }`;
         return message;

--- a/src/components/cards/TradeCard/TradeRoute.vue
+++ b/src/components/cards/TradeCard/TradeRoute.vue
@@ -20,7 +20,7 @@
         <div>
           <div class="flex justify-between text-xs">
             <div>
-              <div class="font-bold">
+              <div class="font-bold font-numeric">
                 {{ input.amount }}
               </div>
               <div>
@@ -28,7 +28,7 @@
               </div>
             </div>
             <div class="flex flex-col items-end">
-              <div class="font-bold">
+              <div class="font-bold font-numeric">
                 {{ output.amount }}
               </div>
               <div>
@@ -109,7 +109,9 @@
                   </a>
                 </div>
               </div>
-              <div class="w-10 mr-4 text-xs text-right text-gray-500">
+              <div
+                class="w-10 mr-4 text-xs text-right text-gray-500 font-numeric"
+              >
                 {{ formatShare(route.share) }}
               </div>
             </div>

--- a/src/components/cards/TradeCardGP/TradeCardGP.vue
+++ b/src/components/cards/TradeCardGP/TradeCardGP.vue
@@ -1,5 +1,5 @@
 <template>
-  <BalCard class="relative" :shadow="tradeCardShadow" no-border>
+  <BalCard class="relative card-container" :shadow="tradeCardShadow" no-border>
     <template v-slot:header>
       <div class="w-full flex items-center justify-between">
         <h4 class="font-bold">{{ title }}</h4>
@@ -371,3 +371,9 @@ export default defineComponent({
   }
 });
 </script>
+<style scoped>
+/* This is needed because the trade settings popover overflows */
+.card-container {
+  overflow: unset;
+}
+</style>

--- a/src/components/cards/TradeCardGP/TradePairGP.vue
+++ b/src/components/cards/TradeCardGP/TradePairGP.vue
@@ -5,7 +5,7 @@
         class="p-2 flex justify-between text-sm rounded-t-lg dark:bg-gray-900 border dark:border-gray-900 w-full border-b-0"
       >
         <div>{{ $t('send') }}</div>
-        <div v-if="tokenInValue > 0" class="text-gray-500">
+        <div v-if="tokenInValue > 0" class="text-gray-500 font-numeric">
           {{ fNum(tokenInValue, 'usd') }}
         </div>
       </div>
@@ -56,7 +56,8 @@
       </template>
       <template v-slot:info>
         <div class="cursor-pointer" @click="handleInMax">
-          {{ $t('balance') }}: {{ fNum(tokenInBalance, 'token') }}
+          {{ $t('balance') }}:
+          <span class="font-numeric">{{ fNum(tokenInBalance, 'token') }}</span>
         </div>
       </template>
       <template v-slot:append>
@@ -69,11 +70,11 @@
     </BalTextInput>
     <div class="flex items-center mb-4">
       <TradePairToggle @toggle="handleSwitchTokens" />
-      <div v-if="rateMessage" class="flex-auto ml-4">
+      <div v-if="rateMessage" class="flex-auto ml-4 numeric">
         <span
           class="text-sm text-gray-500 cursor-pointer"
           @click="toggleRate"
-          v-text="rateMessage"
+          v-html="rateMessage"
         />
       </div>
     </div>
@@ -82,7 +83,7 @@
         class="p-2 flex justify-between text-sm rounded-t-lg dark:bg-gray-900 border dark:border-gray-900 w-full border-b-0"
       >
         <div>{{ $t('receive') }}</div>
-        <div v-if="tokenOutValue > 0" class="text-gray-500">
+        <div v-if="tokenOutValue > 0" class="text-gray-500 font-numeric">
           {{ fNum(tokenOutValue, 'usd') }}
         </div>
       </div>
@@ -133,7 +134,8 @@
       </template>
       <template v-slot:info>
         <div class="cursor-pointer" @click="handleOutMax">
-          {{ $t('balance') }}: {{ fNum(tokenOutBalance, 'token') }}
+          {{ $t('balance') }}:
+          <span class="font-numeric">{{ fNum(tokenOutBalance, 'token') }}</span>
         </div>
       </template>
       <template v-slot:append>

--- a/src/components/forms/AppSlippageForm.vue
+++ b/src/components/forms/AppSlippageForm.vue
@@ -4,6 +4,7 @@
       :options="options"
       v-model="fixedSlippage"
       @update:modelValue="onFixedInput"
+      class="font-numeric"
     />
     <div
       :class="[
@@ -15,7 +16,7 @@
       ]"
     >
       <input
-        class="w-12 text-right bg-transparent"
+        class="w-12 text-right bg-transparent font-numeric"
         v-model="customSlippage"
         placeholder="0.1"
         type="number"

--- a/src/components/forms/pool_actions/InvestForm.vue
+++ b/src/components/forms/pool_actions/InvestForm.vue
@@ -15,14 +15,15 @@
             class="flex items-center justify-between mb-3 text-sm text-gray-600"
           >
             <span v-text="$t('amountToInvest')" />
-            <span>{{ propPercentage }}%</span>
+            <span class="font-numeric">{{ propPercentage }}%</span>
           </div>
           <div class="flex items-end">
             <span
               class="mr-2 text-lg font-medium w-1/2 break-words leading-none"
               :title="total"
             >
-              {{ missingPrices ? '-' : total }}
+              <template v-if="missingPrices">-</template>
+              <span class="font-numeric" v-else>{{ total }}</span>
             </span>
             <BalRangeInput
               class="w-1/2"
@@ -53,7 +54,7 @@
               <BalAsset :address="token" class="mr-2" />
               <div class="flex flex-col w-3/4 leading-none">
                 <span
-                  class="break-words"
+                  class="break-words font-numeric"
                   :title="
                     `${fNum(amounts[i], 'token')} ${
                       pool.onchain.tokens[token].symbol
@@ -67,15 +68,22 @@
                   class="text-xs text-gray-400 break-words"
                   :title="`${formatBalance(i)} balance`"
                 >
-                  {{ $t('balance') }}: {{ formatBalance(i) }}
+                  {{ $t('balance') }}:
+                  <span class="font-numeric">{{ formatBalance(i) }}</span>
                 </span>
               </div>
             </div>
             <div class="flex flex-col w-1/2 leading-none text-right pl-2">
-              <span class="break-words" :title="fNum(amountUSD(i), 'usd')">
+              <span
+                class="break-words font-numeric"
+                :title="fNum(amountUSD(i), 'usd')"
+              >
                 {{ amountUSD(i) === 0 ? '-' : fNum(amountUSD(i), 'usd') }}
               </span>
-              <span v-if="!isStableLikePool" class="text-xs text-gray-400">
+              <span
+                v-if="!isStableLikePool"
+                class="text-xs text-gray-400 font-numeric"
+              >
                 {{ fNum(tokenWeights[i], 'percent_lg') }}
               </span>
             </div>
@@ -205,7 +213,10 @@
           @click.prevent
         >
           <span
-            >{{ $t('priceImpact') }}: {{ fNum(priceImpact, 'percent') }}</span
+            >{{ $t('priceImpact') }}:
+            <span class="font-numeric">{{
+              fNum(priceImpact, 'percent')
+            }}</span></span
           >
           <BalTooltip>
             <template v-slot:activator>
@@ -253,8 +264,12 @@
             block
             @click="trackGoal(Goals.ClickInvest)"
           >
-            {{ $t('invest') }}
-            {{ missingPrices || total.length > 15 ? '' : total }}
+            <span>{{ $t('invest') }}</span>
+            <span
+              v-if="!(missingPrices || total.length > 15)"
+              class="font-numeric"
+              >&nbsp;{{ total }}</span
+            >
           </BalBtn>
         </template>
       </template>

--- a/src/components/forms/pool_actions/shared/FormTypeToggle.vue
+++ b/src/components/forms/pool_actions/shared/FormTypeToggle.vue
@@ -14,7 +14,8 @@
           {{ type.label }}
         </span>
         <span v-if="!missingPrices" class="text-xs text-gray-500">
-          ({{ `${type.max} ${$t('max').toLowerCase()}` }})
+          (<span class="font-numeric">{{ type.max }}</span>
+          {{ $t('max').toLowerCase() }})
         </span>
         <BalTooltip v-if="type.tooltip">
           <template v-slot:activator>

--- a/src/components/heros/AppHero.vue
+++ b/src/components/heros/AppHero.vue
@@ -11,7 +11,7 @@
           class="h-10 w-40 mx-auto"
           white
         />
-        <span v-else class="text-3xl font-bold text-white">
+        <span v-else class="text-3xl font-bold text-white font-numeric">
           {{ fNum(totalInvestedAmount, 'usd', { forcePreset: true }) }}
         </span>
       </template>

--- a/src/components/lists/TokenListItem.vue
+++ b/src/components/lists/TokenListItem.vue
@@ -15,7 +15,7 @@
         {{ token.name }}
       </div>
     </div>
-    <span class="flex flex-col items-end text-right font-medium">
+    <span class="flex flex-col items-end text-right font-medium font-numeric">
       <BalLoadingNumber v-if="balanceLoading" type="token" />
       <template v-else>
         <template v-if="balance > 0">
@@ -36,7 +36,7 @@
         numberHeight="4"
         class="text-sm font-normal"
       />
-      <div v-else class="text-gray-500 text-sm font-normal">
+      <div v-else class="text-gray-500 text-sm font-normal font-numeric">
         <template v-if="value > 0">
           {{ fNum(value, 'usd') }}
         </template>

--- a/src/components/modals/TradePreviewModal.vue
+++ b/src/components/modals/TradePreviewModal.vue
@@ -11,15 +11,20 @@
         />
         <div class="flex flex-col">
           <div class="font-bold">
-            {{ fNum(amountIn, 'token') }} {{ symbolIn }} ->
-            {{ fNum(amountOut, 'token') }} {{ symbolOut }}
+            <span class="font-numeric">{{ fNum(amountIn, 'token') }}</span>
+            {{ symbolIn }} ->
+            <span class="font-numeric">{{ fNum(amountOut, 'token') }}</span>
+            {{ symbolOut }}
           </div>
-          <div class="text-gray-500 text-sm">{{ fNum(valueIn, 'usd') }}</div>
+          <div class="text-gray-500 text-sm font-numeric">
+            {{ fNum(valueIn, 'usd') }}
+          </div>
         </div>
       </div>
       <div>
         <div class="mt-6 mb-3 text-sm">
-          Requires {{ totalRequiredTransactions }}
+          Requires
+          <span class="font-numeric">{{ totalRequiredTransactions }}</span>
           {{ requiresApproval ? 'transactions' : 'transaction' }}:
         </div>
         <div>
@@ -62,7 +67,9 @@
               {{ totalRequiredTransactions }}
             </div>
             <div class="ml-3">
-              {{ $t('trade') }} {{ fNum(valueIn, 'usd') }} {{ symbolIn }} ->
+              {{ $t('trade') }}
+              <span class="font-numeric">{{ fNum(valueIn, 'usd') }}</span>
+              {{ symbolIn }} ->
               {{ symbolOut }}
             </div>
           </div>

--- a/src/components/modals/TradePreviewModalGP.vue
+++ b/src/components/modals/TradePreviewModalGP.vue
@@ -9,11 +9,13 @@
             <span>
               {{ $t('effectivePrice') }}
             </span>
-            {{
-              trading.exactIn.value
-                ? trading.effectivePriceMessage.value.tokenIn
-                : trading.effectivePriceMessage.value.tokenOut
-            }}
+            <span
+              v-html="
+                trading.exactIn.value
+                  ? trading.effectivePriceMessage.value.tokenIn
+                  : trading.effectivePriceMessage.value.tokenOut
+              "
+            />
           </div>
         </template>
         <div>
@@ -26,10 +28,14 @@
               </div>
               <div>
                 <div class="font-medium">
-                  {{ fNum(trading.tokenInAmountInput.value, 'token') }}
+                  <span class="font-numeric">{{
+                    fNum(trading.tokenInAmountInput.value, 'token')
+                  }}</span>
                   {{ trading.tokenIn.value.symbol }}
                 </div>
-                <div class="text-gray-500 dark:text-gray-400 text-sm">
+                <div
+                  class="text-gray-500 dark:text-gray-400 text-sm font-numeric"
+                >
                   {{ tokenInFiatValue }}
                 </div>
               </div>
@@ -48,11 +54,13 @@
               </div>
               <div>
                 <div class="font-medium">
-                  {{ fNum(trading.tokenOutAmountInput.value, 'token') }}
+                  <span class="font-numeric">{{
+                    fNum(trading.tokenOutAmountInput.value, 'token')
+                  }}</span>
                   {{ trading.tokenOut.value.symbol }}
                 </div>
                 <div class="text-gray-500 dark:text-gray-400 text-sm">
-                  {{ tokenOutFiatValue }}
+                  <span class="font-numeric">{{ tokenOutFiatValue }}</span>
                   <span
                     v-if="
                       trading.isBalancerTrade.value ||
@@ -60,8 +68,10 @@
                     "
                   >
                     / {{ $t('priceImpact') }}:
-                    {{ fNum(trading.sor.priceImpact.value, 'percent') }}</span
-                  >
+                    <span class="font-numeric">{{
+                      fNum(trading.sor.priceImpact.value, 'percent')
+                    }}</span>
+                  </span>
                 </div>
               </div>
             </div>
@@ -103,9 +113,7 @@
             <div>
               {{ labels.tradeSummary.totalBeforeFees }}
             </div>
-            <div>
-              {{ summary.amountBeforeFees }}
-            </div>
+            <div v-html="summary.amountBeforeFees" />
           </div>
           <div class="summary-item-row" v-if="trading.isGnosisTrade.value">
             <div>{{ $t('tradeSummary.gasCosts') }}</div>
@@ -113,8 +121,8 @@
           </div>
           <div class="summary-item-row">
             <div>{{ labels.tradeSummary.tradeFees }}</div>
-            <div>
-              {{
+            <div
+              v-html="
                 trading.isWrapUnwrapTrade.value
                   ? zeroFee
                   : trading.isGnosisTrade.value
@@ -122,8 +130,8 @@
                     ? `-${summary.tradeFees}`
                     : `+${summary.tradeFees}`
                   : summary.tradeFees
-              }}
-            </div>
+              "
+            />
           </div>
         </div>
         <template v-slot:footer>
@@ -134,21 +142,19 @@
               <div class="w-64">
                 {{ labels.tradeSummary.totalAfterFees }}
               </div>
-              <div>
-                {{ summary.totalWithoutSlippage }}
-              </div>
+              <div v-html="summary.totalWithoutSlippage" />
             </div>
             <div class="summary-item-row text-gray-500 dark:text-gray-400">
               <div class="w-64">
                 {{ labels.tradeSummary.totalWithSlippage }}
               </div>
-              <div>
-                {{
+              <div
+                v-html="
                   trading.isWrapUnwrapTrade.value
                     ? ''
                     : summary.totalWithSlippage
-                }}
-              </div>
+                "
+              />
             </div>
           </div>
         </template>
@@ -481,17 +487,19 @@ export default defineComponent({
       }
 
       if (showSummaryInFiat.value) {
-        return mapValues(summaryItems, itemValue =>
-          fNum(
-            toFiat(itemValue, exactIn ? tokenOut.address : tokenIn.address),
-            'usd'
-          )
+        return mapValues(
+          summaryItems,
+          itemValue =>
+            `<span class="font-numeric">${fNum(
+              toFiat(itemValue, exactIn ? tokenOut.address : tokenIn.address),
+              'usd'
+            )}`
         );
       } else {
         return mapValues(
           summaryItems,
           itemValue =>
-            `${fNum(itemValue, 'token')} ${
+            `<span class="font-numeric">${fNum(itemValue, 'token')}</span> ${
               exactIn || props.trading.isWrapUnwrapTrade.value
                 ? tokenOut.symbol
                 : tokenIn.symbol

--- a/src/components/navs/AppNav/AppNavClaimBtn.vue
+++ b/src/components/navs/AppNav/AppNavClaimBtn.vue
@@ -12,7 +12,7 @@
           v-if="upToLargeBreakpoint ? !userClaimsLoading : true"
         />
         <BalLoadingIcon size="sm" v-if="userClaimsLoading" />
-        <span class="hidden lg:block" v-else>{{
+        <span class="hidden lg:block font-numeric" v-else>{{
           fNum(totalRewards, totalRewards > 0 ? 'token_fixed' : 'token')
         }}</span>
       </BalBtn>
@@ -35,7 +35,7 @@
           {{ $t('availableToClaim') }}
         </div>
         <div v-if="isMainnet" class="flex justify-between items-center mb-2">
-          <div class="text-lg font-bold">
+          <div class="text-lg font-bold font-numeric">
             {{
               fNum(
                 userClaims.availableToClaim,
@@ -44,7 +44,7 @@
             }}
             BAL
           </div>
-          <div>
+          <div class="font-numeric">
             {{
               availableToClaimInUSD != null
                 ? fNum(availableToClaimInUSD, 'usd')
@@ -57,7 +57,7 @@
           color="gradient"
           size="md"
           block
-          class="mb-1"
+          class="mb-1 "
           :loading="isClaiming"
           :loading-label="$t('claiming')"
           @click="claimAvailableRewards"
@@ -70,13 +70,13 @@
           {{ $t('pendingEstimate') }}
         </div>
         <div class="flex justify-between items-center mb-2">
-          <div class="text-lg font-bold">
+          <div class="text-lg font-bold font-numeric">
             {{
               fNum(currentRewards, currentRewards > 0 ? 'token_fixed' : 'token')
             }}
             BAL
           </div>
-          <div>
+          <div class="font-numeric">
             {{
               currentRewardsInUSD != null
                 ? fNum(currentRewardsInUSD, 'usd')

--- a/src/components/pages/pool/PoolActivitiesCard/Table.vue
+++ b/src/components/pages/pool/PoolActivitiesCard/Table.vue
@@ -48,14 +48,14 @@
                 :address="tokenAmount.address"
                 class="mr-2 flex-shrink-0"
               />
-              {{ tokenAmount.amount }}
+              <span class="font-numeric">{{ tokenAmount.amount }}</span>
             </div>
           </template>
         </div>
       </template>
 
       <template v-slot:valueCell="action">
-        <div class="px-6 py-4 flex justify-end">
+        <div class="px-6 py-4 flex justify-end font-numeric">
           {{ fNum(action.value, 'usd_m') }}
         </div>
       </template>

--- a/src/components/pages/pool/PoolBalancesCard.vue
+++ b/src/components/pages/pool/PoolBalancesCard.vue
@@ -37,17 +37,17 @@
         </div>
       </template>
       <template v-slot:tokenWeightCell="token">
-        <div class="px-6 py-4 text-right">
+        <div class="px-6 py-4 text-right font-numeric">
           {{ weightFor(token.address) }}
         </div>
       </template>
       <template v-slot:tokenBalanceCell="token">
-        <div class="px-6 py-4 text-right">
+        <div class="px-6 py-4 text-right font-numeric">
           {{ balanceFor(token.address) }}
         </div>
       </template>
       <template v-slot:tokenValueCell="token">
-        <div class="px-6 py-4 text-right">
+        <div class="px-6 py-4 text-right font-numeric">
           {{ fiatValueFor(token.address) }}
         </div>
       </template>

--- a/src/components/pages/pool/PoolStatCards.vue
+++ b/src/components/pages/pool/PoolStatCards.vue
@@ -9,7 +9,7 @@
           {{ stat.label }}
         </div>
         <div class="text-xl font-medium truncate flex items-center">
-          {{ stat.value }}
+          <span class="font-numeric">{{ stat.value }}</span>
           <LiquidityMiningTooltip :pool="pool" v-if="stat.id === 'apr'" />
         </div>
       </BalCard>

--- a/src/components/tables/LMTable/LMTable.vue
+++ b/src/components/tables/LMTable/LMTable.vue
@@ -67,7 +67,9 @@
             :key="tokenDist.tokenAddress"
           >
             <span v-if="tokenIndex !== 0">+</span>&nbsp;
-            {{ fNum(tokenDist.amount, 'token_lg') }}
+            <span class="font-numeric">{{
+              fNum(tokenDist.amount, 'token_lg')
+            }}</span>
             {{ tokens[getAddress(tokenDist.tokenAddress)]?.symbol || 'N/A' }}
           </span>
         </div>
@@ -87,10 +89,10 @@
             class="font-semibold text-right"
           >
             <span v-if="i !== 0">+</span>&nbsp;
-            {{ fNum(total, 'token_lg') }}
+            <span class="font-numeric">{{ fNum(total, 'token_lg') }}</span>
             {{ tokens[getAddress(token)]?.symbol || 'N/A' }}
           </span>
-          <span class="mt-2 text-gray-500"
+          <span class="mt-2 text-gray-500 font-numeric"
             >~${{ fNum(calculatePricesFor(totals[week.week])) }}</span
           >
         </div>

--- a/src/components/tables/PoolsTable/PoolsTable.vue
+++ b/src/components/tables/PoolsTable/PoolsTable.vue
@@ -55,7 +55,7 @@
         </div>
       </template>
       <template v-slot:aprCell="pool">
-        <div class="px-6 py-4 -mt-1 flex justify-end">
+        <div class="px-6 py-4 -mt-1 flex justify-end font-numeric">
           {{
             Number(pool.dynamic.apr.pool) > 10000
               ? '-'
@@ -158,7 +158,8 @@ export default defineComponent({
         id: 'myBalance',
         hidden: !props.showPoolShares,
         sortKey: pool => Number(pool.shares),
-        width: 150
+        width: 150,
+        cellClassName: 'font-numeric'
       },
       {
         name: t('poolValue'),
@@ -170,7 +171,8 @@ export default defineComponent({
           if (apr === Infinity || isNaN(apr)) return 0;
           return apr;
         },
-        width: 150
+        width: 150,
+        cellClassName: 'font-numeric'
       },
       {
         name: t('volume24h', [t('hourAbbrev')]),
@@ -182,7 +184,8 @@ export default defineComponent({
           if (apr === Infinity || isNaN(apr)) return 0;
           return apr;
         },
-        width: 175
+        width: 175,
+        cellClassName: 'font-numeric'
       },
       {
         name: t('apr'),

--- a/src/components/tables/PoolsTable/TokenPills/WeightedTokenPill.vue
+++ b/src/components/tables/PoolsTable/TokenPills/WeightedTokenPill.vue
@@ -9,7 +9,7 @@
     <span>
       {{ symbol }}
     </span>
-    <span class="font-medium text-gray-400 text-xs mt-px ml-1">
+    <span class="font-medium text-gray-400 text-xs mt-px ml-1 font-numeric">
       {{ weight }}
     </span>
   </div>

--- a/src/components/tooltips/LiquidityMiningTooltip.vue
+++ b/src/components/tooltips/LiquidityMiningTooltip.vue
@@ -10,26 +10,32 @@
     <div class="text-sm divide-y dark:divide-gray-900">
       <div class="px-3 pt-3 pb-1 bg-gray-50 dark:bg-gray-800 rounded-t">
         <div class="text-gray-500">{{ $t('totalAPR') }}</div>
-        <div class="text-lg">
+        <div class="text-lg font-numeric">
           {{ fNum(pool.dynamic.apr.total, 'percent') }}
         </div>
       </div>
       <div class="p-3">
         <div class="whitespace-nowrap flex items-center mb-1">
-          {{ fNum(pool.dynamic.apr.pool, 'percent') }}
+          <span class="font-numeric">{{
+            fNum(pool.dynamic.apr.pool, 'percent')
+          }}</span>
           <span class="ml-1 text-gray-500 text-xs">{{ $t('swapFeeAPR') }}</span>
         </div>
         <div
           v-if="hasThirdPartyAPR"
           class="whitespace-nowrap flex items-center mb-1"
         >
-          {{ fNum(pool.dynamic.apr.thirdParty, 'percent') }}
+          <span class="font-numeric">{{
+            fNum(pool.dynamic.apr.thirdParty, 'percent')
+          }}</span>
           <span class="ml-1 text-gray-500 text-xs">
             {{ thirdPartyAPRLabel }}
           </span>
         </div>
         <div class="whitespace-nowrap flex items-center">
-          {{ fNum(pool.dynamic.apr.liquidityMining, 'percent') }}
+          <span class="font-numeric">{{
+            fNum(pool.dynamic.apr.liquidityMining, 'percent')
+          }}</span>
           <span class="ml-1 text-gray-500 text-xs flex items-center">
             {{ $t('liquidityMiningAPR') }}
             <StarsIcon class="h-4 text-yellow-300" />
@@ -47,7 +53,7 @@
             <div v-if="index === 0" class="init-vert-bar" />
             <div v-else class="vert-bar" />
             <div class="horiz-bar" />
-            {{ fNum(apr, 'percent') }}
+            <span class="font-numeric">{{ fNum(apr, 'percent') }}</span>
             <span class="text-gray-500 text-xs ml-2">
               {{ lmTokens[address].symbol }} {{ $t('apr') }}
             </span>

--- a/src/composables/trade/useTrading.ts
+++ b/src/composables/trade/useTrading.ts
@@ -68,18 +68,22 @@ export default function useTrading(
 
     if (tokenInAmount > 0 && tokenOutAmount > 0) {
       return {
-        tokenIn: `1 ${tokenIn.value?.symbol} = ${fNum(
+        tokenIn: `<span class="font-numeric">1</span> ${
+          tokenIn.value?.symbol
+        } = <span class="font-numeric">${fNum(
           bnum(tokenOutAmount)
             .div(tokenInAmount)
             .toString(),
           'token'
-        )} ${tokenOut.value?.symbol}`,
-        tokenOut: `1 ${tokenOut.value?.symbol} = ${fNum(
+        )}</span> ${tokenOut.value?.symbol}`,
+        tokenOut: `<span class="font-numeric">1</span> ${
+          tokenOut.value?.symbol
+        } = <span class="font-numeric">${fNum(
           bnum(tokenInAmount)
             .div(tokenOutAmount)
             .toString(),
           'token'
-        )} ${tokenIn.value?.symbol}`
+        )}</span> ${tokenIn.value?.symbol}`
       };
     }
     return {

--- a/src/pages/LiquidityMining.vue
+++ b/src/pages/LiquidityMining.vue
@@ -4,7 +4,7 @@
       <span class="text-white font-semibold"
         >Week {{ currentWeek }} Liquidity mining incentives</span
       >
-      <h1 class="font-body mt-2 text-white font-semi bold">
+      <h1 class="font-body mt-2 text-white font-semi bold font-numeric">
         ~{{ fNum(currentWeekTotalFiat, 'usd') }}
       </h1>
     </div>

--- a/src/pages/Pool.vue
+++ b/src/pages/Pool.vue
@@ -19,7 +19,7 @@
               </span>
               <span
                 v-if="!isStableLikePool"
-                class="font-medium text-gray-400 text-xs mt-px ml-1"
+                class="font-medium text-gray-400 text-xs mt-px ml-1 font-numeric"
               >
                 {{ fNum(tokenMeta.weight, 'percent_lg') }}
               </span>
@@ -243,7 +243,10 @@ export default defineComponent({
 
     const poolFeeLabel = computed(() => {
       if (!pool.value) return '';
-      const feeLabel = fNum(pool.value.onchain.swapFee, 'percent');
+      const feeLabel = `<span class="font-numeric">${fNum(
+        pool.value.onchain.swapFee,
+        'percent'
+      )}</span>`;
 
       if (feesFixed.value) {
         return t('fixedSwapFeeLabel', [feeLabel]);


### PR DESCRIPTION
# Description

Pon requested that we use the tabular (monospaced) for all numbers. I have tried to cover it all, hopefully I haven't missed :)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other

## How should this be tested?

Please provide instructions so we can test. Please also list any relevant details for your test configuration.

- [ ] Pretty much every feature that has numbers should have the new `font-numeric` class.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] My changes generate no new console warnings
- [x] The base of this PR is `master` if hotfix, `develop` if not
