### PR TITLE
Hotfix - remove copper module

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.32.9",
+  "version": "1.32.10",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@balancer-labs/frontend-v2",
-      "version": "1.32.9",
+      "version": "1.32.10",
       "license": "MIT",
       "devDependencies": {
         "@babel/core": "^7.13.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.32.9",
+  "version": "1.32.10",
   "engines": {
     "node": "14.x",
     "npm": ">=7"

--- a/src/pages/pool/_id.vue
+++ b/src/pages/pool/_id.vue
@@ -136,7 +136,7 @@
           :missingPrices="missingPrices"
         />
       </div>
-      <div v-else class="order-1 lg:order-2 px-1 lg:px-0">
+      <!-- <div v-else class="order-1 lg:order-2 px-1 lg:px-0">
         <BalCard
           v-if="isCopperPool"
           noPad
@@ -169,7 +169,7 @@
             </BalLink>
           </div>
         </BalCard>
-      </div>
+      </div> -->
     </div>
   </div>
 </template>


### PR DESCRIPTION
# Description

Additional LBP projects are going to be adding pools soon, this PR temporarily hides the Copper module that links through to the Copper website for all LBPs until we can distinguish between projects via the subgraph.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## How should this be tested?

- [ ] LBP pages should no longer display the copper module.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] My changes generate no new console warnings
- [x] The base of this PR is `master` if hotfix, `develop` if not
