### PR TITLE
Hotfix - Remove BPT from table LM

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.34.6",
+  "version": "1.34.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@balancer-labs/frontend-v2",
-      "version": "1.34.6",
+      "version": "1.34.7",
       "license": "MIT",
       "devDependencies": {
         "@aave/protocol-js": "^4.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.34.6",
+  "version": "1.34.7",
   "engines": {
     "node": "14.x",
     "npm": ">=7"

--- a/src/components/tables/LMTable/LMTable.vue
+++ b/src/components/tables/LMTable/LMTable.vue
@@ -125,7 +125,7 @@ import useTokens from '@/composables/useTokens';
 import useNumbers from '@/composables/useNumbers';
 import { last, sum } from 'lodash';
 import useDarkMode from '@/composables/useDarkMode';
-import { isStableLike } from '@/composables/usePool';
+import { isStableLike, isStablePhantom } from '@/composables/usePool';
 import { startOfWeek, subWeeks, format, addDays } from 'date-fns';
 
 function getWeekName(week: string) {
@@ -213,6 +213,8 @@ export default defineComponent({
     const latestWeek = computed(() => last(weeks.value)?.week);
 
     function orderedPoolTokens(pool: DecoratedPoolWithShares): PoolToken[] {
+      if (isStablePhantom(pool.poolType))
+        return pool.tokens.filter(token => token.address !== pool.address);
       if (isStableLike(pool.poolType)) return pool.tokens;
 
       const sortedTokens = pool.tokens.slice();


### PR DESCRIPTION
# Description

The liquidity mining table duplicates the logic for the pool token pills. This PR copies the filtering of the StablePhantom BPT token from the pool tokens used on the home page.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## How should this be tested?

- [ ] Check that the bb-a-USD BPT token doesn't appear in the token pills on the liquidity-mining page.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] My changes generate no new console warnings
- [x] The base of this PR is `master` if hotfix, `develop` if not
