### PR TITLE
Add Element.fi trading support

### DIFF
--- a/src/composables/queries/usePoolQuery.ts
+++ b/src/composables/queries/usePoolQuery.ts
@@ -10,7 +10,7 @@ import { POOLS } from '@/constants/pools';
 import useApp from '../useApp';
 import useUserSettings from '../useUserSettings';
 import { forChange } from '@/lib/utils';
-import { isStableLike } from '../usePool';
+import { isElement, isStableLike } from '../usePool';
 
 export default function usePoolQuery(
   id: string,
@@ -43,7 +43,10 @@ export default function usePoolQuery(
       }
     });
 
-    if (isStableLike(pool) && !POOLS.Stable.AllowList.includes(id)) {
+    if (
+      (isStableLike(pool) && !POOLS.Stable.AllowList.includes(id)) ||
+      isElement(pool)
+    ) {
       throw new Error('Pool not allowed');
     }
 

--- a/src/composables/usePool.ts
+++ b/src/composables/usePool.ts
@@ -36,6 +36,10 @@ export function isWeightedLike(pool: AnyPool): boolean {
   return isWeighted(pool) || isInvestment(pool);
 }
 
+export function isElement(pool: AnyPool): boolean {
+  return pool.poolType === PoolType.Element;
+}
+
 export function isWeth(pool: AnyPool, networkId: string): boolean {
   return pool.tokenAddresses.includes(TOKENS.AddressMap[networkId].WETH);
 }

--- a/src/constants/tokenlists.ts
+++ b/src/constants/tokenlists.ts
@@ -23,6 +23,7 @@ export const TOKEN_LIST_MAP: TokenListMapByNetwork = {
     },
     External: [
       'ipns://tokens.uniswap.org',
+      'https://raw.githubusercontent.com/element-fi/elf-tokenlist/main/dist/mainnet.tokenlist.json',
       'tokenlist.zerion.eth',
       'tokens.1inch.eth',
       'tokenlist.aave.eth',

--- a/src/services/balancer/subgraph/entities/pools/query.ts
+++ b/src/services/balancer/subgraph/entities/pools/query.ts
@@ -7,8 +7,7 @@ const defaultArgs = {
   orderDirection: 'desc',
   where: {
     totalShares_gt: 0.01,
-    id_not_in: POOLS.BlockList,
-    poolType_not: 'Element'
+    id_not_in: POOLS.BlockList
   }
 };
 

--- a/src/services/balancer/subgraph/types.ts
+++ b/src/services/balancer/subgraph/types.ts
@@ -9,7 +9,8 @@ export enum PoolType {
   Weighted = 'Weighted',
   Investment = 'Investment',
   Stable = 'Stable',
-  MetaStable = 'MetaStable'
+  MetaStable = 'MetaStable',
+  Element = 'Element'
 }
 export type TimeTravelPeriod = '24h';
 


### PR DESCRIPTION
# Description

This PR adds support for us to trade using Element.fi assets - most notably their principle/yield tokens (The tokenlist also includes some irrelevant tokens but we can filter these out at some point.) We keep the same behaviour of not showing them on the Invest pages.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## How should this be tested?

- [ ] Check that no Element pools appear in the invest pages
- [ ] Check that you can route a trade from an asset (e.g. USDC) to the relevant principle/yield tokens
- [ ] Check that you can route a trade from a principle/yield tokens to other principle/yield tokens with the same underlying
- [ ] Check that prices are near those quoted on Element.fi

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] My changes generate no new console warnings
- [x] The base of this PR is `master` if hotfix, `develop` if not
