### PR TITLE
hotfix/1.27.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.27.4",
+  "version": "1.27.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@balancer-labs/frontend-v2",
-      "version": "1.27.4",
+      "version": "1.27.5",
       "license": "MIT",
       "dependencies": {
         "@balancer-labs/assets": "github:balancer-labs/assets#master",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.27.4",
+  "version": "1.27.5",
   "engines": {
     "node": "14.x",
     "npm": ">=7"

--- a/src/composables/trade/useGnosis.ts
+++ b/src/composables/trade/useGnosis.ts
@@ -290,6 +290,10 @@ export default function useGnosis({
       ? tokenInAmountScaled.value
       : tokenOutAmountScaled.value;
 
+    if (amountToExchange === undefined) {
+      return;
+    }
+
     if (amountToExchange.isZero()) {
       tokenInAmountInput.value = '0';
       tokenOutAmountInput.value = '0';


### PR DESCRIPTION
Fixes this bug:

<img width="743" alt="Screen Shot 2021-11-11 at 11 03 11 am" src="https://user-images.githubusercontent.com/254095/141213065-e57297e1-c47d-483e-8541-a5b655fe6369.png">

Adds a guard to protect from undefined amount being accessed.