### PR TITLE
Fix vue template compiling

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -42,7 +42,7 @@
         "paraswap": "^4.18.0",
         "parse-filepath": "1.0.2",
         "swiper": "^6.4.5",
-        "vue": "^3.2.6",
+        "vue": "3.2.6",
         "vue-composable-tester": "^0.1.3",
         "vue-echarts": "^6.0.0",
         "vue-i18n": "^9.0.0-rc.1",
@@ -81,7 +81,7 @@
         "@vue/cli-plugin-unit-jest": "^4.5.9",
         "@vue/cli-plugin-vuex": "^4.4.0",
         "@vue/cli-service": "^4.4.0",
-        "@vue/compiler-sfc": "^3.2.6",
+        "@vue/compiler-sfc": "3.2.6",
         "@vue/eslint-config-prettier": "^6.0.0",
         "@vue/eslint-config-typescript": "^7.0.0",
         "@vue/test-utils": "^2.0.0-alpha.1",
@@ -98,6 +98,7 @@
         "tailwind-config-viewer": "^1.5.0",
         "tailwindcss": "npm:@tailwindcss/postcss7-compat@^2.2.17",
         "typescript": "^4.3.5",
+        "vue": "3.2.6",
         "vue-cli-plugin-webpack-bundle-analyzer": "^2.0.0",
         "vue-loader": "^16.8.1",
         "worker-loader": "^3.0.8"
@@ -1842,7 +1843,7 @@
     "node_modules/@balancer-labs/assets": {
       "name": "assets",
       "version": "1.0.0",
-      "resolved": "git+ssh://git@github.com/balancer-labs/assets.git#71d3d528d3d0690bd75c1cf287910ae92533f045",
+      "resolved": "git+ssh://git@github.com/balancer-labs/assets.git#d87715591f429c46615ad4979b614ec50adcd800",
       "license": "ISC",
       "dependencies": {
         "dotenv": "^8.2.0"
@@ -2053,26 +2054,6 @@
         "@ethersproject/web": "^5.4.0"
       }
     },
-    "node_modules/@ethersproject/abstract-provider/node_modules/@ethersproject/bignumber": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.5.0.tgz",
-      "integrity": "sha512-6Xytlwvy6Rn3U3gKEc1vP7nR92frHkv6wtVr95LFR3jREXiCPzdWxKQ1cx4JGQBXxcguAwjA8murlYN2TSiEbg==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-        },
-        {
-          "type": "individual",
-          "url": "https://www.buymeacoffee.com/ricmoo"
-        }
-      ],
-      "dependencies": {
-        "@ethersproject/bytes": "^5.5.0",
-        "@ethersproject/logger": "^5.5.0",
-        "bn.js": "^4.11.9"
-      }
-    },
     "node_modules/@ethersproject/abstract-signer": {
       "version": "5.4.1",
       "resolved": "https://registry.npmjs.org/@ethersproject/abstract-signer/-/abstract-signer-5.4.1.tgz",
@@ -2093,26 +2074,6 @@
         "@ethersproject/bytes": "^5.4.0",
         "@ethersproject/logger": "^5.4.0",
         "@ethersproject/properties": "^5.4.0"
-      }
-    },
-    "node_modules/@ethersproject/abstract-signer/node_modules/@ethersproject/bignumber": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.5.0.tgz",
-      "integrity": "sha512-6Xytlwvy6Rn3U3gKEc1vP7nR92frHkv6wtVr95LFR3jREXiCPzdWxKQ1cx4JGQBXxcguAwjA8murlYN2TSiEbg==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-        },
-        {
-          "type": "individual",
-          "url": "https://www.buymeacoffee.com/ricmoo"
-        }
-      ],
-      "dependencies": {
-        "@ethersproject/bytes": "^5.5.0",
-        "@ethersproject/logger": "^5.5.0",
-        "bn.js": "^4.11.9"
       }
     },
     "node_modules/@ethersproject/address": {
@@ -5233,12 +5194,13 @@
       }
     },
     "node_modules/@vue/compiler-core": {
-      "version": "3.2.21",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.2.21.tgz",
-      "integrity": "sha512-NhhiQZNG71KNq1h5pMW/fAXdTF7lJRaSI7LDm2edhHXVz1ROMICo8SreUmQnSf4Fet0UPBVqJ988eF4+936iDQ==",
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.2.6.tgz",
+      "integrity": "sha512-vbwnz7+OhtLO5p5i630fTuQCL+MlUpEMTKHuX+RfetQ+3pFCkItt2JUH+9yMaBG2Hkz6av+T9mwN/acvtIwpbw==",
       "dependencies": {
         "@babel/parser": "^7.15.0",
-        "@vue/shared": "3.2.21",
+        "@babel/types": "^7.15.0",
+        "@vue/shared": "3.2.6",
         "estree-walker": "^2.0.2",
         "source-map": "^0.6.1"
       }
@@ -5252,40 +5214,81 @@
       }
     },
     "node_modules/@vue/compiler-dom": {
-      "version": "3.2.21",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.2.21.tgz",
-      "integrity": "sha512-gsJD3DpYZSYquiA7UIPsMDSlAooYWDvHPq9VRsqzJEk2PZtFvLvHPb4aaMD8Ufd62xzYn32cnnkzsEOJhyGilA==",
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.2.6.tgz",
+      "integrity": "sha512-+a/3oBAzFIXhHt8L5IHJOTP4a5egzvpXYyi13jR7CUYOR1S+Zzv7vBWKYBnKyJLwnrxTZnTQVjeHCgJq743XKg==",
       "dependencies": {
-        "@vue/compiler-core": "3.2.21",
-        "@vue/shared": "3.2.21"
+        "@vue/compiler-core": "3.2.6",
+        "@vue/shared": "3.2.6"
       }
     },
     "node_modules/@vue/compiler-sfc": {
-      "version": "3.2.21",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.2.21.tgz",
-      "integrity": "sha512-+yDlUSebKpz/ovxM2vLRRx7w/gVfY767pOfYTgbIhAs+ogvIV2BsIt4fpxlThnlCNChJ+yE0ERUNoROv2kEGEQ==",
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.2.6.tgz",
+      "integrity": "sha512-Ariz1eDsf+2fw6oWXVwnBNtfKHav72RjlWXpEgozYBLnfRPzP+7jhJRw4Nq0OjSsLx2HqjF3QX7HutTjYB0/eA==",
+      "dev": true,
       "dependencies": {
         "@babel/parser": "^7.15.0",
-        "@vue/compiler-core": "3.2.21",
-        "@vue/compiler-dom": "3.2.21",
-        "@vue/compiler-ssr": "3.2.21",
-        "@vue/ref-transform": "3.2.21",
-        "@vue/shared": "3.2.21",
+        "@babel/types": "^7.15.0",
+        "@types/estree": "^0.0.48",
+        "@vue/compiler-core": "3.2.6",
+        "@vue/compiler-dom": "3.2.6",
+        "@vue/compiler-ssr": "3.2.6",
+        "@vue/ref-transform": "3.2.6",
+        "@vue/shared": "3.2.6",
+        "consolidate": "^0.16.0",
         "estree-walker": "^2.0.2",
+        "hash-sum": "^2.0.0",
+        "lru-cache": "^5.1.1",
         "magic-string": "^0.25.7",
+        "merge-source-map": "^1.1.0",
         "postcss": "^8.1.10",
+        "postcss-modules": "^4.0.0",
+        "postcss-selector-parser": "^6.0.4",
         "source-map": "^0.6.1"
+      }
+    },
+    "node_modules/@vue/compiler-sfc/node_modules/@types/estree": {
+      "version": "0.0.48",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.48.tgz",
+      "integrity": "sha512-LfZwXoGUDo0C3me81HXgkBg5CTQYb6xzEl+fNmbO4JdRiSKQ8A0GD1OBBvKAIsbCUgoyAty7m99GqqMQe784ew==",
+      "dev": true
+    },
+    "node_modules/@vue/compiler-sfc/node_modules/consolidate": {
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/consolidate/-/consolidate-0.16.0.tgz",
+      "integrity": "sha512-Nhl1wzCslqXYTJVDyJCu3ODohy9OfBMB5uD2BiBTzd7w+QY0lBzafkR8y8755yMYHAaMD4NuzbAw03/xzfw+eQ==",
+      "dev": true,
+      "dependencies": {
+        "bluebird": "^3.7.2"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      }
+    },
+    "node_modules/@vue/compiler-sfc/node_modules/icss-utils": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/icss-utils/-/icss-utils-5.1.0.tgz",
+      "integrity": "sha512-soFhflCVWLfRNOPU3iv5Z9VUdT44xFRbzjLsEzSr5AQmgqPMTHdU3PMT1Cf1ssx8fLNJDA1juftYl+PUcv3MqA==",
+      "dev": true,
+      "engines": {
+        "node": "^10 || ^12 || >= 14"
+      },
+      "peerDependencies": {
+        "postcss": "^8.1.0"
       }
     },
     "node_modules/@vue/compiler-sfc/node_modules/picocolors": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
