### PR TITLE
Prevent subgraph from blowing up app when it is behind.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.20.4",
+  "version": "1.20.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@balancer-labs/frontend-v2",
-      "version": "1.20.4",
+      "version": "1.20.5",
       "license": "MIT",
       "dependencies": {
         "@balancer-labs/assets": "github:balancer-labs/assets#master",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.20.4",
+  "version": "1.20.5",
   "engines": {
     "node": "14.x",
     "npm": ">=7"

--- a/src/services/balancer/subgraph/entities/pools/index.ts
+++ b/src/services/balancer/subgraph/entities/pools/index.ts
@@ -58,8 +58,15 @@ export default class Pools {
     const block = { number: blockNumber };
     const isInPoolIds = { id_in: pools.map(pool => pool.id) };
     const pastPoolsQuery = this.query({ where: isInPoolIds, block });
-    const { pools: pastPools } = await this.service.client.get(pastPoolsQuery);
-
+    let pastPools: Pool[] = [];
+    try {
+      const data: { pools: Pool[] } = await this.service.client.get(
+        pastPoolsQuery
+      );
+      pastPools = data.pools;
+    } catch {
+      // eslint-disable-previous-line no-empty
+    }
     return this.serialize(pools, pastPools, period, prices, currency);
   }
 


### PR DESCRIPTION
# Description

If subgraph hasn't indexed the block we're querying at then return empty data rather than throwing.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## How should this be tested?

Open on Arbitrum and see if pools load

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] My changes generate no new console warnings
- [x] The base of this PR is `master` if hotfix, `develop` if not
