### PR TITLE
Hotfix: Don't run exploit watcher when no wallet is connected

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.35.14",
+  "version": "1.35.15",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@balancer-labs/frontend-v2",
-      "version": "1.35.14",
+      "version": "1.35.15",
       "license": "MIT",
       "devDependencies": {
         "@aave/protocol-js": "^4.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.35.14",
+  "version": "1.35.15",
   "engines": {
     "node": "14.x",
     "npm": ">=7"

--- a/src/composables/watchers/useExploitWatcher.ts
+++ b/src/composables/watchers/useExploitWatcher.ts
@@ -14,6 +14,7 @@ export default function useExploitWatcher() {
   }
 
   watch(account, () => {
+    if (!account.value) return;
     for (const exploitedProtocol of exploits) {
       const exploit = ACTIVE_EXPLOITS[exploitedProtocol];
       // the list of wallets may not always be checksummed


### PR DESCRIPTION
# Description

- Disconnecting a wallet is currently broken because after disconnecting
the exploit watcher attempts to check against an empty account address
string. If account.value is not set, skip running the watcher.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## How should this be tested?

- Connect a wallet to Balancer
- Disconnect wallet, ensure that wallet disconnects correctly. 

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] My changes generate no new console warnings
- [x] The base of this PR is `master` if hotfix, `develop` if not
