### PR TITLE
Hotfix - gnosis fee quote

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.26.2",
+  "version": "1.26.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@balancer-labs/frontend-v2",
-      "version": "1.26.2",
+      "version": "1.26.3",
       "license": "MIT",
       "dependencies": {
         "@balancer-labs/assets": "github:balancer-labs/assets#master",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.26.2",
+  "version": "1.26.3",
   "engines": {
     "node": "14.x",
     "npm": ">=7"

--- a/src/composables/trade/useGnosis.ts
+++ b/src/composables/trade/useGnosis.ts
@@ -2,6 +2,7 @@ import { computed, ComputedRef, reactive, ref, Ref, toRefs } from 'vue';
 import { useStore } from 'vuex';
 import { BigNumber } from 'bignumber.js';
 import { formatUnits } from '@ethersproject/units';
+import { AddressZero } from '@ethersproject/constants';
 import { OrderBalance, OrderKind } from '@gnosis.pm/gp-v2-contracts';
 import { onlyResolvesLast } from 'awesome-only-resolves-last-promise';
 
@@ -307,8 +308,8 @@ export default function useGnosis({
       const feeQuoteParams: FeeQuoteParams = {
         sellToken: toErc20Address(tokenInAddressInput.value),
         buyToken: toErc20Address(tokenOutAddressInput.value),
-        from: account.value,
-        receiver: account.value,
+        from: account.value || AddressZero,
+        receiver: account.value || AddressZero,
         validTo: calculateValidTo(appTransactionDeadline.value),
         appData: APP_DATA,
         partiallyFillable: false,


### PR DESCRIPTION
# Description

If a wallet is disconnected and you enter values in the trade ui you get a very generic error message. This is due to the inputs for fetching the gnosis fee quote relying on the user's addresses. In this hotfix I am passing in the zero address if no wallet is connected.

![image](https://user-images.githubusercontent.com/2406506/139857819-763ca83c-79b4-475a-ab60-101109f41fbd.png) 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## How should this be tested?

- [ ] Test no generic errors are thrown in the trade UI (gasless turned on) with no wallet connected.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] My changes generate no new console warnings
- [x] The base of this PR is `master` if hotfix, `develop` if not
