### PR TITLE
Hotfix 1.20.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.20.0",
+  "version": "1.20.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@balancer-labs/frontend-v2",
-      "version": "1.20.0",
+      "version": "1.20.1",
       "license": "MIT",
       "dependencies": {
         "@balancer-labs/assets": "github:balancer-labs/assets#master",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.20.0",
+  "version": "1.20.1",
   "engines": {
     "node": "14.x",
     "npm": ">=7"

--- a/src/components/inputs/TokenInput/TokenInput.vue
+++ b/src/components/inputs/TokenInput/TokenInput.vue
@@ -159,6 +159,7 @@ watchEffect(() => {
     validateOn="input"
     autocomplete="off"
     autocorrect="off"
+    step="any"
     spellcheck="false"
     v-bind="$attrs"
     inputAlignRight


### PR DESCRIPTION
# Description

TokenInput was preventing decimal inputs as part of the HTML number input validation. It requires the `step` attribute to be set to `any` to allow for decimals.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## How should this be tested?

- [ ] Test decimal investment and withdrawals.


## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] My changes generate no new console warnings
- [x] The base of this PR is `master` if hotfix, `develop` if not
