### PR TITLE
Show a slippage error message when a trade fails with error #507

### DIFF
--- a/src/components/cards/TradeCard/TradeCard.vue
+++ b/src/components/cards/TradeCard/TradeCard.vue
@@ -81,6 +81,7 @@
       :address-out="tokenOutAddress"
       :amount-out="tokenOutAmount"
       :trading="trading"
+      :slippage-error="slippageError"
       @trade="trade"
       @close="modalTradePreviewIsOpen = false"
     />
@@ -204,7 +205,8 @@ export default defineComponent({
       latestTxHash,
       pools,
       fetchPools,
-      poolsLoading
+      poolsLoading,
+      slippageError
     } = useSor({
       exactIn,
       tokenInAddressInput: tokenInAddress,
@@ -281,6 +283,7 @@ export default defineComponent({
     }
 
     function showTradePreviewModal() {
+      slippageError.value = false;
       modalTradePreviewIsOpen.value = true;
     }
 
@@ -343,7 +346,8 @@ export default defineComponent({
       bp,
       darkMode,
       tradeCardShadow,
-      explorer: explorerLinks
+      explorer: explorerLinks,
+      slippageError
     };
   }
 });

--- a/src/components/modals/TradePreviewModal.vue
+++ b/src/components/modals/TradePreviewModal.vue
@@ -1,6 +1,20 @@
 <template>
-  <BalModal show @close="onClose" :title="$t('previewTradeTransactions')">
-    <div>
+  <BalModal
+    show
+    @close="onClose"
+    :title="
+      slippageError
+        ? $t('slippageErrorHeadline')
+        : $t('previewTradeTransactions')
+    "
+  >
+    <div v-if="slippageError">
+      <div class="mb-6 text-md">
+        {{ $t('slippageErrorBody') }}
+      </div>
+      <BalBtn class="mt-5" label="Close" color="red" block @click="onClose" />
+    </div>
+    <div v-else>
       <div
         class="-mx-4 p-4 flex items-center border-b border-t dark:border-gray-800"
       >
@@ -145,6 +159,10 @@ export default defineComponent({
       required: true
     },
     trading: {
+      type: Boolean,
+      required: true
+    },
+    slippageError: {
       type: Boolean,
       required: true
     }

--- a/src/composables/trade/useSor.ts
+++ b/src/composables/trade/useSor.ts
@@ -122,6 +122,7 @@ export default function useSor({
   const priceImpact = ref(0);
   const latestTxHash = ref('');
   const poolsLoading = ref(true);
+  const slippageError = ref(false);
 
   // COMPOSABLES
   const store = useStore();
@@ -527,6 +528,10 @@ export default function useSor({
           successCallback();
         }
       } catch (e) {
+        if (isSlippageError(e)) {
+          slippageError.value = true;
+        }
+
         console.log(e);
         state.submissionError = e.message;
         trading.value = false;
@@ -557,6 +562,10 @@ export default function useSor({
           successCallback();
         }
       } catch (e) {
+        if (isSlippageError(e)) {
+          slippageError.value = true;
+        }
+
         console.log(e);
         state.submissionError = e.message;
         trading.value = false;
@@ -628,6 +637,10 @@ export default function useSor({
     };
   }
 
+  function isSlippageError(e) {
+    return e.message.indexOf('BAL#507') !== -1;
+  }
+
   /**
    * Under certain circumstance we need to adjust an amount
    * for the price impact calc due to background wrapping taking place
@@ -662,6 +675,7 @@ export default function useSor({
     poolsLoading,
     getQuote,
     resetState,
-    confirming
+    confirming,
+    slippageError
   };
 }

--- a/src/locales/default.json
+++ b/src/locales/default.json
@@ -410,5 +410,7 @@
     "featuredProtocol": "Featured ecosystem protocol",
     "aboutElementFinance": "Element is an open source protocol for fixed and variable yield markets. It is built on Balancer V2. View and manage your liquidity positions directly on Element.fi.",
     "viewAndManangeOnElement": "View and manage all pools on Element.fi",
-    "viewOnElement": "View on Element.fi"
+    "viewOnElement": "View on Element.fi",
+    "slippageErrorHeadline": "Trade failure",
+    "slippageErrorBody": "Your trade failed because of excessive slippage. You can attempt to increase your slippage and try again."
 }


### PR DESCRIPTION
# Description

When a trade fails due to slippage, the user does not receive a visual cue. The button goes from loading and then back to enabled, but Metamask does not pop up. They continue to try to swap repeatedly.

Parse the error message for **BAL#507**, and if found toggle the TradePreviewModal to a simple error message saying their trade failed due to slippage. It may be a better approach to generalize this to handle more error cases. We'd be happy to do that if this is useful for you guys.

![Screen Shot 2021-09-17 at 11 38 57 AM](https://user-images.githubusercontent.com/89448254/133765386-564fd863-a226-4469-9bac-9fb6da97c2ef.png)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## How should this be tested?

- [ ] Navigate to Trade, set your slippage to be VERY low, attempt a trade that should fail due to **SWAP_LIMIT**. Upon failure, the modal should change to the simple error modal.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] My changes generate no new console warnings
- [x] The base of this PR is `master` if hotfix, `develop` if not
