### PR TITLE
Add ability to initJoin WETH pools with ETH

### DIFF
--- a/src/components/cards/CreatePool/InitialLiquidity.vue
+++ b/src/components/cards/CreatePool/InitialLiquidity.vue
@@ -1,6 +1,8 @@
 <script setup lang="ts">
-import { onMounted, ref } from 'vue';
+import { onMounted, onBeforeMount, watch, ref } from 'vue';
+import { bnum } from '@/lib/utils';
 import useWeb3 from '@/services/web3/useWeb3';
+import useTokens from '@/composables/useTokens';
 import usePoolCreation from '@/composables/pools/usePoolCreation';
 
 import TokenInput from '@/components/inputs/TokenInput/TokenInput.vue';
@@ -9,20 +11,31 @@ import TokenInput from '@/components/inputs/TokenInput/TokenInput.vue';
  * STATE
  */
 const { userNetworkConfig } = useWeb3();
+const { balanceFor, nativeAsset, wrappedNativeAsset } = useTokens();
 const {
   seedTokens,
+  tokensList,
   proceed,
   optimisedLiquidity,
   scaledLiquidity,
   goBack,
   manuallySetToken,
   updateManuallySetToken,
-  autoOptimiseBalances
+  autoOptimiseBalances,
+  isWethPool,
+  useNativeAsset
 } = usePoolCreation();
+
+const tokenAddresses = ref([] as string[]);
 
 /**
  * LIFECYCLE
  */
+onBeforeMount(() => {
+  tokenAddresses.value = [...tokensList.value];
+  if (isWethPool.value) setNativeAssetIfRequired();
+});
+
 onMounted(() => {
   optimiseLiquidity();
   scaleLiquidity();
@@ -31,7 +44,6 @@ onMounted(() => {
 /**
  * METHODS
  */
-
 function optimiseLiquidity() {
   if (manuallySetToken.value) return;
 
@@ -41,7 +53,7 @@ function optimiseLiquidity() {
 }
 
 function scaleLiquidity() {
-  if (!autoOptimiseBalances.value) return;
+  if (!autoOptimiseBalances.value || !manuallySetToken.value) return;
 
   for (const token of seedTokens.value) {
     if (token.tokenAddress !== manuallySetToken.value) {
@@ -69,6 +81,38 @@ function handleAmountChange(tokenAddress) {
   updateManuallySetToken(tokenAddress);
 
   checkLiquidityScaling();
+}
+
+function handleAddressChange(newAddress: string): void {
+  useNativeAsset.value = newAddress === nativeAsset.address;
+}
+
+function tokenOptions(index: number): string[] {
+  if (tokenAddresses.value[index] === wrappedNativeAsset.value.address)
+    return [wrappedNativeAsset.value.address, nativeAsset.address];
+  if (tokenAddresses.value[index] === nativeAsset.address)
+    return [nativeAsset.address, wrappedNativeAsset.value.address];
+  return [];
+}
+
+// If useNativeAsset is set, or ETH has a higher balance than WETH, then use it for the input.
+function setNativeAssetIfRequired(): void {
+  const nativeAssetBalance = balanceFor(nativeAsset.address);
+  const wrappedNativeAssetBalance = balanceFor(
+    wrappedNativeAsset.value.address
+  );
+
+  if (
+    useNativeAsset.value ||
+    bnum(nativeAssetBalance).gt(wrappedNativeAssetBalance)
+  ) {
+    tokenAddresses.value = tokenAddresses.value.map(address => {
+      if (address == wrappedNativeAsset.value.address) {
+        return nativeAsset.address;
+      }
+      return address;
+    });
+  }
 }
 </script>
 
@@ -108,14 +152,16 @@ function handleAmountChange(tokenAddress) {
       </BalStack>
       <BalStack isDynamic vertical>
         <TokenInput
-          v-for="(token, i) in seedTokens"
-          :key="token.tokenAddress"
+          v-for="(address, i) in tokenAddresses"
+          :key="i"
           v-model:amount="seedTokens[i].amount"
-          v-model:address="seedTokens[i].tokenAddress"
-          @update:amount="handleAmountChange(token.tokenAddress)"
+          v-model:address="tokenAddresses[i]"
           :weight="seedTokens[i].weight / 100"
           :name="`initial-token-${seedTokens[i].tokenAddress}`"
           fixedToken
+          :options="tokenOptions(i)"
+          @update:amount="handleAmountChange(address)"
+          @update:address="handleAddressChange($event)"
         />
       </BalStack>
       <BalBtn @click="proceed" block color="gradient">Preview</BalBtn>

--- a/src/components/cards/CreatePool/PreviewPoolModal.vue
+++ b/src/components/cards/CreatePool/PreviewPoolModal.vue
@@ -37,9 +37,10 @@ const {
   goBack,
   name: poolName,
   symbol: poolSymbol,
-  setActiveStep
+  setActiveStep,
+  useNativeAsset
 } = usePoolCreation();
-const { tokens, priceFor } = useTokens();
+const { tokens, priceFor, nativeAsset, wrappedNativeAsset } = useTokens();
 const { fNum } = useNumbers();
 const { t } = useI18n();
 const { userNetworkConfig } = useWeb3();
@@ -57,7 +58,15 @@ const title = computed((): string =>
 const initialWeightLabel = computed(() => t('initialWeight'));
 
 const tokenAddresses = computed((): string[] => {
-  return seedTokens.value.map(token => token.tokenAddress);
+  return seedTokens.value.map(token => {
+    if (
+      token.tokenAddress == wrappedNativeAsset.value.address &&
+      useNativeAsset.value
+    ) {
+      return nativeAsset.address;
+    }
+    return token.tokenAddress;
+  });
 });
 
 const tokenAmounts = computed((): string[] => {


### PR DESCRIPTION
# Description

Add the ability to invest in pools which take a wrapped native asset (such as WETH) using the native asset. 

I made it so the token address in global state is always kept as the wrapped asset to not cause state issues. On create the wrapped native asset is used, then on join it is changed to `AddressZero` and `value` is passed along with the transaction. 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## How should this be tested?

- Go through create pool flow. Create a pool with WETH as an asset
- On initial balances page, switch WETH to ETH and set a value
- Complete creation and join pool with ETH
- Repeat the above with WETH to ensure that also works correctly. 

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] My changes generate no new console warnings
- [ ] The base of this PR is `master` if hotfix, `develop` if not