-      "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ=="
+      "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==",
+      "dev": true
     },
     "node_modules/@vue/compiler-sfc/node_modules/postcss": {
       "version": "8.3.11",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.3.11.tgz",
       "integrity": "sha512-hCmlUAIlUiav8Xdqw3Io4LcpA1DOt7h3LSTAC4G6JGHFFaWzI6qvFt9oilvl8BmkbBRX1IhM90ZAmpk68zccQA==",
+      "dev": true,
       "dependencies": {
         "nanoid": "^3.1.30",
         "picocolors": "^1.0.0",
@@ -5299,21 +5302,101 @@
         "url": "https://opencollective.com/postcss/"
       }
     },
+    "node_modules/@vue/compiler-sfc/node_modules/postcss-modules": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/postcss-modules/-/postcss-modules-4.2.2.tgz",
+      "integrity": "sha512-/H08MGEmaalv/OU8j6bUKi/kZr2kqGF6huAW8m9UAgOLWtpFdhA14+gPBoymtqyv+D4MLsmqaF2zvIegdCxJXg==",
+      "dev": true,
+      "dependencies": {
+        "generic-names": "^2.0.1",
+        "icss-replace-symbols": "^1.1.0",
+        "lodash.camelcase": "^4.3.0",
+        "postcss-modules-extract-imports": "^3.0.0",
+        "postcss-modules-local-by-default": "^4.0.0",
+        "postcss-modules-scope": "^3.0.0",
+        "postcss-modules-values": "^4.0.0",
+        "string-hash": "^1.1.1"
+      },
+      "peerDependencies": {
+        "postcss": "^8.0.0"
+      }
+    },
+    "node_modules/@vue/compiler-sfc/node_modules/postcss-modules-extract-imports": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/postcss-modules-extract-imports/-/postcss-modules-extract-imports-3.0.0.tgz",
+      "integrity": "sha512-bdHleFnP3kZ4NYDhuGlVK+CMrQ/pqUm8bx/oGL93K6gVwiclvX5x0n76fYMKuIGKzlABOy13zsvqjb0f92TEXw==",
+      "dev": true,
+      "engines": {
+        "node": "^10 || ^12 || >= 14"
+      },
+      "peerDependencies": {
+        "postcss": "^8.1.0"
+      }
+    },
+    "node_modules/@vue/compiler-sfc/node_modules/postcss-modules-local-by-default": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/postcss-modules-local-by-default/-/postcss-modules-local-by-default-4.0.0.tgz",
+      "integrity": "sha512-sT7ihtmGSF9yhm6ggikHdV0hlziDTX7oFoXtuVWeDd3hHObNkcHRo9V3yg7vCAY7cONyxJC/XXCmmiHHcvX7bQ==",
+      "dev": true,
+      "dependencies": {
+        "icss-utils": "^5.0.0",
+        "postcss-selector-parser": "^6.0.2",
+        "postcss-value-parser": "^4.1.0"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >= 14"
+      },
+      "peerDependencies": {
+        "postcss": "^8.1.0"
+      }
+    },
+    "node_modules/@vue/compiler-sfc/node_modules/postcss-modules-scope": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/postcss-modules-scope/-/postcss-modules-scope-3.0.0.tgz",
+      "integrity": "sha512-hncihwFA2yPath8oZ15PZqvWGkWf+XUfQgUGamS4LqoP1anQLOsOJw0vr7J7IwLpoY9fatA2qiGUGmuZL0Iqlg==",
+      "dev": true,
+      "dependencies": {
+        "postcss-selector-parser": "^6.0.4"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >= 14"
+      },
+      "peerDependencies": {
+        "postcss": "^8.1.0"
+      }
+    },
+    "node_modules/@vue/compiler-sfc/node_modules/postcss-modules-values": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/postcss-modules-values/-/postcss-modules-values-4.0.0.tgz",
+      "integrity": "sha512-RDxHkAiEGI78gS2ofyvCsu7iycRv7oqw5xMWn9iMoR0N/7mf9D50ecQqUo5BZ9Zh2vH4bCUR/ktCqbB9m8vJjQ==",
+      "dev": true,
+      "dependencies": {
+        "icss-utils": "^5.0.0"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >= 14"
+      },
+      "peerDependencies": {
+        "postcss": "^8.1.0"
+      }
+    },
     "node_modules/@vue/compiler-sfc/node_modules/source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/@vue/compiler-ssr": {
-      "version": "3.2.21",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.2.21.tgz",
-      "integrity": "sha512-eU+A0iWYy+1zAo2CRIJ0zSVlv1iuGAIbNRCnllSJ31pV1lX3jypJYzGbJlSRAbB7VP6E+tYveVT1Oq8JKewa3g==",
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.2.6.tgz",
+      "integrity": "sha512-A7IKRKHSyPnTC4w1FxHkjzoyjXInsXkcs/oX22nBQ+6AWlXj2Tt1le96CWPOXy5vYlsTYkF1IgfBaKIdeN/39g==",
+      "dev": true,
       "dependencies": {
-        "@vue/compiler-dom": "3.2.21",
-        "@vue/shared": "3.2.21"
+        "@vue/compiler-dom": "3.2.6",
+        "@vue/shared": "3.2.6"
       }
     },
     "node_modules/@vue/component-compiler-utils": {
@@ -5417,41 +5500,42 @@
       }
     },
     "node_modules/@vue/reactivity": {
-      "version": "3.2.21",
-      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.2.21.tgz",
-      "integrity": "sha512-7C57zFm/5E3SSTUhVuYj1InDwuJ+GIVQ/z+H43C9sST85gIThGXVhksl1yWTAadf8Yz4T5lSbqi5Ds8U/ueWcw==",
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.2.6.tgz",
+      "integrity": "sha512-8vIDD2wpCnYisNNZjmcIj+Rixn0uhZNY3G1vzlgdVdLygeRSuFjkmnZk6WwvGzUWpKfnG0e/NUySM3mVi59hAA==",
       "dependencies": {
-        "@vue/shared": "3.2.21"
+        "@vue/shared": "3.2.6"
       }
     },
     "node_modules/@vue/ref-transform": {
-      "version": "3.2.21",
-      "resolved": "https://registry.npmjs.org/@vue/ref-transform/-/ref-transform-3.2.21.tgz",
-      "integrity": "sha512-uiEWWBsrGeun9O7dQExYWzXO3rHm/YdtFNXDVqCSoPypzOVxWxdiL+8hHeWzxMB58fVuV2sT80aUtIVyaBVZgQ==",
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vue/ref-transform/-/ref-transform-3.2.6.tgz",
+      "integrity": "sha512-ie39+Y4nbirDLvH+WEq6Eo/l3n3mFATayqR+kEMSphrtMW6Uh/eEMx1Gk2Jnf82zmj3VLRq7dnmPx72JLcBYkQ==",
+      "dev": true,
       "dependencies": {
         "@babel/parser": "^7.15.0",
-        "@vue/compiler-core": "3.2.21",
-        "@vue/shared": "3.2.21",
+        "@vue/compiler-core": "3.2.6",
+        "@vue/shared": "3.2.6",
         "estree-walker": "^2.0.2",
         "magic-string": "^0.25.7"
       }
     },
     "node_modules/@vue/runtime-core": {
-      "version": "3.2.21",
-      "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.2.21.tgz",
-      "integrity": "sha512-7oOxKaU0D2IunOAMOOHZgJVrHg63xwng8BZx3fbgmakqEIMwHhQcp+5GV1sOg/sWW7R4UhaRDIUCukO2GRVK2Q==",
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.2.6.tgz",
+      "integrity": "sha512-3mqtgpj/YSGFxtvTufSERRApo92B16JNNxz9p+5eG6PPuqTmuRJz214MqhKBEgLEAIQ6R6YCbd83ZDtjQnyw2g==",
       "dependencies": {
-        "@vue/reactivity": "3.2.21",
-        "@vue/shared": "3.2.21"
+        "@vue/reactivity": "3.2.6",
+        "@vue/shared": "3.2.6"
       }
     },
     "node_modules/@vue/runtime-dom": {
-      "version": "3.2.21",
-      "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.2.21.tgz",
-      "integrity": "sha512-apBdriD6QsI4ywbllY8kjr9/0scGuStDuvLbJULPQkFPtHzntd51bP5PQTQVAEIc9kwnTozmj6x6ZdX/cwo7xA==",
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.2.6.tgz",
+      "integrity": "sha512-fq33urnP0BNCGm2O3KCzkJlKIHI80C94HJ4qDZbjsTtxyOn5IHqwKSqXVN3RQvO6epcQH+sWS+JNwcNDPzoasg==",
       "dependencies": {
-        "@vue/runtime-core": "3.2.21",
-        "@vue/shared": "3.2.21",
+        "@vue/runtime-core": "3.2.6",
+        "@vue/shared": "3.2.6",
         "csstype": "^2.6.8"
       }
     },
