### PR TITLE
feat: add block explorer url to metamask when importing chain

### DIFF
--- a/src/services/web3/utils/helpers.ts
+++ b/src/services/web3/utils/helpers.ts
@@ -46,7 +46,8 @@ export async function importNetworkDetailsToWallet(provider: ExternalProvider) {
             name: appNetworkConfig.nativeAsset.name,
             symbol: appNetworkConfig.nativeAsset.symbol,
             decimals: appNetworkConfig.nativeAsset.decimals
-          }
+          },
+          blockExplorerUrls: [appNetworkConfig.explorer]
         }
       ]
     };


### PR DESCRIPTION
# Description

Metamask allows loading a block explorer when adding a new chain:
https://docs.metamask.io/guide/rpc-api.html#wallet-addethereumchain

This PR adds the block explorer for the new network to the payload.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## How should this be tested?

Delete Polygon/Arbitrum from your metamask and then reload it from the app. Under "View all details" you should see the url.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] My changes generate no new console warnings
- [x] The base of this PR is `master` if hotfix, `develop` if not
