### PR TITLE
hotfix/1.28.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.28.1",
+  "version": "1.28.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@balancer-labs/frontend-v2",
-      "version": "1.28.1",
+      "version": "1.28.2",
       "license": "MIT",
       "devDependencies": {
         "@babel/core": "^7.13.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.28.1",
+  "version": "1.28.2",
   "engines": {
     "node": "14.x",
     "npm": ">=7"

--- a/src/components/modals/TradePreviewModalGP.vue
+++ b/src/components/modals/TradePreviewModalGP.vue
@@ -777,14 +777,14 @@ export default defineComponent({
         const newQuote = props.trading.getQuote();
 
         if (props.trading.exactIn.value) {
-          priceUpdated.value = bnum(lastQuote.value.minimumOutAmount)
-            .minus(newQuote.minimumOutAmount)
+          priceUpdated.value = lastQuote.value.minimumOutAmount
+            .sub(newQuote.minimumOutAmount)
             .abs()
             .div(lastQuote.value.minimumOutAmount)
             .gt(PRICE_UPDATE_THRESHOLD);
         } else {
-          priceUpdated.value = bnum(lastQuote.value.maximumInAmount)
-            .minus(newQuote.maximumInAmount)
+          priceUpdated.value = lastQuote.value.maximumInAmount
+            .sub(newQuote.maximumInAmount)
             .abs()
             .div(lastQuote.value.maximumInAmount)
             .gt(PRICE_UPDATE_THRESHOLD);

--- a/src/composables/trade/types.ts
+++ b/src/composables/trade/types.ts
@@ -1,6 +1,8 @@
+import { BigNumber } from '@ethersproject/bignumber';
+
 export type TradeQuote = {
   feeAmountInToken: string;
   feeAmountOutToken: string;
-  maximumInAmount: string;
-  minimumOutAmount: string;
+  maximumInAmount: BigNumber;
+  minimumOutAmount: BigNumber;
 };

--- a/src/composables/trade/useGnosis.ts
+++ b/src/composables/trade/useGnosis.ts
@@ -161,14 +161,12 @@ export default function useGnosis({
     const maximumInAmount = tokenInAmountScaled.value
       .add(feeAmountInToken)
       .mul(parseFixed(String(1 + slippageBufferRate.value), 18))
-      .div(ONE)
-      .toString();
+      .div(ONE);
 
     const minimumOutAmount = tokenOutAmountScaled.value
       .sub(feeAmountOutToken)
       .mul(ONE)
-      .div(parseFixed(String(1 + slippageBufferRate.value), 18))
-      .toString();
+      .div(parseFixed(String(1 + slippageBufferRate.value), 18));
 
     return {
       feeAmountInToken,

--- a/src/composables/trade/useSor.ts
+++ b/src/composables/trade/useSor.ts
@@ -605,14 +605,12 @@ export default function useSor({
 
   function getQuote(): TradeQuote {
     const maximumInAmount =
-      tokenInAmountScaled != null
-        ? getMaxIn(tokenInAmountScaled.value).toString()
-        : '';
+      tokenInAmountScaled != null ? getMaxIn(tokenInAmountScaled.value) : Zero;
 
     const minimumOutAmount =
       tokenOutAmountScaled != null
-        ? getMinOut(tokenOutAmountScaled.value).toString()
-        : '';
+        ? getMinOut(tokenOutAmountScaled.value)
+        : Zero;
 
     return {
       feeAmountInToken: '0',


### PR DESCRIPTION
# Description

Fixes a very surprising bug where the `.sub` function which is used to deduct in `BigNumber` was wrapping a `<sub>` around the number.

See: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/sub

The solution was to switch to using BigNumber instead of a string.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## How should this be tested?

Please provide instructions so we can test. Please also list any relevant details for your test configuration.

- [ ] The bug only happened when you did an "exact out" trade on Gnosis

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code where relevant, particularly in hard-to-understand areas
- [ ] My changes generate no new console warnings
- [ ] The base of this PR is `master` if hotfix, `develop` if not
