### PR TITLE
Suppress nonsensical APRs

### DIFF
--- a/src/components/contextual/pages/pool/PoolStatCards.vue
+++ b/src/components/contextual/pages/pool/PoolStatCards.vue
@@ -21,11 +21,12 @@
 import { PropType, defineComponent, computed } from 'vue';
 import { useI18n } from 'vue-i18n';
 
-import useNumbers, { APR_THRESHOLD } from '@/composables/useNumbers';
+import useNumbers from '@/composables/useNumbers';
 
 import { DecoratedPool } from '@/services/balancer/subgraph/types';
 
 import LiquidityAPRTooltip from '@/components/tooltips/LiquidityAPRTooltip.vue';
+import { APR_THRESHOLD } from '@/constants/poolAPR';
 
 export default defineComponent({
   components: {

--- a/src/components/contextual/pages/pool/PoolStatCards.vue
+++ b/src/components/contextual/pages/pool/PoolStatCards.vue
@@ -21,7 +21,7 @@
 import { PropType, defineComponent, computed } from 'vue';
 import { useI18n } from 'vue-i18n';
 
-import useNumbers from '@/composables/useNumbers';
+import useNumbers, { APR_THRESHOLD } from '@/composables/useNumbers';
 
 import { DecoratedPool } from '@/services/balancer/subgraph/types';
 
@@ -65,7 +65,10 @@ export default defineComponent({
         {
           id: 'apr',
           label: 'APR',
-          value: fNum(props.pool.dynamic.apr.total, 'percent')
+          value:
+            Number(props.pool.dynamic.apr.total) > APR_THRESHOLD
+              ? '-'
+              : fNum(props.pool.dynamic.apr.total, 'percent')
         }
       ];
     });

--- a/src/components/tooltips/LiquidityAPRTooltip.vue
+++ b/src/components/tooltips/LiquidityAPRTooltip.vue
@@ -2,9 +2,10 @@
 import { computed } from 'vue';
 import { useI18n } from 'vue-i18n';
 
-import useNumbers, { APR_THRESHOLD } from '@/composables/useNumbers';
+import useNumbers from '@/composables/useNumbers';
 import useTokens from '@/composables/useTokens';
 import { isStablePhantom, isWstETH } from '@/composables/usePool';
+import { APR_THRESHOLD } from '@/constants/poolAPR';
 
 import { DecoratedPool } from '@/services/balancer/subgraph/types';
 import { bnum } from '@/lib/utils';

--- a/src/components/tooltips/LiquidityAPRTooltip.vue
+++ b/src/components/tooltips/LiquidityAPRTooltip.vue
@@ -2,7 +2,7 @@
 import { computed } from 'vue';
 import { useI18n } from 'vue-i18n';
 
-import useNumbers from '@/composables/useNumbers';
+import useNumbers, { APR_THRESHOLD } from '@/composables/useNumbers';
 import useTokens from '@/composables/useTokens';
 import { isStablePhantom, isWstETH } from '@/composables/usePool';
 
@@ -35,6 +35,9 @@ const lmBreakdown = computed(
   () => props.pool.dynamic.apr.liquidityMiningBreakdown
 );
 
+const validAPR = computed(
+  () => Number(props.pool.dynamic.apr) <= APR_THRESHOLD
+);
 const lmTokens = computed(() => getTokens(Object.keys(lmBreakdown.value)));
 
 const lmMultiRewardPool = computed(
@@ -67,7 +70,7 @@ const thirdPartyAPRLabel = computed(() => {
 </script>
 
 <template v-slot:aprCell="pool">
-  <BalTooltip width="auto" noPad>
+  <BalTooltip width="auto" noPad v-if="validAPR">
     <template v-slot:activator>
       <div class="ml-1">
         <StarsIcon

--- a/src/composables/useNumbers.ts
+++ b/src/composables/useNumbers.ts
@@ -20,10 +20,6 @@ enum PresetFormats {
   percent_lg = '0%'
 }
 
-// Do not display APR values greater than this amount; they are likely to be nonsensical
-// These can arise from pools with extremely low balances (e.g., completed LBPs)
-export const APR_THRESHOLD = 10000;
-
 export type Preset = keyof typeof PresetFormats;
 
 export function fNum(

--- a/src/composables/useNumbers.ts
+++ b/src/composables/useNumbers.ts
@@ -20,6 +20,10 @@ enum PresetFormats {
   percent_lg = '0%'
 }
 
+// Do not display APR values greater than this amount; they are likely to be nonsensical
+// These can arise from pools with extremely low balances (e.g., completed LBPs)
+export const APR_THRESHOLD = 10000;
+
 export type Preset = keyof typeof PresetFormats;
 
 export function fNum(

--- a/src/constants/poolAPR.ts
+++ b/src/constants/poolAPR.ts
@@ -1,0 +1,3 @@
+// Do not display APR values greater than this amount; they are likely to be nonsensical
+// These can arise from pools with extremely low balances (e.g., completed LBPs)
+export const APR_THRESHOLD = 10000;


### PR DESCRIPTION
# Description

When looking at the N/A pool symbol/name issue, I noticed the APRs for completed LBPs are huge and nonsensical (arising from very small balances). This is suppressed in some parts of the code, but not others. This fixes the APR display of completed LBPs (and other similar cases).

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## How should this be tested?

This pool has a huge APR:
0x053f3c35d557a76e9cb6c13a4842d9cfcddac8330002000000000000000000cd

It should display '-' after the fix: and not have a tooltip.

## Checklist:

- [X] I have performed a self-review of my own code
- [X] I have commented my code where relevant, particularly in hard-to-understand areas
- [X] My changes generate no new console warnings
- [ ] The base of this PR is `master` if hotfix, `develop` if not
