### PR TITLE
feat: add support for ENS avatar resolution

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35,6 +35,7 @@
         "@sentry/browser": "^6.3.2",
         "@sentry/tracing": "^6.3.2",
         "@sentry/webpack-plugin": "^1.15.1",
+        "@tomfrench/ens-avatar-resolver": "^0.1.0",
         "@types/animejs": "^3.1.3",
         "@types/jest": "^24.0.19",
         "@types/lodash": "^4.14.168",
@@ -250,11 +251,31 @@
         "minimalistic-assert": "^1.0.0"
       }
     },
+    "node_modules/@0x/utils/node_modules/isomorphic-fetch": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
+      "integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
+      "dev": true,
+      "dependencies": {
+        "node-fetch": "^1.0.1",
+        "whatwg-fetch": ">=0.10.0"
+      }
+    },
     "node_modules/@0x/utils/node_modules/js-sha3": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.7.0.tgz",
       "integrity": "sha512-Wpks3yBDm0UcL5qlVhwW9Jr9n9i4FfeWBFOOXP5puDS/SiudJGhw7DPyBqn3487qD4F0lsC0q3zxink37f7zeA==",
       "dev": true
+    },
+    "node_modules/@0x/utils/node_modules/node-fetch": {
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
+      "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
+      "dev": true,
+      "dependencies": {
+        "encoding": "^0.1.11",
+        "is-stream": "^1.0.1"
+      }
     },
     "node_modules/@0x/utils/node_modules/scrypt-js": {
       "version": "2.0.4",
@@ -1949,6 +1970,26 @@
         "ws": "7.2.3"
       }
     },
+    "node_modules/@balancer-labs/sor/node_modules/isomorphic-fetch": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
+      "integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
+      "dev": true,
+      "dependencies": {
+        "node-fetch": "^1.0.1",
+        "whatwg-fetch": ">=0.10.0"
+      }
+    },
+    "node_modules/@balancer-labs/sor/node_modules/node-fetch": {
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
+      "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
+      "dev": true,
+      "dependencies": {
+        "encoding": "^0.1.11",
+        "is-stream": "^1.0.1"
+      }
+    },
     "node_modules/@balancer-labs/sor/node_modules/ws": {
       "version": "7.2.3",
       "resolved": "https://registry.npmjs.org/ws/-/ws-7.2.3.tgz",
@@ -1987,6 +2028,26 @@
         "@ethersproject/constants": "^5.4.0",
         "@ethersproject/contracts": "^5.4.1",
         "@ethersproject/providers": "^5.4.4"
+      }
+    },
+    "node_modules/@balancer-labs/sor2/node_modules/isomorphic-fetch": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
+      "integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
+      "dev": true,
+      "dependencies": {
+        "node-fetch": "^1.0.1",
+        "whatwg-fetch": ">=0.10.0"
+      }
+    },
+    "node_modules/@balancer-labs/sor2/node_modules/node-fetch": {
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
+      "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
+      "dev": true,
+      "dependencies": {
+        "encoding": "^0.1.11",
+        "is-stream": "^1.0.1"
       }
     },
     "node_modules/@balancer-labs/typechain": {
@@ -3820,6 +3881,20 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/@tomfrench/ens-avatar-resolver": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@tomfrench/ens-avatar-resolver/-/ens-avatar-resolver-0.1.0.tgz",
+      "integrity": "sha512-B4AdWUF62jndLHnKflNDwsqR9deQhhROHpcFsOJr4vEdSGaGmu3H5BhPWtYHKOoBVqFv978e+RZvG3ibZ6X3VQ==",
+      "dev": true,
+      "peerDependencies": {
+        "@ethersproject/address": "^5.4.0",
+        "@ethersproject/bignumber": "^5.4.0",
+        "@ethersproject/constants": "^5.4.0",
+        "@ethersproject/contracts": "^5.4.0",
+        "@ethersproject/providers": "^5.4.1",
+        "isomorphic-fetch": "^3.0.0"
       }
     },
     "node_modules/@types/animejs": {
@@ -15669,23 +15744,14 @@
       }
     },
     "node_modules/isomorphic-fetch": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
-      "integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-3.0.0.tgz",
+      "integrity": "sha512-qvUtwJ3j6qwsF3jLxkZ72qCgjMysPzDfeV240JHiGZsANBYd+EEuu35v7dfrJ9Up0Ak07D7GGSkGhCHTqg/5wA==",
       "dev": true,
+      "peer": true,
       "dependencies": {
-        "node-fetch": "^1.0.1",
-        "whatwg-fetch": ">=0.10.0"
-      }
-    },
-    "node_modules/isomorphic-fetch/node_modules/node-fetch": {
-      "version": "1.7.3",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
-      "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
-      "dev": true,
-      "dependencies": {
-        "encoding": "^0.1.11",
-        "is-stream": "^1.0.1"
+        "node-fetch": "^2.6.1",
+        "whatwg-fetch": "^3.4.1"
       }
     },
     "node_modules/isstream": {
@@ -29009,11 +29075,31 @@
             "minimalistic-assert": "^1.0.0"
           }
         },
