### PR TITLE
Liquidity Mining, week 82

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.34.5",
+  "version": "1.34.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@balancer-labs/frontend-v2",
-      "version": "1.34.5",
+      "version": "1.34.6",
       "license": "MIT",
       "devDependencies": {
         "@aave/protocol-js": "^4.3.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.34.6",
+  "version": "1.34.9",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@balancer-labs/frontend-v2",
-      "version": "1.34.6",
+      "version": "1.34.9",
       "license": "MIT",
       "devDependencies": {
         "@aave/protocol-js": "^4.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.34.5",
+  "version": "1.34.6",
   "engines": {
     "node": "14.x",
     "npm": ">=7"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.34.6",
+  "version": "1.34.9",
   "engines": {
     "node": "14.x",
     "npm": ">=7"

--- a/src/lib/utils/liquidityMining/MultiTokenLiquidityMining.json
+++ b/src/lib/utils/liquidityMining/MultiTokenLiquidityMining.json
@@ -7557,5 +7557,410 @@
         ]
       }
     }
+  ],
+"week_82": [
+    {
+      "chainId": 1,
+      "pools": {
+        "0xa6f548df93de924d73be7d25dc02554c6bd66db500020000000000000000000e": [
+          {
+            "tokenAddress": "0xba100000625a3754423978a60c9317c58a424e3d",
+            "amount": 15000
+          }
+        ],
+        "0x0b09dea16768f0799065c475be02919503cb2a3500020000000000000000001a": [
+          {
+            "tokenAddress": "0xba100000625a3754423978a60c9317c58a424e3d",
+            "amount": 15000
+          }
+        ],
+        "0x7B50775383d3D6f0215A8F290f2C9e2eEBBEceb2": [
+          {
+            "tokenAddress": "0xba100000625a3754423978a60c9317c58a424e3d",
+            "amount": 25000
+          }
+        ],
+         "0x7b50775383d3d6f0215a8f290f2c9e2eebbeceb20000000000000000000000fe": [
+          {
+            "tokenAddress": "0xba100000625a3754423978a60c9317c58a424e3d",
+            "amount": 5000
+          }
+        ],
+        "0x06df3b2bbb68adc8b0e302443692037ed9f91b42000000000000000000000063": [
+          {
+            "tokenAddress": "0xba100000625a3754423978a60c9317c58a424e3d",
+            "amount": 15000
+          }
+        ],
+        "0x96646936b91d6b9d7d0c47c496afbf3d6ec7b6f8000200000000000000000019": [
+          {
+            "tokenAddress": "0xba100000625a3754423978a60c9317c58a424e3d",
+            "amount": 1100
+          }
+        ],
+        "0xa1116930326d21fb917d5a27f1e9943a9595fb47": [
+          {
+            "tokenAddress": "0xba100000625a3754423978a60c9317c58a424e3d",
+            "amount": 12500
+          }
+        ],
+        "0x3e5fa9518ea95c3e533eb377c001702a9aacaa32000200000000000000000052": [
+          {
+            "tokenAddress": "0xba100000625a3754423978a60c9317c58a424e3d",
+            "amount": 120
+          }
+        ],
+        "0xaac98ee71d4f8a156b6abaa6844cdb7789d086ce00020000000000000000001b": [
+          {
+            "tokenAddress": "0xba100000625a3754423978a60c9317c58a424e3d",
+            "amount": 2500
+          }
+        ],
+        "0x186084ff790c65088ba694df11758fae4943ee9e000200000000000000000013": [
+          {
+            "tokenAddress": "0xba100000625a3754423978a60c9317c58a424e3d",
+            "amount": 500
+          }
+        ],
+        "0x072f14b85add63488ddad88f855fda4a99d6ac9b000200000000000000000027": [
+          {
+            "tokenAddress": "0xba100000625a3754423978a60c9317c58a424e3d",
+            "amount": 1000
+          }
+        ],
+        "0xe99481dc77691d8e2456e5f3f61c1810adfc1503000200000000000000000018": [
+          {
+            "tokenAddress": "0xba100000625a3754423978a60c9317c58a424e3d",
+            "amount": 2500
+          }
+        ],
+        "0xefaa1604e82e1b3af8430b90192c1b9e8197e377000200000000000000000021": [
+          {
+            "tokenAddress": "0xba100000625a3754423978a60c9317c58a424e3d",
+            "amount": 500
+          }
+        ],
+        "0xfeadd389a5c427952d8fdb8057d6c8ba1156cc56000000000000000000000066": [
+          {
+            "tokenAddress": "0xba100000625a3754423978a60c9317c58a424e3d",
+            "amount": 2500
+          }
+        ],
+        "0x32296969ef14eb0c6d29669c550d4a0449130230000200000000000000000080": [
+          {
+            "tokenAddress": "0xba100000625a3754423978a60c9317c58a424e3d",
+            "amount": 2500
+          },
+          {
+            "tokenAddress": "0x5a98fcbea516cf06857215779fd812ca3bef1b32",
+            "amount": 75000
+          }
+        ],
+        "0xbf96189eee9357a95c7719f4f5047f76bde804e5000200000000000000000087": [
+          {
+            "tokenAddress": "0xba100000625a3754423978a60c9317c58a424e3d",
+            "amount": 1000
+          }
+        ],
+        "0x702605f43471183158938c1a3e5f5a359d7b31ba00020000000000000000009f": [
+          {
+            "tokenAddress": "0xba100000625a3754423978a60c9317c58a424e3d",
+            "amount": 1000
+          }
+        ],
+        "0xec60a5fef79a92c741cb74fdd6bfc340c0279b01000200000000000000000015": [
+          {
+            "tokenAddress": "0xba100000625a3754423978a60c9317c58a424e3d",
+            "amount": 400
+          }
+        ],
+        "0xa02e4b3d18d4e6b8d18ac421fbc3dfff8933c40a00020000000000000000004b": [
+          {
+            "tokenAddress": "0xba100000625a3754423978a60c9317c58a424e3d",
+            "amount": 400
+          }
+        ],
+        "0xf5aaf7ee8c39b651cebf5f1f50c10631e78e0ef9000200000000000000000069": [
+          {
+            "tokenAddress": "0xba100000625a3754423978a60c9317c58a424e3d",
+            "amount": 250
+          }
+        ],
+        "0xf4c0dd9b82da36c07605df83c8a416f11724d88b000200000000000000000026": [
+          {
+            "tokenAddress": "0xba100000625a3754423978a60c9317c58a424e3d",
+            "amount": 1000
+          }
+        ],
+        "0xbaeec99c90e3420ec6c1e7a769d2a856d2898e4d00020000000000000000008a": [
+          {
+            "tokenAddress": "0xba100000625a3754423978a60c9317c58a424e3d",
+            "amount": 170
+          },
+          {
+            "tokenAddress": "0x81f8f0bb1cb2a06649e51913a151f0e7ef6fa321",
+            "amount": 2855
+          }
+        ],
+        "0x350196326aeaa9b98f1903fb5e8fc2686f85318c000200000000000000000084": [
+          {
+            "tokenAddress": "0xba100000625a3754423978a60c9317c58a424e3d",
+            "amount": 110
+          },
+          {
+            "tokenAddress": "0x81f8f0bb1cb2a06649e51913a151f0e7ef6fa321",
+            "amount": 1845
+          }
+        ],
+        "0xe2469f47ab58cf9cf59f9822e3c5de4950a41c49000200000000000000000089": [
+          {
+            "tokenAddress": "0xba100000625a3754423978a60c9317c58a424e3d",
+            "amount": 500
+          }
+        ],
+        "0x51735bdfbfe3fc13dea8dc6502e2e958989429610002000000000000000000a0": [
+          {
+            "tokenAddress": "0xba100000625a3754423978a60c9317c58a424e3d",
+            "amount": 250
+          },
+          {
+            "tokenAddress": "0x226f7b842e0f0120b7e194d05432b3fd14773a9d",
+            "amount": 375000
+          }
+        ],
+        "0x87165b659ba7746907a48763063efa3b323c2b0700020000000000000000002d" : [
+          {
+            "tokenAddress": "0xba100000625a3754423978a60c9317c58a424e3d",
+            "amount": 480
+          },
+          {
+            "tokenAddress": "0x2d94aa3e47d9d5024503ca8491fce9a2fb4da198",
+            "amount": 85000
+          }
+        ],
+        "0x5f7fa48d765053f8dd85e052843e12d23e3d7bc50002000000000000000000c0": [
+          {
+            "tokenAddress": "0xba100000625a3754423978a60c9317c58a424e3d",
+            "amount": 500
+          },
+          {
+            "tokenAddress": "0xcfeaead4947f0705a14ec42ac3d44129e1ef3ed5",
+            "amount": 30000
+          }
+        ],
+        "0x5e6989c0e2b6600ab585d56bf05479d5450a60c80002000000000000000000c1": [
+          {
+            "tokenAddress": "0xba100000625a3754423978a60c9317c58a424e3d",
+            "amount": 300
+          },
+          {
+            "tokenAddress": "0xb62132e35a6c13ee1ee0f84dc5d40bad8d815206",
+            "amount": 2000
+          }
+        ]
+      }
+    },
+    {
+      "chainId": 137,
+      "pools": {
+        "0x0297e37f1873d2dab4487aa67cd56b58e2f27875000100000000000000000002": [
+          {
+            "tokenAddress": "0x9a71012b13ca4d3d0cdc72a177df3ef03b0e76a3",
+            "amount": 5500
+          }
+        ],
+        "0x36128d5436d2d70cab39c9af9cce146c38554ff0000100000000000000000008": [
+          {
+            "tokenAddress": "0x9a71012b13ca4d3d0cdc72a177df3ef03b0e76a3",
+            "amount": 4000
+          }
+        ],
+        "0x03cd191f589d12b0582a99808cf19851e468e6b500010000000000000000000a": [
+          {
+            "tokenAddress": "0x9a71012b13ca4d3d0cdc72a177df3ef03b0e76a3",
+            "amount": 2250
+          }
+        ],
+        "0xce66904b68f1f070332cbc631de7ee98b650b499000100000000000000000009": [
+          {
+            "tokenAddress": "0x9a71012b13ca4d3d0cdc72a177df3ef03b0e76a3",
+            "amount": 650
+          }
+        ],
+        "0x06df3b2bbb68adc8b0e302443692037ed9f91b42000000000000000000000012": [
+          {
+            "tokenAddress": "0x9a71012b13ca4d3d0cdc72a177df3ef03b0e76a3",
+            "amount": 2500
+          },
+          {
+            "tokenAddress": "0x580a84c73811e1839f75d86d75d88cca0c241ff4",
+            "amount": 15000
+          }
+        ],
+        "0x827ad315960f5a0f5280d6936c8e52a5878bba0400020000000000000000005c": [
+          {
+            "tokenAddress": "0x9a71012b13ca4d3d0cdc72a177df3ef03b0e76a3",
+            "amount": 300
+          },
+          {
+            "tokenAddress": "0x580a84c73811e1839f75d86d75d88cca0c241ff4",
+            "amount": 15000
+          }
+        ],
+        "0x614b5038611729ed49e0ded154d8a5d3af9d1d9e00010000000000000000001d": [
+          {
+            "tokenAddress": "0x9a71012b13ca4d3d0cdc72a177df3ef03b0e76a3",
+            "amount": 450
+          },
+          {
+            "tokenAddress": "0xF501dd45a1198C2E1b5aEF5314A68B9006D842E0",
+            "amount": 15000
+          }
+        ],
+        "0x4e7f40cd37cee710f5e87ad72959d30ef8a01a5d00010000000000000000000b": [
+          {
+            "tokenAddress": "0x9a71012b13ca4d3d0cdc72a177df3ef03b0e76a3",
+            "amount": 350
+          }
+        ],
+        "0x7c9cf12d783821d5c63d8e9427af5c44bad92445000100000000000000000051": [
+          {
+            "tokenAddress": "0x9a71012b13ca4d3d0cdc72a177df3ef03b0e76a3",
+            "amount": 1000
+          }
+        ],
+        "0xfeadd389a5c427952d8fdb8057d6c8ba1156cc5600020000000000000000001e": [
+          {
+            "tokenAddress": "0x9a71012b13ca4d3d0cdc72a177df3ef03b0e76a3",
+            "amount": 1000
+          }
+        ],
+        "0x186084ff790c65088ba694df11758fae4943ee9e000200000000000000000032": [
+          {
+            "tokenAddress": "0x9a71012b13ca4d3d0cdc72a177df3ef03b0e76a3",
+            "amount": 500
+          },
+          {
+            "tokenAddress": "0xdf7837de1f2fa4631d716cf2502f8b230f1dcc32",
+            "amount": 750000
+          }
+        ],
+        "0xdb1db6e248d7bb4175f6e5a382d0a03fe3dcc813000100000000000000000035": [
+          {
+            "tokenAddress": "0x9a71012b13ca4d3d0cdc72a177df3ef03b0e76a3",
+            "amount": 500
+          },
+          {
+            "tokenAddress": "0xdf7837de1f2fa4631d716cf2502f8b230f1dcc32",
+            "amount": 750000
+          }
+        ],
+        "0xcf354603a9aebd2ff9f33e1b04246d8ea204ae9500020000000000000000005a": [
+          {
+            "tokenAddress": "0x9a71012b13ca4d3d0cdc72a177df3ef03b0e76a3",
+            "amount": 1750
+          }
+        ],
+        "0x10f21c9bd8128a29aa785ab2de0d044dcdd79436000200000000000000000059": [
+          {
+            "tokenAddress": "0x9a71012b13ca4d3d0cdc72a177df3ef03b0e76a3",
+            "amount": 1750
+          }
+        ],
+        "0x0d34e5dd4d8f043557145598e4e2dc286b35fd4f000000000000000000000068": [
+          {
+            "tokenAddress": "0x9a71012b13ca4d3d0cdc72a177df3ef03b0e76a3",
+            "amount": 2500
+          },
+          {
+            "tokenAddress": "0x0d500b1d8e8ef31e21c99d1db9a6444d3adf1270",
+            "amount": 27500
+          },
+          {
+            "tokenAddress": "0x2e1ad108ff1d8c782fcbbb89aad783ac49586756",
+            "amount": 55000
+          }
+        ]
+      }
+    },
+    {
+      "chainId": 42161,
+      "pools": {
+        "0x64541216bafffeec8ea535bb71fbc927831d0595000100000000000000000002": [
+          {
+            "tokenAddress": "0x040d1edc9569d4bab2d15287dc5a4f10f56a56b8",
+            "amount": 2850
+          }
+        ],
+        "0xcc65a812ce382ab909a11e434dbf75b34f1cc59d000200000000000000000001": [
+          {
+            "tokenAddress": "0x040d1edc9569d4bab2d15287dc5a4f10f56a56b8",
+            "amount": 3500
+          }
+        ],
+        "0x1533a3278f3f9141d5f820a184ea4b017fce2382000000000000000000000016": [
+          {
+            "tokenAddress": "0x040d1edc9569d4bab2d15287dc5a4f10f56a56b8",
+            "amount": 2500
+          }
+        ],
+        "0xc2f082d33b5b8ef3a7e3de30da54efd3114512ac000200000000000000000017": [
+          {
+            "tokenAddress": "0x040d1edc9569d4bab2d15287dc5a4f10f56a56b8",
+            "amount": 400
+          },
+          {
+            "tokenAddress": "0x965772e0e9c84b6f359c8597c891108dcf1c5b1a",
+            "amount": 1023
+          }
+        ],
+        "0x5ced962afbfb7e13fb215defc2b027678237aa3a000200000000000000000011": [
+          {
+            "tokenAddress": "0x040d1edc9569d4bab2d15287dc5a4f10f56a56b8",
+            "amount": 250
+          }
+        ],
+        "0x8a9f8b5334dacb052cd62797e2bdf68d89c0bfd8000200000000000000000013": [
+          {
+            "tokenAddress": "0x040d1edc9569d4bab2d15287dc5a4f10f56a56b8",
+            "amount": 100
+          }
+        ],
+        "0x4a3a22a3e7fee0ffbb66f1c28bfac50f75546fc7000200000000000000000008": [
+          {
+            "tokenAddress": "0x040d1edc9569d4bab2d15287dc5a4f10f56a56b8",
+            "amount": 250
+          }
+        ],
+        "0xb5b77f1ad2b520df01612399258e7787af63025d000200000000000000000010": [
+          {
+            "tokenAddress": "0x040d1edc9569d4bab2d15287dc5a4f10f56a56b8",
+            "amount": 1600
+          },
+          {
+            "tokenAddress": "0x4e352cf164e64adcbad318c3a1e222e9eba4ce42",
+            "amount": 875
+          }
+        ],
+        "0x651e00ffd5ecfa7f3d4f33d62ede0a97cf62ede2000200000000000000000006": [
+          {
+            "tokenAddress": "0x040d1edc9569d4bab2d15287dc5a4f10f56a56b8",
+            "amount": 420
+          }
+        ],
+        "0xa6625f741400f90d31e39a17b0d429a92e347a6000020000000000000000000e": [
+          {
+            "tokenAddress": "0x040d1edc9569d4bab2d15287dc5a4f10f56a56b8",
+            "amount": 350
+          }
+        ],
+        "0xb28670b3e7ad27bd41fb5938136bf9e9cba90d6500020000000000000000001e": [
+          {
+            "tokenAddress": "0x040d1edc9569d4bab2d15287dc5a4f10f56a56b8",
+            "amount": 700
+          }
+        ]
+      }
+    }
   ]
 }

