### PR TITLE
refactor: use multicall for claim status

### DIFF
--- a/src/services/claim/claim.service.ts
+++ b/src/services/claim/claim.service.ts
@@ -7,7 +7,8 @@ import { getAddress } from '@ethersproject/address';
 
 import { networkId } from '@/composables/useNetwork';
 
-import { call, sendTransaction } from '@/lib/utils/balancer/web3';
+import { sendTransaction } from '@/lib/utils/balancer/web3';
+import { multicall } from '@/lib/utils/balancer/contract';
 import { bnum } from '@/lib/utils';
 import configs from '@/lib/config';
 
@@ -255,13 +256,18 @@ export class ClaimService {
         ? 72
         : 1;
 
-    const weekEnd = totalWeeks + weekStart - 1;
-
-    return call(provider, merkleOrchardAbi, [
+    const claimStatusCalls = Array.from({ length: totalWeeks }).map((_, i) => [
       configService.network.addresses.merkleOrchard,
-      'claimStatus',
-      [token, distributor, account, weekStart, weekEnd]
+      'isClaimed',
+      [token, distributor, weekStart + i, account]
     ]);
+
+    return multicall(
+      String(networkId.value),
+      provider,
+      merkleOrchardAbi,
+      claimStatusCalls
+    );
   }
 
   private async getReports(snapshot: Snapshot, weeks: number[]) {


### PR DESCRIPTION
# Description

Switches use of `claimStatus` to using multicall on `isClaimed`

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other

## How should this be tested?

Everything should be identical to the end user. We just need to check that claims display correctly.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] My changes generate no new console warnings
- [x] The base of this PR is `master` if hotfix, `develop` if not
