### PR TITLE
Hotfix 1.20.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.20.1",
+  "version": "1.20.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@balancer-labs/frontend-v2",
-      "version": "1.20.1",
+      "version": "1.20.2",
       "license": "MIT",
       "dependencies": {
         "@balancer-labs/assets": "github:balancer-labs/assets#master",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.20.1",
+  "version": "1.20.2",
   "engines": {
     "node": "14.x",
     "npm": ">=7"

--- a/src/components/forms/pool_actions/WithdrawForm.vue
+++ b/src/components/forms/pool_actions/WithdrawForm.vue
@@ -80,7 +80,7 @@
         class="mb-4"
         fixedToken
         @click="setSingleAsset(i)"
-        @update:amount="setSingleAsset(i)"
+        @update:amount="setSingleAsset(i, $event)"
       />
     </div>
 
@@ -459,13 +459,15 @@ export default defineComponent({
       data.amounts = receive;
     }
 
-    function setSingleAsset(index) {
+    function setSingleAsset(index, value = '0') {
       if (!isSingleAsset.value) return;
       data.singleAsset = index;
 
+      const newAmount = value === '0' ? singleAssetMaxes.value[index] : value;
+
       props.pool.tokenAddresses.forEach((_, i) => {
         if (i === index) {
-          data.amounts[i] = singleAssetMaxes.value[index];
+          data.amounts[i] = newAmount;
         } else {
           data.amounts[i] = '0';
         }


### PR DESCRIPTION
# Description

With new TokenInput, because we hook into the amount update event for single asset withdrawals to set the other inputs to zero, when a user inputs a number it just uses that event handler and sets the amount to max again. It should allow for using the input amount if it's passed.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## How should this be tested?

- [ ] Test custom input amounts for single asset withdrawals work.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] My changes generate no new console warnings
- [x] The base of this PR is `master` if hotfix, `develop` if not
