### PR TITLE
Hotfix 1.29.2 - Fix invest/withdraw if missing prices

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.29.1",
+  "version": "1.29.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@balancer-labs/frontend-v2",
-      "version": "1.29.1",
+      "version": "1.29.2",
       "license": "MIT",
       "devDependencies": {
         "@babel/core": "^7.13.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.29.1",
+  "version": "1.29.2",
   "engines": {
     "node": "14.x",
     "npm": ">=7"

--- a/src/components/forms/pool_actions/InvestForm/composables/useInvestMath.ts
+++ b/src/components/forms/pool_actions/InvestForm/composables/useInvestMath.ts
@@ -89,7 +89,9 @@ export default function useInvestFormMath(
     fNum(fiatTotal.value, currency.value)
   );
 
-  const hasAmounts = computed(() => bnum(fiatTotal.value).gt(0));
+  const hasAmounts = computed(() =>
+    fullAmounts.value.some(amount => bnum(amount).gt(0))
+  );
 
   const priceImpact = computed((): number => {
     if (!hasAmounts.value) return 0;

--- a/src/components/forms/pool_actions/WithdrawForm/composables/useWithdrawMath.ts
+++ b/src/components/forms/pool_actions/WithdrawForm/composables/useWithdrawMath.ts
@@ -132,7 +132,9 @@ export default function useWithdrawMath(
     return addSlippage(_bptIn, pool.value.onchain.decimals);
   });
 
-  const hasAmounts = computed(() => bnum(fiatTotal.value).gt(0));
+  const hasAmounts = computed(() =>
+    fullAmounts.value.some(amount => bnum(amount).gt(0))
+  );
 
   const singleAssetMaxes = computed((): string[] => {
     return tokens.value.map((token, tokenIndex) => {


### PR DESCRIPTION
# Description

If prices are missing the from validation check hasAmounts was failing because it was checking via the fiatTotal prop. This PR fixes the hasAmount check by checking if the fullAmounts array contains a non-zero value.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## How should this be tested?

- [ ] Test invest/withdraw flows in a AVAX pool on polygon

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] My changes generate no new console warnings
- [x] The base of this PR is `master` if hotfix, `develop` if not
