### PR TITLE
Fiat price fix for "My pool balance"

### DIFF
--- a/src/components/contextual/pages/pool/MyPoolBalancesCard.vue
+++ b/src/components/contextual/pages/pool/MyPoolBalancesCard.vue
@@ -26,11 +26,12 @@ const props = defineProps<Props>();
  */
 const {
   fiatTotalLabel,
+  fiatAmounts,
   initMath,
   proportionalPoolTokenAmounts
 } = useWithdrawMath(toRef(props, 'pool'));
 const { getTokens } = useTokens();
-const { fNum, toFiat } = useNumbers();
+const { fNum } = useNumbers();
 const { currency } = useUserSettings();
 const { isWalletReady } = useWeb3();
 const { isStableLikePool } = usePool(toRef(props, 'pool'));
@@ -47,9 +48,8 @@ function weightLabelFor(address: string): string {
   return fNum(props.pool.onchain.tokens[address].weight, 'percent_lg');
 }
 
-function fiatLabelFor(index: number, address: string): string {
-  const fiatValue = toFiat(proportionalPoolTokenAmounts.value[index], address);
-  return fNum(fiatValue, currency.value);
+function fiatLabelFor(index: number): string {
+  return fNum(fiatAmounts.value[index], currency.value);
 }
 
 /**
@@ -100,7 +100,7 @@ onBeforeMount(() => {
               : '-'
           }}
           <span class="text-gray-500 text-sm">
-            {{ isWalletReady ? fiatLabelFor(index, token.address) : '-' }}
+            {{ isWalletReady ? fiatLabelFor(index) : '-' }}
           </span>
         </span>
       </div>


### PR DESCRIPTION
# Description

Apparently the fix is quicker than I thought... I initially implemented the "latestPrices" subgraph query only to find out that this is the existing `priceRate` we already used.

Since total was calculated correctly, all what was needed is to use `fiatAmounts` (which already calcs the fiat amount)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## How should this be tested?

Please provide instructions so we can test. Please also list any relevant details for your test configuration.

- [ ] Check "My pool balance" - total should match the sum of all the pool tokens.

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code where relevant, particularly in hard-to-understand areas
- [ ] My changes generate no new console warnings
- [ ] The base of this PR is `master` if hotfix, `develop` if not