@@ -5460,22 +5544,10 @@
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.18.tgz",
       "integrity": "sha512-RSU6Hyeg14am3Ah4VZEmeX8H7kLwEEirXe6aU2IPfKNvhXwTflK5HQRDNI0ypQXoqmm+QPyG2IaPuQE5zMwSIQ=="
     },
-    "node_modules/@vue/server-renderer": {
-      "version": "3.2.21",
-      "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.2.21.tgz",
-      "integrity": "sha512-QBgYqVgI7XCSBCqGa4LduV9vpfQFdZBOodFmq5Txk5W/v1KrJ1LoOh2Q0RHiRgtoK/UR9uyvRVcYqOmwHkZNEg==",
-      "dependencies": {
-        "@vue/compiler-ssr": "3.2.21",
-        "@vue/shared": "3.2.21"
-      },
-      "peerDependencies": {
-        "vue": "3.2.21"
-      }
-    },
     "node_modules/@vue/shared": {
-      "version": "3.2.21",
-      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.2.21.tgz",
-      "integrity": "sha512-5EQmIPK6gw4UVYUbM959B0uPsJ58+xoMESCZs3N89XyvJ9e+fX4pqEPrOGV8OroIk3SbEvJcC+eYc8BH9JQrHA=="
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.2.6.tgz",
+      "integrity": "sha512-uwX0Qs2e6kdF+WmxwuxJxOnKs/wEkMArtYpHSm7W+VY/23Tl8syMRyjnzEeXrNCAP0/8HZxEGkHJsjPEDNRuHw=="
     },
     "node_modules/@vue/test-utils": {
       "version": "2.0.0-rc.16",
@@ -6172,10 +6244,10 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/ansi-html": {
-      "version": "0.0.7",
-      "resolved": "https://registry.npmjs.org/ansi-html/-/ansi-html-0.0.7.tgz",
-      "integrity": "sha1-gTWEAhliqenm/QOflA0S9WynhZ4=",
+    "node_modules/ansi-html-community": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/ansi-html-community/-/ansi-html-community-0.0.8.tgz",
+      "integrity": "sha512-1APHAyr3+PCamwNw3bXCPp4HFLONZt/yIH0sZp0/469KWNTEy+qN5jQ3GVX6DMZ1UXAi34yVwtTeaG/HpBuuzw==",
       "dev": true,
       "engines": [
         "node >= 0.8.0"
@@ -13227,6 +13299,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/generic-names": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/generic-names/-/generic-names-2.0.1.tgz",
+      "integrity": "sha512-kPCHWa1m9wGG/OwQpeweTwM/PYiQLrUIxXbt/P4Nic3LbGjCP0YwrALHW1uNLKZ0LIMg+RF+XRlj2ekT9ZlZAQ==",
+      "dev": true,
+      "dependencies": {
+        "loader-utils": "^1.1.0"
+      }
+    },
     "node_modules/gensync": {
       "version": "1.0.0-beta.2",
       "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
@@ -14079,6 +14160,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/icss-replace-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/icss-replace-symbols/-/icss-replace-symbols-1.1.0.tgz",
+      "integrity": "sha1-Bupvg2ead0njhs/h/oEq5dsiPe0=",
+      "dev": true
     },
     "node_modules/icss-utils": {
       "version": "4.1.1",
@@ -16916,6 +17003,12 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
+    "node_modules/lodash.camelcase": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
+      "integrity": "sha1-soqmKIorn8ZRA1x3EfZathkDMaY=",
+      "dev": true
+    },
     "node_modules/lodash.debounce": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
@@ -17048,6 +17141,7 @@
       "version": "0.25.7",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.7.tgz",
       "integrity": "sha512-4CrMT5DOHTDk4HYDlzmwu4FVCcIYI8gauveasrdCu2IKIFOJ3f0v/8MDGJCDL9oD2ppz/Av1b0Nj345H9M+XIA==",
+      "dev": true,
       "dependencies": {
         "sourcemap-codec": "^1.4.4"
       }
@@ -17816,6 +17910,7 @@
       "version": "3.1.30",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.30.tgz",
       "integrity": "sha512-zJpuPDwOv8D2zq2WRoMe1HsfZthVewpel9CAvTfc/2mBD1uUT/agc5f7GHGWXlYkFvi1mVxe4IjvP2HNrop7nQ==",
+      "dev": true,
       "bin": {
         "nanoid": "bin/nanoid.cjs"
       },
@@ -22424,6 +22519,7 @@
       "version": "0.6.2",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-0.6.2.tgz",
       "integrity": "sha512-/3GptzWzu0+0MBQFrDKzw/DvvMTUORvgY6k6jd/VS6iCR4RDTKWH6v6WPwQoUO8667uQEf9Oe38DxAYWY5F/Ug==",
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -22469,7 +22565,8 @@
     "node_modules/sourcemap-codec": {
       "version": "1.4.8",
       "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
-      "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA=="
+      "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==",
+      "dev": true
     },
     "node_modules/spdx-correct": {
       "version": "3.1.1",
@@ -22854,6 +22951,12 @@
           "url": "https://feross.org/support"
         }
       ]
