### PR TITLE
Show bb tokens in pool transactions table

### DIFF
--- a/src/components/contextual/pages/pool/PoolTransactionsCard/BoostedPoolActivities/Table.vue
+++ b/src/components/contextual/pages/pool/PoolTransactionsCard/BoostedPoolActivities/Table.vue
@@ -185,11 +185,11 @@ function getTokenAmounts(swaps: PoolSwap[], type: SwapType) {
 
     return [
       {
-        address: getUnderlyingTokenAddress(tokenIn),
+        address: tokenIn,
         amount: tokenAmountIn
       },
       {
-        address: getUnderlyingTokenAddress(tokenOut),
+        address: tokenOut,
         amount: tokenAmountOut
       }
     ];
@@ -197,23 +197,11 @@ function getTokenAmounts(swaps: PoolSwap[], type: SwapType) {
   return swaps.map(swap => {
     let address = isInvest ? swap.tokenIn : swap.tokenOut;
 
-    address = isInvest
-      ? getUnderlyingTokenAddress(swap.tokenIn)
-      : getUnderlyingTokenAddress(swap.tokenOut);
-
     return {
       address,
       amount: isInvest ? swap.tokenAmountIn : swap.tokenAmountOut
     };
   });
-}
-
-function getUnderlyingTokenAddress(address: string) {
-  const { linearPools } = props.pool.onchain;
-
-  return linearPools != null && linearPools[address] != null
-    ? linearPools[address].mainToken.address
-    : address;
 }
 </script>
 

--- a/src/components/contextual/pages/pool/PoolTransactionsCard/BoostedPoolActivities/Table.vue
+++ b/src/components/contextual/pages/pool/PoolTransactionsCard/BoostedPoolActivities/Table.vue
@@ -154,16 +154,23 @@ const swapRows = computed<SwapRow[]>(() => {
  */
 function getTransactionValue(tokenAmounts: TokenAmount[], type: SwapType) {
   if (type === 'trade') {
-    return bnum(priceFor(tokenAmounts[1].address))
-      .times(tokenAmounts[1].amount)
+    const mainTokenAddress = getUnderlyingTokenAddress(tokenAmounts[1].address);
+    const mainEquivAmount = getMainTokenEquivalentAmount(
+      tokenAmounts[1].address,
+      tokenAmounts[1].amount
+    );
+    return bnum(priceFor(mainTokenAddress))
+      .times(mainEquivAmount)
       .toNumber();
   }
 
   let total = bnum(0);
 
   for (const { address, amount } of tokenAmounts) {
-    const price = priceFor(address);
-    const amountNumber = Math.abs(parseFloat(amount));
+    const mainTokenAddress = getUnderlyingTokenAddress(address);
+    const mainEquivAmount = getMainTokenEquivalentAmount(address, amount);
+    const price = priceFor(mainTokenAddress);
+    const amountNumber = Math.abs(parseFloat(mainEquivAmount));
 
     // If the price is unknown for any of the positive amounts - the value cannot be computed.
     if (amountNumber > 0 && price === 0) {
@@ -202,6 +209,20 @@ function getTokenAmounts(swaps: PoolSwap[], type: SwapType) {
       amount: isInvest ? swap.tokenAmountIn : swap.tokenAmountOut
     };
   });
+}
+
+function getUnderlyingTokenAddress(address: string) {
+  const { linearPools } = props.pool.onchain;
+  return linearPools != null && linearPools[address] != null
+    ? linearPools[address].mainToken.address
+    : address;
+}
+
+function getMainTokenEquivalentAmount(address: string, amount: string) {
+  const { linearPools } = props.pool.onchain;
+  return linearPools != null && linearPools[address] != null
+    ? bnum(amount).times(linearPools[address].priceRate)
+    : bnum(amount);
 }
 </script>
 


### PR DESCRIPTION
# Description

The pool transactions table in the bb-a-USD pool displays the symbols of the underlying linear pool's main tokens, but the amounts of the bb-a tokens.
![image](https://user-images.githubusercontent.com/34865315/146646131-65ea239e-e493-4b81-8134-145e2d1fdb77.png)

Ideally we would be able to detect if the underlying operation invested/withdrew from the linear pool using aTokens or main tokens, but that would require implementing a much more sophisticated logic.

This PR proposes we simply remove the inconsistency, by displaying the bb-a-token symbols instead of the main underlying one.

![image](https://user-images.githubusercontent.com/34865315/146646203-1c625d5d-7d86-4185-bdf5-6060c5f5e61e.png)

Because the price of the bb-a-tokens isn't available, we compute the value based on the equivalent balance, computed from the bb-a-token priceRate and the price of the main token.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## How should this be tested?

Pool transactions table in bb-a-USD pool should display the bb-a-DAI symbol where it now displays the DAI symbol. Same for USDC and USDT. Other pools should not be affected.

## Checklist:

- [X] I have performed a self-review of my own code
- [X] I have commented my code where relevant, particularly in hard-to-understand areas
- [X] My changes generate no new console warnings
- [X] The base of this PR is `master` if hotfix, `develop` if not
