### PR TITLE
Hotfix 1.26.6 - Invest/withdraw flow guard

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.26.5",
+  "version": "1.26.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@balancer-labs/frontend-v2",
-      "version": "1.26.5",
+      "version": "1.26.6",
       "license": "MIT",
       "dependencies": {
         "@balancer-labs/assets": "github:balancer-labs/assets#master",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.26.5",
+  "version": "1.26.6",
   "engines": {
     "node": "14.x",
     "npm": ">=7"

--- a/src/composables/contextual/pool-transfers/usePoolTransfers.ts
+++ b/src/composables/contextual/pool-transfers/usePoolTransfers.ts
@@ -9,6 +9,7 @@ import useTokens from '@/composables/useTokens';
  * STATE
  */
 const useNativeAsset = ref(false);
+const transfersAllowed = ref(true);
 
 export default function usePoolTransfers() {
   const route = useRoute();
@@ -56,6 +57,7 @@ export default function usePoolTransfers() {
     pool,
     loadingPool,
     useNativeAsset,
-    missingPrices
+    missingPrices,
+    transfersAllowed
   };
 }

--- a/src/composables/contextual/pool-transfers/usePoolTransfersGuard.ts
+++ b/src/composables/contextual/pool-transfers/usePoolTransfersGuard.ts
@@ -1,0 +1,54 @@
+import { usePool } from '@/composables/usePool';
+import { FullPool } from '@/services/balancer/subgraph/types';
+import { watch, onBeforeMount } from 'vue';
+import { useRouter } from 'vue-router';
+import usePoolTransfers from './usePoolTransfers';
+
+/**
+ * This should only be used once at the highest level of the invest/withdraw flow
+ * which is the PoolTransfersLayout.
+ *
+ * Before page mount it checks if the pool has been loaded and if so checks if transfers
+ * are allowed. If not, redirects back to pool page. It also watches the pool value
+ * in the case where the page is accessed before the pool is loaded, e.g. direct access.
+ * When the pool has a value, i.e. it's loaded, it then checks if transfers are allowed
+ * and redirects if not.
+ */
+export default function usePoolTransfersGuard() {
+  /**
+   * COMPOSABLES
+   */
+  const router = useRouter();
+  const { pool, transfersAllowed } = usePoolTransfers();
+  const { noInitLiquidity } = usePool(pool);
+
+  /**
+   * METHODS
+   */
+  function shouldBlockAccess(pool: FullPool): boolean {
+    if (noInitLiquidity(pool)) return true;
+    return false;
+  }
+
+  /**
+   * WATCHERS
+   */
+  watch(pool, loadedPool => {
+    if (loadedPool && shouldBlockAccess(loadedPool)) {
+      transfersAllowed.value = false;
+      router.push({ name: 'pool', params: { id: loadedPool.id } });
+    }
+  });
+
+  /**
+   * CALLBACKS
+   */
+  onBeforeMount(() => {
+    transfersAllowed.value = false;
+    if (pool.value && shouldBlockAccess(pool.value)) {
+      router.push({ name: 'pool', params: { id: pool.value.id } });
+    } else {
+      transfersAllowed.value = true;
+    }
+  });
+}

--- a/src/composables/usePool.ts
+++ b/src/composables/usePool.ts
@@ -2,6 +2,7 @@ import { Ref, computed } from 'vue';
 import { PoolType, AnyPool } from '@/services/balancer/subgraph/types';
 import { configService } from '@/services/config/config.service';
 import { getAddress } from 'ethers/lib/utils';
+import { bnum } from '@/lib/utils';
 
 export function isStable(poolType: PoolType): boolean {
   return poolType === PoolType.Stable;
@@ -52,6 +53,10 @@ export function isWstETH(pool: AnyPool): boolean {
   );
 }
 
+export function noInitLiquidity(pool: AnyPool): boolean {
+  return bnum(pool?.onchain?.totalSupply || '0').eq(0);
+}
+
 export function usePool(pool: Ref<AnyPool> | Ref<undefined>) {
   const isStablePool = computed(
     (): boolean => !!pool.value && isStable(pool.value.poolType)
@@ -84,6 +89,9 @@ export function usePool(pool: Ref<AnyPool> | Ref<undefined>) {
   const isWstETHPool = computed(
     (): boolean => !!pool.value && isWstETH(pool.value)
   );
+  const noInitLiquidityPool = computed(
+    () => !!pool.value && noInitLiquidity(pool.value)
+  );
 
   return {
     // computed
@@ -97,6 +105,7 @@ export function usePool(pool: Ref<AnyPool> | Ref<undefined>) {
     managedPoolWithTradingHalted,
     isWethPool,
     isWstETHPool,
+    noInitLiquidityPool,
     // methods
     isStable,
     isMetaStable,
@@ -105,6 +114,7 @@ export function usePool(pool: Ref<AnyPool> | Ref<undefined>) {
     isLiquidityBootstrapping,
     isWeightedLike,
     isTradingHaltable,
-    isWeth
+    isWeth,
+    noInitLiquidity
   };
 }

--- a/src/pages/_layouts/PoolTransferLayout.vue
+++ b/src/pages/_layouts/PoolTransferLayout.vue
@@ -9,6 +9,7 @@ import MyPoolBalancesCard from '@/components/cards/MyPoolBalancesCard/MyPoolBala
 import MyWalletTokensCard from '@/components/cards/MyWalletTokensCard/MyWalletTokensCard.vue';
 import BalAccordion from '@/components/_global/BalAccordion/BalAccordion.vue';
 import Col3Layout from '@/components/layouts/Col3Layout.vue';
+import usePoolTransfersGuard from '@/composables/contextual/pool-transfers/usePoolTransfersGuard';
 
 /**
  * STATE
@@ -20,7 +21,13 @@ const id = ref<string>(route.params.id as string);
  * COMPOSABLES
  */
 const { upToLargeBreakpoint } = useBreakpoints();
-const { pool, loadingPool, useNativeAsset } = usePoolTransfers();
+const {
+  pool,
+  loadingPool,
+  useNativeAsset,
+  transfersAllowed
+} = usePoolTransfers();
+usePoolTransfersGuard();
 </script>
 
 <template>
@@ -34,7 +41,7 @@ const { pool, loadingPool, useNativeAsset } = usePoolTransfers();
 
     <Col3Layout offsetGutters mobileHideGutters>
       <template #gutterLeft v-if="!upToLargeBreakpoint">
-        <BalLoadingBlock v-if="loadingPool" class="h-64" />
+        <BalLoadingBlock v-if="loadingPool || !transfersAllowed" class="h-64" />
         <MyWalletTokensCard
           v-else
           :pool="pool"
@@ -59,7 +66,10 @@ const { pool, loadingPool, useNativeAsset } = usePoolTransfers();
         ]"
       >
         <template #myWalletTokens>
-          <BalLoadingBlock v-if="loadingPool" class="h-64" />
+          <BalLoadingBlock
+            v-if="loadingPool || !transfersAllowed"
+            class="h-64"
+          />
           <MyWalletTokensCard
             v-else
             :pool="pool"
@@ -70,13 +80,16 @@ const { pool, loadingPool, useNativeAsset } = usePoolTransfers();
           />
         </template>
         <template #myPoolBalances>
-          <BalLoadingBlock v-if="loadingPool" class="h-64" />
+          <BalLoadingBlock
+            v-if="loadingPool || !transfersAllowed"
+            class="h-64"
+          />
           <MyPoolBalancesCard v-else :pool="pool" hideHeader noBorder square />
         </template>
       </BalAccordion>
 
       <template #gutterRight v-if="!upToLargeBreakpoint">
-        <BalLoadingBlock v-if="loadingPool" class="h-64" />
+        <BalLoadingBlock v-if="loadingPool || !transfersAllowed" class="h-64" />
         <MyPoolBalancesCard v-else :pool="pool" />
       </template>
     </Col3Layout>

--- a/src/pages/pool/invest.vue
+++ b/src/pages/pool/invest.vue
@@ -12,12 +12,12 @@ import usePoolTransfers from '@/composables/contextual/pool-transfers/usePoolTra
  * STATE
  */
 const { network } = configService;
-const { pool, loadingPool } = usePoolTransfers();
+const { pool, loadingPool, transfersAllowed } = usePoolTransfers();
 </script>
 
 <template>
   <div>
-    <BalLoadingBlock v-if="loadingPool" class="h-96" />
+    <BalLoadingBlock v-if="loadingPool || !transfersAllowed" class="h-96" />
     <BalCard v-else shadow="xl" exposeOverflow noBorder>
       <template #header>
         <div class="w-full">

--- a/src/pages/pool/withdraw.vue
+++ b/src/pages/pool/withdraw.vue
@@ -12,12 +12,12 @@ import TradeSettingsPopover, {
  * STATE
  */
 const { network } = configService;
-const { pool, loadingPool } = usePoolTransfers();
+const { pool, loadingPool, transfersAllowed } = usePoolTransfers();
 </script>
 
 <template>
   <div>
-    <BalLoadingBlock v-if="loadingPool" class="h-96" />
+    <BalLoadingBlock v-if="loadingPool || !transfersAllowed" class="h-96" />
     <BalCard v-else shadow="xl" exposeOverflow noBorder>
       <template #header>
         <div class="w-full">


### PR DESCRIPTION
# Description

The PR prevents access to the invest/withdraw flow if any blocking criteria is met. To start with, the only thing that cause a redirect back to the pool page is if the pool has no initial liquidity.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## How should this be tested?

- [ ] Try to access the invest page for this polygon pool `0xf93e20844fd084b657d5e71342157b36c5f3032d00010000000000000000001a`
- [ ] Make sure you can access the invest/withdraw flow for other pools where there is liquidity.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] My changes generate no new console warnings
- [x] The base of this PR is `master` if hotfix, `develop` if not