+        "isomorphic-fetch": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
+          "integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
+          "dev": true,
+          "requires": {
+            "node-fetch": "^1.0.1",
+            "whatwg-fetch": ">=0.10.0"
+          }
+        },
         "js-sha3": {
           "version": "0.7.0",
           "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.7.0.tgz",
           "integrity": "sha512-Wpks3yBDm0UcL5qlVhwW9Jr9n9i4FfeWBFOOXP5puDS/SiudJGhw7DPyBqn3487qD4F0lsC0q3zxink37f7zeA==",
           "dev": true
+        },
+        "node-fetch": {
+          "version": "1.7.3",
+          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
+          "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
+          "dev": true,
+          "requires": {
+            "encoding": "^0.1.11",
+            "is-stream": "^1.0.1"
+          }
         },
         "scrypt-js": {
           "version": "2.0.4",
@@ -30211,6 +30297,26 @@
             "ws": "7.2.3"
           }
         },
+        "isomorphic-fetch": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
+          "integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
+          "dev": true,
+          "requires": {
+            "node-fetch": "^1.0.1",
+            "whatwg-fetch": ">=0.10.0"
+          }
+        },
+        "node-fetch": {
+          "version": "1.7.3",
+          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
+          "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
+          "dev": true,
+          "requires": {
+            "encoding": "^0.1.11",
+            "is-stream": "^1.0.1"
+          }
+        },
         "ws": {
           "version": "7.2.3",
           "resolved": "https://registry.npmjs.org/ws/-/ws-7.2.3.tgz",
@@ -30228,6 +30334,28 @@
       "requires": {
         "@georgeroman/balancer-v2-pools": "^0.0.5",
         "isomorphic-fetch": "^2.2.1"
+      },
+      "dependencies": {
+        "isomorphic-fetch": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
+          "integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
+          "dev": true,
+          "requires": {
+            "node-fetch": "^1.0.1",
+            "whatwg-fetch": ">=0.10.0"
+          }
+        },
+        "node-fetch": {
+          "version": "1.7.3",
+          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
+          "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
+          "dev": true,
+          "requires": {
+            "encoding": "^0.1.11",
+            "is-stream": "^1.0.1"
+          }
+        }
       }
     },
     "@balancer-labs/typechain": {
@@ -31496,6 +31624,13 @@
         "defer-to-connect": "^1.0.1"
       }
     },
+    "@tomfrench/ens-avatar-resolver": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@tomfrench/ens-avatar-resolver/-/ens-avatar-resolver-0.1.0.tgz",
+      "integrity": "sha512-B4AdWUF62jndLHnKflNDwsqR9deQhhROHpcFsOJr4vEdSGaGmu3H5BhPWtYHKOoBVqFv978e+RZvG3ibZ6X3VQ==",
+      "dev": true,
+      "requires": {}
+    },
     "@types/animejs": {
       "version": "3.1.4",
       "resolved": "https://registry.npmjs.org/@types/animejs/-/animejs-3.1.4.tgz",
@@ -32106,6 +32241,7 @@
       "integrity": "sha512-J+YttzvwRfV1BPczf8r3qCevznYk+jh531agVF+5EYlHF4Sgh/cGXTz9qkkiux3LQgvhEGXgmCteg1n38WuuKg==",
       "dev": true,
       "requires": {
+        "@babel/core": "^7.11.0",
         "@babel/helper-compilation-targets": "^7.9.6",
         "@babel/helper-module-imports": "^7.8.3",
         "@babel/plugin-proposal-class-properties": "^7.8.3",
@@ -32118,6 +32254,7 @@
         "@vue/babel-plugin-jsx": "^1.0.3",
         "@vue/babel-preset-jsx": "^1.2.4",
         "babel-plugin-dynamic-import-node": "^2.3.3",
+        "core-js": "^3.6.5",
         "core-js-compat": "^3.6.5",
         "semver": "^6.1.0"
       }
@@ -41135,25 +41272,14 @@
       "dev": true
     },
     "isomorphic-fetch": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
-      "integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-3.0.0.tgz",
+      "integrity": "sha512-qvUtwJ3j6qwsF3jLxkZ72qCgjMysPzDfeV240JHiGZsANBYd+EEuu35v7dfrJ9Up0Ak07D7GGSkGhCHTqg/5wA==",
       "dev": true,
+      "peer": true,
       "requires": {
-        "node-fetch": "^1.0.1",
-        "whatwg-fetch": ">=0.10.0"
-      },
-      "dependencies": {
-        "node-fetch": {
-          "version": "1.7.3",
-          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
-          "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
-          "dev": true,
-          "requires": {
-            "encoding": "^0.1.11",
-            "is-stream": "^1.0.1"
-          }
-        }
+        "node-fetch": "^2.6.1",
+        "whatwg-fetch": "^3.4.1"
       }
     },
     "isstream": {

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "@sentry/browser": "^6.3.2",
     "@sentry/tracing": "^6.3.2",
     "@sentry/webpack-plugin": "^1.15.1",
+    "@tomfrench/ens-avatar-resolver": "^0.1.0",
     "@types/animejs": "^3.1.3",
     "@types/jest": "^24.0.19",
     "@types/lodash": "^4.14.168",

--- a/src/components/images/Avatar.vue
+++ b/src/components/images/Avatar.vue
@@ -1,23 +1,78 @@
 <template>
+  <img
+    v-if="iconSRC && !error"
+    :src="iconSRC"
+    :style="{
+      width: `${size}px`,
+      height: `${size}px`,
+      background: 'white'
+    }"
+    @error="error = true"
+    class="rounded-full inline-block leading-none shadow-sm"
+  />
   <div
