### PR TITLE
Use npm ci for Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ COPY prepare.js ./
 COPY package*.json ./
 
 RUN npm install -g npm@7
-RUN npm install
+RUN npm ci
 
 FROM dependencies AS build
 


### PR DESCRIPTION
# Description

Change the Dockerfile to use npm ci to install packages from package-lock.json instead of package.json for more safety for users. 

Tested with running `docker build .` and running the new Dockerfile and it loaded