### PR TITLE
UI 769 one click deploy to digital ocean

### DIFF
--- a/.do/deploy.template.yaml
+++ b/.do/deploy.template.yaml
@@ -2,10 +2,10 @@ spec:
   name: balancer-frontend-v2
   services:
   - name: frontend-v2
-    git:
-      branch: UI-769-one-click-deploy-to-digital-ocean
-      repo_clone_url: https://github.com/balancer-labs/frontend-v2.git
-    dockerfile_path: Dockerfile
+    image:
+      registry_type: "DOCKER_HUB"
+      registry: "registry.hub.docker"
+      repository: "balancerfi/frontend-v2"
     envs:
     - key: INFURA_PROJECT_ID
       scope: RUN_AND_BUILD_TIME

--- a/.do/deploy.template.yaml
+++ b/.do/deploy.template.yaml
@@ -2,10 +2,7 @@ spec:
   name: balancer-frontend-v2
   services:
   - name: frontend-v2
-    image:
-      registry_type: "DOCKER_HUB"
-      registry: "registry.hub.docker"
-      repository: "balancerfi/frontend-v2"
+    http_port: 80
     envs:
     - key: INFURA_PROJECT_ID
       scope: RUN_AND_BUILD_TIME
@@ -13,5 +10,12 @@ spec:
       scope: RUN_AND_BUILD_TIME
     - key: BLOCKNATIVE_DAPP_ID
       scope: RUN_AND_BUILD_TIME
-    http_port: 80
-    instance_size_slug: basic-xs
+    git:
+      branch: UI-769-one-click-deploy-to-digital-ocean
+      repo_clone_url: https://github.com/balancer-labs/frontend-v2.git
+    image:
+      registry: docker.io
+      registry_type: DOCKER_HUB
+      repository: balancerfi/frontend-v2
+      tag: latest
+    instance_size_slug: basic-xxs

--- a/.do/deploy.template.yaml
+++ b/.do/deploy.template.yaml
@@ -1,21 +1,25 @@
 spec:
-  name: balancer-frontend-v2
+  alerts:
+  - rule: DEPLOYMENT_FAILED
+  - rule: DOMAIN_FAILED
+  name: frontend-v2
   services:
-  - name: frontend-v2
-    http_port: 80
-    envs:
+  - envs:
     - key: INFURA_PROJECT_ID
       scope: RUN_AND_BUILD_TIME
     - key: ALCHEMY_KEY
       scope: RUN_AND_BUILD_TIME
     - key: BLOCKNATIVE_DAPP_ID
       scope: RUN_AND_BUILD_TIME
-    git:
-      branch: UI-769-one-click-deploy-to-digital-ocean
-      repo_clone_url: https://github.com/balancer-labs/frontend-v2.git
+    http_port: 80
     image:
-      registry: docker.io
       registry_type: DOCKER_HUB
-      repository: balancerfi/frontend-v2
+      registry: balancerfi
+      repository: frontend-v2
       tag: latest
+    instance_count: 1
     instance_size_slug: basic-xxs
+    name: frontend-v2
+    routes:
+    - path: /
+    source_dir: /

--- a/.do/deploy.template.yaml
+++ b/.do/deploy.template.yaml
@@ -1,0 +1,17 @@
+spec:
+  name: balancer-frontend-v2
+  services:
+  - name: frontend-v2
+    git:
+      branch: UI-769-one-click-deploy-to-digital-ocean
+      repo_clone_url: https://github.com/balancer-labs/frontend-v2.git
+    dockerfile_path: Dockerfile
+    envs:
+    - key: INFURA_PROJECT_ID
+      scope: RUN_AND_BUILD_TIME
+    - key: ALCHEMY_KEY
+      scope: RUN_AND_BUILD_TIME
+    - key: BLOCKNATIVE_DAPP_ID
+      scope: RUN_AND_BUILD_TIME
+    http_port: 80
+    instance_size_slug: basic-xs

--- a/README.md
+++ b/README.md
@@ -53,9 +53,7 @@ docker run \
 
 ### Digital Ocean Deploy
 
-Click the button below to deploy the frontend Docker image to a new instance in your Digital Ocean account. You will be prompted to provide your Infura Project ID, Alchemy Key, and Blocknative Dapp ID as these are required for the frontend to work correctly. 
-
-This container requires a minimum of 1GB of ram to build and run.
+Click the button below to deploy the frontend Docker image to a new instance in your Digital Ocean account. You will be prompted to provide your Infura Project ID, Alchemy Key, and Blocknative Dapp ID as these are required for the frontend to work correctly.
 
 [![Deploy to DO](https://www.deploytodo.com/do-btn-blue.svg)](https://cloud.digitalocean.com/apps/new?repo=https://github.com/balancer-labs/frontend-v2/tree/UI-769-one-click-deploy-to-digital-ocean)
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,12 @@ docker-compose up
 
 The app should be live at [http://localhost:8080](http://localhost:8080)
 
+## Self-Hosting
+
+As we believe in decentralization at all layers, we've made it easy to host your own Balancer Frontend.
+
 ### Docker Production Image
+
 We've created a production ready [docker image](./Dockerfile) that connects to Mainnet and runs
 a pre-built version of Balancer Frontend-v2 using nginx. You'll need your own [Infura](https://infura.io), [Alchemy](https://www.alchemy.com/), and [Blocknative](https://blocknative.com) API keys in order to fetch data and make trades.
 
@@ -45,6 +50,14 @@ docker run \
   -e PORTIS_DAPP_ID=      \ # Optional
   balancerfi/frontend-v2
 ```
+
+### Digital Ocean Deploy
+
+Click the button below to deploy the frontend Docker image to a new instance in your Digital Ocean account. You will be prompted to provide your Infura Project ID, Alchemy Key, and Blocknative Dapp ID as these are required for the frontend to work correctly. 
+
+This container requires a minimum of 1GB of ram to build and run.
+
+[![Deploy to DO](https://www.deploytodo.com/do-btn-blue.svg)](https://cloud.digitalocean.com/apps/new?repo=https://github.com/balancer-labs/frontend-v2/tree/UI-769-one-click-deploy-to-digital-ocean)
 
 ## Design System
 The app is using [Tailwind](https://tailwindcss.com/) to configure base styles. In development these styles can be viewed by running:


### PR DESCRIPTION

# Description

- Add script to take the docker image and deploy to a Digital Ocean Droplet with it.
- Update README to include deploy button.

This currently works when deploying via Digital Oceans `doctl` cli tool, but doesn't work with their "Deploy with DO" button because it appears to be broken currently. I've lodged a support ticket to figure out what's going on. 

Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## How should this be tested?

- Switch to this branch on the homepage of this repository
- Click the Deploy to Digital Ocean button
- Sign into your Digital ocean account and deploy
- After deploy is complete, visit the URL Digital Ocean gives and check deploy is working
- 
## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] My changes generate no new console warnings
- [x] The base of this PR is `master` if hotfix, `develop` if not
