### PR TITLE
Add support for 8+ tokens display

### DIFF
--- a/src/components/_global/BalAsset/BalAssetSet.vue
+++ b/src/components/_global/BalAsset/BalAssetSet.vue
@@ -1,29 +1,36 @@
 <template>
-  <div
-    class="relative"
-    :style="{
-      width: `${width}px`,
-      height: `${size}px`
-    }"
+  <template
+    v-for="(addressesChunk, addressChunkIndex) in addressesChunks"
+    :key="`addressChunk-${addressChunkIndex}`"
   >
-    <BalAsset
-      v-for="(address, i) in addresses"
-      :key="i"
-      :address="address"
-      :size="size"
-      class="token-icon"
+    <div
+      class="addresses-row"
       :style="{
-        left: `${leftOffsetFor(i)}px`,
-        zIndex: `${20 - i}`,
-        width: `${size}px`,
+        width: `${width}px`,
         height: `${size}px`
       }"
-    />
-  </div>
+    >
+      <BalAsset
+        v-for="(address, i) in addressesChunk"
+        :key="i"
+        :address="address"
+        :size="size"
+        class="token-icon"
+        :style="{
+          left: `${leftOffsetFor(i)}px`,
+          zIndex: `${20 - i}`,
+          width: `${size}px`,
+          height: `${size}px`
+        }"
+      />
+    </div>
+  </template>
 </template>
 
 <script lang="ts">
-import { defineComponent, PropType } from 'vue';
+import { computed, defineComponent, PropType } from 'vue';
+import { chunk } from 'lodash';
+
 import BalAsset from './BalAsset.vue';
 
 export default defineComponent({
@@ -43,23 +50,58 @@ export default defineComponent({
     size: {
       type: Number,
       default: 26
+    },
+    maxAssetsPerLine: {
+      type: Number,
+      default: 8
     }
   },
 
   setup(props) {
-    function leftOffsetFor(i: number): number {
-      const maxCount = 8;
-      const radius = props.size / 2;
-      const spacer = (maxCount / props.addresses.length - 1) * (radius * 2);
-      return ((props.width - radius * 2 + spacer) / (maxCount - 1)) * i;
+    /**
+     * COMPUTED
+     */
+    const addressesChunks = computed(() =>
+      chunk(props.addresses, props.maxAssetsPerLine)
+    );
+
+    const radius = computed(() => props.size / 2);
+
+    const spacer = computed(
+      () =>
+        (props.maxAssetsPerLine / props.addresses.length - 1) *
+        (radius.value * 2)
+    );
+
+    /**
+     * METHODS
+     */
+    function leftOffsetFor(i: number) {
+      return (
+        ((props.width - radius.value * 2 + spacer.value) /
+          (props.maxAssetsPerLine - 1)) *
+        i
+      );
     }
 
-    return { leftOffsetFor };
+    return {
+      // computed
+      addressesChunks,
+
+      // methods
+      leftOffsetFor
+    };
   }
 });
 </script>
 
 <style scoped>
+.addresses-row {
+  @apply relative mb-3;
+}
+.addresses-row:last-child {
+  @apply mb-0;
+}
 .token-icon {
   margin-left: -2px;
   @apply absolute rounded-full overflow-hidden shadow-none;

--- a/src/components/_global/BalAsset/BalAssetSet.vue
+++ b/src/components/_global/BalAsset/BalAssetSet.vue
@@ -1,7 +1,7 @@
 <template>
   <template
     v-for="(addressesChunk, addressChunkIndex) in addressesChunks"
-    :key="`addressChunk-${addressChunkIndex}`"
+    :key="addressChunkIndex"
   >
     <div
       class="addresses-row"

--- a/src/components/tables/PoolsTable/TokenPills/HiddenTokensPills.vue
+++ b/src/components/tables/PoolsTable/TokenPills/HiddenTokensPills.vue
@@ -10,7 +10,7 @@
     />
     <div
       v-for="n in 2"
-      :key="`hidden-pill-${n}`"
+      :key="n"
       class="pill hidden-pill"
       :style="{
         transform: `translateX(${n * 8}px)`,

--- a/src/components/tables/PoolsTable/TokenPills/HiddenTokensPills.vue
+++ b/src/components/tables/PoolsTable/TokenPills/HiddenTokensPills.vue
@@ -8,15 +8,15 @@
       class="balance-indicator"
       :style="{ zIndex: tokens.length }"
     />
-    <template v-for="n in 2" :key="`hidden-pill-${n}`">
-      <div
-        class="pill hidden-pill"
-        :style="{
-          transform: `translateX(${n * 8}px)`,
-          zIndex: tokens.length - n
-        }"
-      />
-    </template>
+    <div
+      v-for="n in 2"
+      :key="`hidden-pill-${n}`"
+      class="pill hidden-pill"
+      :style="{
+        transform: `translateX(${n * 8}px)`,
+        zIndex: tokens.length - n
+      }"
+    />
   </div>
 </template>
 
@@ -44,7 +44,8 @@ export default defineComponent({
 .pill {
   @apply px-2 py-1;
   @apply rounded-lg;
-  @apply bg-gray-50 dark:bg-gray-600;
+  @apply bg-gray-50 dark:bg-gray-600 text-gray-500 dark:text-gray-400;
+  @apply text-sm;
   box-shadow: 2px 2px 4px rgba(0, 0, 0, 0.07);
 }
 

--- a/src/components/tables/PoolsTable/TokenPills/HiddenTokensPills.vue
+++ b/src/components/tables/PoolsTable/TokenPills/HiddenTokensPills.vue
@@ -5,7 +5,7 @@
     </div>
     <div
       v-for="n in 2"
-      :key="n"
+      :key="`hidden-pill-${n}`"
       class="pill hidden-pill"
       :style="{
         transform: `translateX(${n * 8}px)`,

--- a/src/components/tables/PoolsTable/TokenPills/HiddenTokensPills.vue
+++ b/src/components/tables/PoolsTable/TokenPills/HiddenTokensPills.vue
@@ -1,0 +1,43 @@
+<template>
+  <div class="relative flex mr-2 my-1">
+    <div class="pill" :style="{ zIndex: tokens.length }">
+      {{ $t('tokenPills.hiddenTokens', [tokens.length]) }}
+    </div>
+    <div
+      v-for="n in 2"
+      :key="n"
+      class="pill hidden-pill"
+      :style="{
+        transform: `translateX(${n * 8}px)`,
+        zIndex: tokens.length - n
+      }"
+    />
+  </div>
+</template>
+
+<script lang="ts">
+import { defineComponent, PropType } from 'vue';
+
+import { PoolToken } from '@/services/balancer/subgraph/types';
+
+export default defineComponent({
+  name: 'HiddenTokensPills',
+
+  props: {
+    tokens: {
+      type: Array as PropType<PoolToken[]>,
+      required: true
+    }
+  }
+});
+</script>
+<style scoped>
+.pill {
+  @apply px-2 py-1 rounded-lg bg-gray-50 dark:bg-gray-600;
+  box-shadow: 2px 2px 4px rgba(0, 0, 0, 0.07);
+}
+.hidden-pill {
+  @apply absolute top-0 left-0 h-full w-full;
+  box-shadow: 2px 0px 4px rgba(0, 0, 0, 0.07);
+}
+</style>

--- a/src/components/tables/PoolsTable/TokenPills/HiddenTokensPills.vue
+++ b/src/components/tables/PoolsTable/TokenPills/HiddenTokensPills.vue
@@ -4,14 +4,19 @@
       {{ $t('tokenPills.hiddenTokens', [tokens.length]) }}
     </div>
     <div
-      v-for="n in 2"
-      :key="`hidden-pill-${n}`"
-      class="pill hidden-pill"
-      :style="{
-        transform: `translateX(${n * 8}px)`,
-        zIndex: tokens.length - n
-      }"
+      v-if="hasBalance"
+      class="balance-indicator"
+      :style="{ zIndex: tokens.length }"
     />
+    <template v-for="n in 2" :key="`hidden-pill-${n}`">
+      <div
+        class="pill hidden-pill"
+        :style="{
+          transform: `translateX(${n * 8}px)`,
+          zIndex: tokens.length - n
+        }"
+      />
+    </template>
   </div>
 </template>
 