+    },
+    "node_modules/string-hash": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/string-hash/-/string-hash-1.1.3.tgz",
+      "integrity": "sha1-6Kr8CsGFW0Zmkp7X3RJ1311sgRs=",
+      "dev": true
     },
     "node_modules/string-length": {
       "version": "2.0.0",
@@ -24993,15 +25096,13 @@
       "dev": true
     },
     "node_modules/vue": {
-      "version": "3.2.21",
-      "resolved": "https://registry.npmjs.org/vue/-/vue-3.2.21.tgz",
-      "integrity": "sha512-jpy7ckXdyclfRzqLjL4mtq81AkzQleE54KjZsJg/9OorNVurAxdlU5XpD49GpjKdnftuffKUvx2C5jDOrgc/zg==",
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/vue/-/vue-3.2.6.tgz",
+      "integrity": "sha512-Zlb3LMemQS3Xxa6xPsecu45bNjr1hxO8Bh5FUmE0Dr6Ot0znZBKiM47rK6O7FTcakxOnvVN+NTXWJF6u8ajpCQ==",
       "dependencies": {
-        "@vue/compiler-dom": "3.2.21",
-        "@vue/compiler-sfc": "3.2.21",
-        "@vue/runtime-dom": "3.2.21",
-        "@vue/server-renderer": "3.2.21",
-        "@vue/shared": "3.2.21"
+        "@vue/compiler-dom": "3.2.6",
+        "@vue/runtime-dom": "3.2.6",
+        "@vue/shared": "3.2.6"
       }
     },
     "node_modules/vue-cli-plugin-webpack-bundle-analyzer": {
@@ -25120,9 +25221,9 @@
       }
     },
     "node_modules/vue-loader": {
-      "version": "16.8.3",
-      "resolved": "https://registry.npmjs.org/vue-loader/-/vue-loader-16.8.3.tgz",
-      "integrity": "sha512-7vKN45IxsKxe5GcVCbc2qFU5aWzyiLrYJyUuMz4BQLKctCj/fmCa0w6fGiiQ2cLFetNcek1ppGJQDCup0c1hpA==",
+      "version": "16.8.1",
+      "resolved": "https://registry.npmjs.org/vue-loader/-/vue-loader-16.8.1.tgz",
+      "integrity": "sha512-V53TJbHmzjBhCG5OYI2JWy/aYDspz4oVHKxS43Iy212GjGIG1T3EsB3+GWXFm/1z5VwjdjLmdZUFYM70y77vtQ==",
       "dev": true,
       "dependencies": {
         "chalk": "^4.1.0",
@@ -26547,12 +26648,12 @@
       }
     },
     "node_modules/webpack-dev-server": {
-      "version": "3.11.2",
-      "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-3.11.2.tgz",
-      "integrity": "sha512-A80BkuHRQfCiNtGBS1EMf2ChTUs0x+B3wGDFmOeT4rmJOHhHTCH2naNxIHhmkr0/UillP4U3yeIyv1pNp+QDLQ==",
+      "version": "3.11.3",
+      "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-3.11.3.tgz",
+      "integrity": "sha512-3x31rjbEQWKMNzacUZRE6wXvUFuGpH7vr0lIEbYpMAG9BOxi0928QU1BBswOAP3kg3H1O4hiS+sq4YyAn6ANnA==",
       "dev": true,
       "dependencies": {
-        "ansi-html": "0.0.7",
+        "ansi-html-community": "0.0.8",
         "bonjour": "^3.5.0",
         "chokidar": "^2.1.8",
         "compression": "^1.7.4",
@@ -29129,7 +29230,7 @@
       }
     },
     "@balancer-labs/assets": {
-      "version": "git+ssh://git@github.com/balancer-labs/assets.git#71d3d528d3d0690bd75c1cf287910ae92533f045",
+      "version": "git+ssh://git@github.com/balancer-labs/assets.git#d87715591f429c46615ad4979b614ec50adcd800",
       "from": "@balancer-labs/assets@github:balancer-labs/assets#master",
       "requires": {
         "dotenv": "^8.2.0"
@@ -29285,18 +29386,6 @@
         "@ethersproject/properties": "^5.4.0",
         "@ethersproject/transactions": "^5.4.0",
         "@ethersproject/web": "^5.4.0"
-      },
-      "dependencies": {
-        "@ethersproject/bignumber": {
-          "version": "5.5.0",
-          "resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.5.0.tgz",
-          "integrity": "sha512-6Xytlwvy6Rn3U3gKEc1vP7nR92frHkv6wtVr95LFR3jREXiCPzdWxKQ1cx4JGQBXxcguAwjA8murlYN2TSiEbg==",
-          "requires": {
-            "@ethersproject/bytes": "^5.5.0",
-            "@ethersproject/logger": "^5.5.0",
-            "bn.js": "^4.11.9"
-          }
-        }
       }
     },
     "@ethersproject/abstract-signer": {
@@ -29309,18 +29398,6 @@
         "@ethersproject/bytes": "^5.4.0",
         "@ethersproject/logger": "^5.4.0",
         "@ethersproject/properties": "^5.4.0"
-      },
-      "dependencies": {
-        "@ethersproject/bignumber": {
-          "version": "5.5.0",
-          "resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.5.0.tgz",
-          "integrity": "sha512-6Xytlwvy6Rn3U3gKEc1vP7nR92frHkv6wtVr95LFR3jREXiCPzdWxKQ1cx4JGQBXxcguAwjA8murlYN2TSiEbg==",
-          "requires": {
-            "@ethersproject/bytes": "^5.5.0",
-            "@ethersproject/logger": "^5.5.0",
-            "bn.js": "^4.11.9"
-          }
-        }
       }
     },
     "@ethersproject/address": {
@@ -31634,12 +31711,13 @@
       }
     },
     "@vue/compiler-core": {
-      "version": "3.2.21",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.2.21.tgz",
-      "integrity": "sha512-NhhiQZNG71KNq1h5pMW/fAXdTF7lJRaSI7LDm2edhHXVz1ROMICo8SreUmQnSf4Fet0UPBVqJ988eF4+936iDQ==",
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.2.6.tgz",
+      "integrity": "sha512-vbwnz7+OhtLO5p5i630fTuQCL+MlUpEMTKHuX+RfetQ+3pFCkItt2JUH+9yMaBG2Hkz6av+T9mwN/acvtIwpbw==",
       "requires": {
         "@babel/parser": "^7.15.0",
-        "@vue/shared": "3.2.21",
+        "@babel/types": "^7.15.0",
+        "@vue/shared": "3.2.6",
         "estree-walker": "^2.0.2",
         "source-map": "^0.6.1"
       },
@@ -31652,60 +31730,147 @@
       }
     },
     "@vue/compiler-dom": {
-      "version": "3.2.21",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.2.21.tgz",
-      "integrity": "sha512-gsJD3DpYZSYquiA7UIPsMDSlAooYWDvHPq9VRsqzJEk2PZtFvLvHPb4aaMD8Ufd62xzYn32cnnkzsEOJhyGilA==",
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.2.6.tgz",
+      "integrity": "sha512-+a/3oBAzFIXhHt8L5IHJOTP4a5egzvpXYyi13jR7CUYOR1S+Zzv7vBWKYBnKyJLwnrxTZnTQVjeHCgJq743XKg==",
       "requires": {
-        "@vue/compiler-core": "3.2.21",
-        "@vue/shared": "3.2.21"
+        "@vue/compiler-core": "3.2.6",
+        "@vue/shared": "3.2.6"
       }
     },
     "@vue/compiler-sfc": {
-      "version": "3.2.21",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.2.21.tgz",
-      "integrity": "sha512-+yDlUSebKpz/ovxM2vLRRx7w/gVfY767pOfYTgbIhAs+ogvIV2BsIt4fpxlThnlCNChJ+yE0ERUNoROv2kEGEQ==",
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.2.6.tgz",
+      "integrity": "sha512-Ariz1eDsf+2fw6oWXVwnBNtfKHav72RjlWXpEgozYBLnfRPzP+7jhJRw4Nq0OjSsLx2HqjF3QX7HutTjYB0/eA==",
+      "dev": true,
       "requires": {
         "@babel/parser": "^7.15.0",
-        "@vue/compiler-core": "3.2.21",
-        "@vue/compiler-dom": "3.2.21",
-        "@vue/compiler-ssr": "3.2.21",
-        "@vue/ref-transform": "3.2.21",
-        "@vue/shared": "3.2.21",
+        "@babel/types": "^7.15.0",
+        "@types/estree": "^0.0.48",
+        "@vue/compiler-core": "3.2.6",
+        "@vue/compiler-dom": "3.2.6",
+        "@vue/compiler-ssr": "3.2.6",
+        "@vue/ref-transform": "3.2.6",
+        "@vue/shared": "3.2.6",
+        "consolidate": "^0.16.0",
         "estree-walker": "^2.0.2",
+        "hash-sum": "^2.0.0",
+        "lru-cache": "^5.1.1",
         "magic-string": "^0.25.7",
+        "merge-source-map": "^1.1.0",
         "postcss": "^8.1.10",
+        "postcss-modules": "^4.0.0",
+        "postcss-selector-parser": "^6.0.4",
         "source-map": "^0.6.1"
       },
       "dependencies": {
+        "@types/estree": {
+          "version": "0.0.48",
+          "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.48.tgz",
+          "integrity": "sha512-LfZwXoGUDo0C3me81HXgkBg5CTQYb6xzEl+fNmbO4JdRiSKQ8A0GD1OBBvKAIsbCUgoyAty7m99GqqMQe784ew==",
+          "dev": true
+        },
+        "consolidate": {
+          "version": "0.16.0",
+          "resolved": "https://registry.npmjs.org/consolidate/-/consolidate-0.16.0.tgz",
+          "integrity": "sha512-Nhl1wzCslqXYTJVDyJCu3ODohy9OfBMB5uD2BiBTzd7w+QY0lBzafkR8y8755yMYHAaMD4NuzbAw03/xzfw+eQ==",
+          "dev": true,
+          "requires": {
+            "bluebird": "^3.7.2"
+          }
+        },
+        "icss-utils": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/icss-utils/-/icss-utils-5.1.0.tgz",
+          "integrity": "sha512-soFhflCVWLfRNOPU3iv5Z9VUdT44xFRbzjLsEzSr5AQmgqPMTHdU3PMT1Cf1ssx8fLNJDA1juftYl+PUcv3MqA==",
+          "dev": true,
+          "requires": {}
+        },
         "picocolors": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
-          "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ=="
+          "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==",
+          "dev": true
         },
         "postcss": {
           "version": "8.3.11",
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.3.11.tgz",
           "integrity": "sha512-hCmlUAIlUiav8Xdqw3Io4LcpA1DOt7h3LSTAC4G6JGHFFaWzI6qvFt9oilvl8BmkbBRX1IhM90ZAmpk68zccQA==",
+          "dev": true,
           "requires": {
             "nanoid": "^3.1.30",
             "picocolors": "^1.0.0",
             "source-map-js": "^0.6.2"
           }
         },
