### PR TITLE
Liquidity Mining, week 68

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.18.1",
+  "version": "1.18.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@balancer-labs/frontend-v2",
-      "version": "1.18.1",
+      "version": "1.18.2",
       "license": "MIT",
       "dependencies": {
         "@balancer-labs/assets": "github:balancer-labs/assets#master",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.18.1",
+  "version": "1.18.2",
   "engines": {
     "node": "14.x",
     "npm": ">=7"

--- a/src/lib/utils/liquidityMining/MultiTokenLiquidityMining.json
+++ b/src/lib/utils/liquidityMining/MultiTokenLiquidityMining.json
@@ -2603,5 +2603,245 @@
         ]
       }
     }
+  ],
+  "week_68": [
+    {
+      "chainId": 1,
+      "pools": {
+        "0xa6f548df93de924d73be7d25dc02554c6bd66db500020000000000000000000e": [
+          {
+            "tokenAddress": "0xba100000625a3754423978a60c9317c58a424e3d",
+            "amount": 15000
+          }
+        ],
+        "0x0b09dea16768f0799065c475be02919503cb2a3500020000000000000000001a": [
+          {
+            "tokenAddress": "0xba100000625a3754423978a60c9317c58a424e3d",
+            "amount": 15000
+          }
+        ],
+        "0x5c6ee304399dbdb9c8ef030ab642b10820db8f56000200000000000000000014": [
+          {
+            "tokenAddress": "0xba100000625a3754423978a60c9317c58a424e3d",
+            "amount": 30000
+          }
+        ],
+        "0x06df3b2bbb68adc8b0e302443692037ed9f91b42000000000000000000000063": [
+          {
+            "tokenAddress": "0xba100000625a3754423978a60c9317c58a424e3d",
+            "amount": 15000
+          }
+        ],
+        "0x96646936b91d6b9d7d0c47c496afbf3d6ec7b6f8000200000000000000000019": [
+          {
+            "tokenAddress": "0xba100000625a3754423978a60c9317c58a424e3d",
+            "amount": 3000
+          }
+        ],
+        "0xa1116930326d21fb917d5a27f1e9943a9595fb47": [
+          {
+            "tokenAddress": "0xba100000625a3754423978a60c9317c58a424e3d",
+            "amount": 12500
+          }
+        ],
+        "0x3e5fa9518ea95c3e533eb377c001702a9aacaa32000200000000000000000052": [
+          {
+            "tokenAddress": "0xba100000625a3754423978a60c9317c58a424e3d",
+            "amount": 2720
+          }
+        ],
+        "0xaac98ee71d4f8a156b6abaa6844cdb7789d086ce00020000000000000000001b": [
+          {
+            "tokenAddress": "0xba100000625a3754423978a60c9317c58a424e3d",
+            "amount": 2500
+          }
+        ],
+        "0x186084ff790c65088ba694df11758fae4943ee9e000200000000000000000013": [
+          {
+            "tokenAddress": "0xba100000625a3754423978a60c9317c58a424e3d",
+            "amount": 1000
+          }
+        ],
+        "0x072f14b85add63488ddad88f855fda4a99d6ac9b000200000000000000000027": [
+          {
+            "tokenAddress": "0xba100000625a3754423978a60c9317c58a424e3d",
+            "amount": 2500
+          }
+        ],
+        "0xe99481dc77691d8e2456e5f3f61c1810adfc1503000200000000000000000018": [
+          {
+            "tokenAddress": "0xba100000625a3754423978a60c9317c58a424e3d",
+            "amount": 2500
+          }
+        ],
+        "0xefaa1604e82e1b3af8430b90192c1b9e8197e377000200000000000000000021": [
+          {
+            "tokenAddress": "0xba100000625a3754423978a60c9317c58a424e3d",
+            "amount": 2500
+          }
+        ],
+        "0xfeadd389a5c427952d8fdb8057d6c8ba1156cc56000000000000000000000066": [
+          {
+            "tokenAddress": "0xba100000625a3754423978a60c9317c58a424e3d",
+            "amount": 2500
+          }
+        ],
+        "0x32296969ef14eb0c6d29669c550d4a0449130230000200000000000000000080": [
+          {
+            "tokenAddress": "0xba100000625a3754423978a60c9317c58a424e3d",
+            "amount": 2500
+          },
+          {
+            "tokenAddress": "0x5a98fcbea516cf06857215779fd812ca3bef1b32",
+            "amount": 25000
+          }
+        ],
+        "0xbf96189eee9357a95c7719f4f5047f76bde804e5000200000000000000000087": [
+          {
+            "tokenAddress": "0xba100000625a3754423978a60c9317c58a424e3d",
+            "amount": 1000
+          }
+        ],
+        "0xec60a5fef79a92c741cb74fdd6bfc340c0279b01000200000000000000000015": [
+          {
+            "tokenAddress": "0xba100000625a3754423978a60c9317c58a424e3d",
+            "amount": 1000
+          }
+        ],
+        "0xa02e4b3d18d4e6b8d18ac421fbc3dfff8933c40a00020000000000000000004b": [
+          {
+            "tokenAddress": "0xba100000625a3754423978a60c9317c58a424e3d",
+            "amount": 500
+          }
+        ],
+        "0x61d5dc44849c9c87b0856a2a311536205c96c7fd000100000000000000000001": [
+          {
+            "tokenAddress": "0xba100000625a3754423978a60c9317c58a424e3d",
+            "amount": 500
+          }
+        ],
+        "0xf5aaf7ee8c39b651cebf5f1f50c10631e78e0ef9000200000000000000000069": [
+          {
+            "tokenAddress": "0xba100000625a3754423978a60c9317c58a424e3d",
+            "amount": 500
+          }
+        ],
+        "0xf4c0dd9b82da36c07605df83c8a416f11724d88b000200000000000000000026": [
+          {
+            "tokenAddress": "0xba100000625a3754423978a60c9317c58a424e3d",
+            "amount": 1000
+          }
+        ],
+        "0xbaeec99c90e3420ec6c1e7a769d2a856d2898e4d00020000000000000000008a": [
+          {
+            "tokenAddress": "0xba100000625a3754423978a60c9317c58a424e3d",
+            "amount": 140
+          },
+          {
+            "tokenAddress": "0x81f8f0bb1cb2a06649e51913a151f0e7ef6fa321",
+            "amount": 2350
+          }
+        ],
+        "0x350196326aeaa9b98f1903fb5e8fc2686f85318c000200000000000000000084": [
+          {
+            "tokenAddress": "0xba100000625a3754423978a60c9317c58a424e3d",
+            "amount": 140
+          },
+          {
+            "tokenAddress": "0x81f8f0bb1cb2a06649e51913a151f0e7ef6fa321",
+            "amount": 2350
+          }
+        ]
+        
+      }
+    },
+    {
+      "chainId": 137,
+      "pools": {
+        "0x0297e37f1873d2dab4487aa67cd56b58e2f27875000100000000000000000002": [
+          {
+            "tokenAddress": "0x9a71012b13ca4d3d0cdc72a177df3ef03b0e76a3",
+            "amount": 7500
+          }
+        ],
+        "0x36128d5436d2d70cab39c9af9cce146c38554ff0000100000000000000000008": [
+          {
+            "tokenAddress": "0x9a71012b13ca4d3d0cdc72a177df3ef03b0e76a3",
+            "amount": 6000
+          }
+        ],
+        "0x03cd191f589d12b0582a99808cf19851e468e6b500010000000000000000000a": [
+          {
+            "tokenAddress": "0x9a71012b13ca4d3d0cdc72a177df3ef03b0e76a3",
+            "amount": 2500
+          }
+        ],
+        "0xce66904b68f1f070332cbc631de7ee98b650b499000100000000000000000009": [
+          {
+            "tokenAddress": "0x9a71012b13ca4d3d0cdc72a177df3ef03b0e76a3",
+            "amount": 2500
+          }
+        ],
+        "0x06df3b2bbb68adc8b0e302443692037ed9f91b42000000000000000000000012": [
+          {
+            "tokenAddress": "0x9a71012b13ca4d3d0cdc72a177df3ef03b0e76a3",
+            "amount": 2500
+          },
+          {
+            "tokenAddress": "0x580a84c73811e1839f75d86d75d88cca0c241ff4",
+            "amount": 15000
+          }
+        ],
+        "0xf461f2240b66d55dcf9059e26c022160c06863bf000100000000000000000006": [
+          {
+            "tokenAddress": "0x9a71012b13ca4d3d0cdc72a177df3ef03b0e76a3",
+            "amount": 1000
+          },
+          {
+            "tokenAddress": "0x580a84c73811e1839f75d86d75d88cca0c241ff4",
+            "amount": 15000
+          }
+        ],
+        "0x614b5038611729ed49e0ded154d8a5d3af9d1d9e00010000000000000000001d": [
+          {
+            "tokenAddress": "0x9a71012b13ca4d3d0cdc72a177df3ef03b0e76a3",
+            "amount": 1000
+          },
+          {
+            "tokenAddress": "0xF501dd45a1198C2E1b5aEF5314A68B9006D842E0",
+            "amount": 15000
+          }
+        ],
+        "0x4e7f40cd37cee710f5e87ad72959d30ef8a01a5d00010000000000000000000b": [
+          {
+            "tokenAddress": "0x9a71012b13ca4d3d0cdc72a177df3ef03b0e76a3",
+            "amount": 1000
+          }
+        ],
+        "0xfeadd389a5c427952d8fdb8057d6c8ba1156cc5600020000000000000000001e": [
+          {
+            "tokenAddress": "0x9a71012b13ca4d3d0cdc72a177df3ef03b0e76a3",
+            "amount": 1000
+          }
+        ]
+      }
+    },
+    {
+      "chainId": 42161,
+      "pools": {
+        "0x64541216bafffeec8ea535bb71fbc927831d0595000100000000000000000002": [
+          {
+            "tokenAddress": "0x040d1edc9569d4bab2d15287dc5a4f10f56a56b8",
+            "amount": 2500
+          }
+        ],
+        "0xcc65a812ce382ab909a11e434dbf75b34f1cc59d000200000000000000000001": [
+          {
+            "tokenAddress": "0x040d1edc9569d4bab2d15287dc5a4f10f56a56b8",
+            "amount": 3500
+          }
+        ]
+      }
+    }
   ]
 }

--- a/src/lib/utils/liquidityMining/MultiTokenLiquidityMining.json
+++ b/src/lib/utils/liquidityMining/MultiTokenLiquidityMining.json
@@ -2693,7 +2693,7 @@
           },
           {
             "tokenAddress": "0x5a98fcbea516cf06857215779fd812ca3bef1b32",
-            "amount": 25000
+            "amount": 75000
           }
         ],
         "0xbf96189eee9357a95c7719f4f5047f76bde804e5000200000000000000000087": [


### PR DESCRIPTION
# Description

Ballers [vote](https://snapshot.org/#/ballersvote.eth/proposal/QmUNh4hR2DdJx4QCLE6vhEFbpvA1a392rUGV24MV6WKpou)

ETHEREUM CHANGES
- Introduced dual incentives on eth for VITA/WETH - 80/20, VITA/WETH - 50/50 pools. They will receive 140 BAL/week each, and 2,350 VITA/week each. 
- stETH/ETH pool increased to 75k LDO/week

POLYGON CHANGES
- No changes.

ARBITRUM CHANGES
- No changes.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Other

## How should this be tested?

- [x] Liquidity mining page should reflect the changes described above

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] My changes generate no new console warnings
- [x] The base of this PR is `master` if hotfix, `develop` if not
