### PR TITLE
fix: add missing entry for Arbitrum in network prefix map

### DIFF
--- a/src/components/cards/TradeCard/TradeRoute.vue
+++ b/src/components/cards/TradeCard/TradeRoute.vue
@@ -436,7 +436,8 @@ export default defineComponent({
       const prefixMap = {
         [Network.MAINNET]: 'app.',
         [Network.KOVAN]: 'kovan.',
-        [Network.POLYGON]: 'polygon.'
+        [Network.POLYGON]: 'polygon.',
+        [Network.ARBITRUM]: 'arbitrum.'
       };
       const prefix = prefixMap[chainId] || '';
       if (props.sorReturn.isV1swap && chainId === 1) {


### PR DESCRIPTION
# Description

Fixes the issue of the `arbitrum` subdomain not being applied to links from a displayed trade route resulting in being redirected to mainnet.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## How should this be tested?

Check that clicking a pool from a displayed route on the trade UI routes you to a valid pool on arbitrum.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] My changes generate no new console warnings
- [x] The base of this PR is `master` if hotfix, `develop` if not
