### PR TITLE
Add auto-optimize toggle to Create Pool

### DIFF
--- a/src/components/cards/CreatePool/InitialLiquidity.vue
+++ b/src/components/cards/CreatePool/InitialLiquidity.vue
@@ -25,6 +25,7 @@ const {
  */
 onMounted(() => {
   optimiseLiquidity();
+  scaleLiquidity();
 });
 
 /**

--- a/src/composables/pools/usePoolCreation.spec.ts
+++ b/src/composables/pools/usePoolCreation.spec.ts
@@ -21,28 +21,28 @@ describe('usePoolCreation', () => {
       tokenAddress: '0x9f8F72aA9304c8B593d555F12eF6589cC3A579A2',
       weight: 70,
       isLocked: false,
-      id: 0,
+      id: '0',
       amount: 0
     };
     tokens.WETH = {
       tokenAddress: '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2',
       weight: 20,
       isLocked: false,
-      id: 1,
+      id: '1',
       amount: 0
     };
     tokens.USDT = {
       tokenAddress: '0xdac17f958d2ee523a2206206994597c13d831ec7',
       weight: 10,
       isLocked: false,
-      id: 2,
+      id: '2',
       amount: 0
     };
     tokens.USDC = {
       tokenAddress: '0xc2569dd7d0fd715B054fBf16E75B001E5c0C1115',
       weight: 50,
       isLocked: false,
-      id: 3,
+      id: '3',
       amount: Number(7643.537999999996)
     };
   });

--- a/src/composables/pools/usePoolCreation.ts
+++ b/src/composables/pools/usePoolCreation.ts
@@ -21,6 +21,11 @@ export type PoolSeedToken = {
   id: string;
 };
 
+export type OptimisedLiquidity = {
+  liquidityRequired: string;
+  balanceRequired: number;
+};
+
 type FeeManagementType = 'governance' | 'self';
 type FeeType = 'fixed' | 'dynamic';
 type FeeController = 'self' | 'other';
@@ -39,9 +44,8 @@ const emptyPoolCreationState = {
   tokensList: [] as string[],
   poolId: '' as string,
   poolAddress: '',
-  hasManuallySetInitialBalances: false,
   symbol: '',
-  lastManuallySetTokenNum: -1,
+  manuallySetToken: '' as string,
   autoOptimiseBalances: false,
   type: PoolType.Weighted
 };
@@ -82,18 +86,12 @@ export default function usePoolCreation() {
    */
   const tokensList = computed(() => poolCreationState.tokensList);
 
-  const optimisedLiquidity = computed(() => {
-    // need to filter out the empty tokens just in case
-    const validTokens = tokensList.value.filter(t => t !== '');
-    const optimisedLiquidity = {};
-    let bip;
-    // If a user has modified the amount for a token, that token is used to optimise the rest
-    if (poolCreationState.lastManuallySetTokenNum != -1) {
-      const modifiedToken = poolCreationState.seedTokens[poolCreationState.lastManuallySetTokenNum];
-      bip = bnum(priceFor(modifiedToken.tokenAddress || '0'))
-        .times(modifiedToken.amount)
-        .div(modifiedToken.weight);
-    } else {
+  const optimisedLiquidity = computed(
+    (): Record<string, OptimisedLiquidity> => {
+      // need to filter out the empty tokens just in case
+      const validTokens = tokensList.value.filter(t => t !== '');
+      const optimisedLiquidity = {};
+
       // token with the lowest balance is the bottleneck
       const bottleneckToken = minBy(
         validTokens,
@@ -106,24 +104,29 @@ export default function usePoolCreation() {
           t => t.tokenAddress === bottleneckToken
         )?.weight || 0;
 
-      bip = bnum(priceFor(bottleneckToken || '0'))
+      const bip = bnum(priceFor(bottleneckToken || '0'))
         .times(balanceFor(bottleneckToken))
         .div(bottleneckWeight);
-    }
 
-    for (const token of poolCreationState.seedTokens) {
-      // get the price for a single token
-      const tokenPrice = bnum(priceFor(token.tokenAddress));
-      // the usd value needed for its weight
-      const liquidityRequired = bip.times(token.weight);
-      const balanceRequired = liquidityRequired.div(tokenPrice);
-      optimisedLiquidity[token.tokenAddress] = {
-        liquidityRequired: liquidityRequired.toString(),
-        balanceRequired: balanceRequired.toString()
-      };
+      return getTokensScaledByBIP(bip);
     }
-    return optimisedLiquidity;
-  });
+  );
+
+  const scaledLiquidity = computed(
+    (): Record<string, OptimisedLiquidity> => {
+      const scaledLiquidity = {};
+      const modifiedToken = findSeedTokenByAddress(
+        poolCreationState.manuallySetToken
+      );
+      if (!modifiedToken) return scaledLiquidity;
+
+      const bip = bnum(priceFor(modifiedToken.tokenAddress || '0'))
+        .times(modifiedToken.amount)
+        .div(modifiedToken.weight);
+
+      return getTokensScaledByBIP(bip);
+    }
+  );
 
   const maxInitialLiquidity = computed(() => {
     return sumBy(Object.values(optimisedLiquidity.value), (liq: any) =>
@@ -222,6 +225,12 @@ export default function usePoolCreation() {
     poolCreationState.activeStep -= 1;
   }
 
+  function findSeedTokenByAddress(address: string) {
+    return poolCreationState.seedTokens.find((token: PoolSeedToken) => {
+      return token.tokenAddress === address;
+    });
+  }
+
   function setFeeManagement(type: FeeManagementType) {
     poolCreationState.feeManagementType = type;
   }
@@ -246,8 +255,24 @@ export default function usePoolCreation() {
     tokenColors.value = colors;
   }
 
-  function updateManualLiquidityFlag(isManual: boolean) {
-    poolCreationState.hasManuallySetInitialBalances = isManual;
+  function updateManuallySetToken(address: string) {
+    poolCreationState.manuallySetToken = address;
+  }
+
+  function getTokensScaledByBIP(bip): Record<string, OptimisedLiquidity> {
+    const optimisedLiquidity = {};
+    for (const token of poolCreationState.seedTokens) {
+      // get the price for a single token
+      const tokenPrice = bnum(priceFor(token.tokenAddress));
+      // the usd value needed for its weight
+      const liquidityRequired = bip.times(token.weight);
+      const balanceRequired = liquidityRequired.div(tokenPrice);
+      optimisedLiquidity[token.tokenAddress] = {
+        liquidityRequired: liquidityRequired.toString(),
+        balanceRequired: balanceRequired.toNumber()
+      };
+    }
+    return optimisedLiquidity;
   }
 
   function getScaledAmounts() {
@@ -366,9 +391,10 @@ export default function usePoolCreation() {
     getScaledAmounts,
     createPool,
     joinPool,
-    updateManualLiquidityFlag,
     setActiveStep,
+    updateManuallySetToken,
     optimisedLiquidity,
+    scaledLiquidity,
     tokensWithNoPrice,
     similarPools,
     isLoadingSimilarPools,

--- a/src/locales/default.json
+++ b/src/locales/default.json
@@ -36,6 +36,10 @@
     "approvingGnosisRelayer": "Approving Gnosis relayer",
     "approvingLidoRelayer": "Approving Lido relayer",
     "apr": "APR",
+    "autoOptimiseLiquidityToggle": {
+        "label": "Auto optimize liquidity",
+        "tooltip": "Optimise token values automatically to match the token weights you specified."
+    },
     "availableToClaim": "Available to claim:",
     "balance": "Balance",
     "balances": "Balances",

--- a/src/services/balancer/pools/weighted-pool.service.spec.ts
+++ b/src/services/balancer/pools/weighted-pool.service.spec.ts
@@ -36,21 +36,21 @@ describe('PoolCreator', () => {
       tokenAddress: '0x9f8F72aA9304c8B593d555F12eF6589cC3A579A2',
       weight: 70,
       isLocked: false,
-      id: 0,
+      id: '0',
       amount: 0
     };
     tokens.WETH = {
       tokenAddress: '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2',
       weight: 20,
       isLocked: false,
-      id: 1,
+      id: '1',
       amount: 0
     };
     tokens.USDT = {
       tokenAddress: '0xdac17f958d2ee523a2206206994597c13d831ec7',
       weight: 10,
       isLocked: false,
-      id: 2,
+      id: '2',
       amount: 0
     };
   });


### PR DESCRIPTION
Adds a toggle to the set liquidity step of create pool.  When toggled, if the user changes any of the token values all other
tokens are automatically set to the same value.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## How should this be tested?

- Create a new pool. 
- On step 3, set the auto-optimise toggle to true
- Ensure other values are changing when any value is set
- Set auto-optimise toggle to false
- Ensure other values are not changing automatically. 


## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] My changes generate no new console warnings
- [ ] The base of this PR is `master` if hotfix, `develop` if not
