### PR TITLE
fix: show small number indication

### DIFF
--- a/src/composables/useNumbers.ts
+++ b/src/composables/useNumbers.ts
@@ -32,6 +32,15 @@ export function fNum(
   if (number >= 10_000 && !options.forcePreset) {
     adjustedPreset = `${preset}_lg`;
   }
+
+  if (
+    (preset === 'token' || preset === 'token_fixed') &&
+    number > 0 &&
+    number < 0.0001
+  ) {
+    return '< 0.0001';
+  }
+
   if (number < 1e-6) {
     // Numeral returns NaN in this case so just set to zero.
     // https://github.com/adamwdraper/Numeral-js/issues/596


### PR DESCRIPTION
# Description

Shows `< 0.0001` when numbers of the `token` preset are passed to `fNum`.

Without this fix, this row would basically show nothing since it will be treated as `0`.
<img width="1045" alt="Screen Shot 2021-11-05 at 3 26 05 pm" src="https://user-images.githubusercontent.com/254095/140458253-d655b541-3436-4f0e-9023-d33d0e622b76.png">

Other examples:

<img width="1033" alt="Screen Shot 2021-11-05 at 3 19 26 pm" src="https://user-images.githubusercontent.com/254095/140458242-84d28cb4-70d7-41e5-9604-abb1105845be.png">

<img width="1065" alt="Screen Shot 2021-11-05 at 3 23 34 pm" src="https://user-images.githubusercontent.com/254095/140458248-f20613e3-972d-4e0d-800f-4a66f9291aab.png">


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## How should this be tested?

Please provide instructions so we can test. Please also list any relevant details for your test configuration.

- [ ] Best to test on L2's - I've mostly tested on Polygon SOL/AVAX pools.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] My changes generate no new console warnings
- [x] The base of this PR is `master` if hotfix, `develop` if not
