### PR TITLE
Hotfix 1.22.1 - Fix custom slippage input

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.22.0",
+  "version": "1.22.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@balancer-labs/frontend-v2",
-      "version": "1.22.0",
+      "version": "1.22.1",
       "license": "MIT",
       "dependencies": {
         "@balancer-labs/assets": "github:balancer-labs/assets#master",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.22.0",
+  "version": "1.22.1",
   "engines": {
     "node": "14.x",
     "npm": ">=7"

--- a/src/components/cards/TradeCard/TradeCard.vue
+++ b/src/components/cards/TradeCard/TradeCard.vue
@@ -112,6 +112,7 @@ import useDarkMode from '@/composables/useDarkMode';
 import { configService } from '@/services/config/config.service';
 
 import { getWrapAction, WrapType } from '@/lib/utils/balancer/wrapper';
+import useUserSettings from '@/composables/useUserSettings';
 
 const { nativeAsset } = configService.network;
 
@@ -136,6 +137,7 @@ export default defineComponent({
     const { tokens } = useTokens();
     const { userNetworkConfig } = useWeb3();
     const { darkMode } = useDarkMode();
+    const { slippage } = useUserSettings();
 
     const exactIn = ref(true);
     const tokenInAddress = ref('');
@@ -146,9 +148,7 @@ export default defineComponent({
     const txHash = ref('');
     const modalTradePreviewIsOpen = ref(false);
 
-    const slippageBufferRate = computed(() =>
-      parseFloat(store.state.app.slippage)
-    );
+    const slippageBufferRate = computed(() => parseFloat(slippage.value));
 
     const tokenIn = computed(() => tokens.value[tokenInAddress.value]);
 

--- a/src/components/forms/AppSlippageForm.vue
+++ b/src/components/forms/AppSlippageForm.vue
@@ -1,22 +1,94 @@
+<script setup lang="ts">
+import { computed, watch, reactive } from 'vue';
+import useNumbers from '@/composables/useNumbers';
+import useUserSettings from '@/composables/useUserSettings';
+import { bnum } from '@/lib/utils';
+
+const FIXED_OPTIONS = ['0.005', '0.01', '0.02'];
+
+/**
+ * COMPOSABLES
+ */
+const { fNum } = useNumbers();
+const { slippage, setSlippage } = useUserSettings();
+
+/**
+ * STATE
+ */
+const state = reactive({
+  fixedSlippage: '',
+  customSlippage: '',
+  isCustomInput: false
+});
+
+const options = FIXED_OPTIONS.map(option => {
+  return {
+    label: fNum(option, null, { format: '0.0%' }),
+    value: option
+  };
+});
+
+/**
+ * COMPUTED
+ */
+const isFixedSlippage = computed(() => {
+  return FIXED_OPTIONS.includes(slippage.value);
+});
+
+const customInputClasses = computed(() => ({
+  'border border-blue-500 text-blue-500':
+    !isFixedSlippage.value || state.isCustomInput,
+  'border dark:border-gray-900': isFixedSlippage.value && !state.isCustomInput
+}));
+
+/**
+ * METHODS
+ */
+function onFixedInput(val: string): void {
+  state.isCustomInput = false;
+  state.customSlippage = '';
+  setSlippage(val);
+}
+
+function onCustomInput(val: string): void {
+  state.isCustomInput = true;
+  val = bnum(val)
+    .div(100)
+    .toString();
+  setSlippage(val);
+}
+
+/**
+ * WATCHERS
+ */
+watch(
+  slippage,
+  newSlippage => {
+    if (isFixedSlippage.value && !state.isCustomInput) {
+      state.fixedSlippage = newSlippage;
+      state.customSlippage = '';
+    } else {
+      state.customSlippage = bnum(newSlippage)
+        .times(100)
+        .toString();
+      state.fixedSlippage = '';
+    }
+  },
+  { immediate: true }
+);
+</script>
+
 <template>
   <div class="flex">
     <BalBtnGroup
       :options="options"
-      v-model="fixedSlippage"
+      v-model="state.fixedSlippage"
       @update:modelValue="onFixedInput"
     />
-    <div
-      :class="[
-        'flex items-center px-1 rounded-lg shadow-inner',
-        {
-          'border border-blue-500 text-blue-500': !isFixedSlippage,
-          'border dark:border-gray-900': isFixedSlippage
-        }
-      ]"
-    >
+    <div :class="['custom-input', customInputClasses]">
       <input
         class="w-12 text-right bg-transparent"
-        v-model="customSlippage"
+        v-model="state.customSlippage"
         placeholder="0.1"
         type="number"
         step="any"
@@ -30,85 +102,8 @@
   </div>
 </template>
 
-<script lang="ts">
-import { defineComponent, ref, computed, watch } from 'vue';
-import { useStore } from 'vuex';
-import useNumbers from '@/composables/useNumbers';
-
-const FIXED_OPTIONS = ['0.005', '0.01', '0.02'];
-
-export default defineComponent({
-  name: 'AppSlipageForm',
-
-  setup() {
-    // COMPOSABLES
-    const store = useStore();
-    const { fNum } = useNumbers();
-
-    // DATA
-    const fixedSlippage = ref('');
-    const customSlippage = ref('');
-    const options = FIXED_OPTIONS.map(option => {
-      return {
-        label: fNum(option, null, { format: '0.0%' }),
-        value: option
-      };
-    });
-
-    // COMPUTED
-    const appSlippage = computed(() => store.state.app.slippage);
-    const isFixedSlippage = computed(() => {
-      return FIXED_OPTIONS.includes(appSlippage.value);
-    });
-
-    // METHODS
-    function setAppSlippage(slippage: string): void {
-      store.commit('app/setSlippage', slippage);
-    }
-
-    function onFixedInput(val: string): void {
-      customSlippage.value = '';
-      setAppSlippage(val);
-    }
-
-    function onCustomInput(val: string): void {
-      val = (Number(val) / 100).toString();
-
-      if (FIXED_OPTIONS.includes(val)) {
-        fixedSlippage.value = val;
-        customSlippage.value = '';
-      } else {
-        fixedSlippage.value = '';
-      }
-      setAppSlippage(val);
-    }
-
-    // WATCHERS
-    watch(
-      appSlippage,
-      newSlippage => {
-        if (isFixedSlippage.value) {
-          fixedSlippage.value = newSlippage;
-          customSlippage.value = '';
-        } else {
-          customSlippage.value = (Number(newSlippage) * 100).toString();
-          fixedSlippage.value = '';
-        }
-      },
-      { immediate: true }
-    );
-
-    return {
-      // data
-      fixedSlippage,
-      customSlippage,
-      options,
-      // computed
-      isFixedSlippage,
-      // methods
-      onFixedInput,
-      onCustomInput
-    };
-  }
-});
-</script>
+<style scoped>
+.custom-input {
+  @apply flex items-center px-1 rounded-lg shadow-inner;
+}
+</style>

--- a/src/components/modals/TradePreviewModalGP.vue
+++ b/src/components/modals/TradePreviewModalGP.vue
@@ -338,7 +338,6 @@
 
 <script lang="ts">
 import { defineComponent, computed, PropType, ref, watch } from 'vue';
-import { useStore } from 'vuex';
 import { formatUnits } from '@ethersproject/units';
 import { useI18n } from 'vue-i18n';
 import { mapValues } from 'lodash';
@@ -358,6 +357,7 @@ import TradeRoute from '@/components/cards/TradeCard/TradeRoute.vue';
 import { bnum } from '@/lib/utils';
 
 import { FiatCurrency } from '@/constants/currency';
+import useUserSettings from '@/composables/useUserSettings';
 
 const PRICE_UPDATE_THRESHOLD = 0.02;
 
@@ -374,11 +374,13 @@ export default defineComponent({
   },
   setup(props, { emit }) {
     // COMPOSABLES
-    const store = useStore();
     const { t } = useI18n();
     const { fNum, toFiat } = useNumbers();
     const { tokens, approvalRequired } = useTokens();
     const { blockNumber } = useWeb3();
+    const { slippage } = useUserSettings();
+
+    // state
     const lastQuote = ref<TradeQuote | null>(
       props.trading.isWrapUnwrapTrade.value ? null : props.trading.getQuote()
     );
@@ -389,9 +391,7 @@ export default defineComponent({
     const showSummaryInFiat = ref(false);
 
     // COMPUTED
-    const slippageRatePercent = computed(() =>
-      fNum(store.state.app.slippage, 'percent')
-    );
+    const slippageRatePercent = computed(() => fNum(slippage.value, 'percent'));
 
     const addressIn = computed(() => props.trading.tokenIn.value.address);
 

--- a/src/composables/trade/useTrading.ts
+++ b/src/composables/trade/useTrading.ts
@@ -9,6 +9,7 @@ import useGnosis from './useGnosis';
 import useTokens from '../useTokens';
 import { NATIVE_ASSET_ADDRESS } from '@/constants/tokens';
 import { getWrapAction, WrapType } from '@/lib/utils/balancer/wrapper';
+import useUserSettings from '../useUserSettings';
 
 export type TradeRoute = 'wrapUnwrap' | 'balancer' | 'gnosis';
 
@@ -27,11 +28,10 @@ export default function useTrading(
   const { tokens } = useTokens();
   const { blockNumber } = useWeb3();
   const router = useRouter();
+  const { slippage } = useUserSettings();
 
   // COMPUTED
-  const slippageBufferRate = computed(() =>
-    parseFloat(store.state.app.slippage)
-  );
+  const slippageBufferRate = computed(() => parseFloat(slippage.value));
 
   const liquiditySelection = computed(() => store.state.app.tradeLiquidity);
 

--- a/src/composables/useSlippage.ts
+++ b/src/composables/useSlippage.ts
@@ -1,12 +1,15 @@
 import { computed } from 'vue';
-import { useStore } from 'vuex';
 import { parseUnits, formatUnits } from '@ethersproject/units';
+import useUserSettings from './useUserSettings';
+import { bnum } from '@/lib/utils';
 
 export default function useSlippage() {
-  const store = useStore();
+  const { slippage } = useUserSettings();
 
-  const slippageBasisPoints = computed(() => {
-    return Number(store.state.app.slippage) * 10000;
+  const slippageBasisPoints = computed((): string => {
+    return bnum(slippage.value)
+      .times(10000)
+      .toString();
   });
 
   function minusSlippage(_amount: string, decimals: number): string {

--- a/src/providers/user-settings.provider.ts
+++ b/src/providers/user-settings.provider.ts
@@ -2,18 +2,21 @@ import { provide, InjectionKey, reactive, Ref, toRefs } from 'vue';
 import symbolKeys from '@/constants/symbol.keys';
 import LS_KEYS from '@/constants/local-storage.keys';
 import { FiatCurrency } from '@/constants/currency';
-import { lsGet } from '@/lib/utils';
+import { lsGet, lsSet } from '@/lib/utils';
 
 /**
  * TYPES
  */
 export interface UserSettingsState {
   currency: FiatCurrency;
+  slippage: string;
 }
 
 export interface UserSettingsProviderResponse {
   currency: Ref<FiatCurrency>;
+  slippage: Ref<string>;
   setCurrency: (newCurrency: FiatCurrency) => void;
+  setSlippage: (newSlippage: string) => void;
 }
 
 /**
@@ -24,13 +27,28 @@ export const UserSettingsProviderSymbol: InjectionKey<UserSettingsProviderRespon
 );
 
 const lsCurrency = lsGet(LS_KEYS.UserSettings.Currency, FiatCurrency.usd);
+const lsSlippage = lsGet(LS_KEYS.App.TradeSlippage, '0.01');
 
 /**
  * STATE
  */
 const state: UserSettingsState = reactive({
-  currency: lsCurrency
+  currency: lsCurrency,
+  slippage: lsSlippage
 });
+
+/**
+ * METHODS
+ */
+function setCurrency(newCurrency: FiatCurrency): void {
+  lsSet(LS_KEYS.UserSettings.Currency, newCurrency);
+  state.currency = newCurrency;
+}
+
+function setSlippage(newSlippage: string): void {
+  lsSet(LS_KEYS.App.TradeSlippage, newSlippage);
+  state.slippage = newSlippage;
+}
 
 /**
  * UserSettingsProvider
@@ -40,17 +58,11 @@ export default {
   name: 'UserSettingsProvider',
 
   setup(props, { slots }) {
-    /**
-     * METHODS
-     */
-    function setCurrency(newCurrency: FiatCurrency): void {
-      state.currency = newCurrency;
-    }
-
     provide(UserSettingsProviderSymbol, {
       ...toRefs(state),
       // methods
-      setCurrency
+      setCurrency,
+      setSlippage
     });
 
     return () => slots.default();

--- a/src/store/modules/app.ts
+++ b/src/store/modules/app.ts
@@ -12,7 +12,6 @@ export interface AppState {
   loading: boolean;
   modalOpen: boolean;
   locale: string;
-  slippage: string;
   tradeLiquidity: LiquiditySelection;
   tradeInterface: TradeInterface;
   transactionDeadline: number;
@@ -22,7 +21,6 @@ const state: AppState = {
   loading: true,
   modalOpen: false,
   locale: lsGet(LS_KEYS.App.Locale, 'en-US'),
-  slippage: lsGet(LS_KEYS.App.TradeSlippage, '0.01'),
   tradeLiquidity: lsGet(LS_KEYS.App.TradeLiquidity, LiquiditySelection.Best),
   transactionDeadline: lsGet(LS_KEYS.App.TradeDeadline, 20), // minutes
   tradeInterface: lsGet(LS_KEYS.App.TradeInterface, TradeInterface.BALANCER)
@@ -57,11 +55,6 @@ const mutations = {
     state.locale = locale;
     lsSet(LS_KEYS.App.Locale, locale);
     i18n.global.locale = locale;
-  },
-
-  setSlippage(state: AppState, slippage: AppState['slippage']) {
-    state.slippage = slippage;
-    lsSet(LS_KEYS.App.TradeSlippage, slippage);
   },
 
   setTradeLiquidity(state: AppState, tradeLiquidity: LiquiditySelection) {


### PR DESCRIPTION
# Description

The custom slippage input wouldn't let you input numbers that matched the preset options. e.g. you couldn't input 1.5 because on typing 1 it would select the preset 1% option then on typing 5 it would set the custom amount to 5%.

This PR refactors the AppSlippageForm component to allow for any type of custom input even if it matches a preset. I have also refactored where we store the user's slippage state into the user-settings provider instead of the Vuex store.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## How should this be tested?

Please provide instructions so we can test. Please also list any relevant details for your test configuration.

- [ ] Test that you can enter any number for the custom slippage
- [ ] Test that any input is preserved on page load
- [ ] Test that you can also use the presets and they are preserved

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code where relevant, particularly in hard-to-understand areas
- [ ] My changes generate no new console warnings
- [ ] The base of this PR is `master` if hotfix, `develop` if not
