### PR TITLE
Always allow pool owner to view their own pools

### DIFF
--- a/src/composables/queries/usePoolQuery.ts
+++ b/src/composables/queries/usePoolQuery.ts
@@ -9,6 +9,7 @@ import { FullPool } from '@/services/balancer/subgraph/types';
 import { POOLS } from '@/constants/pools';
 import useApp from '../useApp';
 import useUserSettings from '../useUserSettings';
+import useWeb3 from '@/services/web3/useWeb3';
 import { forChange } from '@/lib/utils';
 import { isManaged, isStableLike } from '../usePool';
 import { getAddress } from '@ethersproject/address';
@@ -22,6 +23,7 @@ export default function usePoolQuery(
    */
   const { getTokens, injectTokens, prices, dynamicDataLoading } = useTokens();
   const { appLoading } = useApp();
+  const { account } = useWeb3();
   const { currency } = useUserSettings();
 
   /**
@@ -44,10 +46,11 @@ export default function usePoolQuery(
       }
     });
 
-    if (
-      (isStableLike(pool.poolType) && !POOLS.Stable.AllowList.includes(id)) ||
-      (isManaged(pool.poolType) && !POOLS.Investment.AllowList.includes(id))
-    ) {
+    const isOwnedByUser = getAddress(pool.owner) === getAddress(account.value);
+    const isAllowlisted =
+      (isStableLike(pool.poolType) && POOLS.Stable.AllowList.includes(id)) ||
+      (isManaged(pool.poolType) && POOLS.Investment.AllowList.includes(id));
+    if (!isOwnedByUser && !isAllowlisted) {
       throw new Error('Pool not allowed');
     }
 


### PR DESCRIPTION
# Description

Currently if someone deploys a `ManagedPool` they're unable to view it within the official frontend unless it's allowlisted. I've updated `usePoolQuery` so that we skip checking the allowlist if the user has connected with the address which deployed the pool.

We should potentially show a warning flagging up that other addresses won't be able to see this pool but I'll leave that up to you guys.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## How should this be tested?

Impersonate an address which is the owner of a managed pool which is not on the allowlist and navigate to its page. It should load properly.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] My changes generate no new console warnings
- [x] The base of this PR is `master` if hotfix, `develop` if not
