### PR TITLE
Fix the 1 Day price chart

### DIFF
--- a/src/services/coingecko/api/price.service.ts
+++ b/src/services/coingecko/api/price.service.ts
@@ -119,7 +119,8 @@ export class PriceService {
       throw new Error('To many requests for rate limit.');
 
     const now = Math.floor(Date.now() / 1000);
-    const end = now - (now % twentyFourHoursInSecs);
+    const end =
+      aggregateBy === 'hour' ? now : now - (now % twentyFourHoursInSecs);
     const start = end - days * twentyFourHoursInSecs;
 
     // TODO - remove once wsteth is supported


### PR DESCRIPTION
# Description

The historical price end time is currently getting rounded to the start of day UTC, regardless of interval. Fix to not round the end time when the interval is `hourly`, this allows it to show up to date pricing on the 1 day chart.

Both of the screenshots below were taken at the same time:

Before:
<img width="332" alt="Screenshot 2021-11-28 at 10 31 59" src="https://user-images.githubusercontent.com/91405705/143781365-9c3c832e-4514-445e-9dca-e6a9b48653d0.png">

After:
<img width="336" alt="Screenshot 2021-11-28 at 10 34 50" src="https://user-images.githubusercontent.com/91405705/143781370-bf0c3ad2-26f3-4f2b-959c-82c19ce790f6.png">

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## How should this be tested?

- [ ] Navigate to the swap page, hover over the latest hourly price, ensure it is in line with the current time

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] My changes generate no new console warnings
- [x] The base of this PR is `master` if hotfix, `develop` if not
