### PR TITLE
Hide LM estimate on Arbitrum

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.18.1",
+  "version": "1.18.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@balancer-labs/frontend-v2",
-      "version": "1.18.1",
+      "version": "1.18.3",
       "license": "MIT",
       "dependencies": {
         "@balancer-labs/assets": "github:balancer-labs/assets#master",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.18.1",
+  "version": "1.18.3",
   "engines": {
     "node": "14.x",
     "npm": ">=7"

--- a/src/components/navs/AppNav/AppNavClaimBtn.vue
+++ b/src/components/navs/AppNav/AppNavClaimBtn.vue
@@ -69,10 +69,10 @@
         <div class="text-sm text-gray-600 mb-1">
           {{ $t('pendingEstimate') }}
         </div>
-        <div class="p-3 text-sm" v-if="isArbitrum">
+        <div v-if="isArbitrum" class="p-3 text-sm">
           Sorry, estimates for Arbitrum are not available at the moment
         </div>
-        <div class="flex justify-between items-center mb-2" v-if="!isArbitrum">
+        <div v-else class="flex justify-between items-center mb-2">
           <div class="text-lg font-bold">
             {{
               fNum(currentRewards, currentRewards > 0 ? 'token_fixed' : 'token')

--- a/src/components/navs/AppNav/AppNavClaimBtn.vue
+++ b/src/components/navs/AppNav/AppNavClaimBtn.vue
@@ -69,7 +69,10 @@
         <div class="text-sm text-gray-600 mb-1">
           {{ $t('pendingEstimate') }}
         </div>
-        <div class="flex justify-between items-center mb-2">
+        <div class="p-3 text-sm" v-if="isArbitrum">
+          Sorry, estimates for Arbitrum are not available at the moment
+        </div>
+        <div class="flex justify-between items-center mb-2" v-if="!isArbitrum">
           <div class="text-lg font-bold">
             {{
               fNum(currentRewards, currentRewards > 0 ? 'token_fixed' : 'token')
@@ -130,6 +133,7 @@ export default defineComponent({
       getProvider,
       isMainnet,
       isPolygon,
+      isArbitrum,
       isMismatchedNetwork
     } = useWeb3();
     const { txListener } = useEthers();
@@ -259,6 +263,7 @@ export default defineComponent({
       // computed
       isMainnet,
       isPolygon,
+      isArbitrum,
       userClaims,
       availableToClaimInUSD,
       currentRewards,


### PR DESCRIPTION
# Description

We're having some issues with the underlying dataset used to compute LM estimates on Arbitrum. This hides the estimates on the frontend until we can fix that. 

Version bump assumes this will be merged after #804 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Other

## How should this be tested?

- [x] On Arbitrum, the estimates card shows a message "Sorry, estimates for Arbitrum are not available at the moment" instead of the estimated BAL
![image](https://user-images.githubusercontent.com/34865315/132986352-63ff1e3b-a91d-4774-96fa-abea202e5f77.png)
- [x] No changes on mainnet or polygon
![image](https://user-images.githubusercontent.com/34865315/132986409-c799d10e-00d5-4c25-9b49-5e5538c16006.png)
![image](https://user-images.githubusercontent.com/34865315/132986181-0a1f298c-1803-4e1a-a5f0-f07926c6c42e.png)

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] My changes generate no new console warnings
- [x] The base of this PR is `master` if hotfix, `develop` if not