+        "postcss-modules": {
+          "version": "4.2.2",
+          "resolved": "https://registry.npmjs.org/postcss-modules/-/postcss-modules-4.2.2.tgz",
+          "integrity": "sha512-/H08MGEmaalv/OU8j6bUKi/kZr2kqGF6huAW8m9UAgOLWtpFdhA14+gPBoymtqyv+D4MLsmqaF2zvIegdCxJXg==",
+          "dev": true,
+          "requires": {
+            "generic-names": "^2.0.1",
+            "icss-replace-symbols": "^1.1.0",
+            "lodash.camelcase": "^4.3.0",
+            "postcss-modules-extract-imports": "^3.0.0",
+            "postcss-modules-local-by-default": "^4.0.0",
+            "postcss-modules-scope": "^3.0.0",
+            "postcss-modules-values": "^4.0.0",
+            "string-hash": "^1.1.1"
+          }
+        },
+        "postcss-modules-extract-imports": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/postcss-modules-extract-imports/-/postcss-modules-extract-imports-3.0.0.tgz",
+          "integrity": "sha512-bdHleFnP3kZ4NYDhuGlVK+CMrQ/pqUm8bx/oGL93K6gVwiclvX5x0n76fYMKuIGKzlABOy13zsvqjb0f92TEXw==",
+          "dev": true,
+          "requires": {}
+        },
+        "postcss-modules-local-by-default": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/postcss-modules-local-by-default/-/postcss-modules-local-by-default-4.0.0.tgz",
+          "integrity": "sha512-sT7ihtmGSF9yhm6ggikHdV0hlziDTX7oFoXtuVWeDd3hHObNkcHRo9V3yg7vCAY7cONyxJC/XXCmmiHHcvX7bQ==",
+          "dev": true,
+          "requires": {
+            "icss-utils": "^5.0.0",
+            "postcss-selector-parser": "^6.0.2",
+            "postcss-value-parser": "^4.1.0"
+          }
+        },
+        "postcss-modules-scope": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/postcss-modules-scope/-/postcss-modules-scope-3.0.0.tgz",
+          "integrity": "sha512-hncihwFA2yPath8oZ15PZqvWGkWf+XUfQgUGamS4LqoP1anQLOsOJw0vr7J7IwLpoY9fatA2qiGUGmuZL0Iqlg==",
+          "dev": true,
+          "requires": {
+            "postcss-selector-parser": "^6.0.4"
+          }
+        },
+        "postcss-modules-values": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/postcss-modules-values/-/postcss-modules-values-4.0.0.tgz",
+          "integrity": "sha512-RDxHkAiEGI78gS2ofyvCsu7iycRv7oqw5xMWn9iMoR0N/7mf9D50ecQqUo5BZ9Zh2vH4bCUR/ktCqbB9m8vJjQ==",
+          "dev": true,
+          "requires": {
+            "icss-utils": "^5.0.0"
+          }
+        },
         "source-map": {
           "version": "0.6.1",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
         }
       }
     },
     "@vue/compiler-ssr": {
-      "version": "3.2.21",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.2.21.tgz",
-      "integrity": "sha512-eU+A0iWYy+1zAo2CRIJ0zSVlv1iuGAIbNRCnllSJ31pV1lX3jypJYzGbJlSRAbB7VP6E+tYveVT1Oq8JKewa3g==",
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.2.6.tgz",
+      "integrity": "sha512-A7IKRKHSyPnTC4w1FxHkjzoyjXInsXkcs/oX22nBQ+6AWlXj2Tt1le96CWPOXy5vYlsTYkF1IgfBaKIdeN/39g==",
+      "dev": true,
       "requires": {
-        "@vue/compiler-dom": "3.2.21",
-        "@vue/shared": "3.2.21"
+        "@vue/compiler-dom": "3.2.6",
+        "@vue/shared": "3.2.6"
       }
     },
     "@vue/component-compiler-utils": {
@@ -31786,41 +31951,42 @@
       "requires": {}
     },
     "@vue/reactivity": {
-      "version": "3.2.21",
-      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.2.21.tgz",
-      "integrity": "sha512-7C57zFm/5E3SSTUhVuYj1InDwuJ+GIVQ/z+H43C9sST85gIThGXVhksl1yWTAadf8Yz4T5lSbqi5Ds8U/ueWcw==",
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.2.6.tgz",
+      "integrity": "sha512-8vIDD2wpCnYisNNZjmcIj+Rixn0uhZNY3G1vzlgdVdLygeRSuFjkmnZk6WwvGzUWpKfnG0e/NUySM3mVi59hAA==",
       "requires": {
-        "@vue/shared": "3.2.21"
+        "@vue/shared": "3.2.6"
       }
     },
     "@vue/ref-transform": {
-      "version": "3.2.21",
-      "resolved": "https://registry.npmjs.org/@vue/ref-transform/-/ref-transform-3.2.21.tgz",
-      "integrity": "sha512-uiEWWBsrGeun9O7dQExYWzXO3rHm/YdtFNXDVqCSoPypzOVxWxdiL+8hHeWzxMB58fVuV2sT80aUtIVyaBVZgQ==",
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vue/ref-transform/-/ref-transform-3.2.6.tgz",
+      "integrity": "sha512-ie39+Y4nbirDLvH+WEq6Eo/l3n3mFATayqR+kEMSphrtMW6Uh/eEMx1Gk2Jnf82zmj3VLRq7dnmPx72JLcBYkQ==",
+      "dev": true,
       "requires": {
         "@babel/parser": "^7.15.0",
-        "@vue/compiler-core": "3.2.21",
-        "@vue/shared": "3.2.21",
+        "@vue/compiler-core": "3.2.6",
+        "@vue/shared": "3.2.6",
         "estree-walker": "^2.0.2",
         "magic-string": "^0.25.7"
       }
     },
     "@vue/runtime-core": {
-      "version": "3.2.21",
-      "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.2.21.tgz",
-      "integrity": "sha512-7oOxKaU0D2IunOAMOOHZgJVrHg63xwng8BZx3fbgmakqEIMwHhQcp+5GV1sOg/sWW7R4UhaRDIUCukO2GRVK2Q==",
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.2.6.tgz",
+      "integrity": "sha512-3mqtgpj/YSGFxtvTufSERRApo92B16JNNxz9p+5eG6PPuqTmuRJz214MqhKBEgLEAIQ6R6YCbd83ZDtjQnyw2g==",
       "requires": {
-        "@vue/reactivity": "3.2.21",
-        "@vue/shared": "3.2.21"
+        "@vue/reactivity": "3.2.6",
+        "@vue/shared": "3.2.6"
       }
     },
     "@vue/runtime-dom": {
-      "version": "3.2.21",
-      "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.2.21.tgz",
-      "integrity": "sha512-apBdriD6QsI4ywbllY8kjr9/0scGuStDuvLbJULPQkFPtHzntd51bP5PQTQVAEIc9kwnTozmj6x6ZdX/cwo7xA==",
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.2.6.tgz",
+      "integrity": "sha512-fq33urnP0BNCGm2O3KCzkJlKIHI80C94HJ4qDZbjsTtxyOn5IHqwKSqXVN3RQvO6epcQH+sWS+JNwcNDPzoasg==",
       "requires": {
-        "@vue/runtime-core": "3.2.21",
-        "@vue/shared": "3.2.21",
+        "@vue/runtime-core": "3.2.6",
+        "@vue/shared": "3.2.6",
         "csstype": "^2.6.8"
       },
       "dependencies": {
@@ -31831,19 +31997,10 @@
         }
       }
     },
