### PR TITLE
Fix asset row rendering issue when an asset is missing an icon

### DIFF
--- a/src/components/_global/BalAsset/BalAssetSet.vue
+++ b/src/components/_global/BalAsset/BalAssetSet.vue
@@ -102,7 +102,7 @@ export default defineComponent({
 
 <style scoped>
 .addresses-row {
-  @apply relative mb-3;
+  @apply relative mb-3 flex;
 }
 .addresses-row:last-child {
   @apply mb-0;


### PR DESCRIPTION
# Description

When an asset is missing an icon, the rendering of the "My Wallet" component breaks down.

<img width="334" alt="Screenshot 2021-11-16 at 07 19 38" src="https://user-images.githubusercontent.com/91405705/142035811-1285d076-a239-4bbb-aceb-3d53e0a75916.png">

Apply a `display: flex` to the row so that it properly inlines the div component that gets rendered when the asset has no icon image.

Tested the fix with assets only with icons, a mixture, and all without. Every combination renders properly now.

<img width="340" alt="Screenshot 2021-11-16 at 07 38 14" src="https://user-images.githubusercontent.com/91405705/142037541-039c5c9e-b43b-4234-9ab8-74829edaa87e.png">

<img width="345" alt="Screenshot 2021-11-16 at 07 42 02" src="https://user-images.githubusercontent.com/91405705/142037668-83be8234-abd5-4840-89c9-bb7510f7961b.png">

<img width="313" alt="Screenshot 2021-11-16 at 07 40 07" src="https://user-images.githubusercontent.com/91405705/142037654-8b459b02-79af-4f69-a7c4-c7e96bb62271.png">

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## How should this be tested?

- [ ] Have an asset in your wallet that does not have an icon, navigate to the trade page, ensure the items are still laid out correctly 
- [ ] Ensure that assets with images still render correctly

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] My changes generate no new console warnings
- [x] The base of this PR is `master` if hotfix, `develop` if not
