### PR TITLE
Hotfix 1.26.5 - Hide pool actions if no init pool liquidity

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.26.4",
+  "version": "1.26.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@balancer-labs/frontend-v2",
-      "version": "1.26.4",
+      "version": "1.26.5",
       "license": "MIT",
       "dependencies": {
         "@balancer-labs/assets": "github:balancer-labs/assets#master",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.26.4",
+  "version": "1.26.5",
   "engines": {
     "node": "14.x",
     "npm": ">=7"

--- a/src/pages/pool/_id.vue
+++ b/src/pages/pool/_id.vue
@@ -120,7 +120,11 @@
         />
 
         <BalLoadingBlock v-if="loadingPool" class="pool-actions-card h-40" />
-        <PoolActionsCard v-else :pool="pool" :missingPrices="missingPrices" />
+        <PoolActionsCard
+          v-else-if="!noInitLiquidity"
+          :pool="pool"
+          :missingPrices="missingPrices"
+        />
       </div>
       <div v-else class="order-1 lg:order-2 px-1 lg:px-0">
         <BalCard noPad imgSrc="/images/partners/copper-launch.png">

--- a/src/pages/pool/_id.vue
+++ b/src/pages/pool/_id.vue
@@ -64,16 +64,16 @@
           v-if="!appLoading && missingPrices"
           type="warning"
           :title="$t('noPriceInfo')"
-          size="sm"
           class="mt-2"
+          block
         />
         <BalAlert
           v-if="!appLoading && noInitLiquidity"
           type="warning"
           :title="$t('noInitLiquidity')"
           :description="$t('noInitLiquidityDetail')"
-          size="sm"
           class="mt-2"
+          block
         />
       </div>
 
@@ -113,7 +113,7 @@
           class="pool-actions-card h-60 mb-4"
         />
         <MyPoolBalancesCard
-          v-else
+          v-else-if="!noInitLiquidity"
           :pool="pool"
           :missingPrices="missingPrices"
           class="mb-4"


### PR DESCRIPTION
# Description

In cases where pools have no initial liquidity we should not allow access to the invest/withdraw flow. This PR takes the first step towards this by hiding the pool actions card which links to the invest/withdraw flow from the pool page. The next step is to add some router middleware to prevent access to the invest/withdraw flow via the URL. That will come in a subsequent PR.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## How should this be tested?

- [ ] Check that you cannot click through to the invest/withdraw flow on the pool page of this polygon pool `0xf93e20844fd084b657d5e71342157b36c5f3032d00010000000000000000001a`

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] My changes generate no new console warnings
- [x] The base of this PR is `master` if hotfix, `develop` if not
