### PR TITLE
Hotfix 1.29.3 - Remove NOTE from claims

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.29.2",
+  "version": "1.29.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@balancer-labs/frontend-v2",
-      "version": "1.29.2",
+      "version": "1.29.3",
       "license": "MIT",
       "devDependencies": {
         "@babel/core": "^7.13.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.29.2",
+  "version": "1.29.3",
   "engines": {
     "node": "14.x",
     "npm": ">=7"

--- a/src/components/navs/AppNav/AppNavClaimBtn.vue
+++ b/src/components/navs/AppNav/AppNavClaimBtn.vue
@@ -22,6 +22,9 @@ import useWeb3 from '@/services/web3/useWeb3';
 import BalLink from '@/components/_global/BalLink/BalLink.vue';
 
 import { TOKENS } from '@/constants/tokens';
+import useTranasactionErrors, {
+  TransactionError
+} from '@/composables/useTransactionErrors';
 
 type ClaimableToken = {
   token: string;
@@ -48,7 +51,7 @@ const tabs = [
 const activeTab = ref(tabs[0].value);
 const isClaiming = ref(false);
 const elapstedTimeSinceEstimateTimestamp = ref(0);
-const claimError = ref<string | null>(null);
+const claimError = ref<TransactionError | null>(null);
 
 // COMPOSABLES
 const { upToLargeBreakpoint } = useBreakpoints();
@@ -71,6 +74,7 @@ const {
   priceQueryLoading,
   loading: tokensLoading
 } = useTokens();
+const { parseError } = useTranasactionErrors();
 
 const BALTokenAddress = getAddress(TOKENS.AddressMap[networkId.value].BAL);
 
@@ -242,7 +246,7 @@ async function claimAvailableRewards() {
       });
     } catch (e) {
       console.log(e);
-      claimError.value = e.message;
+      claimError.value = parseError(e);
       isClaiming.value = false;
     }
   }
@@ -360,8 +364,8 @@ async function claimAvailableRewards() {
           class="mb-6 -mt-4"
           type="error"
           size="md"
-          title="An error has occurred"
-          :description="claimError"
+          :title="claimError.title"
+          :description="claimError.description"
           block
           action-label="Dismiss"
           @actionClick="claimError = null"

--- a/src/composables/useTransactionErrors.ts
+++ b/src/composables/useTransactionErrors.ts
@@ -19,6 +19,11 @@ export default function useTranasactionErrors() {
     description: t('transactionErrors.gasTooLow.description')
   };
 
+  const cannotEstimateGasError: TransactionError = {
+    title: t('transactionErrors.cannotEstGas.title'),
+    description: t('transactionErrors.cannotEstGas.description')
+  };
+
   const slippageError: TransactionError = {
     title: t('transactionErrors.slippage.title'),
     description: t('transactionErrors.slippage.description')
@@ -38,6 +43,8 @@ export default function useTranasactionErrors() {
    */
   function parseError(error): TransactionError | null {
     if (error?.code && error.code === 4001) return null; // User rejected transaction
+    if (error?.code && error.code === 'UNPREDICTABLE_GAS_LIMIT')
+      return cannotEstimateGasError;
 
     if (error?.message) {
       if (error.message.includes('-32010')) return gasTooLowError;

--- a/src/locales/default.json
+++ b/src/locales/default.json
@@ -491,6 +491,10 @@
             "title": "Gas too low",
             "description": "Transaction gas is too low. There is not enough gas to cover minimal cost of the transaction. Try increasing supplied gas."
         },
+        "cannotEstGas": {
+            "title": "Cannot estimate gas",
+            "description": "Transaction may fail or require manual gas limit."
+        },
         "slippage": {
             "title": "Transaction failed due to slippage",
             "description": "The market price changed beyond your slippage tolerance due to other trades processed before yours. Try again or increase your slippage tolerance."

--- a/src/services/claim/MultiTokenClaim.json
+++ b/src/services/claim/MultiTokenClaim.json
@@ -20,13 +20,6 @@
             "token": "0x2d94AA3e47d9D5024503Ca8491fcE9A2fB4DA198",
             "manifest": "https://raw.githubusercontent.com/balancer-labs/bal-mining-scripts/master/reports/_current-bankless.json",
             "weekStart": 1
-        },
-        {
-            "label": "NOTE",
-            "distributor": "0x22341fb5d92d3d801144aa5a925f401a91418a05",
-            "token": "0xcfeaead4947f0705a14ec42ac3d44129e1ef3ed5",
-            "manifest": "https://raw.githubusercontent.com/balancer-labs/bal-mining-scripts/master/reports/_current-note.json",
-            "weekStart": 1
         }
     ],
     "42": [


### PR DESCRIPTION
# Description

There is an issue with handling non 18 decimal tokens in the claims flow. This PR simply removes NOTE from the MultiTokenClaim json file so it doesn't appear in our UI.

Additionally, the PR includes a fix to handle `UNPREDICTABLE_GAS_LIMIT` errors more gracefully.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] My changes generate no new console warnings
- [x] The base of this PR is `master` if hotfix, `develop` if not
