### PR TITLE
Fix close button on alert banner

### DIFF
--- a/src/components/navs/AppNav/AppNavAlert.vue
+++ b/src/components/navs/AppNav/AppNavAlert.vue
@@ -14,7 +14,7 @@
       />
     </div>
     <div v-if="!alert.persistent" class="w-8">
-      <BalIcon name="x" class="cursor-pointer" @click="handleClose" />
+      <BalIcon name="x" class="cursor-pointer" @click.stop="handleClose" />
     </div>
   </div>
 </template>


### PR DESCRIPTION
# Description

Fixes the alert banner so that when you click the close button it doesn't also click the banner.

Currently if you click the cross on the boosted pools banner it takes you to the pool instead, ignoring the close button, which is not intended. 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## How should this be tested?

Add a `!` to `if (!isMainnet.value) {` in App.vue to test on Kovan. 
Close the banner, ensure that it closes and doesn't redirect you to the boosted pool

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have requested at least 2 reviews (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] If package-lock.json has changes, it was intentional.
- [x] The base of this PR is `master` if hotfix, `develop` if not
