### PR TITLE
Hotfix/1.21.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.21.4",
+  "version": "1.21.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@balancer-labs/frontend-v2",
-      "version": "1.21.4",
+      "version": "1.21.5",
       "license": "MIT",
       "dependencies": {
         "@balancer-labs/assets": "github:balancer-labs/assets#master",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.21.4",
+  "version": "1.21.5",
   "engines": {
     "node": "14.x",
     "npm": ">=7"

--- a/src/composables/trade/useSor.ts
+++ b/src/composables/trade/useSor.ts
@@ -580,6 +580,7 @@ export default function useSor({
   ): Promise<void> {
     await sorManager.setCostOutputToken(
       tokenAddress,
+      tokenDecimals,
       calculateEthPriceInToken(tokenAddress)
     );
   }


### PR DESCRIPTION
# Description

`getCostOfSwapInToken` was being called with default swap cost value, this value was then used as V1 swap cost. For V2 `getSwap` is being called with a higher swap cost (SWAP_COST). This meant that when V1 and V2 return amounts considering fees were being compared V1 would show a better amount. I've changed `getCostOfSwapInToken` to use SWAP_COST so we have a fair comparrison.

Also V1 uses EVM scaled value for swap cost but we were passing in human scale number. It's now scaled correctly.

Fixes # (issue)

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## How should this be tested?

Monitor console logs and check V1 return amount with fees and V2 return amount with fees outputs. V2 liquidity should usually be chosen even if prices are similar.

## Checklist:

- [X] I have performed a self-review of my own code
- [X] I have commented my code where relevant, particularly in hard-to-understand areas
- [X] My changes generate no new console warnings
- [X] The base of this PR is `master` if hotfix, `develop` if not
