### PR TITLE
Liquidity Mining, week 69

### DIFF
--- a/src/lib/utils/liquidityMining/MultiTokenLiquidityMining.json
+++ b/src/lib/utils/liquidityMining/MultiTokenLiquidityMining.json
@@ -1,3 +1,5 @@
+      }
+
 {
   "week_52": [
     {
@@ -714,7 +716,6 @@
             "amount": 1000
           }
         ]
-        
       }
     },
     {
@@ -943,7 +944,6 @@
             "amount": 1000
           }
         ]
-        
       }
     },
     {
@@ -1172,7 +1172,6 @@
             "amount": 1000
           }
         ]
-        
       }
     },
     {
@@ -1401,7 +1400,6 @@
             "amount": 1000
           }
         ]
-        
       }
     },
     {
@@ -1630,7 +1628,6 @@
             "amount": 1000
           }
         ]
-        
       }
     },
     {
@@ -1869,7 +1866,6 @@
             "amount": 1000
           }
         ]
-        
       }
     },
     {
@@ -2102,7 +2098,6 @@
             "amount": 1000
           }
         ]
-        
       }
     },
     {
@@ -2178,8 +2173,7 @@
     },
     {
       "chainId": 42161,
-      "pools": {
-      }
+      "pools": {}
     }
   ],
   "week_66": [
@@ -2304,7 +2298,6 @@
             "amount": 1000
           }
         ]
-        
       }
     },
     {
@@ -2380,8 +2373,7 @@
     },
     {
       "chainId": 42161,
-      "pools": {
-      }
+      "pools": {}
     }
   ],
   "week_67": [
@@ -2512,7 +2504,6 @@
             "amount": 1000
           }
         ]
-        
       }
     },
     {
@@ -2752,7 +2743,6 @@
             "amount": 2350
           }
         ]
