### PR TITLE
Search for tokens through all tokenlists

### DIFF
--- a/src/constants/tokenlists.ts
+++ b/src/constants/tokenlists.ts
@@ -23,10 +23,8 @@ export const TOKEN_LIST_MAP: TokenListMapByNetwork = {
     },
     External: [
       'ipns://tokens.uniswap.org',
-      'tokenlist.zerion.eth',
-      'tokens.1inch.eth',
+      'https://www.gemini.com/uniswap/manifest.json',
       'tokenlist.aave.eth',
-      // 'https://tokens.coingecko.com/uniswap/all.json', Breaks balance/allowance fetching
       'https://umaproject.org/uma.tokenlist.json'
     ]
   },

--- a/src/providers/tokens.provider.ts
+++ b/src/providers/tokens.provider.ts
@@ -142,6 +142,16 @@ export default {
      */
 
     /**
+     * All tokens from all token lists.
+     */
+    const allTokenListTokens = computed(
+      (): TokenInfoMap => ({
+        ...mapTokenListTokens(Object.values(allTokenLists.value)),
+        ...state.injectedTokens
+      })
+    );
+
+    /**
      * All tokens from token lists that are toggled on.
      */
     const activeTokenListTokens = computed(
@@ -163,15 +173,12 @@ export default {
      * and any injected tokens. Static and dynamic
      * meta data should be available for these tokens.
      */
-    const tokens = computed(() => ({
-      ...activeTokenListTokens.value,
-      ...state.injectedTokens
-    }));
-
-    const allTokens = computed(() => ({
-      ...mapTokenListTokens(Object.values(allTokenLists.value)),
-      ...state.injectedTokens
-    }));
+    const tokens = computed(
+      (): TokenInfoMap => ({
+        ...activeTokenListTokens.value,
+        ...state.injectedTokens
+      })
+    );
 
     const tokenAddresses = computed((): string[] => Object.keys(tokens.value));
 
@@ -294,7 +301,7 @@ export default {
 
       if (isAddress(query)) {
         const address = getAddress(query);
-        const token = allTokens.value[address];
+        const token = allTokenListTokens.value[address];
         if (token) {
           return { [address]: token };
         } else {
@@ -306,7 +313,7 @@ export default {
           }
         }
       } else {
-        const tokensArray = Object.entries(allTokens.value);
+        const tokensArray = Object.entries(allTokenListTokens.value);
         const results = tokensArray.filter(
           ([, token]) =>
             token.name.toLowerCase().includes(query.toLowerCase()) ||

--- a/src/providers/tokens.provider.ts
+++ b/src/providers/tokens.provider.ts
@@ -168,6 +168,11 @@ export default {
       ...state.injectedTokens
     }));
 
+    const allTokens = computed(() => ({
+      ...mapTokenListTokens(Object.values(allTokenLists.value)),
+      ...state.injectedTokens
+    }));
+
     const tokenAddresses = computed((): string[] => Object.keys(tokens.value));
 
     const wrappedNativeAsset = computed(
@@ -289,7 +294,7 @@ export default {
 
       if (isAddress(query)) {
         const address = getAddress(query);
-        const token = tokens.value[address];
+        const token = allTokens.value[address];
         if (token) {
           return { [address]: token };
         } else {
@@ -301,7 +306,7 @@ export default {
           }
         }
       } else {
-        const tokensArray = Object.entries(tokens.value);
+        const tokensArray = Object.entries(allTokens.value);
         const results = tokensArray.filter(
           ([, token]) =>
             token.name.toLowerCase().includes(query.toLowerCase()) ||


### PR DESCRIPTION
# Description

Currently when searching for tokens we only look in the currently active tokenlists. This hampers discoverability as it requires us to have listed a token in order for it to show up when the user is looking for it (without the user having to go out of their way to enable the 3rd party tokenlists first).

This PR means that as long as the token exists _somewhere_ in one of our tokenlists then the user will be able to find and inject it.

As a result of this I've removed some of the larger tokenlists as they included a lot of dross and weren't generally helpful. In future we want to add a semi-greyed-out state for tokens which are being loaded from external token lists until the user has injected them to show the distinction.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## How should this be tested?

Search for the name of a token which is not included in the main Balancer tokenlist but in other tokenlists on the relevant network, the token should appear for selection.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] My changes generate no new console warnings
- [x] The base of this PR is `master` if hotfix, `develop` if not