@@ -27,17 +32,32 @@ export default defineComponent({
     tokens: {
       type: Array as PropType<PoolToken[]>,
       required: true
+    },
+    hasBalance: {
+      type: Boolean,
+      default: false
     }
   }
 });
 </script>
 <style scoped>
 .pill {
-  @apply px-2 py-1 rounded-lg bg-gray-50 dark:bg-gray-600;
+  @apply px-2 py-1;
+  @apply rounded-lg;
+  @apply bg-gray-50 dark:bg-gray-600;
   box-shadow: 2px 2px 4px rgba(0, 0, 0, 0.07);
 }
+
+.balance-indicator {
+  @apply w-3 h-3;
+  @apply rounded-full border-2 border-white dark:border-gray-850;
+  @apply bg-green-200 dark:bg-green-500;
+  @apply absolute top-0 right-0 -mt-1 -mr-1;
+}
+
 .hidden-pill {
-  @apply absolute top-0 left-0 h-full w-full;
+  @apply h-full w-full;
+  @apply absolute top-0 left-0;
   box-shadow: 2px 0px 4px rgba(0, 0, 0, 0.07);
 }
 </style>

--- a/src/components/tables/PoolsTable/TokenPills/TokenPills.vue
+++ b/src/components/tables/PoolsTable/TokenPills/TokenPills.vue
@@ -3,40 +3,48 @@
     <template v-if="isStablePool">
       <div class="bg-gray-100 dark:bg-gray-700 rounded-lg flex">
         <StableTokenPill
-          v-for="(token, i) in tokens"
+          v-for="(token, i) in visibleTokens"
           :key="token"
           :hasBalance="hasBalance(token.address)"
           :symbol="symbolFor(token)"
