### PR TITLE
Fix linear pool composition balances

### DIFF
--- a/src/components/contextual/pages/pool/PoolBalancesCard/BoostedPool.vue
+++ b/src/components/contextual/pages/pool/PoolBalancesCard/BoostedPool.vue
@@ -4,6 +4,8 @@ import { defineProps } from 'vue';
 import { FullPool } from '@/services/balancer/subgraph/types';
 import useWeb3 from '@/services/web3/useWeb3';
 
+import { bnum } from '@/lib/utils';
+
 import useBreakpoints from '@/composables/useBreakpoints';
 
 import AssetRow from './components/AssetRow';
@@ -38,6 +40,17 @@ function getUnderlyingTokens(address: string) {
   return linearPools != null
     ? [linearPools[address].mainToken, linearPools[address].wrappedToken]
     : [];
+}
+
+function getTokenShare(address: string) {
+  const totalSupply = props.pool.onchain.totalSupply;
+  const token = props.pool.onchain.tokens[address];
+
+  return token != null
+    ? bnum(token.balance)
+        .div(totalSupply)
+        .toString()
+    : null;
 }
 </script>
 
@@ -82,7 +95,11 @@ function getUnderlyingTokens(address: string) {
             />
           </BalLink>
           <template #item="{ item: asset }">
-            <AssetRow :address="asset.address" :balance="asset.balance" />
+            <AssetRow
+              :address="asset.address"
+              :balance="asset.balance"
+              :share="getTokenShare(address)"
+            />
           </template>
         </BalBreakdown>
       </div>

--- a/src/components/contextual/pages/pool/PoolBalancesCard/components/AssetRow.vue
+++ b/src/components/contextual/pages/pool/PoolBalancesCard/components/AssetRow.vue
@@ -6,6 +6,7 @@ import useTokens from '@/composables/useTokens';
 import useNumbers from '@/composables/useNumbers';
 import useUserSettings from '@/composables/useUserSettings';
 import useWeb3 from '@/services/web3/useWeb3';
+import { bnum } from '@/lib/utils';
 
 /**
  * TYPES
@@ -13,6 +14,7 @@ import useWeb3 from '@/services/web3/useWeb3';
 type Props = {
   address: string;
   balance: string;
+  share: string;
 };
 
 /**
@@ -33,9 +35,15 @@ const { explorerLinks } = useWeb3();
  */
 const token = computed(() => getToken(props.address));
 
-const balance = computed(() =>
-  formatUnits(props.balance, token.value.decimals)
-);
+const balance = computed(() => {
+  const formattedBalance = formatUnits(props.balance, token.value.decimals);
+
+  return props.share != null
+    ? bnum(formattedBalance)
+        .times(props.share)
+        .toString()
+    : formattedBalance;
+});
 
 const balanceLabel = computed(() => fNum(balance.value, 'token'));
 


### PR DESCRIPTION
# Description

Now that `totalSupply` is computed correctly its possible to get the right balances. Awaiting on Markus to confirm if the numbers look right.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## How should this be tested?

Please provide instructions so we can test. Please also list any relevant details for your test configuration.

- [ ] Check pool composition

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code where relevant, particularly in hard-to-understand areas
- [ ] My changes generate no new console warnings
- [ ] The base of this PR is `master` if hotfix, `develop` if not
