### PR TITLE
Hotfix 1.26.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.26.3",
+  "version": "1.26.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@balancer-labs/frontend-v2",
-      "version": "1.26.3",
+      "version": "1.26.4",
       "license": "MIT",
       "dependencies": {
         "@balancer-labs/assets": "github:balancer-labs/assets#master",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.26.3",
+  "version": "1.26.4",
   "engines": {
     "node": "14.x",
     "npm": ">=7"

--- a/src/lib/utils/balancer/helpers/sor/sorManager.ts
+++ b/src/lib/utils/balancer/helpers/sor/sorManager.ts
@@ -56,6 +56,7 @@ export class SorManager {
     v2success: false
   };
   private isV1Supported: boolean;
+  private isFetching: boolean;
   maxPools: number;
   gasPrice: BigNumber;
   selectedPools: (SubgraphPoolBase | Pool)[] = [];
@@ -85,6 +86,7 @@ export class SorManager {
     this.weth = weth;
     this.gasPrice = gasPrice;
     this.maxPools = maxPools;
+    this.isFetching = false;
   }
 
   // Uses SOR V2 to retrieve the cost & reuses for SOR V1 to save time (requires onchain call).
@@ -123,6 +125,10 @@ export class SorManager {
 
   // This fetches ALL pool with onchain info.
   async fetchPools(): Promise<void> {
+    if (this.isFetching) {
+      return;
+    }
+    this.isFetching = true;
     let v1fetch;
     console.log(`[SorManager] fetch Subgraph (V1:${this.isV1Supported})`);
     if (this.isV1Supported) {
@@ -164,6 +170,7 @@ export class SorManager {
     }
 
     this.selectedPools = this.sorV2.getPools();
+    this.isFetching = false;
   }
   // Gets swaps for V1 & V2 liquidity and determined best result
   async getBestSwap(


### PR DESCRIPTION


# Description

- Add flag to fetchPools to ensure only one fetch is done at once

This fixes issues when fetchPools is running slower than the block time which causes many fetches to be done at once causing CPU usage to spike and the browser to lag. Most noticeable on Kovan test network where it has 4s block times. 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## How should this be tested?

- Run app
- View Trade page
- Ensure sor fetches are happening and that only one is being performed at a time, others should finish in <1s. 

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] My changes generate no new console warnings
- [x] The base of this PR is `master` if hotfix, `develop` if not
