### PR TITLE
useNumbers refactoring, multiple currency support

### DIFF
--- a/src/composables/useNumbers.spec.ts
+++ b/src/composables/useNumbers.spec.ts
@@ -1,0 +1,66 @@
+import { FiatCurrency } from '@/constants/currency';
+import { mount } from 'vue-composable-tester';
+import useNumbers from './useNumbers';
+
+const mockTokens = {
+  ETH: {
+    address: '0xEee',
+    price: {
+      usd: 3000,
+      eur: 2500
+    }
+  }
+};
+
+const mockDefaultCurrency = FiatCurrency.usd;
+
+jest.mock('@/composables/useTokens', () => {
+  return jest.fn().mockImplementation(() => {
+    return {
+      priceFor: jest
+        .fn()
+        .mockImplementation((address, currency = mockDefaultCurrency) => {
+          const token = Object.values(mockTokens).find(
+            token => address === token.address
+          );
+          return token?.price[currency];
+        })
+    };
+  });
+});
+
+describe('useNumbers', () => {
+  const { result } = mount(() => useNumbers());
+
+  it('Should load', () => {
+    expect(result).toBeTruthy();
+  });
+
+  describe('fNum', () => {
+    const { fNum } = result;
+
+    it('Should format a number with default formatter when only a number is specified', () => {
+      const number = 1234567.8912345;
+      const formattedNumber = fNum(number);
+      expect(formattedNumber).toEqual('1,234,568');
+    });
+  });
+
+  describe('toFiat', () => {
+    const { toFiat } = result;
+
+    it('Should return the value of ETH in USD, when called without a currency', () => {
+      const totalEth = 2.5;
+      const expectedValue = (totalEth * mockTokens.ETH.price.usd).toString();
+      const value = toFiat(totalEth, mockTokens.ETH.address);
+      expect(value).toEqual(expectedValue);
+    });
+
+    it('Should return the value of ETH in EUR, when called with EUR', () => {
+      const totalEth = 2.5;
+      const expectedValue = (totalEth * mockTokens.ETH.price.eur).toString();
+      const value = toFiat(totalEth, mockTokens.ETH.address, FiatCurrency.eur);
+      expect(value).toEqual(expectedValue);
+    });
+  });
+});

--- a/src/composables/useNumbers.ts
+++ b/src/composables/useNumbers.ts
@@ -1,6 +1,7 @@
 import numeral from 'numeral';
 import BigNumber from 'bignumber.js';
 import useTokens from './useTokens';
+import { FiatCurrency } from '@/constants/currency';
 
 export type Preset =
   | 'default'
@@ -54,8 +55,12 @@ export function fNum(
 export default function useNumbers() {
   const { priceFor } = useTokens();
 
-  function toFiat(amount: number | string, tokenAddress: string): string {
-    const price = priceFor(tokenAddress);
+  function toFiat(
+    amount: number | string,
+    tokenAddress: string,
+    currency: FiatCurrency = FiatCurrency.usd
+  ): string {
+    const price = priceFor(tokenAddress, currency);
     const tokenAmount = new BigNumber(amount);
     return tokenAmount.times(price).toString();
   }

--- a/src/constants/currency.ts
+++ b/src/constants/currency.ts
@@ -1,9 +1,11 @@
 export enum FiatCurrency {
-  usd = 'usd'
+  usd = 'usd',
+  eur = 'eur'
 }
 
 export enum FiatSymbol {
-  usd = '$'
+  usd = '$',
+  eur = '€'
 }
 
 export const SUPPORTED_FIAT = [FiatCurrency.usd];

--- a/src/providers/tokens.provider.ts
+++ b/src/providers/tokens.provider.ts
@@ -31,6 +31,7 @@ import { BalanceMap } from '@/services/token/concerns/balances.concern';
 import { ContractAllowancesMap } from '@/services/token/concerns/allowances.concern';
 import { tokenService } from '@/services/token/token.service';
 import { configService } from '@/services/config/config.service';
+import { FiatCurrency } from '@/constants/currency';
 
 /**
  * TYPES
@@ -73,7 +74,7 @@ export interface TokensProviderResponse {
     amounts: string[],
     contractAddress?: string
   ) => string[];
-  priceFor: (address: string) => number;
+  priceFor: (address: string, currency?: FiatCurrency) => number;
   balanceFor: (address: string) => string;
   getTokens: (addresses: string[]) => TokenInfoMap;
   getToken: (address: string) => TokenInfo;
@@ -103,7 +104,7 @@ export default {
       activeTokenLists,
       loadingTokenLists
     } = useTokenLists();
-    const { currency } = useUserSettings();
+    const { currency: currencySetting } = useUserSettings();
 
     /**
      * STATE
@@ -337,9 +338,12 @@ export default {
     /**
      * Fetch price for a token
      */
-    function priceFor(address: string): number {
+    function priceFor(
+      address: string,
+      currency: FiatCurrency = currencySetting.value
+    ): number {
       try {
-        return prices.value[address][currency.value] || 0;
+        return prices.value[address][currency] || 0;
       } catch {
         return 0;
       }


### PR DESCRIPTION
# Description

Working on refactoring useNumbers for better formatting and multiple currency support. 

- Add unit test for useNumbers composable that checks the happy cases.
- Add EUR currency and add toFiat and priceFor support for it

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## How should this be tested?

- Run `npm run test:unit`

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] My changes generate no new console warnings
- [x] The base of this PR is `master` if hotfix, `develop` if not