--- a/src/lib/utils/liquidityMining/MultiTokenLiquidityMining.json
+++ b/src/lib/utils/liquidityMining/MultiTokenLiquidityMining.json
@@ -7574,7 +7574,7 @@
             "amount": 15000
           }
         ],
-        "0x7B50775383d3D6f0215A8F290f2C9e2eEBBEceb2": [
+        "0x5c6ee304399dbdb9c8ef030ab642b10820db8f56000200000000000000000014": [
           {
             "tokenAddress": "0xba100000625a3754423978a60c9317c58a424e3d",
             "amount": 25000

--- a/src/lib/utils/liquidityMining/MultiTokenLiquidityMining.json
+++ b/src/lib/utils/liquidityMining/MultiTokenLiquidityMining.json
@@ -7835,6 +7835,12 @@
             "amount": 1000
           }
         ],
+        "0xb204bf10bc3a5435017d3db247f56da601dfe08a0002000000000000000000fe": [
+          {
+            "tokenAddress": "0x9a71012b13ca4d3d0cdc72a177df3ef03b0e76a3",
+            "amount": 66.66
+          }
+        ],
         "0x186084ff790c65088ba694df11758fae4943ee9e000200000000000000000032": [
           {
             "tokenAddress": "0x9a71012b13ca4d3d0cdc72a177df3ef03b0e76a3",


### PR DESCRIPTION
Pending [Baller Vote](https://snapshot.org/#/ballersvote.eth/proposal/0xf7f768c821fdaafe62907e309fbcf7340c61b05e81839dbfa416118adabc1e0d)

## Ethereum
* Allocate 5000 BAL (one T2 slot) per week to the [bb-a-USD boosted pool](https://app.balancer.fi/#/pool/0x7b50775383d3d6f0215a8f290f2c9e2eebbeceb20000000000000000000000fe). This pool will now receive 5000 BAL per week.
* Remove 5000 BAL (one T2 slot) per week from BAL/WETH - 80/20. This pool will now receive 25000 BAL per week total.

## Polygon
* No proposed changes from the LM committee this week.
* 66.66 BAL from [Alchemist](https://vote.balancer.fi/#/proposal/0x00305705cf9c57b648729494c07224c5902bda5f1db5d2f95cf6ff510d7d850c) allocated to the [THX/USDC pool](https://polygon.balancer.fi/#/pool/0xb204bf10bc3a5435017d3db247f56da601dfe08a0002000000000000000000fe)


## Arbitrum
No proposed changes this week.