-          :isLast="tokens.length - 1 === i"
+          :isLast="visibleTokens.length - 1 === i"
         />
       </div>
     </template>
     <template v-else>
       <WeightedTokenPill
-        v-for="token in tokens"
+        v-for="token in visibleTokens"
         :key="token.address"
         :hasBalance="hasBalance(token.address)"
         :symbol="symbolFor(token)"
         :weight="weightFor(token)"
       />
     </template>
+    <HiddenTokensPills v-if="hiddenTokens.length > 0" :tokens="hiddenTokens" />
   </div>
 </template>
 
 <script lang="ts">
+import { computed, defineComponent, PropType } from 'vue';
+
 import useNumbers from '@/composables/useNumbers';
-import { PoolToken } from '@/services/balancer/subgraph/types';
-import { defineComponent, PropType } from 'vue';
 import useTokens from '@/composables/useTokens';
+
+import { PoolToken } from '@/services/balancer/subgraph/types';
+
 import WeightedTokenPill from './WeightedTokenPill.vue';
 import StableTokenPill from './StableTokenPill.vue';
+import HiddenTokensPills from './HiddenTokensPills.vue';
+
+const MAX_PILLS = 11;
 
 export default defineComponent({
   name: 'TokenPills',
 
   components: {
     WeightedTokenPill,
-    StableTokenPill
+    StableTokenPill,
+    HiddenTokensPills
   },
 
   props: {
@@ -47,12 +55,19 @@ export default defineComponent({
     isStablePool: { type: Boolean, required: true }
   },
 
-  setup() {
+  setup(props) {
     /**
      * COMPOSABLES
      */
     const { fNum } = useNumbers();
     const { tokens, hasBalance } = useTokens();
+
+    /**
+     * COMPUTED
+     */
+
+    const visibleTokens = computed(() => props.tokens.slice(0, MAX_PILLS));
+    const hiddenTokens = computed(() => props.tokens.slice(MAX_PILLS));
 
     /**
      * METHODS
@@ -66,6 +81,10 @@ export default defineComponent({
     }
 
     return {
+      // computed
+      visibleTokens,
+      hiddenTokens,
+
       // methods
       symbolFor,
       weightFor,

--- a/src/components/tables/PoolsTable/TokenPills/TokenPills.vue
+++ b/src/components/tables/PoolsTable/TokenPills/TokenPills.vue
@@ -20,7 +20,11 @@
         :weight="weightFor(token)"
       />
     </template>
-    <HiddenTokensPills v-if="hiddenTokens.length > 0" :tokens="hiddenTokens" />
+    <HiddenTokensPills
+      v-if="hiddenTokens.length > 0"
+      :tokens="hiddenTokens"
+      :hasBalance="hasBalanceInHiddenTokens"
+    />
   </div>
 </template>
 
@@ -65,9 +69,13 @@ export default defineComponent({
     /**
      * COMPUTED
      */
-
     const visibleTokens = computed(() => props.tokens.slice(0, MAX_PILLS));
+
     const hiddenTokens = computed(() => props.tokens.slice(MAX_PILLS));
+
+    const hasBalanceInHiddenTokens = computed(() =>
+      hiddenTokens.value.some(token => hasBalance(token.address))
+    );
 
     /**
      * METHODS
@@ -84,6 +92,7 @@ export default defineComponent({
       // computed
       visibleTokens,
       hiddenTokens,
+      hasBalanceInHiddenTokens,
 
       // methods
       symbolFor,

--- a/src/locales/default.json
+++ b/src/locales/default.json
@@ -227,7 +227,7 @@
     "noRecentActivity": "Your recent activity will appear here…",
     "switchNetwork": "Switch Network",
     "tokenPills": {
-        "hiddenTokens": "+ {0} tokens"
+        "hiddenTokens": "+{0} tokens"
     },
     "transactionAction": {
         "trade": "Trade",

--- a/src/locales/default.json
+++ b/src/locales/default.json
@@ -226,6 +226,9 @@
     "recentActivityTitle": "Recent activity",
     "noRecentActivity": "Your recent activity will appear here…",
     "switchNetwork": "Switch Network",
+    "tokenPills": {
+        "hiddenTokens": "+ {0} tokens"
+    },
     "transactionAction": {
         "trade": "Trade",
         "approve": "Approve",


### PR DESCRIPTION
# Description

Adds support for displaying 8+ tokens - see design for reference https://www.figma.com/file/sGuETamvER4ifrs4VqnDxE/Investment-pools?node-id=11%3A2080

Note - I'm still waiting for Pon's tweaks for dark mode and how the stable pool pills handle this.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other

## How should this be tested?

Please provide instructions so we can test. Please also list any relevant details for your test configuration.

- [ ] Pools with 11+ tokens show a new "token pill" that shows the number of hidden tokens.
- [ ] The `BalAssetSet` has a multi-line display when it has more than 8 tokens.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] My changes generate no new console warnings
- [x] The base of this PR is `master` if hotfix, `develop` if not
