### PR TITLE
Create pool small fixes

### DIFF
--- a/src/components/_global/BalActionSteps/BalActionSteps.vue
+++ b/src/components/_global/BalActionSteps/BalActionSteps.vue
@@ -120,6 +120,7 @@ async function submit(
 ): Promise<void> {
   try {
     state.init = true;
+    state.error = null;
 
     const tx = await action();
 

--- a/src/components/_global/BalActionSteps/BalActionSteps.vue
+++ b/src/components/_global/BalActionSteps/BalActionSteps.vue
@@ -98,6 +98,10 @@ const lastActionState = computed(
 
 const steps = computed((): Step[] => actions.value.map(action => action.step));
 
+const spacerWidth = computed((): number => {
+  return 13 - steps.value.length;
+});
+
 /**
  * METHODS
  */
@@ -168,6 +172,7 @@ async function submit(
     <BalHorizSteps
       v-if="actions.length > 1 && !lastActionState.confirmed"
       :steps="steps"
+      :spacerWidth="spacerWidth"
       class="flex justify-center"
     />
     <BalBtn

--- a/src/components/_global/BalHorizSteps/BalHorizSteps.vue
+++ b/src/components/_global/BalHorizSteps/BalHorizSteps.vue
@@ -11,6 +11,7 @@ const stepState = StepState;
  */
 type Props = {
   steps: Step[];
+  spacerWidth: number;
 };
 
 /**
@@ -23,7 +24,8 @@ withDefaults(defineProps<Props>(), {
     { tooltip: 'This is pending', state: StepState.Pending },
     { tooltip: 'Do this now', state: StepState.Active },
     { tooltip: 'Do this next', state: StepState.Todo }
-  ]
+  ],
+  spacerWidth: 16
 });
 
 /**
@@ -60,7 +62,10 @@ function stateClasses(state: StepState): string {
 <template>
   <div class="flex items-center">
     <div v-for="(step, i) in steps" :key="i" class="flex items-center">
-      <div v-if="i !== 0" class="h-px bg-gray-100 dark:bg-gray-700 w-16" />
+      <div
+        v-if="i !== 0"
+        :class="['h-px bg-gray-100 dark:bg-gray-700', `w-${spacerWidth}`]"
+      />
       <BalTooltip :text="step.tooltip" width="44" textCenter>
         <template v-slot:activator>
           <div :class="['step', stateClasses(step.state)]">

--- a/src/components/cards/CreatePool/ChooseWeights.vue
+++ b/src/components/cards/CreatePool/ChooseWeights.vue
@@ -67,8 +67,9 @@ const totalWeight = computed(() => {
 });
 
 const isProceedDisabled = computed(() => {
-  if (Number(totalWeight.value) === 100) return false;
-  return true;
+  if (Number(totalWeight.value) !== 100) return true;
+  if (seedTokens.value.length < 2) return true;
+  return false;
 });
 
 const showLiquidityAlert = computed(() => {

--- a/src/components/cards/CreatePool/PreviewPool.vue
+++ b/src/components/cards/CreatePool/PreviewPool.vue
@@ -1,5 +1,5 @@
 <script lang="ts" setup>
-import { ref, computed } from 'vue';
+import { ref, computed, onBeforeMount } from 'vue';
 import CreateActions from '@/components/cards/CreatePool/CreateActions.vue';
 
 import usePoolCreation from '@/composables/pools/usePoolCreation';
@@ -36,12 +36,21 @@ const {
   name: poolName,
   symbol: poolSymbol,
   setActiveStep,
-  useNativeAsset
+  useNativeAsset,
+  sortTokenWeights
 } = usePoolCreation();
+
 const { tokens, priceFor, nativeAsset, wrappedNativeAsset } = useTokens();
 const { fNum } = useNumbers();
 const { t } = useI18n();
 const { userNetworkConfig } = useWeb3();
+
+/**
+ * LIFECYCLE
+ */
+onBeforeMount(() => {
+  sortTokenWeights();
+});
 
 /**
  * COMPUTED

--- a/src/composables/pools/usePoolCreation.ts
+++ b/src/composables/pools/usePoolCreation.ts
@@ -315,7 +315,6 @@ export default function usePoolCreation() {
   }
 
   async function createPool(): Promise<TransactionResponse> {
-    sortTokenWeights();
     const provider = getProvider();
     try {
       const tx = await balancerService.pools.weighted.create(
@@ -361,7 +360,6 @@ export default function usePoolCreation() {
   }
 
   async function joinPool() {
-    sortTokenWeights();
     const provider = getProvider();
     try {
       const tokenAddresses: string[] = poolCreationState.seedTokens.map(
@@ -420,6 +418,7 @@ export default function usePoolCreation() {
     joinPool,
     setActiveStep,
     updateManuallySetToken,
+    sortTokenWeights,
     optimisedLiquidity,
     scaledLiquidity,
     tokensWithNoPrice,

--- a/src/pages/pool/create.vue
+++ b/src/pages/pool/create.vue
@@ -8,7 +8,7 @@ import PoolFees from '@/components/cards/CreatePool/PoolFees.vue';
 import SimilarPools from '@/components/cards/CreatePool/SimilarPools.vue';
 import InitialLiquidity from '@/components/cards/CreatePool/InitialLiquidity.vue';
 import SimilarPoolsCompact from '@/components/cards/CreatePool/SimilarPoolsCompact.vue';
-import PreviewPoolModal from '@/components/cards/CreatePool/PreviewPoolModal.vue';
+import PreviewPool from '@/components/cards/CreatePool/PreviewPool.vue';
 import BalVerticalSteps from '@/components/_global/BalVerticalSteps/BalVerticalSteps.vue';
 import AnimatePresence from '@/components/animate/AnimatePresence.vue';
 import Col3Layout from '@/components/layouts/Col3Layout.vue';
@@ -196,7 +196,7 @@ function setWrapperHeight(dimensions: { width: number; height: number }) {
         :exit="exitAnimateProps"
         @update-dimensions="setWrapperHeight"
       >
-        <PreviewPoolModal />
+        <PreviewPool />
       </AnimatePresence>
     </div>
     <template #gutterRight>

--- a/src/services/balancer/pools/weighted-pool.service.spec.ts
+++ b/src/services/balancer/pools/weighted-pool.service.spec.ts
@@ -166,7 +166,7 @@ describe('PoolCreator', () => {
         mockPoolId,
         mockSender,
         mockReceiver,
-        [tokens.WETH, tokens.USDT],
+        [tokens.WETH.tokenAddress, tokens.USDT.tokenAddress],
         tokenBalances
       );
     });


### PR DESCRIPTION
# Description

- Remove error box when re-trying an action in action steps
- Sort tokens when preview is loaded 
    - Token weights need to be in a specific order for create/join. Best to sort them on the preview page so that the pool name/symbol can be auto-generated in the correct order and so they don't re-order as the create button is clicked.
- Fix issue with a large amount of steps causing them to go off screen, lower space between them as there are more
- Don't allow proceeding with create with only one token set to 100%. 
- Rename PreviewPoolModal file because it's no longer a modal

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## How should this be tested?

- Go through create flow and ensure they are fixed

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] My changes generate no new console warnings
- [ ] The base of this PR is `master` if hotfix, `develop` if not
