### PR TITLE
Fix tradePairSnapshots query, use UTC start of day

### DIFF
--- a/src/components/cards/TrendingPairs/TrendingPairs.vue
+++ b/src/components/cards/TrendingPairs/TrendingPairs.vue
@@ -5,7 +5,7 @@ import QUERY_KEYS from '@/constants/queryKeys';
 import { balancerSubgraphService } from '@/services/balancer/subgraph/balancer-subgraph.service';
 import useWeb3 from '@/services/web3/useWeb3';
 import { getAddress } from '@ethersproject/address';
-import { startOfDay } from 'date-fns';
+import { getUnixTime } from 'date-fns';
 import { computed } from 'vue';
 import { useQuery } from 'vue-query';
 
@@ -23,7 +23,7 @@ const getTrendingTradePairs = async () => {
     orderBy: 'totalSwapVolume',
     orderDirection: 'desc',
     where: {
-      timestamp_gte: startOfDay(new Date()).getTime() / 1000
+      timestamp_gte: getUnixTime(new Date().setUTCHours(0, 0, 0, 0))
     },
     first: 5
   });


### PR DESCRIPTION
# Description

The `tradePairSnapshots` are stored using UTC start of day, but the query is currently using the user's start of day. This results in the Trending Pairs card being blank for certain timezones.

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## How should this be tested?

- [ ] Set your timezone to any locale that has a start of day after UTC, check that Trending pairs are not blank

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] My changes generate no new console warnings
- [x] The base of this PR is `master` if hotfix, `develop` if not
