### PR TITLE
Hotfix - boosted pool chart

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.35.4",
+  "version": "1.35.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@balancer-labs/frontend-v2",
-      "version": "1.35.4",
+      "version": "1.35.5",
       "license": "MIT",
       "devDependencies": {
         "@aave/protocol-js": "^4.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.35.4",
+  "version": "1.35.5",
   "engines": {
     "node": "14.x",
     "npm": ">=7"

--- a/src/components/contextual/pages/pool/PoolChart.vue
+++ b/src/components/contextual/pages/pool/PoolChart.vue
@@ -96,8 +96,10 @@ const history = computed(() => {
     .filter(({ totalShares, prices, amounts, liquidity }) => {
       if (!supportsPoolLiquidity.value && prices.length === 0) {
         return false;
+      } else if (supportsPoolLiquidity.value && liquidity === 0) {
+        return false;
       }
-      return totalShares > 0 && amounts.length > 0 && liquidity > 0;
+      return totalShares > 0 && amounts.length > 0;
     });
 });
 

--- a/src/components/contextual/pages/pool/PoolChart.vue
+++ b/src/components/contextual/pages/pool/PoolChart.vue
@@ -93,11 +93,11 @@ const history = computed(() => {
         liquidity
       };
     })
-    .filter(({ totalShares, prices, amounts }) => {
+    .filter(({ totalShares, prices, amounts, liquidity }) => {
       if (!supportsPoolLiquidity.value && prices.length === 0) {
         return false;
       }
-      return totalShares > 0 && amounts.length > 0;
+      return totalShares > 0 && amounts.length > 0 && liquidity > 0;
     });
 });
 


### PR DESCRIPTION
# Description

The Boosted pool chart is broken. After investigation, it looks like the first element in the chart history array had a zero value for liquidity which was causing a NaN value. This PR simply filters out history elements if their liquidity value is zero. This may not be the best fix, but it seems to fix the chart.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## How should this be tested?

Please provide instructions so we can test. Please also list any relevant details for your test configuration.

- [ ] Test the chart works on the boosted pool page
- [ ] Test that charts work as expected on other pool pages

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] My changes generate no new console warnings
- [x] The base of this PR is `master` if hotfix, `develop` if not
