### PR TITLE
Show the no liquidity error message when relavent

### DIFF
--- a/src/composables/trade/useValidation.ts
+++ b/src/composables/trade/useValidation.ts
@@ -31,7 +31,11 @@ export default function useValidation(
   const validationStatus = computed(() => {
     if (!isWalletReady) return TradeValidation.NO_ACCOUNT;
 
-    if (!tokensAmountsValid.value) return TradeValidation.EMPTY;
+    if (
+      !isValidTokenAmount(tokenInAmount.value) &&
+      !isValidTokenAmount(tokenOutAmount.value)
+    )
+      return TradeValidation.EMPTY;
 
     const nativeAssetBalance = parseFloat(balances.value[nativeAsset.address]);
     if (nativeAssetBalance < MIN_NATIVE_ASSET_REQUIRED) {


### PR DESCRIPTION
# Description

Currently, the no liquidity error message never shows. The user isn't provided with any visual cue on why they can't execute their trade. This PR is a one line change to only show the EMPTY state when both tokenInAmount and tokenOutAmount are empty, rather than either.

**Before:**
![Screen Shot 2021-09-17 at 10 31 28 AM](https://user-images.githubusercontent.com/89448254/133751504-02c4aa78-c91f-431b-8858-a41e9eee2d4c.png)

**After:**
![Screen Shot 2021-09-17 at 10 34 42 AM](https://user-images.githubusercontent.com/89448254/133751936-932e7f33-41dc-480f-9402-c72fcfa36ec3.png)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## How should this be tested?

Please provide instructions so we can test. Please also list any relevant details for your test configuration.

- [ ] Navigate to the Trade view, select ETH -> DAI, enter a very large amount of ETH, verify that the not enough liquidity error message appears.
- [ ] Navigate to the Trade view, select ETH -> DAI, provide empty or zero values to either side, verify that the EMPTY state is present.

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] My changes generate no new console warnings
- [x] The base of this PR is `master` if hotfix, `develop` if not
