### PR TITLE
Prevent the withdraw form from crashing when a large input amount is entered

### DIFF
--- a/src/components/forms/pool_actions/WithdrawForm.vue
+++ b/src/components/forms/pool_actions/WithdrawForm.vue
@@ -93,6 +93,14 @@
       />
       <template v-else>
         <div
+          v-if="inputAmountExceedsPoolBalance"
+          class="flex items-center text-sm mb-4 text-red-500 font-medium"
+          @click.prevent
+        >
+          {{ $t('inputAmountExceedsPoolBalance') }}
+        </div>
+        <div
+          v-else
           :class="['flex items-center text-sm mb-4', priceImpactClasses]"
           @click.prevent
         >
@@ -130,7 +138,9 @@
           type="submit"
           :loading-label="$t('confirming')"
           color="gradient"
-          :disabled="!hasAmounts || isMismatchedNetwork"
+          :disabled="
+            !hasAmounts || isMismatchedNetwork || inputAmountExceedsPoolBalance
+          "
           :loading="loading"
           block
           @click="trackGoal(Goals.ClickWithdraw)"
@@ -361,8 +371,20 @@ export default defineComponent({
       return isSingleAsset.value && !singleAssetMaxed.value;
     });
 
+    const inputAmountExceedsPoolBalance = computed(() => {
+      if (!hasAmounts.value || isProportional.value) return false;
+
+      return poolCalculator.inputAmountExceedsPoolBalance(fullAmounts.value);
+    });
+
     const priceImpact = computed(() => {
-      if (!hasAmounts.value || isProportional.value) return 0;
+      if (
+        !hasAmounts.value ||
+        isProportional.value ||
+        inputAmountExceedsPoolBalance.value
+      )
+        return 0;
+
       return poolCalculator
         .priceImpact(fullAmounts.value, {
           exactOut: exactOut.value,
@@ -625,7 +647,8 @@ export default defineComponent({
       isRequired,
       trackGoal,
       Goals,
-      tokenDecimals
+      tokenDecimals,
+      inputAmountExceedsPoolBalance
     };
   }
 });

--- a/src/locales/default.json
+++ b/src/locales/default.json
@@ -419,5 +419,6 @@
     "featuredProtocol": "Featured ecosystem protocol",
     "aboutElementFinance": "Element is an open source protocol for fixed and variable yield markets. It is built on Balancer V2. View and manage your liquidity positions directly on Element.fi.",
     "viewAndManangeOnElement": "View and manage all pools on Element.fi",
-    "viewOnElement": "View on Element.fi"
+    "viewOnElement": "View on Element.fi",
+    "inputAmountExceedsPoolBalance": "The amount you've input exceeds the pool balance."
 }

--- a/src/services/pool/calculator/calculator.sevice.ts
+++ b/src/services/pool/calculator/calculator.sevice.ts
@@ -8,6 +8,7 @@ import { TokenInfoMap } from '@/types/TokenList';
 import { BalanceMap } from '@/services/token/concerns/balances.concern';
 import { ComputedRef } from 'vue';
 import { isStable, isStableLike } from '@/composables/usePool';
+import { bnum } from '@/lib/utils';
 
 interface Amounts {
   send: string[];
@@ -169,6 +170,23 @@ export default class CalculatorService {
 
   public ratioOf(type: string, index: number) {
     return this[`${type}Ratios`][index];
+  }
+
+  public inputAmountExceedsPoolBalance(tokenAmounts: string[]): boolean {
+    const balances = this.poolTokenBalances.map(b => bnum(b.toString()));
+    const denormAmounts = this.denormAmounts(
+      tokenAmounts,
+      this.poolTokenDecimals
+    );
+    const amounts = denormAmounts.map(a => bnum(a.toString()));
+
+    for (let i = 0; i < amounts.length; i++) {
+      if (amounts[i].gt(bnum(balances[i]))) {
+        return true;
+      }
+    }
+
+    return false;
   }
 
   public get poolTokenBalances(): BigNumberish[] {


### PR DESCRIPTION
# Description

Bit of an edge case, but when entering a very large number into the single token withdraw input, it's possible to crash the WithdrawForm with a SUB_OVERFLOW, causing it to be removed completely from the DOM. This does not happen locally, only in production builds. This happens when the user enters a number that is bigger than the token balance in the pool. We add a check prior to calculating the `priceImpact` to ensure the input amount does not exceed the pool balance. If it does, don't perform the `priceImpact` calculation, show the user an error message, and disable the withdraw button.

Reproducing the error on balancer.fi:
![ezgif-7-f50d5b51d0a8](https://user-images.githubusercontent.com/91405705/134796877-a9acf9f7-ff02-4d3f-b38c-1ea1c2289c49.gif)
The console error when running locally, the form does not disappear when reproducing this error locally, it spits out the error below:
![Screen Shot 2021-09-26 at 7 30 51 AM](https://user-images.githubusercontent.com/91405705/134796920-2f89cee2-4a44-4d59-99f0-99218bccf037.png)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## How should this be tested?

Please provide instructions so we can test. Please also list any relevant details for your test configuration.

- [ ] Navigate to any pool -> Click the Withdraw Tab -> Click "Single Token" -> Enter an amount that is larger than the token balance in the pool. Verify that the form does not crash, verify that the error message is presented to the user, verify that the withdraw button is disabled.

![ezgif-7-91a20d31aa51](https://user-images.githubusercontent.com/91405705/134796895-b69e38b8-1465-4918-b11d-785162f2bf7b.gif)

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] My changes generate no new console warnings
- [x] The base of this PR is `master` if hotfix, `develop` if not
