### PR TITLE
Liquidity Mining, week 75

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.25.9",
+  "version": "1.25.10",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@balancer-labs/frontend-v2",
-      "version": "1.25.9",
+      "version": "1.25.10",
       "license": "MIT",
       "dependencies": {
         "@balancer-labs/assets": "github:balancer-labs/assets#master",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.25.9",
+  "version": "1.25.10",
   "engines": {
     "node": "14.x",
     "npm": ">=7"

--- a/src/lib/utils/liquidityMining/MultiTokenLiquidityMining.json
+++ b/src/lib/utils/liquidityMining/MultiTokenLiquidityMining.json
@@ -4846,5 +4846,370 @@
         ]
       }
     }
+  ],
+  "week_75": [
+    {
+      "chainId": 1,
+      "pools": {
+        "0xa6f548df93de924d73be7d25dc02554c6bd66db500020000000000000000000e": [
+          {
+            "tokenAddress": "0xba100000625a3754423978a60c9317c58a424e3d",
+            "amount": 15000
+          }
+        ],
+        "0x0b09dea16768f0799065c475be02919503cb2a3500020000000000000000001a": [
+          {
+            "tokenAddress": "0xba100000625a3754423978a60c9317c58a424e3d",
+            "amount": 15000
+          }
+        ],
+        "0x5c6ee304399dbdb9c8ef030ab642b10820db8f56000200000000000000000014": [
+          {
+            "tokenAddress": "0xba100000625a3754423978a60c9317c58a424e3d",
+            "amount": 30000
+          }
+        ],
+        "0x06df3b2bbb68adc8b0e302443692037ed9f91b42000000000000000000000063": [
+          {
+            "tokenAddress": "0xba100000625a3754423978a60c9317c58a424e3d",
+            "amount": 15000
+          }
+        ],
+        "0x96646936b91d6b9d7d0c47c496afbf3d6ec7b6f8000200000000000000000019": [
+          {
+            "tokenAddress": "0xba100000625a3754423978a60c9317c58a424e3d",
+            "amount": 1100
+          }
+        ],
+        "0xa1116930326d21fb917d5a27f1e9943a9595fb47": [
+          {
+            "tokenAddress": "0xba100000625a3754423978a60c9317c58a424e3d",
+            "amount": 12500
+          }
+        ],
+        "0x3e5fa9518ea95c3e533eb377c001702a9aacaa32000200000000000000000052": [
+          {
+            "tokenAddress": "0xba100000625a3754423978a60c9317c58a424e3d",
+            "amount": 120
+          }
+        ],
+        "0xaac98ee71d4f8a156b6abaa6844cdb7789d086ce00020000000000000000001b": [
+          {
+            "tokenAddress": "0xba100000625a3754423978a60c9317c58a424e3d",
+            "amount": 2500
+          }
+        ],
+        "0x186084ff790c65088ba694df11758fae4943ee9e000200000000000000000013": [
+          {
+            "tokenAddress": "0xba100000625a3754423978a60c9317c58a424e3d",
+            "amount": 500
+          }
+        ],
+        "0x072f14b85add63488ddad88f855fda4a99d6ac9b000200000000000000000027": [
+          {
+            "tokenAddress": "0xba100000625a3754423978a60c9317c58a424e3d",
+            "amount": 1000
+          }
+        ],
+        "0xe99481dc77691d8e2456e5f3f61c1810adfc1503000200000000000000000018": [
+          {
+            "tokenAddress": "0xba100000625a3754423978a60c9317c58a424e3d",
+            "amount": 2500
+          }
+        ],
+        "0xefaa1604e82e1b3af8430b90192c1b9e8197e377000200000000000000000021": [
+          {
+            "tokenAddress": "0xba100000625a3754423978a60c9317c58a424e3d",
+            "amount": 500
+          }
+        ],
+        "0xfeadd389a5c427952d8fdb8057d6c8ba1156cc56000000000000000000000066": [
+          {
+            "tokenAddress": "0xba100000625a3754423978a60c9317c58a424e3d",
+            "amount": 2500
+          }
+        ],
+        "0x32296969ef14eb0c6d29669c550d4a0449130230000200000000000000000080": [
+          {
+            "tokenAddress": "0xba100000625a3754423978a60c9317c58a424e3d",
+            "amount": 2500
+          },
+          {
+            "tokenAddress": "0x5a98fcbea516cf06857215779fd812ca3bef1b32",
+            "amount": 75000
+          }
+        ],
+        "0xbf96189eee9357a95c7719f4f5047f76bde804e5000200000000000000000087": [
+          {
+            "tokenAddress": "0xba100000625a3754423978a60c9317c58a424e3d",
+            "amount": 1000
+          }
+        ],
+        "0x702605f43471183158938c1a3e5f5a359d7b31ba00020000000000000000009f": [
+          {
+            "tokenAddress": "0xba100000625a3754423978a60c9317c58a424e3d",
+            "amount": 1000
+          }
+        ],
+        "0xec60a5fef79a92c741cb74fdd6bfc340c0279b01000200000000000000000015": [
+          {
+            "tokenAddress": "0xba100000625a3754423978a60c9317c58a424e3d",
+            "amount": 400
+          }
+        ],
+        "0xa02e4b3d18d4e6b8d18ac421fbc3dfff8933c40a00020000000000000000004b": [
+          {
+            "tokenAddress": "0xba100000625a3754423978a60c9317c58a424e3d",
+            "amount": 400
+          }
+        ],
+        "0xf5aaf7ee8c39b651cebf5f1f50c10631e78e0ef9000200000000000000000069": [
+          {
+            "tokenAddress": "0xba100000625a3754423978a60c9317c58a424e3d",
+            "amount": 250
+          }
+        ],
+        "0xf4c0dd9b82da36c07605df83c8a416f11724d88b000200000000000000000026": [
+          {
+            "tokenAddress": "0xba100000625a3754423978a60c9317c58a424e3d",
+            "amount": 1000
+          }
+        ],
+        "0xbaeec99c90e3420ec6c1e7a769d2a856d2898e4d00020000000000000000008a": [
+          {
+            "tokenAddress": "0xba100000625a3754423978a60c9317c58a424e3d",
+            "amount": 170
+          },
+          {
+            "tokenAddress": "0x81f8f0bb1cb2a06649e51913a151f0e7ef6fa321",
+            "amount": 2855
+          }
+        ],
+        "0x350196326aeaa9b98f1903fb5e8fc2686f85318c000200000000000000000084": [
+          {
+            "tokenAddress": "0xba100000625a3754423978a60c9317c58a424e3d",
+            "amount": 110
+          },
+          {
+            "tokenAddress": "0x81f8f0bb1cb2a06649e51913a151f0e7ef6fa321",
+            "amount": 1845
+          }
+        ],
+        "0xe2469f47ab58cf9cf59f9822e3c5de4950a41c49000200000000000000000089": [
+          {
+            "tokenAddress": "0xba100000625a3754423978a60c9317c58a424e3d",
+            "amount": 500
+          }
+        ],
+        "0x51735bdfbfe3fc13dea8dc6502e2e958989429610002000000000000000000a0": [
+          {
+            "tokenAddress": "0xba100000625a3754423978a60c9317c58a424e3d",
+            "amount": 250
+          },
+          {
+            "tokenAddress": "0x226f7b842e0f0120b7e194d05432b3fd14773a9d",
+            "amount": 375000
+          }
+        ],
+        "0x87165b659ba7746907a48763063efa3b323c2b0700020000000000000000002d" : [
+          {
+            "tokenAddress": "0xba100000625a3754423978a60c9317c58a424e3d",
+            "amount": 480
+          },
+          {
+            "tokenAddress": "0x2d94aa3e47d9d5024503ca8491fce9a2fb4da198",
+            "amount": 85000
+          }
+        ]
+      }
+    },
+    {
+      "chainId": 137,
+      "pools": {
+        "0x0297e37f1873d2dab4487aa67cd56b58e2f27875000100000000000000000002": [
+          {
+            "tokenAddress": "0x9a71012b13ca4d3d0cdc72a177df3ef03b0e76a3",
+            "amount": 6000
+          }
+        ],
+        "0x36128d5436d2d70cab39c9af9cce146c38554ff0000100000000000000000008": [
+          {
+            "tokenAddress": "0x9a71012b13ca4d3d0cdc72a177df3ef03b0e76a3",
+            "amount": 4000
+          }
+        ],
+        "0x03cd191f589d12b0582a99808cf19851e468e6b500010000000000000000000a": [
+          {
+            "tokenAddress": "0x9a71012b13ca4d3d0cdc72a177df3ef03b0e76a3",
+            "amount": 2250
+          }
+        ],
+        "0xce66904b68f1f070332cbc631de7ee98b650b499000100000000000000000009": [
+          {
+            "tokenAddress": "0x9a71012b13ca4d3d0cdc72a177df3ef03b0e76a3",
+            "amount": 2250
+          }
+        ],
+        "0x06df3b2bbb68adc8b0e302443692037ed9f91b42000000000000000000000012": [
+          {
+            "tokenAddress": "0x9a71012b13ca4d3d0cdc72a177df3ef03b0e76a3",
+            "amount": 2500
+          },
+          {
+            "tokenAddress": "0x580a84c73811e1839f75d86d75d88cca0c241ff4",
+            "amount": 15000
+          }
+        ],
+        "0x827ad315960f5a0f5280d6936c8e52a5878bba0400020000000000000000005c": [
+          {
+            "tokenAddress": "0x9a71012b13ca4d3d0cdc72a177df3ef03b0e76a3",
+            "amount": 300
+          },
+          {
+            "tokenAddress": "0x580a84c73811e1839f75d86d75d88cca0c241ff4",
+            "amount": 15000
+          }
+        ],
+        "0x614b5038611729ed49e0ded154d8a5d3af9d1d9e00010000000000000000001d": [
+          {
+            "tokenAddress": "0x9a71012b13ca4d3d0cdc72a177df3ef03b0e76a3",
+            "amount": 450
+          },
+          {
+            "tokenAddress": "0xF501dd45a1198C2E1b5aEF5314A68B9006D842E0",
+            "amount": 15000
+          }
+        ],
+        "0x4e7f40cd37cee710f5e87ad72959d30ef8a01a5d00010000000000000000000b": [
+          {
+            "tokenAddress": "0x9a71012b13ca4d3d0cdc72a177df3ef03b0e76a3",
+            "amount": 750
+          }
+        ],
+        "0x7c9cf12d783821d5c63d8e9427af5c44bad92445000100000000000000000051": [
+          {
+            "tokenAddress": "0x9a71012b13ca4d3d0cdc72a177df3ef03b0e76a3",
+            "amount": 1000
+          }
+        ],
+        "0xfeadd389a5c427952d8fdb8057d6c8ba1156cc5600020000000000000000001e": [
+          {
+            "tokenAddress": "0x9a71012b13ca4d3d0cdc72a177df3ef03b0e76a3",
+            "amount": 1000
+          }
+        ],
+        "0x186084ff790c65088ba694df11758fae4943ee9e000200000000000000000032": [
+          {
+            "tokenAddress": "0x9a71012b13ca4d3d0cdc72a177df3ef03b0e76a3",
+            "amount": 500
+          },
+          {
+            "tokenAddress": "0xdf7837de1f2fa4631d716cf2502f8b230f1dcc32",
+            "amount": 750000
+          }
+        ],
+        "0xdb1db6e248d7bb4175f6e5a382d0a03fe3dcc813000100000000000000000035": [
+          {
+            "tokenAddress": "0x9a71012b13ca4d3d0cdc72a177df3ef03b0e76a3",
+            "amount": 500
+          },
+          {
+            "tokenAddress": "0xdf7837de1f2fa4631d716cf2502f8b230f1dcc32",
+            "amount": 750000
+          }
+        ],
+        "0xcf354603a9aebd2ff9f33e1b04246d8ea204ae9500020000000000000000005a": [
+          {
+            "tokenAddress": "0x9a71012b13ca4d3d0cdc72a177df3ef03b0e76a3",
+            "amount": 1750
+          }
+        ],
+        "0x10f21c9bd8128a29aa785ab2de0d044dcdd79436000200000000000000000059": [
+          {
+            "tokenAddress": "0x9a71012b13ca4d3d0cdc72a177df3ef03b0e76a3",
+            "amount": 1750
+          }
+        ]
+      }
+    },
+    {
+      "chainId": 42161,
+      "pools": {
+        "0x64541216bafffeec8ea535bb71fbc927831d0595000100000000000000000002": [
+          {
+            "tokenAddress": "0x040d1edc9569d4bab2d15287dc5a4f10f56a56b8",
+            "amount": 2850
+          }
+        ],
+        "0xcc65a812ce382ab909a11e434dbf75b34f1cc59d000200000000000000000001": [
+          {
+            "tokenAddress": "0x040d1edc9569d4bab2d15287dc5a4f10f56a56b8",
+            "amount": 4000
+          }
+        ],
+        "0x1533a3278f3f9141d5f820a184ea4b017fce2382000000000000000000000016": [
+          {
+            "tokenAddress": "0x040d1edc9569d4bab2d15287dc5a4f10f56a56b8",
+            "amount": 2500
+          }
+        ],
+        "0xc2f082d33b5b8ef3a7e3de30da54efd3114512ac000200000000000000000017": [
+          {
+            "tokenAddress": "0x040d1edc9569d4bab2d15287dc5a4f10f56a56b8",
+            "amount": 400
+          },
+          {
+            "tokenAddress": "0x965772e0e9c84b6f359c8597c891108dcf1c5b1a",
+            "amount": 1023
+          }
+        ],
+        "0x5ced962afbfb7e13fb215defc2b027678237aa3a000200000000000000000011": [
+          {
+            "tokenAddress": "0x040d1edc9569d4bab2d15287dc5a4f10f56a56b8",
+            "amount": 250
+          }
+        ],
+        "0x8a9f8b5334dacb052cd62797e2bdf68d89c0bfd8000200000000000000000013": [
+          {
+            "tokenAddress": "0x040d1edc9569d4bab2d15287dc5a4f10f56a56b8",
+            "amount": 100
+          }
+        ],
+        "0x4a3a22a3e7fee0ffbb66f1c28bfac50f75546fc7000200000000000000000008": [
+          {
+            "tokenAddress": "0x040d1edc9569d4bab2d15287dc5a4f10f56a56b8",
+            "amount": 250
+          }
+        ],
+        "0xb5b77f1ad2b520df01612399258e7787af63025d000200000000000000000010": [
+          {
+            "tokenAddress": "0x040d1edc9569d4bab2d15287dc5a4f10f56a56b8",
+            "amount": 1600
+          },
+          {
+            "tokenAddress": "0x4e352cf164e64adcbad318c3a1e222e9eba4ce42",
+            "amount": 875
+          }
+        ],
+        "0x651e00ffd5ecfa7f3d4f33d62ede0a97cf62ede2000200000000000000000006": [
+          {
+            "tokenAddress": "0x040d1edc9569d4bab2d15287dc5a4f10f56a56b8",
+            "amount": 420
+          }
+        ],
+        "0xa6625f741400f90d31e39a17b0d429a92e347a6000020000000000000000000e": [
+          {
+            "tokenAddress": "0x040d1edc9569d4bab2d15287dc5a4f10f56a56b8",
+            "amount": 350
+          }
+        ],
+        "0xb28670b3e7ad27bd41fb5938136bf9e9cba90d6500020000000000000000001e": [
+          {
+            "tokenAddress": "0x040d1edc9569d4bab2d15287dc5a4f10f56a56b8",
+            "amount": 1000
+          }
+        ]
+      }
+    }
   ]
 }


### PR DESCRIPTION
# Description

Pending Ballers [vote](https://snapshot.org/#/ballersvote.eth/proposal/0x1a863469b799b5fa09bdc6f3000e51aba0c546b4d8fa4b108c87a5e336220e9c)

## Ethereum

- Start incentives for BANK/WETH 80/20. 480 flexible BAL per week, 85,000 BANK per week. 

## Arbitrum

- Reduce LINK/WETH 80/20 to 420 flexible BAL per week.
- Reduce NDX/WETH 80/20 to 250 flexible BAL per week.
- Reduce MCB/WETH 60/40 to 875 MCB per week. BAL allocation remains the same.

## Polygon

- No proposed changes this week.


## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Other

## How should this be tested?

- [ ] Liquidity mining page should reflect the changes described
- [ ] Change system date to some time next week; keep pressing "load more" in the list of pools and confirm that all incentivized pools show the LM APR icon

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] My changes generate no new console warnings
- [x] The base of this PR is `master` if hotfix, `develop` if not
