### PR TITLE
Hotfix/1.22.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.22.3",
+  "version": "1.22.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@balancer-labs/frontend-v2",
-      "version": "1.22.3",
+      "version": "1.22.4",
       "license": "MIT",
       "dependencies": {
         "@balancer-labs/assets": "github:balancer-labs/assets#master",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.22.3",
+  "version": "1.22.4",
   "engines": {
     "node": "14.x",
     "npm": ">=7"

--- a/src/lib/config/homestead.json
+++ b/src/lib/config/homestead.json
@@ -5,6 +5,7 @@
   "name": "Ethereum Mainnet",
   "shortName": "Mainnet",
   "network": "homestead",
+  "portisNetwork": "mainnet",
   "unknown": false,
   "rpc": "https://mainnet.infura.io/v3/daaa68ec242643719749dd1caba2fc66",
   "ws": "wss://mainnet.infura.io/ws/v3/daaa68ec242643719749dd1caba2fc66",

--- a/src/lib/config/index.ts
+++ b/src/lib/config/index.ts
@@ -14,6 +14,7 @@ export interface Config {
   name: string;
   shortName: string;
   network: string;
+  portisNetwork?: string;
   unknown: boolean;
   rpc: string;
   publicRpc?: string;

--- a/src/lib/config/polygon.json
+++ b/src/lib/config/polygon.json
@@ -5,6 +5,7 @@
   "name": "Polygon Mainnet",
   "shortName": "Polygon",
   "network": "polygon",
+  "portisNetwork": "matic",
   "unknown": false,
   "rpc": "https://polygon-mainnet.infura.io/v3/daaa68ec242643719749dd1caba2fc66",
   "ws": "wss://polygon-mainnet.g.alchemy.com/v2/ODJ9G5Ipv-Hb2zTWMNbUFIqv9WtqBOc2",

--- a/src/services/web3/connectors/portis/portis.connector.ts
+++ b/src/services/web3/connectors/portis/portis.connector.ts
@@ -10,7 +10,7 @@ export class PortisConnector extends Connector {
     // exports the default class and no extra types
     const portis = new Portis(
       configService.env.PORTIS_DAPP_ID,
-      configService.network.network
+      configService.network.portisNetwork || configService.network.network
     ) as any;
 
     const provider = portis.provider;


### PR DESCRIPTION
# Description

Portis is currently not working because the network is set incorrectly. This sets the Portis network to "mainnet" for mainnet and "matic" for Polygon, with a fallback to the old network setting for other environments. 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## How should this be tested?

Test using Vercel on Polygon and Mainnet. 
- Click "Connect Wallet"
- Select Portis
- Ensure Portis correctly connects with your wallet. 

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] My changes generate no new console warnings
- [x] The base of this PR is `master` if hotfix, `develop` if not