-    "@vue/server-renderer": {
-      "version": "3.2.21",
-      "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.2.21.tgz",
-      "integrity": "sha512-QBgYqVgI7XCSBCqGa4LduV9vpfQFdZBOodFmq5Txk5W/v1KrJ1LoOh2Q0RHiRgtoK/UR9uyvRVcYqOmwHkZNEg==",
-      "requires": {
-        "@vue/compiler-ssr": "3.2.21",
-        "@vue/shared": "3.2.21"
-      }
-    },
     "@vue/shared": {
-      "version": "3.2.21",
-      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.2.21.tgz",
-      "integrity": "sha512-5EQmIPK6gw4UVYUbM959B0uPsJ58+xoMESCZs3N89XyvJ9e+fX4pqEPrOGV8OroIk3SbEvJcC+eYc8BH9JQrHA=="
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.2.6.tgz",
+      "integrity": "sha512-uwX0Qs2e6kdF+WmxwuxJxOnKs/wEkMArtYpHSm7W+VY/23Tl8syMRyjnzEeXrNCAP0/8HZxEGkHJsjPEDNRuHw=="
     },
     "@vue/test-utils": {
       "version": "2.0.0-rc.16",
@@ -32443,10 +32600,10 @@
         "type-fest": "^0.21.3"
       }
     },
