### PR TITLE
Hotfix - remove no balance alert

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.32.1",
+  "version": "1.32.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@balancer-labs/frontend-v2",
-      "version": "1.32.1",
+      "version": "1.32.2",
       "license": "MIT",
       "devDependencies": {
         "@babel/core": "^7.13.8",
@@ -32106,6 +32106,7 @@
       "integrity": "sha512-J+YttzvwRfV1BPczf8r3qCevznYk+jh531agVF+5EYlHF4Sgh/cGXTz9qkkiux3LQgvhEGXgmCteg1n38WuuKg==",
       "dev": true,
       "requires": {
+        "@babel/core": "^7.11.0",
         "@babel/helper-compilation-targets": "^7.9.6",
         "@babel/helper-module-imports": "^7.8.3",
         "@babel/plugin-proposal-class-properties": "^7.8.3",
@@ -32118,6 +32119,7 @@
         "@vue/babel-plugin-jsx": "^1.0.3",
         "@vue/babel-preset-jsx": "^1.2.4",
         "babel-plugin-dynamic-import-node": "^2.3.3",
+        "core-js": "^3.6.5",
         "core-js-compat": "^3.6.5",
         "semver": "^6.1.0"
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.32.1",
+  "version": "1.32.2",
   "engines": {
     "node": "14.x",
     "npm": ">=7"

--- a/src/components/cards/TradeCard/TradeCard.vue
+++ b/src/components/cards/TradeCard/TradeCard.vue
@@ -247,11 +247,6 @@ export default defineComponent({
               configService.network.chainName
             ])
           };
-        case TradeValidation.NO_BALANCE:
-          return {
-            header: t('insufficientBalance'),
-            body: t('insufficientBalanceDetailed')
-          };
         case TradeValidation.NO_LIQUIDITY:
           return {
             header: t('insufficientLiquidity'),

--- a/src/components/cards/TradeCardGP/TradeCardGP.vue
+++ b/src/components/cards/TradeCardGP/TradeCardGP.vue
@@ -253,13 +253,6 @@ export default defineComponent({
         };
       }
 
-      if (errorMessage.value === TradeValidation.NO_BALANCE) {
-        return {
-          header: t('insufficientBalance'),
-          body: t('insufficientBalanceDetailed')
-        };
-      }
-
       if (trading.isBalancerTrade.value) {
         if (errorMessage.value === TradeValidation.NO_LIQUIDITY) {
           return {


### PR DESCRIPTION
# Description

We already show if the user has exceeded their balance in the input, there is no need to show an alert as well. Also, for some reason showing the alert seems to prevent the result of the trade being presented so the user is unable to test trade amounts and returns if they don't have the balance.

This PR removes the alerts but not the validation.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## How should this be tested?

- [ ] Test that you can see trade outputs when input is above your token balance

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] My changes generate no new console warnings
- [x] The base of this PR is `master` if hotfix, `develop` if not
