### PR TITLE
tempfix: point polygon subgraph to balancer beta

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.36.3",
+  "version": "1.36.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@balancer-labs/frontend-v2",
-      "version": "1.36.3",
+      "version": "1.36.4",
       "license": "MIT",
       "devDependencies": {
         "@aave/protocol-js": "^4.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.36.3",
+  "version": "1.36.4",
   "engines": {
     "node": "14.x",
     "npm": ">=7"

--- a/src/lib/config/polygon.json
+++ b/src/lib/config/polygon.json
@@ -13,7 +13,7 @@
   "publicRpc": "https://polygon-rpc.com",
   "explorer": "https://polygonscan.com",
   "explorerName": "Polygonscan",
-  "subgraph": "https://api.thegraph.com/subgraphs/name/balancer-labs/balancer-polygon-v2",
+  "subgraph": "https://api.thegraph.com/subgraphs/name/balancer-labs/balancer-polygon-v2-beta",
   "poolsUrlV1": "",
   "poolsUrlV2": "",
   "subgraphs": {


### PR DESCRIPTION
# Description

Polygon subgraph is failing. This points the polygon subgraph queries to the beta version of the subgraph where minimal app behaviour is working. Will need to point back to the main url after everything is stable again.2

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## How should this be tested?

Test that polygon app works 

## Visual context

None for this one

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have requested at least 2 reviews (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] If package-lock.json has changes, it was intentional.
- [x] The base of this PR is `master` if hotfix, `develop` if not
