### PR TITLE
Hotfix: Add iROBOT InvestmentPool (mainnet) to allowlist

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.26.1",
+  "version": "1.26.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@balancer-labs/frontend-v2",
-      "version": "1.26.1",
+      "version": "1.26.2",
       "license": "MIT",
       "dependencies": {
         "@balancer-labs/assets": "github:balancer-labs/assets#master",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.26.1",
+  "version": "1.26.2",
   "engines": {
     "node": "14.x",
     "npm": ">=7"

--- a/src/constants/pools.ts
+++ b/src/constants/pools.ts
@@ -69,7 +69,8 @@ export const POOLS = {
   Investment: {
     AllowList: [
       '0x4fd63966879300cafafbb35d157dc5229278ed23000100000000000000000169', // kovan
-      '0xe7b1d394f3b40abeaa0b64a545dbcf89da1ecb3f00010000000000000000009a' // mainnet
+      '0xccf5575570fac94cec733a58ff91bb3d073085c70002000000000000000000af', // iROBOT mainnet
+      '0xe7b1d394f3b40abeaa0b64a545dbcf89da1ecb3f00010000000000000000009a' // Techemy mainnet
     ]
   },
   Factories: {


### PR DESCRIPTION
# Description

Add iROBOT InvestmentPool to allowlist for display on Invest UI. This pool is essentially an LBP, but it will outlast its gradual weight change and have public LPs, so it must be an InvestmentPool instead. It is very similar to the ROBOT/WETH smart pool on V1 and managed by the same entity.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other

## How should this be tested?

- [ ] Pool page for this ID (on mainnet) should populate data rather than spinning indefinitely: 0xccf5575570fac94cec733a58ff91bb3d073085c70002000000000000000000af

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] My changes generate no new console warnings
- [x] The base of this PR is `master` if hotfix, `develop` if not
