### PR TITLE
Hotfix - hide boosted chart

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.35.13",
+  "version": "1.35.14",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@balancer-labs/frontend-v2",
-      "version": "1.35.13",
+      "version": "1.35.14",
       "license": "MIT",
       "devDependencies": {
         "@aave/protocol-js": "^4.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.35.13",
+  "version": "1.35.14",
   "engines": {
     "node": "14.x",
     "npm": ">=7"

--- a/src/components/contextual/pages/pool/PoolChart.vue
+++ b/src/components/contextual/pages/pool/PoolChart.vue
@@ -66,6 +66,8 @@ const history = computed(() => {
   const pricesTimestamps = Object.keys(props.historicalPrices);
   const snapshotsTimestamps = Object.keys(props.snapshots);
 
+  if (supportsPoolLiquidity.value) return [];
+
   if (snapshotsTimestamps.length === 0) {
     return [];
   }


### PR DESCRIPTION
# Description

The pool chart for the bb-a-USD boosted pool is incorrect. As a temporary fix until we can fix the chart values, this PR hides the pool chart for this pool.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## How should this be tested?

Please provide instructions so we can test. Please also list any relevant details for your test configuration.

- [ ] Test that no chart is displayed for bb-a-USD
- [ ] Test that charts work for other pools

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] My changes generate no new console warnings
- [x] The base of this PR is `master` if hotfix, `develop` if not
