### PR TITLE
Correct logic for determining managed pool halted state

### DIFF
--- a/src/composables/usePool.ts
+++ b/src/composables/usePool.ts
@@ -81,7 +81,7 @@ export function usePool(pool: Ref<AnyPool> | Ref<undefined>) {
   );
   const managedPoolWithTradingHalted = computed(
     (): boolean =>
-      !!pool.value && isManagedPool.value && !!pool.value.onchain?.swapEnabled
+      !!pool.value && isManagedPool.value && !pool.value.onchain?.swapEnabled
   );
   const isWethPool = computed(
     (): boolean => !!pool.value && isWeth(pool.value)


### PR DESCRIPTION
# Description

Managed pools are showing that swaps are disabled when they aren't - blocking all non-proportional investments in Managed Pools.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## How should this be tested?

Managed pools with swaps enabled should not show the "Trading disabled" banner:

0xccf5575570fac94cec733a58ff91bb3d073085c70002000000000000000000af (MetaFactory)
0x3b40d7d5ae25df2561944dd68b252016c4c7b2800001000000000000000000c2 (WSB)

## Checklist:

- [X] I have performed a self-review of my own code
- [ ] I have commented my code where relevant, particularly in hard-to-understand areas
- [ ] My changes generate no new console warnings
- [ ] The base of this PR is `master` if hotfix, `develop` if not
