### PR TITLE
TrendingPairs: Map WETH to ETH

### DIFF
--- a/src/components/cards/TrendingPairs/TrendingPairs.vue
+++ b/src/components/cards/TrendingPairs/TrendingPairs.vue
@@ -15,7 +15,7 @@ type TrendingPair = {
 };
 
 const { setTokenOutAddress, setTokenInAddress } = useTradeState();
-const { chainId: userNetworkId } = useWeb3();
+const { chainId: userNetworkId, appNetworkConfig } = useWeb3();
 const { upToLargeBreakpoint } = useBreakpoints();
 
 const getTrendingTradePairs = async () => {
@@ -33,16 +33,27 @@ const { data: tradePairSnapshots } = useQuery(
   QUERY_KEYS.Tokens.TrendingPairs(userNetworkId),
   () => getTrendingTradePairs()
 );
+
+function formatToken({ address, symbol }: { address: string; symbol: string }) {
+  const formatted = getAddress(address);
+
+  if (formatted === appNetworkConfig.addresses.weth) {
+    return {
+      address: appNetworkConfig.nativeAsset.address,
+      symbol: appNetworkConfig.nativeAsset.symbol
+    };
+  }
+
+  return {
+    address: formatted,
+    symbol
+  };
+}
+
 const trendingPairs = computed(() => {
   return (tradePairSnapshots.value || []).map(pairSnapshot => [
-    {
-      symbol: pairSnapshot.pair.token0.symbol,
-      address: getAddress(pairSnapshot.pair.token0.address)
-    },
-    {
-      symbol: pairSnapshot.pair.token1.symbol,
-      address: getAddress(pairSnapshot.pair.token1.address)
-    }
+    formatToken(pairSnapshot.pair.token0),
+    formatToken(pairSnapshot.pair.token1)
   ]);
 });
 


### PR DESCRIPTION
# Description

For the TrendingPairs card, map WETH to ETH. It was a request from our users, but makes sense. Most people hold the native asset, not the wrapped asset. 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## How should this be tested?

Please provide instructions so we can test. Please also list any relevant details for your test configuration.

- [ ] Navigate to the trade page, verify that all trending pairs with WETH now show ETH
- [ ] Click a trending with ETH, it should populate ETH in the trading window.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] My changes generate no new console warnings
- [x] The base of this PR is `master` if hotfix, `develop` if not
