### PR TITLE
fix: token pill rendering in LMTable

### DIFF
--- a/src/components/tables/PoolsTable/TokenPills/TokenPills.vue
+++ b/src/components/tables/PoolsTable/TokenPills/TokenPills.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, defineProps } from 'vue';
+import { computed, defineProps, withDefaults } from 'vue';
 
 import useNumbers from '@/composables/useNumbers';
 import useTokens from '@/composables/useTokens';
@@ -13,10 +13,12 @@ import HiddenTokensPills from './HiddenTokensPills.vue';
 type Props = {
   tokens: PoolToken[];
   isStablePool: boolean;
-  selectedTokens: string[];
+  selectedTokens?: string[];
 };
 
-const props = defineProps<Props>();
+const props = withDefaults(defineProps<Props>(), {
+  selectedTokens: () => []
+});
 
 const { fNum } = useNumbers();
 const { tokens, hasBalance } = useTokens();
@@ -33,9 +35,7 @@ const hasBalanceInHiddenTokens = computed(() =>
 );
 
 const isSelectedInHiddenTokens = computed(() =>
-  hiddenTokens.value.some(token =>
-    props.selectedTokens?.includes(token.address)
-  )
+  hiddenTokens.value.some(token => props.selectedTokens.includes(token.address))
 );
 
 /**


### PR DESCRIPTION
# Description

Fixes an issue with token pills being broken, just needed a default.

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## How should this be tested?

Please provide instructions so we can test. Please also list any relevant details for your test configuration.

- [ ] Liquidity mining page should render token pills

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] My changes generate no new console warnings
- [x] The base of this PR is `master` if hotfix, `develop` if not
