### PR TITLE
Add PICKLE to the claim UI

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.25.11",
+  "version": "1.25.12",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@balancer-labs/frontend-v2",
-      "version": "1.25.11",
+      "version": "1.25.12",
       "license": "MIT",
       "dependencies": {
         "@balancer-labs/assets": "github:balancer-labs/assets#master",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.25.11",
+  "version": "1.25.12",
   "engines": {
     "node": "14.x",
     "npm": ">=7"

--- a/src/services/claim/MultiTokenClaim.json
+++ b/src/services/claim/MultiTokenClaim.json
@@ -54,6 +54,13 @@
             "token": "0x4e352cf164e64adcbad318c3a1e222e9eba4ce42",
             "manifest": "https://raw.githubusercontent.com/balancer-labs/bal-mining-scripts/master/reports/_current-mcdex-arbitrum.json",
             "weekStart": 4
+        },
+        {
+            "label": "PICKLE",
+            "distributor": "0xf02CeB58d549E4b403e8F85FBBaEe4c5dfA47c01",
+            "token": "0x965772e0e9c84b6f359c8597c891108dcf1c5b1a",
+            "manifest": "https://raw.githubusercontent.com/balancer-labs/bal-mining-scripts/master/reports/_current-pickle-arbitrum.json",
+            "weekStart": 4
         }
     ]
   }


### PR DESCRIPTION
# Description

PICKLE started using the merkle orchard for their distributions. This adds the relevant metadata so that LPs can claim PICKLE on the app's UI.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other

## How should this be tested?

- Using https://apoorvlathey.com/impersonator/ with `0x0154d25120Ed20A516fE43991702e7463c5A6F6e` on Arbitrum should see ~22 PICKLE available to claim

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] My changes generate no new console warnings
- [x] The base of this PR is `master` if hotfix, `develop` if not
