### PR TITLE
fix: trade input validation fix for Balancer routed trades

### DIFF
--- a/src/components/cards/TradeCard/TradePair.vue
+++ b/src/components/cards/TradeCard/TradePair.vue
@@ -18,6 +18,7 @@ type Props = {
   exactIn: boolean;
   priceImpact?: number;
   effectivePriceMessage?: UseTrading['effectivePriceMessage'];
+  tradeLoading?: boolean;
 };
 
 /**
@@ -135,6 +136,7 @@ watchEffect(() => {
       @update:amount="handleInAmountChange"
       @update:address="emit('update:tokenInAddress', $event)"
       :excludedTokens="[_tokenOutAddress]"
+      :disabled="tradeLoading"
     />
 
     <div class="flex items-center my-2">
@@ -157,6 +159,7 @@ watchEffect(() => {
       @update:address="emit('update:tokenOutAddress', $event)"
       noRules
       noMax
+      :disabled="tradeLoading"
       :excludedTokens="[_tokenInAddress]"
     />
   </div>

--- a/src/components/cards/TradeCardGP/TradeCardGP.vue
+++ b/src/components/cards/TradeCardGP/TradeCardGP.vue
@@ -52,8 +52,8 @@
       />
       <BalBtn
         v-if="trading.isLoading.value"
-        :loading="true"
-        :disabled="true"
+        loading
+        disabled
         :loading-label="
           trading.isGnosisTrade.value ? $t('loadingBestPrice') : $t('loading')
         "

--- a/src/components/cards/TradeCardGP/TradeCardGP.vue
+++ b/src/components/cards/TradeCardGP/TradeCardGP.vue
@@ -16,6 +16,9 @@
         v-model:tokenOutAmount="tokenOutAmount"
         v-model:tokenOutAddress="tokenOutAddress"
         v-model:exactIn="exactIn"
+        :tradeLoading="
+          trading.isBalancerTrade.value ? trading.isLoading.value : false
+        "
         :effectivePriceMessage="trading.effectivePriceMessage"
         @amountChange="trading.handleAmountChange"
         class="mb-4"
@@ -49,8 +52,8 @@
       />
       <BalBtn
         v-if="trading.isLoading.value"
-        loading
-        disabled
+        :loading="true"
+        :disabled="true"
         :loading-label="
           trading.isGnosisTrade.value ? $t('loadingBestPrice') : $t('loading')
         "


### PR DESCRIPTION
# Description

This is a follow to https://github.com/balancer-labs/frontend-v2/pull/1065
The problem was that Gnosis didn't really need this check since its "loading" state is more like "refreshing". For Balancer routed trades - this is a good solution.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## How should this be tested?

Please provide instructions so we can test. Please also list any relevant details for your test configuration.

- [ ] Try to input quickly before the pools are loaded (Balancer trades) - it won't let you since the input is disabled.
- [ ] Gnosis / Wrapped trades should be working as normal (without losing their focus)


## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] My changes generate no new console warnings
- [x] The base of this PR is `master` if hotfix, `develop` if not
