### PR TITLE
fix: prevent pool ownership check throwing if no wallet is connected

### DIFF
--- a/src/composables/queries/usePoolQuery.ts
+++ b/src/composables/queries/usePoolQuery.ts
@@ -46,13 +46,15 @@ export default function usePoolQuery(
       }
     });
 
+    const requiresAllowlisting =
+      isStableLike(pool.poolType) || isManaged(pool.poolType);
     const isOwnedByUser =
       isAddress(account.value) &&
       getAddress(pool.owner) === getAddress(account.value);
     const isAllowlisted =
-      (isStableLike(pool.poolType) && POOLS.Stable.AllowList.includes(id)) ||
-      (isManaged(pool.poolType) && POOLS.Investment.AllowList.includes(id));
-    if (!isOwnedByUser && !isAllowlisted) {
+      POOLS.Stable.AllowList.includes(id) ||
+      POOLS.Investment.AllowList.includes(id);
+    if (requiresAllowlisting && !isAllowlisted && !isOwnedByUser) {
       throw new Error('Pool not allowed');
     }
 

--- a/src/composables/queries/usePoolQuery.ts
+++ b/src/composables/queries/usePoolQuery.ts
@@ -12,7 +12,7 @@ import useUserSettings from '../useUserSettings';
 import useWeb3 from '@/services/web3/useWeb3';
 import { forChange } from '@/lib/utils';
 import { isManaged, isStableLike } from '../usePool';
-import { getAddress } from '@ethersproject/address';
+import { getAddress, isAddress } from '@ethersproject/address';
 
 export default function usePoolQuery(
   id: string,
@@ -46,7 +46,9 @@ export default function usePoolQuery(
       }
     });
 
-    const isOwnedByUser = getAddress(pool.owner) === getAddress(account.value);
+    const isOwnedByUser =
+      isAddress(account.value) &&
+      getAddress(pool.owner) === getAddress(account.value);
     const isAllowlisted =
       (isStableLike(pool.poolType) && POOLS.Stable.AllowList.includes(id)) ||
       (isManaged(pool.poolType) && POOLS.Investment.AllowList.includes(id));


### PR DESCRIPTION
# Description

`getAddress(account.value)` will throw if no wallet is connected. This PR adds a safety check to prevent this.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## How should this be tested?

Load up a pool page without connecting a wallet. It should display correctly.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] My changes generate no new console warnings
- [x] The base of this PR is `master` if hotfix, `develop` if not
