### PR TITLE
Hotfix 1.27.4 - Fix ETH trades

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.27.3",
+  "version": "1.27.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@balancer-labs/frontend-v2",
-      "version": "1.27.3",
+      "version": "1.27.4",
       "license": "MIT",
       "dependencies": {
         "@balancer-labs/assets": "github:balancer-labs/assets#master",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.27.3",
+  "version": "1.27.4",
   "engines": {
     "node": "14.x",
     "npm": ">=7"

--- a/src/lib/utils/balancer/swapper.ts
+++ b/src/lib/utils/balancer/swapper.ts
@@ -113,7 +113,7 @@ export async function batchSwapGivenInV1(
   const overrides: any = {};
 
   if (tokenIn === NATIVE_ASSET_ADDRESS) {
-    overrides.value = `0x${tokenInAmount.toHexString()}`;
+    overrides.value = tokenInAmount.toHexString();
   }
 
   try {
@@ -149,7 +149,7 @@ export async function batchSwapGivenOutV1(
   const overrides: any = {};
 
   if (tokenIn === NATIVE_ASSET_ADDRESS) {
-    overrides.value = `0x${tokenInAmountMax.toHexString()}`;
+    overrides.value = tokenInAmountMax.toHexString();
   }
 
   try {
@@ -181,7 +181,7 @@ async function batchSwapGivenInV2(
   const overrides: any = {};
 
   if (tokenIn === AddressZero) {
-    overrides.value = `0x${tokenInAmount.toHexString()}`;
+    overrides.value = tokenInAmount.toHexString();
   }
 
   const address = await web3.getSigner().getAddress();
@@ -261,7 +261,7 @@ async function batchSwapGivenOutV2(
   const overrides: any = {};
 
   if (tokenIn === AddressZero) {
-    overrides.value = `0x${tokenInAmountMax.toHexString()}`;
+    overrides.value = tokenInAmountMax.toHexString();
   }
 
   const address = await web3.getSigner().getAddress();
@@ -341,7 +341,7 @@ async function lidoBatchSwapGivenIn(
   const overrides: any = {};
 
   if (tokenIn === AddressZero) {
-    overrides.value = `0x${tokenInAmount.toHexString()}`;
+    overrides.value = tokenInAmount.toHexString();
   }
 
   // Convert tokenIn/tokenOut so that it matches what's in tokenAddresses
@@ -431,7 +431,7 @@ async function lidoBatchSwapGivenOut(
   const overrides: any = {};
 
   if (tokenIn === AddressZero) {
-    overrides.value = `0x${tokenInAmountMax.toHexString()}`;
+    overrides.value = tokenInAmountMax.toHexString();
   }
 
   // Convert tokenIn/tokenOut so that it matches what's in tokenAddresses


### PR DESCRIPTION
# Description

Prepending 0x to a toHexString string seems to result in a double 0x0x... this PR removes that prepending for transaction values.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## How should this be tested?

- [ ] Test ETH trades work

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] My changes generate no new console warnings
- [x] The base of this PR is `master` if hotfix, `develop` if not
