### PR TITLE
Lowercase InvestmentPool factory; add factories for other networks

### DIFF
--- a/src/constants/pools.ts
+++ b/src/constants/pools.ts
@@ -79,6 +79,8 @@ export const POOLS = {
     '0x2433477a10fc5d31b9513c638f19ee85caed53fd': 'stablePool', // Arbitrum Stable
     '0xebfd5681977e38af65a7487dc70b8221d089ccad': 'stablePool', // Arbitrum MetaStable
     '0x751a0bc0e3f75b38e01cf25bfce7ff36de1c87de': 'liquidityBootstrappingPool', // Mainnet LBP
-    '0x48767F9F868a4A7b86A90736632F6E44C2df7fa9': 'investmentPool' // Mainnet Investment
+    '0x48767f9f868a4a7b86a90736632f6e44c2df7fa9': 'investmentPool', // Mainnet Investment
+    '0x0f7bb7ce7b6ed9366f9b6b910adefe72dc538193': 'investmentPool', // Polygon Investment
+    '0xacd615b3705b9c880e4e7293f1030b34e57b4c1c': 'investmentPool' // Arbitrum Investment
   }
 };


### PR DESCRIPTION
# Description

Factory address needs to be lowercase; add other Investment Pool networks

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Other

## How should this be tested?

Should see this pool with the proper type (Investment Pool):
0xe7b1d394f3b40abeaa0b64a545dbcf89da1ecb3f00010000000000000000009a

## Checklist:

- [X] I have performed a self-review of my own code
- [ ] I have commented my code where relevant, particularly in hard-to-understand areas
- [ ] My changes generate no new console warnings
- [ ] The base of this PR is `master` if hotfix, `develop` if not
