### PR TITLE
Hotfix 1.20.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.20.5",
+  "version": "1.20.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@balancer-labs/frontend-v2",
-      "version": "1.20.5",
+      "version": "1.20.6",
       "license": "MIT",
       "dependencies": {
         "@balancer-labs/assets": "github:balancer-labs/assets#master",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.20.5",
+  "version": "1.20.6",
   "engines": {
     "node": "14.x",
     "npm": ">=7"

--- a/src/composables/trade/useSor.ts
+++ b/src/composables/trade/useSor.ts
@@ -578,10 +578,10 @@ export default function useSor({
     tokenDecimals: number,
     sorManager: SorManager
   ): Promise<void> {
-    const ethPriceToken = calculateEthPriceInToken(tokenAddress).times(
-      new BigNumber(10 ** tokenDecimals)
+    await sorManager.setCostOutputToken(
+      tokenAddress,
+      calculateEthPriceInToken(tokenAddress)
     );
-    await sorManager.setCostOutputToken(tokenAddress, ethPriceToken);
   }
 
   function getMaxIn(amount: BigNumber) {


### PR DESCRIPTION
# Description

This hotfix removes some incorrect scaling which was resulting in us treating the gas fees for V2 as orders of magnitude greater than they are.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## How should this be tested?

Check that trade ui correctly routes trades through V2.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] My changes generate no new console warnings
- [x] The base of this PR is `master` if hotfix, `develop` if not
