### PR TITLE
Fix links sending users to wrap native assets

### DIFF
--- a/src/components/cards/TradeCardGP/TradeCardGP.vue
+++ b/src/components/cards/TradeCardGP/TradeCardGP.vue
@@ -319,7 +319,7 @@ export default defineComponent({
     }
 
     function switchToWETH() {
-      tokenInAddress.value = TOKENS.AddressMap[appNetworkConfig.key].WETH;
+      tokenInAddress.value = appNetworkConfig.addresses.weth;
     }
 
     function handlePreviewButton() {

--- a/src/components/forms/pool_actions/InvestForm.vue
+++ b/src/components/forms/pool_actions/InvestForm.vue
@@ -158,8 +158,8 @@
           :to="{
             name: 'trade',
             params: {
-              assetIn: TOKENS.AddressMap[appNetworkConfig.key].ETH,
-              assetOut: TOKENS.AddressMap[appNetworkConfig.key].WETH
+              assetIn: appNetworkConfig.nativeAsset.address,
+              assetOut: appNetworkConfig.addresses.weth
             }
           }"
           class="text-xs text-gray-500 underline"

--- a/src/components/inputs/TokenSearchInput.vue
+++ b/src/components/inputs/TokenSearchInput.vue
@@ -122,7 +122,7 @@ export default defineComponent({
       // special case for ETH where we want it to filter as WETH regardless
       // as ETH is the native asset
       if (getAddress(token) === NATIVE_ASSET_ADDRESS) {
-        _token = TOKENS.AddressMap[appNetworkConfig.key].WETH;
+        _token = appNetworkConfig.addresses.weth;
       }
       // const newSelected = [...props.modelValue, _token];
       emit('add', _token);

--- a/src/composables/usePool.ts
+++ b/src/composables/usePool.ts
@@ -5,8 +5,6 @@ import {
   FullPool,
   PoolType
 } from '@/services/balancer/subgraph/types';
-import { TOKENS } from '@/constants/tokens';
-import useWeb3 from '@/services/web3/useWeb3';
 import { configService } from '@/services/config/config.service';
 import { getAddress } from 'ethers/lib/utils';
 
@@ -36,8 +34,8 @@ export function isWeightedLike(pool: AnyPool): boolean {
   return isWeighted(pool) || isInvestment(pool);
 }
 
-export function isWeth(pool: AnyPool, networkId: string): boolean {
-  return pool.tokenAddresses.includes(TOKENS.AddressMap[networkId].WETH);
+export function isWeth(pool: AnyPool): boolean {
+  return pool.tokenAddresses.includes(configService.network.addresses.weth);
 }
 
 export function isWstETH(pool: AnyPool): boolean {
@@ -49,7 +47,6 @@ export function isWstETH(pool: AnyPool): boolean {
 }
 
 export function usePool(pool: Ref<AnyPool> | Ref<undefined>) {
-  const { appNetworkConfig } = useWeb3();
   const isStablePool = computed(() => pool.value && isStable(pool.value));
   const isMetaStablePool = computed(
     () => pool.value && isMetaStable(pool.value)
@@ -62,9 +59,7 @@ export function usePool(pool: Ref<AnyPool> | Ref<undefined>) {
     () => pool.value && isWeightedLike(pool.value)
   );
 
-  const isWethPool = computed(
-    () => pool.value && isWeth(pool.value, appNetworkConfig.key)
-  );
+  const isWethPool = computed(() => pool.value && isWeth(pool.value));
   const isWstETHPool = computed(() => pool.value && isWstETH(pool.value));
 
   return {

--- a/src/constants/tokens.ts
+++ b/src/constants/tokens.ts
@@ -6,22 +6,18 @@ export const TOKENS = {
   },
   AddressMap: {
     '1': {
-      ETH: '0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE',
       WETH: '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2',
       BAL: '0xba100000625a3754423978a60c9317c58a424e3d'
     },
     '42': {
-      ETH: '0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE',
       WETH: '0xdFCeA9088c8A88A76FF74892C1457C17dfeef9C1',
       BAL: '0x41286Bb1D3E870f3F750eB7E1C25d7E48c8A1Ac7'
     },
     '137': {
-      ETH: '0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE',
       WETH: '0x7ceb23fd6bc0add59e62ac25578270cff1b9f619',
       BAL: '0x9a71012b13ca4d3d0cdc72a177df3ef03b0e76a3'
     },
     '42161': {
-      ETH: '0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE',
       WETH: '0x82aF49447D8a07e3bd95BD0d56f35241523fBab1',
       BAL: '0x040d1EdC9569d4Bab2D15287Dc5A4F10F56a56B8'
     }


### PR DESCRIPTION
# Description

Our links to wrap ETH/MATIC were broken on a couple of networks. This was stemming from us using a parallel mapping in the `TOKENS.ADDRESSMAP` causing some confusion. I've changed most references to this to rely on the `appNetworkConfig` directly instead.

This mapping remains as we need it to get the BAL address in a couple of places. I'd be inclined to move this to the config json file as well though. Thoughts on this?

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## How should this be tested?

Go to a MATIC/WETH pool on each network and click the "Wrap ETH into WETH" button. Check that correct tokens are selected in the trade UI.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] My changes generate no new console warnings
- [x] The base of this PR is `master` if hotfix, `develop` if not
