### PR TITLE
Hotfix: Add mapping for NDX token price on Arbitrum

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.19.0",
+  "version": "1.19.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@balancer-labs/frontend-v2",
-      "version": "1.19.0",
+      "version": "1.19.1",
       "license": "MIT",
       "dependencies": {
         "@balancer-labs/assets": "github:balancer-labs/assets#master",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.19.0",
+  "version": "1.19.1",
   "engines": {
     "node": "14.x",
     "npm": ">=7"

--- a/src/constants/tokens.ts
+++ b/src/constants/tokens.ts
@@ -59,6 +59,8 @@ export const TOKENS = {
           '0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e',
         '0xa0b862f60edef4452f25b4160f177db44deb6cf1':
           '0x6810e776880c02933d47db1b9fc05908e5386b96',
+        '0xb965029343d55189c25a7f3e0c9394dc0f5d41b1':
+          '0x86772b1409b61c639eaac9ba0acfbb6e238e5f83',
         '0xc3ae0333f0f34aa734d5493276223d95b8f9cb37':
           '0xa1d65e8fb6e87b60feccbc582f7f97804b725521',
         '0xd4d42f0b6def4ce0383636770ef773390d85c61a':


### PR DESCRIPTION
# Description

Add ChainMap entry for the Indexed Finance NDX token, mapping its Arbitrum address to its Ethereum address:
0xB965029343D55189c25a7f3e0c9394DC0F5D41b1 -> 0x86772b1409b61c639EaAc9Ba0AcfBb6E238e5F83

The address pairing used above can be found in Arbitrum's official token list: https://bridge.arbitrum.io/token-list-42161.json

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## How should this be tested?

- [ ] Verify that the dedicated page for this pool ID (on Arbitrum!) displays a dollar value for the NDX token: 0x5ced962afbfb7e13fb215defc2b027678237aa3a000200000000000000000011
- [ ] Verify that this warning is not shown for the same pool: "Price information is missing for this pool, since it contains a token not found by our price provider."

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] My changes generate no new console warnings
- [x] The base of this PR is `master` if hotfix, `develop` if not
