### PR TITLE
Show aToken balance in pool composition table

### DIFF
--- a/src/components/contextual/pages/pool/PoolBalancesCard/components/AssetRow.vue
+++ b/src/components/contextual/pages/pool/PoolBalancesCard/components/AssetRow.vue
@@ -48,7 +48,17 @@ const balance = computed(() => {
     : formattedBalance;
 });
 
-const balanceLabel = computed(() => fNum(balance.value, 'token'));
+const balanceLabel = computed(() => {
+  if (props.priceRate && props.mainTokenAddress) {
+    const equivMainTokenBalance = bnum(balance.value)
+      .times(props.priceRate)
+      .toString();
+
+    return fNum(equivMainTokenBalance, 'token');
+  }
+
+  return fNum(balance.value, 'token');
+});
 
 const fiatLabel = computed(() => {
   if (props.priceRate && props.mainTokenAddress) {


### PR DESCRIPTION
# Description

The pool composition table abstracts the notion of wrapped Aave tokens away. We show the aToken logo and symbol in the rows for example, not the wrapped token's

![image](https://user-images.githubusercontent.com/34865315/146644805-fb1ecf00-582e-46b3-8cfb-a9f622b315b7.png)

The balance, however, currently displays the amount of **waTokens** held by the pool.
![image](https://user-images.githubusercontent.com/34865315/146644835-553de42d-c15d-474f-98ea-418f658a6e61.png)
![image](https://user-images.githubusercontent.com/34865315/146644875-9d9e727f-f91f-4753-a1dc-dbe74faea756.png)

This PR proposes we convert that balance into the equivalent in aTokens, using the same logic used for the fiat value. As with the fiat value, this logic only works for the case of Aave, where the waToken<>aToken rate is the same as the waToken<>Token rate (ie, the Token<>aToken rate is 1).

![image](https://user-images.githubusercontent.com/34865315/146644940-afacf531-9d46-464c-9ba5-2a93384d541b.png)

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## How should this be tested?

Balances of aTokens in the bb-a-USD pool should show increased amounts, in line with the fiat value (eg 1 aUSDC = $1). Other pools should not be affected.

## Checklist:

- [X] I have performed a self-review of my own code
- [X] I have commented my code where relevant, particularly in hard-to-understand areas
- [X] My changes generate no new console warnings
- [X] The base of this PR is `master` if hotfix, `develop` if not
