### PR TITLE
Pool creation adjustments

### DIFF
--- a/src/components/_global/BalVerticalSteps/BalVerticalSteps.vue
+++ b/src/components/_global/BalVerticalSteps/BalVerticalSteps.vue
@@ -71,7 +71,7 @@ function handleNavigate(state: StepState, stepIndex: number) {
 
 <template>
   <BalCard noPad shadow="none">
-    <div class="p-2 px-3 border-b dark:border-gray-600">
+    <div class="p-4 border-b dark:border-gray-600">
       <h6 class="dark:text-gray-300">{{ title }}</h6>
     </div>
     <BalStack vertical isDynamic spacing="base" class="p-4" justify="center">

--- a/src/components/cards/CreatePool/ChooseWeights.vue
+++ b/src/components/cards/CreatePool/ChooseWeights.vue
@@ -303,7 +303,7 @@ function onAlertMountChange() {
 
 <template>
   <div ref="cardWrapper" class="mb-16">
-    <BalCard>
+    <BalCard shadow="xl">
       <BalStack vertical spacing="sm">
         <BalStack vertical spacing="xs">
           <span class="text-xs text-gray-700 dark:text-gray-500">{{

--- a/src/components/cards/CreatePool/ChooseWeights.vue
+++ b/src/components/cards/CreatePool/ChooseWeights.vue
@@ -303,7 +303,7 @@ function onAlertMountChange() {
 
 <template>
   <div ref="cardWrapper" class="mb-16">
-    <BalCard shadow="xl">
+    <BalCard shadow="xl" noBorder>
       <BalStack vertical spacing="sm">
         <BalStack vertical spacing="xs">
           <span class="text-xs text-gray-700 dark:text-gray-500">{{

--- a/src/components/cards/CreatePool/InitialLiquidity.vue
+++ b/src/components/cards/CreatePool/InitialLiquidity.vue
@@ -184,7 +184,7 @@ function onAlertMountChange() {
 
 <template>
   <div ref="cardWrapper">
-    <BalCard shadow="xl">
+    <BalCard shadow="xl" noBorder>
       <BalStack vertical>
         <BalStack vertical spacing="xs">
           <span class="text-xs text-gray-700 dark:text-gray-500">{{

--- a/src/components/cards/CreatePool/InitialLiquidity.vue
+++ b/src/components/cards/CreatePool/InitialLiquidity.vue
@@ -184,7 +184,7 @@ function onAlertMountChange() {
 
 <template>
   <div ref="cardWrapper">
-    <BalCard>
+    <BalCard shadow="xl">
       <BalStack vertical>
         <BalStack vertical spacing="xs">
           <span class="text-xs text-gray-700 dark:text-gray-500">{{

--- a/src/components/cards/CreatePool/PoolFees.vue
+++ b/src/components/cards/CreatePool/PoolFees.vue
@@ -133,7 +133,7 @@ async function onChangeFeeController(val: string) {
 
 <template>
   <div ref="cardWrapper">
-    <BalCard shadow="xl">
+    <BalCard shadow="xl" noBorder>
       <BalStack vertical>
         <BalStack vertical spacing="xs">
           <span class="text-xs text-gray-700 dark:text-gray-500">{{

--- a/src/components/cards/CreatePool/PoolFees.vue
+++ b/src/components/cards/CreatePool/PoolFees.vue
@@ -133,7 +133,7 @@ async function onChangeFeeController(val: string) {
 
 <template>
   <div ref="cardWrapper">
-    <BalCard>
+    <BalCard shadow="xl">
       <BalStack vertical>
         <BalStack vertical spacing="xs">
           <span class="text-xs text-gray-700 dark:text-gray-500">{{

--- a/src/components/cards/CreatePool/PoolSummary.vue
+++ b/src/components/cards/CreatePool/PoolSummary.vue
@@ -185,10 +185,7 @@ async function calculateColors() {
 
 <template>
   <BalCard noPad shadow="none">
-    <div
-      class="p-2 px-3 border-b dark:border-gray-600"
-      v-if="!upToLargeBreakpoint"
-    >
+    <div class="p-4 border-b dark:border-gray-600" v-if="!upToLargeBreakpoint">
       <h6 class="dark:text-gray-300">{{ $t('createAPool.poolSummary') }}</h6>
     </div>
     <div class="p-2">

--- a/src/components/cards/CreatePool/PreviewPool.vue
+++ b/src/components/cards/CreatePool/PreviewPool.vue
@@ -118,7 +118,7 @@ function getSwapFeeManager() {
 
 <template>
   <BalStack vertical spacing="xs" class="mb-24">
-    <BalCard>
+    <BalCard shadow="xl">
       <BalStack vertical spacing="xs">
         <span class="text-xs text-gray-700 dark:text-gray-500">{{
           userNetworkConfig?.name

--- a/src/components/cards/CreatePool/PreviewPool.vue
+++ b/src/components/cards/CreatePool/PreviewPool.vue
@@ -118,7 +118,7 @@ function getSwapFeeManager() {
 
 <template>
   <BalStack vertical spacing="xs" class="mb-24">
-    <BalCard shadow="xl">
+    <BalCard shadow="xl" noBorder>
       <BalStack vertical spacing="xs">
         <span class="text-xs text-gray-700 dark:text-gray-500">{{
           userNetworkConfig?.name

--- a/src/components/cards/CreatePool/SimilarPools.vue
+++ b/src/components/cards/CreatePool/SimilarPools.vue
@@ -50,7 +50,7 @@ function cancel() {
 </script>
 
 <template>
-  <BalCard shadow="xl" :class="{ 'border-red-400': existingPool }">
+  <BalCard shadow="xl" noBorder :class="{ 'border-red-400': existingPool }">
     <BalStack vertical>
       <BalStack vertical spacing="xs">
         <span

--- a/src/components/cards/CreatePool/SimilarPools.vue
+++ b/src/components/cards/CreatePool/SimilarPools.vue
@@ -50,7 +50,7 @@ function cancel() {
 </script>
 
 <template>
-  <BalCard :class="{ 'border-red-400': existingPool }">
+  <BalCard shadow="xl" :class="{ 'border-red-400': existingPool }">
     <BalStack vertical>
       <BalStack vertical spacing="xs">
         <span

--- a/src/pages/_layouts/FocusedLayout.vue
+++ b/src/pages/_layouts/FocusedLayout.vue
@@ -1,0 +1,22 @@
+<script setup lang="ts"></script>
+
+<template>
+  <div class="pb-16">
+    <div class="layout-header mb-12">
+      <div></div>
+      <router-link :to="{ name: 'home' }">
+        <BalIcon name="x" size="lg" />
+      </router-link>
+    </div>
+
+    <router-view :key="$route.path" />
+  </div>
+</template>
+
+<style scoped>
+.layout-header {
+  @apply h-16;
+  @apply px-4 lg:px-6;
+  @apply flex items-center justify-between;
+}
+</style>

--- a/src/pages/_layouts/FocusedLayout.vue
+++ b/src/pages/_layouts/FocusedLayout.vue
@@ -1,5 +1,3 @@
-<script setup lang="ts"></script>
-
 <template>
   <div class="pb-16">
     <div class="layout-header mb-12">

--- a/src/pages/_layouts/index.ts
+++ b/src/pages/_layouts/index.ts
@@ -1,3 +1,4 @@
 export { default as DefaultLayout } from './DefaultLayout.vue';
 export { default as BlankLayout } from './BlankLayout.vue';
 export { default as PoolTransferLayout } from './PoolTransferLayout.vue';
+export { default as FocusedLayout } from './FocusedLayout.vue';

--- a/src/plugins/router.ts
+++ b/src/plugins/router.ts
@@ -27,7 +27,8 @@ const routes: RouteRecordRaw[] = [
   {
     path: '/pool/create',
     name: 'create-pool',
-    component: CreatePoolPage
+    component: CreatePoolPage,
+    meta: { layout: 'FocusedLayout' }
   },
   {
     path: '/pool/:id',


### PR DESCRIPTION
# Description

- Adds a focused layout modelled off PoolTransferLayout and nestles the pool creation UI inside it
- Match shadow/elevation of main card in pool creation with invest UI
- Match pool creation UI baseline headings

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Other

## How should this be tested?

- Test that pool creation works fine on mobile and desktop inside the new layout
- Test that the shadows match invest UI
- Test that the headings of side modules and main card on pool creation have the same baseline heading

## Checklist:

- [] I have performed a self-review of my own code
- [X] I have commented my code where relevant, particularly in hard-to-understand areas
- [X] My changes generate no new console warnings
- [X] The base of this PR is `master` if hotfix, `develop` if not
