### PR TITLE
chore: update caniuse-lite

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11736,8 +11736,13 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001205",
-      "license": "CC-BY-4.0"
+      "version": "1.0.30001255",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001255.tgz",
+      "integrity": "sha512-F+A3N9jTZL882f/fg/WWVnKSu6IOo3ueLz4zwaOPbPYHNmM/ZaDUyzyJwS1mZhX7Ex5jqTyW599Gdelh5PDYLQ==",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/browserslist"
+      }
     },
     "node_modules/capture-exit": {
       "version": "2.0.0",
@@ -39753,7 +39758,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001205"
+      "version": "1.0.30001255",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001255.tgz",
+      "integrity": "sha512-F+A3N9jTZL882f/fg/WWVnKSu6IOo3ueLz4zwaOPbPYHNmM/ZaDUyzyJwS1mZhX7Ex5jqTyW599Gdelh5PDYLQ=="
     },
     "capture-exit": {
       "version": "2.0.0",


### PR DESCRIPTION
Just getting rid of these annoying errors:
```
Browserslist: caniuse-lite is outdated. Please run:
npx browserslist@latest --update-db
```