### PR TITLE
Fix weekly yield calc for boosted pools

### DIFF
--- a/src/components/forms/pool_actions/InvestForm/components/InvestPreviewModal/components/InvestSummary.vue
+++ b/src/components/forms/pool_actions/InvestForm/components/InvestPreviewModal/components/InvestSummary.vue
@@ -75,7 +75,7 @@ const thirdPartyMultiRewardPool = computed(
   () => Object.keys(thirdPartyTokens.value).length > 1
 );
 
-const thirdPartyAPRLabel = computed(() => {
+const thirdPartyFiatLabel = computed(() => {
   if (isWstETH(props.pool)) return t('thirdPartyRewards.fiat.steth');
   if (isStablePhantom(props.pool.poolType))
     return t('thirdPartyRewards.fiat.aaveBoosted');
@@ -171,7 +171,7 @@ function weeklyYieldForAPR(apr: string): string {
                 <div class="flex items-center">
                   {{ fNum(thirdPartyWeeklyYield, currency) }}
                   <span class="ml-1 text-gray-500 text-xs">
-                    {{ thirdPartyAPRLabel }}
+                    {{ thirdPartyFiatLabel }}
                   </span>
                 </div>
                 <template v-if="thirdPartyMultiRewardPool" #item="{ item }">

--- a/src/components/forms/pool_actions/InvestForm/components/InvestPreviewModal/components/InvestSummary.vue
+++ b/src/components/forms/pool_actions/InvestForm/components/InvestPreviewModal/components/InvestSummary.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import useNumbers from '@/composables/useNumbers';
-import { isWstETH } from '@/composables/usePool';
+import { isStablePhantom, isWstETH } from '@/composables/usePool';
 import useTokens from '@/composables/useTokens';
 import useUserSettings from '@/composables/useUserSettings';
 import { bnum } from '@/lib/utils';
@@ -55,14 +55,31 @@ const lmBreakdown = computed(
 
 const lmTokens = computed(() => getTokens(Object.keys(lmBreakdown.value)));
 
-const multiRewardPool = computed(() => Object.keys(lmTokens.value).length > 1);
+const lmMultiRewardPool = computed(
+  () => Object.keys(lmTokens.value).length > 1
+);
 
 const hasThirdPartyAPR = computed(() =>
   bnum(props.pool.dynamic.apr.thirdParty).gt(0)
 );
 
+const thirdPartyBreakdown = computed(
+  () => props.pool.dynamic.apr.thirdPartyBreakdown
+);
+
+const thirdPartyTokens = computed(() =>
+  getTokens(Object.keys(thirdPartyBreakdown.value))
+);
+
+const thirdPartyMultiRewardPool = computed(
+  () => Object.keys(thirdPartyTokens.value).length > 1
+);
+
 const thirdPartyAPRLabel = computed(() => {
   if (isWstETH(props.pool)) return t('thirdPartyRewards.fiat.steth');
+  if (isStablePhantom(props.pool.poolType))
+    return t('thirdPartyRewards.fiat.aaveBoosted');
+
   return '';
 });
 
@@ -114,7 +131,19 @@ function weeklyYieldForAPR(apr: string): string {
         <div class="summary-table-label" v-text="$t('potentialWeeklyYield')" />
         <div class="summary-table-number">
           {{ fNum(totalWeeklyYield, currency) }}
-          <BalTooltip icon-size="sm" width="72" class="ml-2" noPad>
+          <BalTooltip icon-size="sm" width="72" noPad>
+            <template v-slot:activator>
+              <StarsIcon
+                v-if="props.pool.hasLiquidityMiningRewards || hasThirdPartyAPR"
+                class="h-4 text-yellow-300"
+              />
+              <BalIcon
+                v-else
+                name="info"
+                size="sm"
+                class="text-gray-300 ml-2"
+              />
+            </template>
             <div
               class="p-2 bg-gray-50 dark:bg-gray-700 rounded-t-lg border-b dark:border-gray-700"
             >
@@ -134,27 +163,36 @@ function weeklyYieldForAPR(apr: string): string {
                   {{ $t('swapFee') }}
                 </span>
               </div>
-              <div
-                v-if="hasThirdPartyAPR"
-                class="whitespace-nowrap flex items-center mb-1"
-              >
-                {{ fNum(thirdPartyWeeklyYield, currency) }}
-                <span class="ml-1 text-gray-500 text-xs">
-                  {{ thirdPartyAPRLabel }}
-                </span>
-              </div>
               <BalBreakdown
+                :items="Object.entries(thirdPartyBreakdown)"
+                v-if="hasThirdPartyAPR"
+                :hideItems="!thirdPartyMultiRewardPool"
+              >
+                <div class="flex items-center">
+                  {{ fNum(thirdPartyWeeklyYield, currency) }}
+                  <span class="ml-1 text-gray-500 text-xs">
+                    {{ thirdPartyAPRLabel }}
+                  </span>
+                </div>
+                <template v-if="thirdPartyMultiRewardPool" #item="{ item }">
+                  {{ fNum(weeklyYieldForAPR(item[1]), currency) }}
+                  <span class="text-gray-500 text-xs ml-1">
+                    {{ thirdPartyTokens[item[0]].symbol }}
+                  </span>
+                </template>
+              </BalBreakdown>
+              <BalBreakdown
+                v-if="props.pool.hasLiquidityMiningRewards"
                 :items="Object.entries(lmBreakdown)"
-                :hideItems="!multiRewardPool"
+                :hideItems="!lmMultiRewardPool"
               >
                 <div class="flex items-center">
                   <span>{{ fNum(lmWeeklyYield, currency) }}</span>
                   <span class="ml-1 text-gray-500">
                     {{ $t('liquidityMining') }}
                   </span>
-                  <StarsIcon class="h-4 text-yellow-300" />
                 </div>
-                <template v-if="multiRewardPool" v-slot:item="{ item }">
+                <template v-if="lmMultiRewardPool" v-slot:item="{ item }">
                   {{ fNum(weeklyYieldForAPR(item[1]), currency) }}
                   <span class="text-gray-500 ml-1">
                     {{ lmTokens[item[0]].symbol }}

--- a/src/locales/default.json
+++ b/src/locales/default.json
@@ -461,7 +461,8 @@
             "aaveBoosted": "Aave boosted APR"
         },
         "fiat": {
-            "steth": "stETH staking rewards"
+            "steth": "stETH staking rewards",
+            "aaveBoosted": "Aave boosted rewards"
         }
     },
     "threeMonths": "3M",


### PR DESCRIPTION
# Description

Adds support boosted pools and third party breakdown.
Also, I've switched the icon to be consistent with what we currently have.

Star icon - Liquidity mining / third part rewards / other future rewards.
Info icon - Swap fees.

<img width="499" alt="Screen Shot 2021-12-15 at 3 46 45 pm" src="https://user-images.githubusercontent.com/254095/146125714-e3a4b64a-1314-43df-b89b-4867190d8af4.png">
<img width="292" alt="Screen Shot 2021-12-15 at 3 47 04 pm" src="https://user-images.githubusercontent.com/254095/146125724-bf133ceb-daf5-4c62-84e2-abfe13d891ee.png">

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## How should this be tested?

Please provide instructions so we can test. Please also list any relevant details for your test configuration.

- [ ] Hover the weekly yield tooltip. (also run a sanity check to see numbers make sense).

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] My changes generate no new console warnings
- [x] The base of this PR is `master` if hotfix, `develop` if not
