### PR TITLE
Hotfix/1.35.15

### DIFF
--- a/src/components/cards/CreatePool/InitialLiquidity.vue
+++ b/src/components/cards/CreatePool/InitialLiquidity.vue
@@ -22,7 +22,13 @@ const cardWrapper = ref<HTMLElement>();
  * COMPOSBALES
  */
 const { userNetworkConfig } = useWeb3();
-const { balanceFor, priceFor, nativeAsset, wrappedNativeAsset } = useTokens();
+const {
+  balances,
+  balanceFor,
+  priceFor,
+  nativeAsset,
+  wrappedNativeAsset
+} = useTokens();
 const { fNum } = useNumbers();
 const {
   seedTokens,
@@ -59,8 +65,8 @@ const areAmountsMaxed = computed(() => {
 const isExceedingWalletBalance = computed(() => {
   // need to perform rounding here as JS cuts off those
   // really long numbers which makes it impossible to compare
-  const isExceeding = seedTokens.value.some(t =>
-    bnum(t.amount).gt(balanceFor(t.tokenAddress))
+  const isExceeding = tokenAddresses.value.some((t, i) =>
+    bnum(seedTokens.value[i].amount).gt(balanceFor(t))
   );
   return isExceeding;
 });

--- a/src/components/cards/CreatePool/InitialLiquidity.vue
+++ b/src/components/cards/CreatePool/InitialLiquidity.vue
@@ -22,13 +22,7 @@ const cardWrapper = ref<HTMLElement>();
  * COMPOSBALES
  */
 const { userNetworkConfig } = useWeb3();
-const {
-  balances,
-  balanceFor,
-  priceFor,
-  nativeAsset,
-  wrappedNativeAsset
-} = useTokens();
+const { balanceFor, priceFor, nativeAsset, wrappedNativeAsset } = useTokens();
 const { fNum } = useNumbers();
 const {
   seedTokens,


### PR DESCRIPTION
# Description

When creating a new pool and reaching the stage when you need to add initial liquidity, there was an issue where the Preview screen would be greyed out for no reason. (See image)

You can see that the user has balances for both ETH and WAMPL, they should be allowed to proceed with pool creation.
The issue here is that when the UI is checking for invalid balances, it checks against the token addresses that are selected for the pool. So in this case WETH/WAMPL. 

So in this case, the user has ETH balance but not WETH balance, if you were to switch to WETH via the dropdown it would show the exceeding balance error. This shouldn't be an issue anyways since we allow creation using native assets. 

I've fixed this by making sure the invalid balance check uses the token addresses that are used on the initial liquidity page rather than the initial token ones.

![image](https://user-images.githubusercontent.com/40786269/148498275-ae7ba3aa-15c6-491a-a066-ddafbb4dc311.png)

Fixes # (issue)

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## How should this be tested?

To test, create a pool which uses WETH as a token. Make sure you have an ETH balance and no WETH balance. Then when you go to create that pool, make sure you can proceed with just an ETH balance and the other token.

## Checklist:

- [X] I have performed a self-review of my own code
- [X] I have commented my code where relevant, particularly in hard-to-understand areas
- [X] My changes generate no new console warnings
- [X] The base of this PR is `master` if hotfix, `develop` if not
