### PR TITLE
Hotfix: fix pool creation form token sorting

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.35.10",
+  "version": "1.35.11",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@balancer-labs/frontend-v2",
-      "version": "1.35.10",
+      "version": "1.35.11",
       "license": "MIT",
       "devDependencies": {
         "@aave/protocol-js": "^4.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.35.10",
+  "version": "1.35.11",
   "engines": {
     "node": "14.x",
     "npm": ">=7"

--- a/src/composables/pools/usePoolCreation.ts
+++ b/src/composables/pools/usePoolCreation.ts
@@ -280,7 +280,10 @@ export default function usePoolCreation() {
 
   function sortSeedTokens() {
     poolCreationState.seedTokens.sort((tokenA, tokenB) => {
-      return tokenA.tokenAddress > tokenB.tokenAddress ? 1 : -1;
+      return tokenA.tokenAddress.toLowerCase() >
+        tokenB.tokenAddress.toLowerCase()
+        ? 1
+        : -1;
     });
   }
 


### PR DESCRIPTION
# Description

Curently tokens are being sorted using the string representation of their address, however checksum addresses results in this not always agreeing with sorting based on the numerical value (as is used on the actual blockchain).

I've removed the checksums to ensure that both sortings match.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## How should this be tested?

Try to create a pool with RPL and rETH (just need to get metamask to appear, no need to send the tx).

This should succeed with this hotfix whereas it will fail in prod.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] My changes generate no new console warnings
- [x] The base of this PR is `master` if hotfix, `develop` if not
