### PR TITLE
Hotfix - price impact warning

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.32.5",
+  "version": "1.32.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@balancer-labs/frontend-v2",
-      "version": "1.32.5",
+      "version": "1.32.6",
       "license": "MIT",
       "devDependencies": {
         "@babel/core": "^7.13.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.32.5",
+  "version": "1.32.6",
   "engines": {
     "node": "14.x",
     "npm": ">=7"

--- a/src/components/forms/pool_actions/InvestForm/components/InvestFormTotals.vue
+++ b/src/components/forms/pool_actions/InvestForm/components/InvestFormTotals.vue
@@ -41,7 +41,8 @@ const {
  * COMPUTED
  */
 const priceImpactClasses = computed(() => ({
-  'bg-red-500 text-white divide-red-400': highPriceImpact.value
+  'dark:bg-gray-800': !highPriceImpact.value,
+  'bg-red-500 dark:bg-red-500 text-white divide-red-400': highPriceImpact.value
 }));
 
 const optimizeBtnClasses = computed(() => ({
@@ -119,7 +120,6 @@ const optimizeBtnClasses = computed(() => ({
 .data-table-row {
   @apply grid grid-cols-4 items-center;
   @apply divide-x dark:divide-gray-900;
-  @apply dark:bg-gray-800;
 }
 
 .data-table-number-col {
@@ -127,7 +127,7 @@ const optimizeBtnClasses = computed(() => ({
 }
 
 .total-row {
-  @apply text-lg font-bold rounded-t-lg;
+  @apply text-lg font-bold rounded-t-lg dark:bg-gray-800;
 }
 
 .price-impact-row {


### PR DESCRIPTION
# Description

Fixes regression, price impact row in investment form used to have a red background when above 1%.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## How should this be tested?

- [ ] Test investment form in dark mode and input values to get above 1% price impact.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] My changes generate no new console warnings
- [x] The base of this PR is `master` if hotfix, `develop` if not