-    "ansi-html": {
-      "version": "0.0.7",
-      "resolved": "https://registry.npmjs.org/ansi-html/-/ansi-html-0.0.7.tgz",
-      "integrity": "sha1-gTWEAhliqenm/QOflA0S9WynhZ4=",
+    "ansi-html-community": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/ansi-html-community/-/ansi-html-community-0.0.8.tgz",
+      "integrity": "sha512-1APHAyr3+PCamwNw3bXCPp4HFLONZt/yIH0sZp0/469KWNTEy+qN5jQ3GVX6DMZ1UXAi34yVwtTeaG/HpBuuzw==",
       "dev": true
     },
     "ansi-regex": {
@@ -38190,6 +38347,15 @@
         }
       }
     },
+    "generic-names": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/generic-names/-/generic-names-2.0.1.tgz",
+      "integrity": "sha512-kPCHWa1m9wGG/OwQpeweTwM/PYiQLrUIxXbt/P4Nic3LbGjCP0YwrALHW1uNLKZ0LIMg+RF+XRlj2ekT9ZlZAQ==",
+      "dev": true,
+      "requires": {
+        "loader-utils": "^1.1.0"
+      }
+    },
     "gensync": {
       "version": "1.0.0-beta.2",
       "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
@@ -38859,6 +39025,12 @@
       "requires": {
         "safer-buffer": ">= 2.1.2 < 3"
       }
+    },
+    "icss-replace-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/icss-replace-symbols/-/icss-replace-symbols-1.1.0.tgz",
+      "integrity": "sha1-Bupvg2ead0njhs/h/oEq5dsiPe0=",
+      "dev": true
     },
     "icss-utils": {
       "version": "4.1.1",
@@ -41137,6 +41309,12 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
+    "lodash.camelcase": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
+      "integrity": "sha1-soqmKIorn8ZRA1x3EfZathkDMaY=",
+      "dev": true
+    },
     "lodash.debounce": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
@@ -41253,6 +41431,7 @@
       "version": "0.25.7",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.7.tgz",
       "integrity": "sha512-4CrMT5DOHTDk4HYDlzmwu4FVCcIYI8gauveasrdCu2IKIFOJ3f0v/8MDGJCDL9oD2ppz/Av1b0Nj345H9M+XIA==",
+      "dev": true,
       "requires": {
         "sourcemap-codec": "^1.4.4"
       }