+    v-else
     class="leading-none rounded-full overflow-hidden"
     :style="{
-      width: `${parseInt(size) || 22}px`,
-      height: `${parseInt(size) || 22}px`
+      width: `${size}px`,
+      height: `${size}px`
     }"
   >
-    <jazzicon :address="address" :diameter="parseInt(size) || 22" />
+    <jazzicon :address="address" :diameter="size" />
   </div>
 </template>
 
 <script>
+import { defineComponent, ref, computed, watch } from 'vue';
 import Jazzicon from 'vue3-jazzicon/src/components';
+import useUrls from '@/composables/useUrls';
 
-export default {
+export default defineComponent({
+  name: 'Avatar',
+
   components: {
     Jazzicon
   },
 
-  props: ['address', 'size']
-};
+  props: {
+    address: {
+      type: String,
+      required: true
+    },
+    iconURI: { type: String },
+    size: {
+      type: Number,
+      default: 24
+    }
+  },
+
+  setup(props) {
+    /**
+     * COMPOSABLES
+     */
+    const { resolve } = useUrls();
+
+    /**
+     * STATE
+     */
+    const error = ref(false);
+
+    /**
+     * COMPUTED
+     */
+    const iconSRC = computed(() => resolve(props.iconURI));
+
+    /**
+     * WATCHERS
+     */
+    watch(iconSRC, newURL => {
+      if (newURL !== '') error.value = false;
+    });
+
+    return {
+      iconSRC,
+      error
+    };
+  }
+});
 </script>

--- a/src/components/navs/AppNav/AppNavAccountBtn.vue
+++ b/src/components/navs/AppNav/AppNavAccountBtn.vue
@@ -10,7 +10,11 @@
         :size="upToLargeBreakpoint ? 'md' : 'sm'"
         :circle="upToLargeBreakpoint"
       >
-        <Avatar :address="account" :size="avatarSize" />
+        <Avatar
+          :iconURI="profile?.avatar"
+          :address="account"
+          :size="avatarSize"
+        />
         <span
           v-if="profile && profile.ens"
           v-text="profile && profile.ens"

--- a/src/components/navs/AppNav/AppNavSettings.vue
+++ b/src/components/navs/AppNav/AppNavSettings.vue
@@ -12,7 +12,7 @@
       <div class="flex mt-1">
         <div class="flex">
           <div class="relative">
-            <Avatar :address="account" size="44" />
+            <Avatar :iconURI="profile?.avatar" :address="account" size="44" />
             <div class="connector-icon-wrapper">
               <img
                 :src="connectorLogo"
@@ -220,6 +220,7 @@ export default defineComponent({
     const {
       explorerLinks,
       account,
+      profile,
       disconnectWallet,
       connector,
       isV1Supported,
@@ -302,6 +303,7 @@ export default defineComponent({
       ENABLE_LEGACY_TRADE_INTERFACE,
       // computed
       account,
+      profile,
       appTradeLiquidity,
       appTradeInterface,
       networkName,

--- a/src/services/web3/web3.service.ts
+++ b/src/services/web3/web3.service.ts
@@ -1,8 +1,10 @@
+import { resolveENSAvatar } from '@tomfrench/ens-avatar-resolver';
 import { JsonRpcProvider } from '@ethersproject/providers';
 import { rpcProviderService as _rpcProviderService } from '../rpc-provider/rpc-provider.service';
 
 interface Web3Profile {
   ens: string | null;
+  avatar: string | null;
 }
 
 export default class Web3Service {
@@ -20,9 +22,18 @@ export default class Web3Service {
     }
   }
 
+  async getEnsAvatar(address: string): Promise<string | null> {
+    try {
+      return await resolveENSAvatar(this.provider, address);
+    } catch (error) {
+      return null;
+    }
+  }
+
   async getProfile(address: string): Promise<Web3Profile> {
     return {
-      ens: await this.getEnsName(address)
+      ens: await this.getEnsName(address),
+      avatar: await this.getEnsAvatar(address)
     };
   }
 }


### PR DESCRIPTION
# Description

I've made a [small package](https://github.com/TomAFrench/ens-avatar-resolver) to resolve the avatar attached to ENS names. This has been added to the web3 service alongside the ENS name lookup so that we can show the user's avatar nav bar.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## How should this be tested?

Impersonate brantly.eth or nick.eth and check that you get a cryptopunk showing up in the nav bar.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] My changes generate no new console warnings
- [x] The base of this PR is `master` if hotfix, `develop` if not