-        
       }
     },
     {
@@ -2839,6 +2829,303 @@
           {
             "tokenAddress": "0x040d1edc9569d4bab2d15287dc5a4f10f56a56b8",
             "amount": 3500
+          }
+        ]
+      }
+    }
+  ],
+  "week_69": [
+    {
+      "chainId": 1,
+      "pools": {
+        "0xa6f548df93de924d73be7d25dc02554c6bd66db500020000000000000000000e": [
+          {
+            "tokenAddress": "0xba100000625a3754423978a60c9317c58a424e3d",
+            "amount": 15000
+          }
+        ],
+        "0x0b09dea16768f0799065c475be02919503cb2a3500020000000000000000001a": [
+          {
+            "tokenAddress": "0xba100000625a3754423978a60c9317c58a424e3d",
+            "amount": 15000
+          }
+        ],
+        "0x5c6ee304399dbdb9c8ef030ab642b10820db8f56000200000000000000000014": [
+          {
+            "tokenAddress": "0xba100000625a3754423978a60c9317c58a424e3d",
+            "amount": 30000
+          }
+        ],
+        "0x06df3b2bbb68adc8b0e302443692037ed9f91b42000000000000000000000063": [
+          {
+            "tokenAddress": "0xba100000625a3754423978a60c9317c58a424e3d",
+            "amount": 15000
+          }
+        ],
+        "0x96646936b91d6b9d7d0c47c496afbf3d6ec7b6f8000200000000000000000019": [
+          {
+            "tokenAddress": "0xba100000625a3754423978a60c9317c58a424e3d",
+            "amount": 1500
+          }
+        ],
+        "0xa1116930326d21fb917d5a27f1e9943a9595fb47": [
+          {
+            "tokenAddress": "0xba100000625a3754423978a60c9317c58a424e3d",
+            "amount": 12500
+          }
+        ],
+        "0x3e5fa9518ea95c3e533eb377c001702a9aacaa32000200000000000000000052": [
+          {
+            "tokenAddress": "0xba100000625a3754423978a60c9317c58a424e3d",
+            "amount": 120
+          }
+        ],
+        "0xaac98ee71d4f8a156b6abaa6844cdb7789d086ce00020000000000000000001b": [
+          {
+            "tokenAddress": "0xba100000625a3754423978a60c9317c58a424e3d",
+            "amount": 2500
+          }
+        ],
+        "0x186084ff790c65088ba694df11758fae4943ee9e000200000000000000000013": [
+          {
+            "tokenAddress": "0xba100000625a3754423978a60c9317c58a424e3d",
+            "amount": 500
+          }
+        ],
+        "0x072f14b85add63488ddad88f855fda4a99d6ac9b000200000000000000000027": [
+          {
+            "tokenAddress": "0xba100000625a3754423978a60c9317c58a424e3d",
+            "amount": 1000
+          }
+        ],
+        "0xe99481dc77691d8e2456e5f3f61c1810adfc1503000200000000000000000018": [
+          {
+            "tokenAddress": "0xba100000625a3754423978a60c9317c58a424e3d",
+            "amount": 2500
+          }
+        ],
+        "0xefaa1604e82e1b3af8430b90192c1b9e8197e377000200000000000000000021": [
+          {
+            "tokenAddress": "0xba100000625a3754423978a60c9317c58a424e3d",
+            "amount": 1000
+          }
+        ],
+        "0xfeadd389a5c427952d8fdb8057d6c8ba1156cc56000000000000000000000066": [
+          {
+            "tokenAddress": "0xba100000625a3754423978a60c9317c58a424e3d",
+            "amount": 2500
+          }
+        ],
+        "0x32296969ef14eb0c6d29669c550d4a0449130230000200000000000000000080": [
+          {
+            "tokenAddress": "0xba100000625a3754423978a60c9317c58a424e3d",
+            "amount": 2500
+          },
+          {
+            "tokenAddress": "0x5a98fcbea516cf06857215779fd812ca3bef1b32",
+            "amount": 75000
+          }
+        ],
+        "0xbf96189eee9357a95c7719f4f5047f76bde804e5000200000000000000000087": [
+          {
+            "tokenAddress": "0xba100000625a3754423978a60c9317c58a424e3d",
+            "amount": 1000
+          }
+        ],
+        "0xec60a5fef79a92c741cb74fdd6bfc340c0279b01000200000000000000000015": [
+          {
+            "tokenAddress": "0xba100000625a3754423978a60c9317c58a424e3d",
+            "amount": 500
+          }
+        ],
+        "0xa02e4b3d18d4e6b8d18ac421fbc3dfff8933c40a00020000000000000000004b": [
+          {
+            "tokenAddress": "0xba100000625a3754423978a60c9317c58a424e3d",
+            "amount": 500
+          }
+        ],
+        "0xf5aaf7ee8c39b651cebf5f1f50c10631e78e0ef9000200000000000000000069": [
+          {
+            "tokenAddress": "0xba100000625a3754423978a60c9317c58a424e3d",
+            "amount": 500
+          }
+        ],
+        "0xf4c0dd9b82da36c07605df83c8a416f11724d88b000200000000000000000026": [
+          {
+            "tokenAddress": "0xba100000625a3754423978a60c9317c58a424e3d",
+            "amount": 1000
+          }
+        ],
+        "0xbaeec99c90e3420ec6c1e7a769d2a856d2898e4d00020000000000000000008a": [
+          {
+            "tokenAddress": "0xba100000625a3754423978a60c9317c58a424e3d",
+            "amount": 140
+          },
+          {
+            "tokenAddress": "0x81f8f0bb1cb2a06649e51913a151f0e7ef6fa321",
+            "amount": 2350
+          }
+        ],
+        "0x350196326aeaa9b98f1903fb5e8fc2686f85318c000200000000000000000084": [
+          {
+            "tokenAddress": "0xba100000625a3754423978a60c9317c58a424e3d",
+            "amount": 140
+          },
+          {
+            "tokenAddress": "0x81f8f0bb1cb2a06649e51913a151f0e7ef6fa321",
+            "amount": 2350
+          }
+        ],
+        "0xe2469f47ab58cf9cf59f9822e3c5de4950a41c49000200000000000000000089": [
+          {
+            "tokenAddress": "0xba100000625a3754423978a60c9317c58a424e3d",
+            "amount": 500
+          }
+        ]
+      }
+    },
+    {
+      "chainId": 137,
+      "pools": {
+        "0x0297e37f1873d2dab4487aa67cd56b58e2f27875000100000000000000000002": [
+          {
+            "tokenAddress": "0x9a71012b13ca4d3d0cdc72a177df3ef03b0e76a3",
+            "amount": 7500
+          }
+        ],
+        "0x36128d5436d2d70cab39c9af9cce146c38554ff0000100000000000000000008": [
+          {
+            "tokenAddress": "0x9a71012b13ca4d3d0cdc72a177df3ef03b0e76a3",
+            "amount": 5000
+          }
+        ],
+        "0x03cd191f589d12b0582a99808cf19851e468e6b500010000000000000000000a": [
+          {
+            "tokenAddress": "0x9a71012b13ca4d3d0cdc72a177df3ef03b0e76a3",
+            "amount": 2500
+          }
+        ],
+        "0xce66904b68f1f070332cbc631de7ee98b650b499000100000000000000000009": [
+          {
+            "tokenAddress": "0x9a71012b13ca4d3d0cdc72a177df3ef03b0e76a3",
+            "amount": 2500
+          }
+        ],
+        "0x06df3b2bbb68adc8b0e302443692037ed9f91b42000000000000000000000012": [
+          {
+            "tokenAddress": "0x9a71012b13ca4d3d0cdc72a177df3ef03b0e76a3",
+            "amount": 2500
+          },
+          {
+            "tokenAddress": "0x580a84c73811e1839f75d86d75d88cca0c241ff4",
+            "amount": 15000
+          }
+        ],
+        "0xf461f2240b66d55dcf9059e26c022160c06863bf000100000000000000000006": [
+          {
+            "tokenAddress": "0x9a71012b13ca4d3d0cdc72a177df3ef03b0e76a3",
+            "amount": 1000
+          },
+          {
+            "tokenAddress": "0x580a84c73811e1839f75d86d75d88cca0c241ff4",
+            "amount": 15000
+          }
+        ],
+        "0x614b5038611729ed49e0ded154d8a5d3af9d1d9e00010000000000000000001d": [
+          {
+            "tokenAddress": "0x9a71012b13ca4d3d0cdc72a177df3ef03b0e76a3",
+            "amount": 1000
+          },
+          {
+            "tokenAddress": "0xF501dd45a1198C2E1b5aEF5314A68B9006D842E0",
+            "amount": 15000
+          }
+        ],
+        "0x4e7f40cd37cee710f5e87ad72959d30ef8a01a5d00010000000000000000000b": [
+          {
+            "tokenAddress": "0x9a71012b13ca4d3d0cdc72a177df3ef03b0e76a3",
+            "amount": 1000
+          }
+        ],
+        "0x7c9cf12d783821d5c63d8e9427af5c44bad92445000100000000000000000051": [
+          {
+            "tokenAddress": "0x9a71012b13ca4d3d0cdc72a177df3ef03b0e76a3",
+            "amount": 1000
+          }
+        ],
+        "0xfeadd389a5c427952d8fdb8057d6c8ba1156cc5600020000000000000000001e": [
+          {
+            "tokenAddress": "0x9a71012b13ca4d3d0cdc72a177df3ef03b0e76a3",
+            "amount": 1000
+          }
+        ]
+      }
+    },
+    {
+      "chainId": 42161,
+      "pools": {
+        "0x64541216bafffeec8ea535bb71fbc927831d0595000100000000000000000002": [
+          {
+            "tokenAddress": "0x040d1edc9569d4bab2d15287dc5a4f10f56a56b8",
+            "amount": 2500
+          }
+        ],
+        "0xcc65a812ce382ab909a11e434dbf75b34f1cc59d000200000000000000000001": [
+          {
+            "tokenAddress": "0x040d1edc9569d4bab2d15287dc5a4f10f56a56b8",
+            "amount": 3500
+          }
+        ],
+        "0x9be7de742865d021c0e8fb9d64311b2c040c1ec1000200000000000000000012": [
+          {
+            "tokenAddress": "0x040d1edc9569d4bab2d15287dc5a4f10f56a56b8",
+            "amount": 2500
+          }
+        ],
+        "0x26d23ec319cad4ad99e237511e792ee326ca1070000100000000000000000014": [
+          {
+            "tokenAddress": "0x040d1edc9569d4bab2d15287dc5a4f10f56a56b8",
+            "amount": 500
+          }
+        ],
+        "0x5ced962afbfb7e13fb215defc2b027678237aa3a000200000000000000000011": [
+          {
+            "tokenAddress": "0x040d1edc9569d4bab2d15287dc5a4f10f56a56b8",
+            "amount": 500
+          }
+        ],
+        "0x8a9f8b5334dacb052cd62797e2bdf68d89c0bfd8000200000000000000000013": [
+          {
+            "tokenAddress": "0x040d1edc9569d4bab2d15287dc5a4f10f56a56b8",
+            "amount": 500
+          }
+        ],
+        "0x4a3a22a3e7fee0ffbb66f1c28bfac50f75546fc7000200000000000000000008": [
+          {
+            "tokenAddress": "0x040d1edc9569d4bab2d15287dc5a4f10f56a56b8",
+            "amount": 500
+          }
+        ],
+        "0xb5b77f1ad2b520df01612399258e7787af63025d000200000000000000000010": [
+          {
+            "tokenAddress": "0x040d1edc9569d4bab2d15287dc5a4f10f56a56b8",
+            "amount": 1600
+          },
+          {
+            "tokenAddress": "0x4e352cf164e64adcbad318c3a1e222e9eba4ce42",
+            "amount": 1260
+          }
+        ],
+        "0x651e00ffd5ecfa7f3d4f33d62ede0a97cf62ede2000200000000000000000006": [
+          {
+            "tokenAddress": "0x040d1edc9569d4bab2d15287dc5a4f10f56a56b8",
+            "amount": 1000
+          }
+        ],
+        "0xa6625f741400f90d31e39a17b0d429a92e347a6000020000000000000000000e": [
+          {
+            "tokenAddress": "0x040d1edc9569d4bab2d15287dc5a4f10f56a56b8",
+            "amount": 1000
           }
         ]
       }


### PR DESCRIPTION
## ETHEREUM POOLS

- Remove 2600 BAL from the Flexible BAL allocation from USDT/WETH 50/50. This pool will now receive 120 BAL per week.
- Remove 1500 BAL from the Flexible BAL allocation from USDC/WETH 50/50. This pool will now receive 1500 BAL per week. 
- Remove a Tier 3 slot from SNX/WETH – 50/50 & COMP/WETH - 50/50. Add a Tier 4 slot to SNX/WETH -50/50 & COMP/WETH – 50/50. These pools will now each receive 1,000 BAL per week. 
- Remove a Tier 4 slot from REN/WETH – 50/50 & YFI/WETH – 50/50. Allocate 500 BAL from the Flexible BAL allocation to each of REN/WETH – 50/50 & YFI/WETH – 50/50. These pools will now each receive 500 BAL per week. 
- Remove 500 BAL from the Flexible BAL allocation from DPI/WBTC/WETH – 33/33/33. This pool will now receive 0 BAL per week.
- Allocate 500 BAL from the Flexible BAL allocation to MTA/WETH – 80/20. This pool will now receive 500 BAL per week. 

## POLYGON POOLS

- Remove a Tier 4 slot from USDC/WETH/LINK/BAL/AAVE. This pool will now receive 5000 BAL per week.
- Add a Tier 4 slot to WETH/SOL/AVAX 33/33/33. This pool will now receive 1000 BAL per week.

## ARBITRUM POOLS

- Allocate 500 BAL from the Flexible BAL allocation to each of DEFI5/WBTC/WETH – 33/33/33, NDX/WETH – 80/20, DHT/WETH – 80/20, GNO/WETH – 80/20. Each of these pools will now receive 500 BAL per week. 
- Allocate 1,000 BAL from the Flexible BAL allocation to each of LINK/WETH – 80/20 and COMP/WETH – 80/20. Each of these pools will now receive 1,000 BAL per week. 
- Allocate 1,600 BAL from the Flexible BAL allocation to MCB/WETH – 60/40. This pool will now receive 1,600 BAL per week. In addition to this, the pool will receive 1,260 MCB per week.