### PR TITLE
Hotfix 1.27.2 - Trade input validation patch

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.27.1",
+  "version": "1.27.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@balancer-labs/frontend-v2",
-      "version": "1.27.1",
+      "version": "1.27.2",
       "license": "MIT",
       "dependencies": {
         "@balancer-labs/assets": "github:balancer-labs/assets#master",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.27.1",
+  "version": "1.27.2",
   "engines": {
     "node": "14.x",
     "npm": ">=7"

--- a/src/components/cards/TradeCard/TradePair.vue
+++ b/src/components/cards/TradeCard/TradePair.vue
@@ -18,6 +18,7 @@ type Props = {
   exactIn: boolean;
   priceImpact?: number;
   effectivePriceMessage?: UseTrading['effectivePriceMessage'];
+  tradeLoading?: boolean;
 };
 
 /**
@@ -135,6 +136,7 @@ watchEffect(() => {
       @update:amount="handleInAmountChange"
       @update:address="emit('update:tokenInAddress', $event)"
       :excludedTokens="[_tokenOutAddress]"
+      :disabled="tradeLoading"
     />
 
     <div class="flex items-center my-2">
@@ -157,6 +159,7 @@ watchEffect(() => {
       @update:address="emit('update:tokenOutAddress', $event)"
       noRules
       noMax
+      :disabled="tradeLoading"
       :excludedTokens="[_tokenInAddress]"
     />
   </div>

--- a/src/components/cards/TradeCardGP/TradeCardGP.vue
+++ b/src/components/cards/TradeCardGP/TradeCardGP.vue
@@ -17,6 +17,7 @@
         v-model:tokenOutAddress="tokenOutAddress"
         v-model:exactIn="exactIn"
         :effectivePriceMessage="trading.effectivePriceMessage"
+        :tradeLoading="trading.isLoading.value"
         @amountChange="trading.handleAmountChange"
         class="mb-4"
       />
@@ -50,6 +51,7 @@
       <BalBtn
         v-if="trading.isLoading.value"
         :loading="true"
+        :disabled="true"
         :loading-label="
           trading.isGnosisTrade.value ? $t('loadingBestPrice') : $t('loading')
         "


### PR DESCRIPTION
# Description

If you input values to the trade interface too quickly, i.e. before the `trading.isLoading` flag is true then you get validation errors that don't reactively change when the trading data is ready. This is a temporary patch to prevent input before loading is finished.

At some point we need to refactor how this works. Ideally, you should be able to enter whatever you want while the data loads in the background, and once the data is ready it checks if the trade is valid again and presents the trade or errors.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## How should this be tested?

- [ ] Test that you can't enter numbers into the trade interface before the preview button stops loading.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] My changes generate no new console warnings
- [x] The base of this PR is `master` if hotfix, `develop` if not
