### PR TITLE
Hotfix 1.28.1 - Hide Copper module for Fei pool

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.28.0",
+  "version": "1.28.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@balancer-labs/frontend-v2",
-      "version": "1.28.0",
+      "version": "1.28.1",
       "license": "MIT",
       "devDependencies": {
         "@babel/core": "^7.13.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.28.0",
+  "version": "1.28.1",
   "engines": {
     "node": "14.x",
     "npm": ">=7"

--- a/src/pages/pool/_id.vue
+++ b/src/pages/pool/_id.vue
@@ -130,7 +130,11 @@
         />
       </div>
       <div v-else class="order-1 lg:order-2 px-1 lg:px-0">
-        <BalCard noPad imgSrc="/images/partners/copper-launch.png">
+        <BalCard
+          v-if="isCopperPool"
+          noPad
+          imgSrc="/images/partners/copper-launch.png"
+        >
           <div class="p-4 mt-2">
             <div class="mb-4 font-semibold">
               {{ $t('copperLaunchPromo.title') }}
@@ -311,6 +315,16 @@ export default defineComponent({
       return false;
     });
 
+    const isCopperPool = computed((): boolean => {
+      const feiPoolId =
+        '0xede4efcc5492cf41ed3f0109d60bc0543cfad23a0002000000000000000000bb';
+      return (
+        !!pool.value &&
+        isLiquidityBootstrappingPool.value &&
+        pool.value.id !== feiPoolId
+      );
+    });
+
     /**
      * METHODS
      */
@@ -362,6 +376,7 @@ export default defineComponent({
       swapFeeToolTip,
       isStableLikePool,
       isLiquidityBootstrappingPool,
+      isCopperPool,
       // methods
       fNum,
       onNewTx

--- a/src/pages/pool/_id.vue
+++ b/src/pages/pool/_id.vue
@@ -315,6 +315,9 @@ export default defineComponent({
       return false;
     });
 
+    // Temporary solution to hide Copper card on Fei pool page.
+    // Longer terms solution is needed distinguish LBP platforms
+    // and display custom widgets linking to their pages.
     const isCopperPool = computed((): boolean => {
       const feiPoolId =
         '0xede4efcc5492cf41ed3f0109d60bc0543cfad23a0002000000000000000000bb';


### PR DESCRIPTION
# Description

We currently display a Copper card for every LBP pool page. This PR hard codes the Fei pool id so that this card doesn't appear on their pool page. Longer term solution needed to distinguish LBP platforms.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## How should this be tested?

- [ ] Test that the copper module doesn't appear on this pool page: `0xede4efcc5492cf41ed3f0109d60bc0543cfad23a0002000000000000000000bb`
- [ ] Test that the copper module does appear on this pool page: `0x89d4a55ca51192109bb85083ff7d9a13ab24c8a10002000000000000000000bc`

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] My changes generate no new console warnings
- [x] The base of this PR is `master` if hotfix, `develop` if not
