### PR TITLE
feat: add progress bar buffer

### DIFF
--- a/src/components/_global/BalProgressBar/BalProgressBar.vue
+++ b/src/components/_global/BalProgressBar/BalProgressBar.vue
@@ -24,12 +24,12 @@ const props = withDefaults(defineProps<Props>(), {
  */
 const barClasses = computed(() => ({
   [`h-${props.size}`]: true,
-  [`bg-${props.color}-500 dark:bg-${props.color}-400`]: true
+  [`bg-${props.color}-400`]: true
 }));
 
 const bufferBarClasses = computed(() => ({
   [`h-${props.size}`]: true,
-  [`bg-yellow-500 dark:bg-yellow-400`]: true
+  [`bg-yellow-500`]: true
 }));
 
 const barStyles = computed(() => ({

--- a/src/components/_global/BalProgressBar/BalProgressBar.vue
+++ b/src/components/_global/BalProgressBar/BalProgressBar.vue
@@ -6,6 +6,7 @@ import { computed } from 'vue';
  */
 type Props = {
   width: string | number;
+  bufferWidth: string | number;
   size?: string;
   color?: string;
 };
@@ -23,27 +24,40 @@ const props = withDefaults(defineProps<Props>(), {
  */
 const barClasses = computed(() => ({
   [`h-${props.size}`]: true,
-  [`bg-${props.color}-400`]: true
+  [`bg-${props.color}-500 dark:bg-${props.color}-400`]: true
+}));
+
+const bufferBarClasses = computed(() => ({
+  [`h-${props.size}`]: true,
+  [`bg-yellow-500 dark:bg-yellow-400`]: true
 }));
 
 const barStyles = computed(() => ({
   width: `${props.width}%`
+}));
+
+const bufferBarStyles = computed(() => ({
+  width: `${props.bufferWidth}%`
 }));
 </script>
 
 <template>
   <div class="progress-track">
     <div :class="['progress-bar', barClasses]" :style="barStyles" />
+    <div
+      v-if="props.bufferWidth != null && props.bufferWidth > 0"
+      :class="['progress-bar', bufferBarClasses]"
+      :style="bufferBarStyles"
+    />
   </div>
 </template>
 
 <style scoped>
 .progress-track {
-  @apply w-full rounded-full bg-gray-100 dark:bg-gray-700 overflow-hidden;
+  @apply w-full rounded-full bg-gray-100 dark:bg-gray-700 overflow-hidden flex;
 }
 
 .progress-bar {
-  @apply rounded-full;
   transition: all 0.3s ease;
 }
 </style>

--- a/src/components/cards/TradeCard/TradeCard.vue
+++ b/src/components/cards/TradeCard/TradeCard.vue
@@ -115,8 +115,6 @@ import { getWrapAction, WrapType } from '@/lib/utils/balancer/wrapper';
 import { useTradeState } from '@/composables/trade/useTradeState';
 import useUserSettings from '@/composables/useUserSettings';
 
-const { nativeAsset } = configService.network;
-
 export default defineComponent({
   components: {
     SuccessOverlay,
@@ -135,7 +133,7 @@ export default defineComponent({
     const { t } = useI18n();
     const { bp } = useBreakpoints();
 
-    const { tokens } = useTokens();
+    const { tokens, nativeAsset } = useTokens();
     const { userNetworkConfig } = useWeb3();
     const { darkMode } = useDarkMode();
     const {

--- a/src/components/cards/TradeCardGP/TradeCardGP.vue
+++ b/src/components/cards/TradeCardGP/TradeCardGP.vue
@@ -150,8 +150,6 @@ import useRelayerApproval, {
 } from '@/composables/trade/useRelayerApproval';
 import { useTradeState } from '@/composables/trade/useTradeState';
 
-const { nativeAsset } = configService.network;
-
 export default defineComponent({
   components: {
     TradePair,
@@ -168,7 +166,7 @@ export default defineComponent({
     const { bp } = useBreakpoints();
     const { fNum } = useNumbers();
     const { appNetworkConfig } = useWeb3();
-    const { tokens } = useTokens();
+    const { tokens, nativeAsset } = useTokens();
     const {
       tokenInAddress,
       tokenOutAddress,

--- a/src/components/forms/pool_actions/InvestForm/composables/useInvestMath.ts
+++ b/src/components/forms/pool_actions/InvestForm/composables/useInvestMath.ts
@@ -8,9 +8,6 @@ import { formatUnits } from '@ethersproject/units';
 import useSlippage from '@/composables/useSlippage';
 import { usePool } from '@/composables/usePool';
 import useUserSettings from '@/composables/useUserSettings';
-import { configService } from '@/services/config/config.service';
-
-const { nativeAsset } = configService.network;
 
 export type InvestMathResponse = {
   // computed
@@ -47,7 +44,7 @@ export default function useInvestFormMath(
    * COMPOSABLES
    */
   const { toFiat } = useNumbers();
-  const { tokens, balances, balanceFor } = useTokens();
+  const { tokens, balances, balanceFor, nativeAsset } = useTokens();
   const { minusSlippage } = useSlippage();
   const { managedPoolWithTradingHalted } = usePool(pool);
   const { currency } = useUserSettings();

--- a/src/components/forms/pool_actions/InvestForm/composables/useInvestMath.ts
+++ b/src/components/forms/pool_actions/InvestForm/composables/useInvestMath.ts
@@ -8,7 +8,9 @@ import { formatUnits } from '@ethersproject/units';
 import useSlippage from '@/composables/useSlippage';
 import { usePool } from '@/composables/usePool';
 import useUserSettings from '@/composables/useUserSettings';
-import { ETH_TX_BUFFER } from '@/constants/transactions';
+import { configService } from '@/services/config/config.service';
+
+const { nativeAsset } = configService.network;
 
 export type InvestMathResponse = {
   // computed
@@ -45,7 +47,7 @@ export default function useInvestFormMath(
    * COMPOSABLES
    */
   const { toFiat } = useNumbers();
-  const { tokens, balances, balanceFor, nativeAsset } = useTokens();
+  const { tokens, balances, balanceFor } = useTokens();
   const { minusSlippage } = useSlippage();
   const { managedPoolWithTradingHalted } = usePool(pool);
   const { currency } = useUserSettings();
@@ -108,7 +110,7 @@ export default function useInvestFormMath(
         return (
           amount ===
           bnum(balance)
-            .minus(ETH_TX_BUFFER)
+            .minus(nativeAsset.minTransactionBuffer)
             .toString()
         );
       } else {
@@ -163,9 +165,9 @@ export default function useInvestFormMath(
     fullAmounts.value.forEach((_, i) => {
       if (tokenAddresses.value[i] === nativeAsset.address) {
         const balance = balanceFor(tokenAddresses.value[i]);
-        amounts.value[i] = bnum(balance).gt(ETH_TX_BUFFER)
+        amounts.value[i] = bnum(balance).gt(nativeAsset.minTransactionBuffer)
           ? bnum(balance)
-              .minus(ETH_TX_BUFFER)
+              .minus(nativeAsset.minTransactionBuffer)
               .toString()
           : '0';
       } else {

--- a/src/components/forms/pool_actions/WithdrawForm/WithdrawForm.vue
+++ b/src/components/forms/pool_actions/WithdrawForm/WithdrawForm.vue
@@ -105,7 +105,7 @@ onBeforeMount(() => {
       :rules="singleAssetRules"
       :balanceLabel="$t('singleTokenMax')"
       fixedToken
-      disableEthBuffer
+      disableNativeAssetBuffer
     >
       <template #tokenSelect>
         <WithdrawalTokenSelect :pool="pool" :initToken="tokenOut" />

--- a/src/components/inputs/TokenInput/TokenInput.vue
+++ b/src/components/inputs/TokenInput/TokenInput.vue
@@ -1,17 +1,24 @@
 <script setup lang="ts">
 import { HtmlInputEvent } from '@/types';
 import { ref, computed, watchEffect } from 'vue';
-import useTokens from '@/composables/useTokens';
-import TokenSelectInput from '@/components/inputs/TokenSelectInput/TokenSelectInput.vue';
-import useNumbers from '@/composables/useNumbers';
-import { bnum } from '@/lib/utils';
-import useUserSettings from '@/composables/useUserSettings';
-import { isPositive, isLessThanOrEqualTo } from '@/lib/utils/validations';
 import { useI18n } from 'vue-i18n';
+
+import useNumbers from '@/composables/useNumbers';
+import useTokens from '@/composables/useTokens';
+import useUserSettings from '@/composables/useUserSettings';
+
+import { bnum } from '@/lib/utils';
+import { isPositive, isLessThanOrEqualTo } from '@/lib/utils/validations';
+
 import useWeb3 from '@/services/web3/useWeb3';
-import { TokenInfo } from '@/types/TokenList';
+import { configService } from '@/services/config/config.service';
+
 import { Rules } from '@/components/_global/BalTextInput/BalTextInput.vue';
-import { ETH_TX_BUFFER } from '@/constants/transactions';
+import TokenSelectInput from '@/components/inputs/TokenSelectInput/TokenSelectInput.vue';
+
+import { TokenInfo } from '@/types/TokenList';
+
+const { nativeAsset } = configService.network;
 
 /**
  * TYPES
@@ -35,7 +42,7 @@ type Props = {
   excludedTokens?: string[];
   options?: string[];
   rules?: Rules;
-  disableEthBuffer?: boolean;
+  disableNativeAssetBuffer?: boolean;
 };
 
 /**
@@ -50,7 +57,7 @@ const props = withDefaults(defineProps<Props>(), {
   fixedToken: false,
   disableMax: false,
   hintAmount: '',
-  disableEthBuffer: false,
+  disableNativeAssetBuffer: false,
   options: () => [],
   rules: () => []
 });
@@ -73,7 +80,8 @@ const _address = ref<string>('');
 /**
  * COMPOSABLEs
  */
-const { getToken, balanceFor, nativeAsset } = useTokens();
+
+const { getToken, balanceFor } = useTokens();
 const { fNum, toFiat } = useNumbers();
 const { currency } = useUserSettings();
 const { t } = useI18n();
@@ -83,15 +91,37 @@ const { isWalletReady } = useWeb3();
  * COMPUTED
  */
 const hasToken = computed(() => !!_address.value);
-const hasAmount = computed(() => bnum(_amount.value).gt(0));
-const hasBalance = computed(() => bnum(tokenBalance.value).gt(0));
+const amountBN = computed(() => bnum(_amount.value));
+const tokenBalanceBN = computed(() => bnum(tokenBalance.value));
+const hasAmount = computed(() => amountBN.value.gt(0));
+const hasBalance = computed(() => tokenBalanceBN.value.gt(0));
+const shouldUseTxBuffer = computed(
+  () =>
+    _address.value === nativeAsset.address && !props.disableNativeAssetBuffer
+);
+const amountExceedsBalance = computed(() =>
+  amountBN.value.gt(tokenBalance.value)
+);
+const shouldShowTxBufferMessage = computed(() => {
+  if (
+    amountExceedsBalance.value ||
+    !shouldUseTxBuffer.value ||
+    !hasBalance.value ||
+    !hasAmount.value
+  ) {
+    return false;
+  }
+
+  return amountBN.value.gte(
+    tokenBalanceBN.value.minus(nativeAsset.minTransactionBuffer)
+  );
+});
+
 const isMaxed = computed(() => {
-  if (_address.value === nativeAsset.address && !props.disableEthBuffer) {
+  if (shouldUseTxBuffer.value) {
     return (
       _amount.value ===
-      bnum(tokenBalance.value)
-        .minus(ETH_TX_BUFFER)
-        .toString()
+      tokenBalanceBN.value.minus(nativeAsset.minTransactionBuffer).toString()
     );
   } else {
     return _amount.value === tokenBalance.value;
@@ -125,16 +155,21 @@ const inputRules = computed(() => {
 const maxPercentage = computed(() => {
   if (!hasBalance.value || !hasAmount.value) return '0';
 
-  return bnum(_amount.value)
-    .div(tokenBalance.value)
-    .times(100)
-    .toFixed(1);
+  const percentage = amountBN.value.div(tokenBalance.value).times(100);
+
+  return percentage.toFixed(2);
 });
 
-const barColor = computed(() => {
-  if (bnum(_amount.value).gt(tokenBalance.value)) return 'red';
-  return 'green';
+const bufferPercentage = computed(() => {
+  if (!shouldShowTxBufferMessage.value) return '0';
+
+  return bnum(nativeAsset.minTransactionBuffer)
+    .div(tokenBalance.value)
+    .times(100)
+    .toFixed(2);
 });
+
+const barColor = computed(() => (amountExceedsBalance.value ? 'red' : 'green'));
 
 const priceImpactSign = computed(() =>
   (props.priceImpact || 0) >= 0 ? '-' : '+'
@@ -150,12 +185,13 @@ const priceImpactClass = computed(() =>
 const setMax = () => {
   if (props.disableMax) return;
 
-  if (_address.value === nativeAsset.address && !props.disableEthBuffer) {
+  if (
+    _address.value === nativeAsset.address &&
+    !props.disableNativeAssetBuffer
+  ) {
     // Subtract buffer for gas
-    _amount.value = bnum(tokenBalance.value).gt(ETH_TX_BUFFER)
-      ? bnum(tokenBalance.value)
-          .minus(ETH_TX_BUFFER)
-          .toString()
+    _amount.value = tokenBalanceBN.value.gt(nativeAsset.minTransactionBuffer)
+      ? tokenBalanceBN.value.minus(nativeAsset.minTransactionBuffer).toString()
       : '0';
   } else {
     _amount.value = tokenBalance.value;
@@ -250,9 +286,21 @@ watchEffect(() => {
         <BalProgressBar
           v-if="hasBalance && !noMax"
           :width="maxPercentage"
+          :buffer-width="bufferPercentage"
           :color="barColor"
           class="mt-2"
         />
+        <div
+          v-if="shouldShowTxBufferMessage"
+          class="mt-2 text-yellow-600 dark:text-yellow-400 text-sm"
+        >
+          {{
+            t('minTransactionBuffer', [
+              nativeAsset.minTransactionBuffer,
+              nativeAsset.symbol
+            ])
+          }}
+        </div>
       </div>
     </template>
   </BalTextInput>

--- a/src/components/inputs/TokenInput/TokenInput.vue
+++ b/src/components/inputs/TokenInput/TokenInput.vue
@@ -292,7 +292,7 @@ watchEffect(() => {
         />
         <div
           v-if="shouldShowTxBufferMessage"
-          class="mt-2 text-yellow-600 dark:text-yellow-400 text-sm"
+          class="mt-2 text-yellow-600 dark:text-yellow-400 text-xs"
         >
           {{
             t('minTransactionBuffer', [

--- a/src/components/inputs/TokenInput/TokenInput.vue
+++ b/src/components/inputs/TokenInput/TokenInput.vue
@@ -96,12 +96,12 @@ const shouldUseTxBuffer = computed(
   () =>
     _address.value === nativeAsset.address && !props.disableNativeAssetBuffer
 );
-const amountExceedsBalance = computed(() =>
+const amountExceedsTokenBalance = computed(() =>
   amountBN.value.gt(tokenBalance.value)
 );
 const shouldShowTxBufferMessage = computed(() => {
   if (
-    amountExceedsBalance.value ||
+    amountExceedsTokenBalance.value ||
     !shouldUseTxBuffer.value ||
     !hasBalance.value ||
     !hasAmount.value
@@ -167,7 +167,9 @@ const bufferPercentage = computed(() => {
     .toFixed(2);
 });
 
-const barColor = computed(() => (amountExceedsBalance.value ? 'red' : 'green'));
+const barColor = computed(() =>
+  amountExceedsTokenBalance.value ? 'red' : 'green'
+);
 
 const priceImpactSign = computed(() =>
   (props.priceImpact || 0) >= 0 ? '-' : '+'

--- a/src/components/inputs/TokenInput/TokenInput.vue
+++ b/src/components/inputs/TokenInput/TokenInput.vue
@@ -11,14 +11,11 @@ import { bnum } from '@/lib/utils';
 import { isPositive, isLessThanOrEqualTo } from '@/lib/utils/validations';
 
 import useWeb3 from '@/services/web3/useWeb3';
-import { configService } from '@/services/config/config.service';
 
 import { Rules } from '@/components/_global/BalTextInput/BalTextInput.vue';
 import TokenSelectInput from '@/components/inputs/TokenSelectInput/TokenSelectInput.vue';
 
 import { TokenInfo } from '@/types/TokenList';
-
-const { nativeAsset } = configService.network;
 
 /**
  * TYPES
@@ -81,7 +78,7 @@ const _address = ref<string>('');
  * COMPOSABLEs
  */
 
-const { getToken, balanceFor } = useTokens();
+const { getToken, balanceFor, nativeAsset } = useTokens();
 const { fNum, toFiat } = useNumbers();
 const { currency } = useUserSettings();
 const { t } = useI18n();

--- a/src/components/inputs/TokenInput/TokenInput.vue
+++ b/src/components/inputs/TokenInput/TokenInput.vue
@@ -152,9 +152,10 @@ const inputRules = computed(() => {
 const maxPercentage = computed(() => {
   if (!hasBalance.value || !hasAmount.value) return '0';
 
-  const percentage = amountBN.value.div(tokenBalance.value).times(100);
-
-  return percentage.toFixed(2);
+  return amountBN.value
+    .div(tokenBalance.value)
+    .times(100)
+    .toFixed(2);
 });
 
 const bufferPercentage = computed(() => {

--- a/src/constants/queryKeys.ts
+++ b/src/constants/queryKeys.ts
@@ -1,5 +1,5 @@
 import { Network } from '@/composables/useNetwork';
-import { TokenInfo } from '@/types/TokenList';
+import { NativeAsset } from '@/types/TokenList';
 import { Ref } from 'vue';
 export const POOLS_ROOT_KEY = 'pools';
 export const BALANCES_ROOT_KEY = 'accountBalances';
@@ -59,8 +59,8 @@ const QUERY_KEYS = {
       tokenOutAddress: Ref<string>,
       activeTimespan: Ref<{ option: string; value: number }>,
       userNetworkId: Ref<number>,
-      nativeAsset: TokenInfo,
-      wrappedNativeAsset: Ref<TokenInfo>
+      nativeAsset: NativeAsset,
+      wrappedNativeAsset: Ref<NativeAsset>
     ) => [
       'pairPriceData',
       {

--- a/src/constants/transactions.ts
+++ b/src/constants/transactions.ts
@@ -1,1 +1,0 @@
-export const ETH_TX_BUFFER = 0.05;

--- a/src/lib/config/arbitrum.json
+++ b/src/lib/config/arbitrum.json
@@ -22,7 +22,8 @@
     "symbol": "ETH",
     "decimals": 18,
     "deeplinkId": "ether",
-    "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2/logo.png"
+    "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2/logo.png",
+    "minTransactionBuffer": "0.05"
   },
   "addresses": {
     "exchangeProxy": "",

--- a/src/lib/config/docker.json
+++ b/src/lib/config/docker.json
@@ -21,7 +21,8 @@
     "symbol": "ETH",
     "decimals": 18,
     "deeplinkId": "ether",
-    "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2/logo.png"
+    "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2/logo.png",
+    "minTransactionBuffer": "0.05"
   },
   "addresses": {
     "exchangeProxy": "",

--- a/src/lib/config/homestead.json
+++ b/src/lib/config/homestead.json
@@ -22,7 +22,8 @@
     "symbol": "ETH",
     "decimals": 18,
     "deeplinkId": "ether",
-    "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2/logo.png"
+    "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2/logo.png",
+    "minTransactionBuffer": "0.05"
   },
   "addresses": {
     "bFactory": "0x9424B1412450D0f8Fc2255FAf6046b98213B76Bd",

--- a/src/lib/config/index.ts
+++ b/src/lib/config/index.ts
@@ -34,6 +34,7 @@ export interface Config {
     decimals: number;
     deeplinkId: string;
     logoURI: string;
+    minTransactionBuffer: string;
   };
   addresses: {
     exchangeProxy: string;

--- a/src/lib/config/kovan.json
+++ b/src/lib/config/kovan.json
@@ -21,7 +21,8 @@
     "symbol": "ETH",
     "decimals": 18,
     "deeplinkId": "ether",
-    "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2/logo.png"
+    "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2/logo.png",
+    "minTransactionBuffer": "0.05"
   },
   "addresses": {
     "bFactory": "0x8f7F78080219d4066A8036ccD30D588B416a40DB",

--- a/src/lib/config/polygon.json
+++ b/src/lib/config/polygon.json
@@ -23,7 +23,8 @@
     "symbol": "MATIC",
     "decimals": 18,
     "deeplinkId": "matic",
-    "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x7D1AfA7B718fb893dB30A3aBc0Cfc608AaCfeBB0/logo.png"
+    "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x7D1AfA7B718fb893dB30A3aBc0Cfc608AaCfeBB0/logo.png",
+    "minTransactionBuffer": "0.1"
   },
   "addresses": {
     "exchangeProxy": "",

--- a/src/lib/config/rinkeby.json
+++ b/src/lib/config/rinkeby.json
@@ -21,7 +21,8 @@
     "symbol": "ETH",
     "decimals": 18,
     "deeplinkId": "ether",
-    "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2/logo.png"
+    "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2/logo.png",
+    "minTransactionBuffer": "0.05"
   },
   "addresses": {
     "bFactory": "0x8f7F78080219d4066A8036ccD30D588B416a40DB",

--- a/src/lib/config/test.json
+++ b/src/lib/config/test.json
@@ -21,7 +21,8 @@
     "symbol": "ETH",
     "decimals": 18,
     "deeplinkId": "ether",
-    "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2/logo.png"
+    "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2/logo.png",
+    "minTransactionBuffer": "0.05"
   },
   "addresses": {
     "bFactory": "0x9424B1412450D0f8Fc2255FAf6046b98213B76Bd",

--- a/src/locales/default.json
+++ b/src/locales/default.json
@@ -221,6 +221,7 @@
     "max": "Max",
     "maxed": "Maxed",
     "maximum": "Maximum",
+    "minTransactionBuffer": "To ensure a smooth transaction, at least {0} {1} must be left in your wallet to pay for gas fees.",
     "menu": "Menu",
     "month": "month",
     "months": "months",

--- a/src/providers/tokens.provider.ts
+++ b/src/providers/tokens.provider.ts
@@ -15,7 +15,12 @@ import { getAddress, isAddress } from '@ethersproject/address';
 import { bnum, forChange } from '@/lib/utils';
 import { currentLiquidityMiningRewardTokens } from '@/lib/utils/liquidityMining';
 
-import { TokenInfo, TokenInfoMap, TokenList } from '@/types/TokenList';
+import {
+  NativeAsset,
+  TokenInfo,
+  TokenInfoMap,
+  TokenList
+} from '@/types/TokenList';
 
 import symbolKeys from '@/constants/symbol.keys';
 
@@ -46,8 +51,8 @@ export interface TokensProviderResponse {
   tokens: ComputedRef<TokenInfoMap>;
   injectedTokens: Ref<TokenInfoMap>;
   allowanceContracts: Ref<string[]>;
-  nativeAsset: TokenInfo;
-  wrappedNativeAsset: ComputedRef<TokenInfo>;
+  nativeAsset: NativeAsset;
+  wrappedNativeAsset: ComputedRef<NativeAsset>;
   activeTokenListTokens: ComputedRef<TokenInfoMap>;
   prices: ComputedRef<TokenPrices>;
   balances: ComputedRef<BalanceMap>;
@@ -109,7 +114,7 @@ export default {
     /**
      * STATE
      */
-    const nativeAsset: TokenInfo = {
+    const nativeAsset: NativeAsset = {
       ...networkConfig.nativeAsset,
       chainId: networkConfig.chainId
     };

--- a/src/providers/tokens.provider.ts
+++ b/src/providers/tokens.provider.ts
@@ -52,7 +52,7 @@ export interface TokensProviderResponse {
   injectedTokens: Ref<TokenInfoMap>;
   allowanceContracts: Ref<string[]>;
   nativeAsset: NativeAsset;
-  wrappedNativeAsset: ComputedRef<NativeAsset>;
+  wrappedNativeAsset: ComputedRef<TokenInfo>;
   activeTokenListTokens: ComputedRef<TokenInfoMap>;
   prices: ComputedRef<TokenPrices>;
   balances: ComputedRef<BalanceMap>;

--- a/src/services/pool/calculator/calculator.sevice.ts
+++ b/src/services/pool/calculator/calculator.sevice.ts
@@ -11,8 +11,6 @@ import { isStable, isStableLike } from '@/composables/usePool';
 import { bnum } from '@/lib/utils';
 import { configService } from '@/services/config/config.service';
 
-const { nativeAsset } = configService.network;
-
 interface Amounts {
   send: string[];
   receive: string[];
@@ -95,7 +93,7 @@ export default class CalculatorService {
       let balance;
       if (token === this.config.network.nativeAsset.address) {
         balance = bnum(this.balances.value[token])
-          .minus(nativeAsset.minTransactionBuffer)
+          .minus(this.config.network.nativeAsset.minTransactionBuffer)
           .toString();
       } else {
         balance = this.balances.value[token] || '0';

--- a/src/services/pool/calculator/calculator.sevice.ts
+++ b/src/services/pool/calculator/calculator.sevice.ts
@@ -10,7 +10,8 @@ import { Ref, ref } from 'vue';
 import { isStable, isStableLike } from '@/composables/usePool';
 import { bnum } from '@/lib/utils';
 import { configService } from '@/services/config/config.service';
-import { ETH_TX_BUFFER } from '@/constants/transactions';
+
+const { nativeAsset } = configService.network;
 
 interface Amounts {
   send: string[];
@@ -94,7 +95,7 @@ export default class CalculatorService {
       let balance;
       if (token === this.config.network.nativeAsset.address) {
         balance = bnum(this.balances.value[token])
-          .minus(ETH_TX_BUFFER)
+          .minus(nativeAsset.minTransactionBuffer)
           .toString();
       } else {
         balance = this.balances.value[token] || '0';

--- a/src/types/TokenList.ts
+++ b/src/types/TokenList.ts
@@ -11,6 +11,11 @@ export interface TokenInfo {
   };
 }
 
+export type NativeAsset = TokenInfo & {
+  deeplinkId: string;
+  minTransactionBuffer: string;
+};
+
 export interface Version {
   readonly major: number;
   readonly minor: number;


### PR DESCRIPTION
# Description

Adds a little buffer for the progress bar to accommodate for a recommended minimum gas fee along with a warning.

Added a new `minTransactionBuffer` to the `nativeAsset` config to have custom values for each network.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## How should this be tested?

Please provide instructions so we can test. Please also list any relevant details for your test configuration.

- [ ] Trying clicking "max" (the buffer along with warning should appear)
- [ ] Try manually input a value that is close to the "max" (the buffer along with warning should appear)


## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code where relevant, particularly in hard-to-understand areas
- [ ] My changes generate no new console warnings
- [ ] The base of this PR is `master` if hotfix, `develop` if not
