### PR TITLE
Hotfix 1.26.1 - Hide weights for stable pools

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.26.0",
+  "version": "1.26.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@balancer-labs/frontend-v2",
-      "version": "1.26.0",
+      "version": "1.26.1",
       "license": "MIT",
       "dependencies": {
         "@balancer-labs/assets": "github:balancer-labs/assets#master",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.26.0",
+  "version": "1.26.1",
   "engines": {
     "node": "14.x",
     "npm": ">=7"

--- a/src/components/contextual/pages/pool/MyPoolBalancesCard.vue
+++ b/src/components/contextual/pages/pool/MyPoolBalancesCard.vue
@@ -6,6 +6,7 @@ import useTokens from '@/composables/useTokens';
 import useNumbers from '@/composables/useNumbers';
 import useUserSettings from '@/composables/useUserSettings';
 import useWeb3 from '@/services/web3/useWeb3';
+import { usePool } from '@/composables/usePool';
 
 /**
  * TYPES
@@ -30,6 +31,7 @@ const { getTokens } = useTokens();
 const { fNum, toFiat } = useNumbers();
 const { currency } = useUserSettings();
 const { isWalletReady } = useWeb3();
+const { isStableLikePool } = usePool(toRef(props, 'pool'));
 
 /**
  * COMPUTED
@@ -78,7 +80,9 @@ onBeforeMount(() => {
           <BalAsset :address="token.address" :size="36" class="mr-4" />
           <div class="flex flex-col">
             <span>
-              {{ weightLabelFor(token.address) }}
+              <span v-if="!isStableLikePool">
+                {{ weightLabelFor(token.address) }}
+              </span>
               {{ token.symbol }}
             </span>
             <span class="text-gray-500 text-sm">


### PR DESCRIPTION
# Description

We are displaying pool weights in the 'My pool balance' card on pool pages for stable pools. This PR hides them.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## How should this be tested?

- [ ] Check stable pools don't show any pool token weights

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] My changes generate no new console warnings
- [x] The base of this PR is `master` if hotfix, `develop` if not
