### PR TITLE
update: add ability to save pool creation state and recover when retu…

### DIFF
--- a/src/components/cards/CreatePool/CreateActions.vue
+++ b/src/components/cards/CreatePool/CreateActions.vue
@@ -52,7 +52,14 @@ const { tokenApprovalActions } = useTokenApprovalActions(
   props.tokenAddresses,
   ref(props.amounts)
 );
-const { createPool, joinPool, poolId, poolTypeString } = usePoolCreation();
+const {
+  createPool,
+  joinPool,
+  poolId,
+  poolTypeString,
+  hasRestoredFromSavedState,
+  needsSeeding
+} = usePoolCreation();
 
 /**
  * COMPUTED
@@ -76,6 +83,17 @@ const actions = computed((): TransactionActionInfo[] => [
   }
 ]);
 
+const requiredActions = computed(() => {
+  if (hasRestoredFromSavedState.value && needsSeeding.value) {
+    console.log(
+      'es',
+      actions.value.filter(action => action.label === t('fundPool'))
+    );
+    return actions.value.filter(action => action.label === t('fundPool'));
+  }
+  return actions.value;
+});
+
 const explorerLink = computed((): string =>
   createState.receipt
     ? explorerLinks.txLink(createState.receipt.transactionHash)
@@ -96,7 +114,7 @@ function handleSuccess(details: any): void {
 
 <template>
   <div>
-    <BalActionSteps :actions="actions" @success="handleSuccess" />
+    <BalActionSteps :actions="requiredActions" @success="handleSuccess" />
     <template v-if="createState.confirmed">
       <div
         class="flex items-center justify-between text-gray-400 dark:text-gray-600 mt-4 text-sm"

--- a/src/components/cards/CreatePool/PreviewPool.vue
+++ b/src/components/cards/CreatePool/PreviewPool.vue
@@ -1,5 +1,5 @@
 <script lang="ts" setup>
-import { ref, computed, onBeforeMount } from 'vue';
+import { ref, computed, onBeforeMount, onMounted } from 'vue';
 import CreateActions from '@/components/cards/CreatePool/CreateActions.vue';
 
 import usePoolCreation from '@/composables/pools/usePoolCreation';
@@ -81,6 +81,15 @@ const tokenAddresses = computed((): string[] => {
 
 const tokenAmounts = computed((): string[] => {
   return getScaledAmounts();
+});
+
+/**
+ * LIFECYCLE
+ */
+onMounted(() => {
+  // upon reaching this step. save the state of pool creation
+  // as all the editable inputs have been set
+  // saveState();
 });
 
 /**

--- a/src/locales/default.json
+++ b/src/locales/default.json
@@ -113,7 +113,9 @@
         "totalWeightAlertTitle": "The total weight must be 100%",
         "arbTitle": "You could lose up to {0} ({1})",
         "arbReason": "Based on pricing information from CoinGecko, you’re vulnerable to losing funds to arbitraguers since the amounts you’re adding to the pool are not in proportion to the pool weights specified.",
-        "maxLiquidityTooltip": "This is the max amount of liquidity you can provide to the pool with the current token selection."
+        "maxLiquidityTooltip": "This is the max amount of liquidity you can provide to the pool with the current token selection.",
+        "addSeedLiquidity": "Add seed liquidity to finalize pool creation",
+        "addSeedLiquidityInfo": "Provide liquidity to start earning swap fees and to make this pool available for others to invest in."
     },
     "createPool": "Create pool",
     "createPoolTooltip": "Create {0} pool",

--- a/src/pages/pool/create.vue
+++ b/src/pages/pool/create.vue
@@ -59,7 +59,8 @@ const {
   setActiveStep,
   hasInjectedToken,
   seedTokens,
-  totalLiquidity
+  totalLiquidity,
+  hasRestoredFromSavedState
 } = usePoolCreation();
 const { upToLargeBreakpoint, upToSmallBreakpoint } = useBreakpoints();
 
@@ -183,7 +184,9 @@ watch([hasInjectedToken, totalLiquidity], () => {
     </template>
     <div class="relative center-col-mh">
       <AnimatePresence
-        :isVisible="!appLoading && activeStep === 0"
+        :isVisible="
+          !appLoading && activeStep === 0 && !hasRestoredFromSavedState
+        "
         :initial="initialAnimateProps"
         :animate="entryAnimateProps"
         :exit="exitAnimateProps"


### PR DESCRIPTION
# Description

Currently we have a problem with pool creation in that there is no recoverability mechanism built into the flow. This PR introduces that ability to recover previous state for the user to return to where they were before.

The main concept is that once the user reaches the PreviewPool stage of pool creation (the step where the buttons for creation and seeding are) the UI will save the pool creation state to the users local storage. The creation state has a new flag called `needsSeeding` which is set after a successful create action.

So the two main points of recovery are: 
- user reaches the final step of creation and doesn't create the pool. the state is saved and the user can return to this
- the user creates the pool but doesn't seed liquidity, or the seed liquidity transaction fails, the user can refresh or come back to this page and it'll recover and allow them to fund the pool


## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## How should this be tested?

1. Go to pool creation, go through the flow as you would and once you reach the final step, exit out and open up the UI again. It should open up to the last step with the inputs you had selected before
2. Go through test 1, but this time create the pool - then exit out. Coming back to the UI it should go to the last step and the only action should be to fund the pool
3. 
## Checklist:

- [X] I have performed a self-review of my own code
- [X] I have commented my code where relevant, particularly in hard-to-understand areas
- [X] My changes generate no new console warnings
- [X] The base of this PR is `master` if hotfix, `develop` if not
