### PR TITLE
hotfix/1.28.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.28.2",
+  "version": "1.28.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@balancer-labs/frontend-v2",
-      "version": "1.28.2",
+      "version": "1.28.3",
       "license": "MIT",
       "devDependencies": {
         "@babel/core": "^7.13.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.28.2",
+  "version": "1.28.3",
   "engines": {
     "node": "14.x",
     "npm": ">=7"

--- a/src/services/web3/connectors/connector.ts
+++ b/src/services/web3/connectors/connector.ts
@@ -25,21 +25,22 @@ export abstract class Connector {
   handleAccountsChanged = (accounts: string[]) => {
     if (accounts.length === 0) {
       this.handleDisconnect();
-    }
-    if (this.selectedAccount !== '') {
-      const account = accounts.find(
-        account => getAddress(account) === getAddress(this.selectedAccount)
-      );
-      // sense check the account that was previously connected
-      if (!account) {
-        this.account.value = accounts[0];
-        console.warn(
-          `Previously connected account [${this.selectedAccount}] was not found in the connection. Defaulting to the first.`
+    } else {
+      if (this.selectedAccount !== '') {
+        const account = accounts.find(
+          account => getAddress(account) === getAddress(this.selectedAccount)
         );
+        // sense check the account that was previously connected
+        if (!account) {
+          this.account.value = accounts[0];
+          console.warn(
+            `Previously connected account [${this.selectedAccount}] was not found in the connection. Defaulting to the first.`
+          );
+        }
+        this.account.value = getAddress(this.selectedAccount);
       }
-      this.account.value = getAddress(this.selectedAccount);
+      this.account.value = getAddress(accounts[0]);
     }
-    this.account.value = getAddress(accounts[0]);
   };
 
   handleChainChanged = chainId => {

--- a/src/services/web3/connectors/connector.ts
+++ b/src/services/web3/connectors/connector.ts
@@ -47,7 +47,6 @@ export abstract class Connector {
   };
 
   handleDisconnect = () => {
-    console.log('disconnecting');
     // reset everything
     if (this.provider?.removeAllListeners) this.provider?.removeAllListeners();
     this.account.value = null;

--- a/src/services/web3/connectors/connector.ts
+++ b/src/services/web3/connectors/connector.ts
@@ -22,7 +22,10 @@ export abstract class Connector {
   // must return the provider
   abstract connect(): Promise<ConnectorPayload>;
 
-  handleAccountsChanged = accounts => {
+  handleAccountsChanged = (accounts: string[]) => {
+    if (accounts.length === 0) {
+      this.handleDisconnect();
+    }
     if (this.selectedAccount !== '') {
       const account = accounts.find(
         account => getAddress(account) === getAddress(this.selectedAccount)
@@ -39,11 +42,12 @@ export abstract class Connector {
     this.account.value = getAddress(accounts[0]);
   };
 
-  handleChainChanged = chainId => {
+  handleChainChanged = (chainId: string | number) => {
     this.chainId.value = Number(chainId);
   };
 
   handleDisconnect = () => {
+    console.log('disconnecting');
     // reset everything
     if (this.provider?.removeAllListeners) this.provider?.removeAllListeners();
     this.account.value = null;
@@ -69,6 +73,5 @@ export abstract class Connector {
 
     this.provider.on('accountsChanged', this.handleAccountsChanged);
     this.provider.on('chainChanged', this.handleChainChanged);
-    this.provider.on('disconnect', this.handleDisconnect);
   }
 }

--- a/src/services/web3/connectors/connector.ts
+++ b/src/services/web3/connectors/connector.ts
@@ -42,7 +42,7 @@ export abstract class Connector {
     this.account.value = getAddress(accounts[0]);
   };
 
-  handleChainChanged = (chainId: string | number) => {
+  handleChainChanged = chainId => {
     this.chainId.value = Number(chainId);
   };
 


### PR DESCRIPTION
# Description

This PR has 2 fixes:

1. I was debugging an issue with our wallet module where switching networks would disconnect the wallet. This happens because the `disconnect` event is not really about disconnecting a user, it's more about when an RPC endpoint might have some issues (see - https://docs.metamask.io/guide/ethereum-provider.html#disconnect). So I would go from Mainnet -> Fantom and sometimes it would work, sometimes disconnect, etc... 

2. It seems that auto disconnecting a wallet is not working. (try to "lock" your MetaMask and you will see that the app does not pick up the fact you are disconnected). I've added a check that looks for an empty accounts array and then triggers the disconnect logic. I believe it's the right behavior.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## How should this be tested?

Please provide instructions so we can test. Please also list any relevant details for your test configuration.

- [ ] Try switching to any network - you should not be disconnected.
- [ ] Try to lock your account and you should be disconnected.

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code where relevant, particularly in hard-to-understand areas
- [ ] My changes generate no new console warnings
- [ ] The base of this PR is `master` if hotfix, `develop` if not