@@ -41918,7 +42097,8 @@
     "nanoid": {
       "version": "3.1.30",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.30.tgz",
-      "integrity": "sha512-zJpuPDwOv8D2zq2WRoMe1HsfZthVewpel9CAvTfc/2mBD1uUT/agc5f7GHGWXlYkFvi1mVxe4IjvP2HNrop7nQ=="
+      "integrity": "sha512-zJpuPDwOv8D2zq2WRoMe1HsfZthVewpel9CAvTfc/2mBD1uUT/agc5f7GHGWXlYkFvi1mVxe4IjvP2HNrop7nQ==",
+      "dev": true
     },
     "nanomatch": {
       "version": "1.2.13",
@@ -45679,7 +45859,8 @@
     "source-map-js": {
       "version": "0.6.2",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-0.6.2.tgz",
-      "integrity": "sha512-/3GptzWzu0+0MBQFrDKzw/DvvMTUORvgY6k6jd/VS6iCR4RDTKWH6v6WPwQoUO8667uQEf9Oe38DxAYWY5F/Ug=="
+      "integrity": "sha512-/3GptzWzu0+0MBQFrDKzw/DvvMTUORvgY6k6jd/VS6iCR4RDTKWH6v6WPwQoUO8667uQEf9Oe38DxAYWY5F/Ug==",
+      "dev": true
     },
     "source-map-resolve": {
       "version": "0.5.3",
@@ -45721,7 +45902,8 @@
     "sourcemap-codec": {
       "version": "1.4.8",
       "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
-      "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA=="
+      "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==",
+      "dev": true
     },
     "spdx-correct": {
       "version": "3.1.1",
@@ -46047,6 +46229,12 @@
           "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
         }
       }
+    },
+    "string-hash": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/string-hash/-/string-hash-1.1.3.tgz",
+      "integrity": "sha1-6Kr8CsGFW0Zmkp7X3RJ1311sgRs=",
+      "dev": true
     },
     "string-length": {
       "version": "2.0.0",
@@ -47725,15 +47913,13 @@
       "dev": true
     },
     "vue": {
-      "version": "3.2.21",
-      "resolved": "https://registry.npmjs.org/vue/-/vue-3.2.21.tgz",
-      "integrity": "sha512-jpy7ckXdyclfRzqLjL4mtq81AkzQleE54KjZsJg/9OorNVurAxdlU5XpD49GpjKdnftuffKUvx2C5jDOrgc/zg==",
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/vue/-/vue-3.2.6.tgz",
+      "integrity": "sha512-Zlb3LMemQS3Xxa6xPsecu45bNjr1hxO8Bh5FUmE0Dr6Ot0znZBKiM47rK6O7FTcakxOnvVN+NTXWJF6u8ajpCQ==",
       "requires": {
-        "@vue/compiler-dom": "3.2.21",
-        "@vue/compiler-sfc": "3.2.21",
-        "@vue/runtime-dom": "3.2.21",
-        "@vue/server-renderer": "3.2.21",
-        "@vue/shared": "3.2.21"
+        "@vue/compiler-dom": "3.2.6",
+        "@vue/runtime-dom": "3.2.6",
+        "@vue/shared": "3.2.6"
       }
     },
     "vue-cli-plugin-webpack-bundle-analyzer": {
@@ -47808,9 +47994,9 @@
       }
     },
     "vue-loader": {
-      "version": "16.8.3",
-      "resolved": "https://registry.npmjs.org/vue-loader/-/vue-loader-16.8.3.tgz",
-      "integrity": "sha512-7vKN45IxsKxe5GcVCbc2qFU5aWzyiLrYJyUuMz4BQLKctCj/fmCa0w6fGiiQ2cLFetNcek1ppGJQDCup0c1hpA==",
+      "version": "16.8.1",
+      "resolved": "https://registry.npmjs.org/vue-loader/-/vue-loader-16.8.1.tgz",
+      "integrity": "sha512-V53TJbHmzjBhCG5OYI2JWy/aYDspz4oVHKxS43Iy212GjGIG1T3EsB3+GWXFm/1z5VwjdjLmdZUFYM70y77vtQ==",
       "dev": true,
       "requires": {
         "chalk": "^4.1.0",
@@ -49072,12 +49258,12 @@
       }
     },
     "webpack-dev-server": {
-      "version": "3.11.2",
-      "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-3.11.2.tgz",
-      "integrity": "sha512-A80BkuHRQfCiNtGBS1EMf2ChTUs0x+B3wGDFmOeT4rmJOHhHTCH2naNxIHhmkr0/UillP4U3yeIyv1pNp+QDLQ==",
+      "version": "3.11.3",
+      "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-3.11.3.tgz",
+      "integrity": "sha512-3x31rjbEQWKMNzacUZRE6wXvUFuGpH7vr0lIEbYpMAG9BOxi0928QU1BBswOAP3kg3H1O4hiS+sq4YyAn6ANnA==",
       "dev": true,
       "requires": {
-        "ansi-html": "0.0.7",
+        "ansi-html-community": "0.0.8",
         "bonjour": "^3.5.0",
         "chokidar": "^2.1.8",
         "compression": "^1.7.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -98,7 +98,6 @@
         "tailwind-config-viewer": "^1.5.0",
         "tailwindcss": "npm:@tailwindcss/postcss7-compat@^2.2.17",
         "typescript": "^4.3.5",
-        "vue": "3.2.6",
         "vue-cli-plugin-webpack-bundle-analyzer": "^2.0.0",
         "vue-loader": "^16.8.1",
         "worker-loader": "^3.0.8"

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "paraswap": "^4.18.0",
     "parse-filepath": "1.0.2",
     "swiper": "^6.4.5",
-    "vue": "^3.2.6",
+    "vue": "3.2.6",
     "vue-composable-tester": "^0.1.3",
     "vue-echarts": "^6.0.0",
     "vue-i18n": "^9.0.0-rc.1",
@@ -65,6 +65,7 @@
     "web3-utils": "^1.3.1"
   },
   "devDependencies": {
+    "vue": "3.2.6",
     "@ethersproject/abi": "~5.4.1",
     "@ethersproject/address": "~5.4.0",
     "@ethersproject/bignumber": "~5.4.2",
@@ -90,7 +91,7 @@
     "@vue/cli-plugin-unit-jest": "^4.5.9",
     "@vue/cli-plugin-vuex": "^4.4.0",
     "@vue/cli-service": "^4.4.0",
-    "@vue/compiler-sfc": "^3.2.6",
+    "@vue/compiler-sfc": "3.2.6",
     "@vue/eslint-config-prettier": "^6.0.0",
     "@vue/eslint-config-typescript": "^7.0.0",
     "@vue/test-utils": "^2.0.0-alpha.1",

--- a/package.json
+++ b/package.json
@@ -65,7 +65,6 @@
     "web3-utils": "^1.3.1"
   },
   "devDependencies": {
-    "vue": "3.2.6",
     "@ethersproject/abi": "~5.4.1",
     "@ethersproject/address": "~5.4.0",
     "@ethersproject/bignumber": "~5.4.2",


### PR DESCRIPTION
# Description

During the pkg upgrades for the SOR v2, a combination of vue/vue-compiler-sfc minor version upgrades caused issues with boolean props not being compiled properly in the new script setup syntax components. This PR locks vue/vue-compiler-sfc pkg versions for now until we can investigate why this happens.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## How should this be tested?

- [x] Check that you can't select any token in the invest flow.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] My changes generate no new console warnings
- [x] The base of this PR is `master` if hotfix, `develop` if not
