### PR TITLE
Refactor fNum to allow for Internationalisation / Multiple Currencies

### DIFF
--- a/src/components/_global/BalLineChart/BalLineChart.vue
+++ b/src/components/_global/BalLineChart/BalLineChart.vue
@@ -357,7 +357,8 @@ export default defineComponent({
           currentDayValue.value() || 0,
           props.axisLabelFormatter.yAxis || {
             style: 'currency',
-            currency: 'USD'
+            currency: 'USD',
+            fixedFormat: true
           }
         );
       }
@@ -399,7 +400,8 @@ export default defineComponent({
           props.data[seriesIndex].values[dataIndex][1],
           props.axisLabelFormatter.yAxis || {
             style: 'currency',
-            currency: 'USD'
+            currency: 'USD',
+            fixedFormat: true
           }
         );
 

--- a/src/components/_global/BalLineChart/BalLineChart.vue
+++ b/src/components/_global/BalLineChart/BalLineChart.vue
@@ -180,7 +180,10 @@ export default defineComponent({
           const latestValue = last(
             props.data.find(d => d.name === legendName)?.values as any
           ) as [string | number, string | number];
-          return `${legendName}: ${fNum2(latestValue[1], props.axisLabelFormatter.yAxis)}`;
+          return `${legendName}: ${fNum2(
+            latestValue[1],
+            props.axisLabelFormatter.yAxis
+          )}`;
         },
         selected: props.legendState || {},
         textStyle: {
@@ -203,8 +206,7 @@ export default defineComponent({
         },
         axisLabel: {
           formatter: props.axisLabelFormatter.xAxis
-            ? value =>
-                fNum2(value, props.axisLabelFormatter.xAxis)
+            ? value => fNum2(value, props.axisLabelFormatter.xAxis)
             : undefined,
           color: tailwind.theme.colors.gray['400']
         }
@@ -227,8 +229,7 @@ export default defineComponent({
         axisLabel: {
           show: !props.hideYAxis,
           formatter: props.axisLabelFormatter.yAxis
-            ? value =>
-                fNum2(value, props.axisLabelFormatter.yAxis) 
+            ? value => fNum2(value, props.axisLabelFormatter.yAxis)
             : undefined,
           color: tailwind.theme.colors.gray['400']
         },
@@ -269,7 +270,10 @@ export default defineComponent({
                 <span>
                 ${param.marker} ${
                     param.seriesName
-                  } <span class='font-medium'>${fNum2(param.value[1], props.axisLabelFormatter.yAxis)})}
+                  } <span class='font-medium'>${fNum2(
+                    param.value[1],
+                    props.axisLabelFormatter.yAxis
+                  )})}
                   </span>
                 </span>
               `

--- a/src/components/_global/BalLineChart/BalLineChart.vue
+++ b/src/components/_global/BalLineChart/BalLineChart.vue
@@ -43,7 +43,7 @@ import numeral from 'numeral';
 import * as echarts from 'echarts/core';
 import ECharts from 'vue-echarts';
 import { last } from 'lodash';
-import useNumbers, { Preset } from '@/composables/useNumbers';
+import useNumbers, { FNumOptions } from '@/composables/useNumbers';
 import useTailwind from '@/composables/useTailwind';
 import useDarkMode from '@/composables/useDarkMode';
 
@@ -58,8 +58,8 @@ type ChartData = {
 };
 
 type AxisLabelFormat = {
-  xAxis?: Preset | string;
-  yAxis?: Preset | string;
+  xAxis?: FNumOptions;
+  yAxis?: FNumOptions;
 };
 
 type PeriodOption = {
@@ -156,7 +156,7 @@ export default defineComponent({
     const lineChart = ref<HTMLElement>();
     const currentValue = ref('$0,00');
     const change = ref(0);
-    const { fNum } = useNumbers();
+    const { fNum2 } = useNumbers();
     const tailwind = useTailwind();
     const { darkMode } = useDarkMode();
 
@@ -180,9 +180,7 @@ export default defineComponent({
           const latestValue = last(
             props.data.find(d => d.name === legendName)?.values as any
           ) as [string | number, string | number];
-          return `${legendName}: ${fNum(latestValue[1], null, {
-            format: props.axisLabelFormatter.yAxis
-          })}`;
+          return `${legendName}: ${fNum2(latestValue[1], props.axisLabelFormatter.yAxis)}`;
         },
         selected: props.legendState || {},
         textStyle: {
@@ -206,7 +204,7 @@ export default defineComponent({
         axisLabel: {
           formatter: props.axisLabelFormatter.xAxis
             ? value =>
-                fNum(value, null, { format: props.axisLabelFormatter.xAxis })
+                fNum2(value, props.axisLabelFormatter.xAxis)
             : undefined,
           color: tailwind.theme.colors.gray['400']
         }
@@ -230,7 +228,7 @@ export default defineComponent({
           show: !props.hideYAxis,
           formatter: props.axisLabelFormatter.yAxis
             ? value =>
-                fNum(value, null, { format: props.axisLabelFormatter.yAxis })
+                fNum2(value, props.axisLabelFormatter.yAxis) 
             : undefined,
           color: tailwind.theme.colors.gray['400']
         },
@@ -271,9 +269,7 @@ export default defineComponent({
                 <span>
                 ${param.marker} ${
                     param.seriesName
-                  } <span class='font-medium'>${fNum(param.value[1], null, {
-                    format: props.axisLabelFormatter.yAxis
-                  })}
+                  } <span class='font-medium'>${fNum2(param.value[1], props.axisLabelFormatter.yAxis)})}
                   </span>
                 </span>
               `
@@ -311,9 +307,7 @@ export default defineComponent({
             borderRadius: 3,
             padding: 4,
             formatter: (params: any) => {
-              return fNum(params.data.yAxis, null, {
-                format: props.axisLabelFormatter.yAxis
-              });
+              return fNum2(params.data.yAxis, props.axisLabelFormatter.yAxis);
             },
             color: '#FFF',
             fontSize: 10
@@ -359,8 +353,12 @@ export default defineComponent({
       );
 
       if (updateCurrentValue) {
-        currentValue.value = currentDayValue.format(
-          props.axisLabelFormatter.yAxis || '$0,0.00'
+        currentValue.value = fNum2(
+          currentDayValue.value() || 0,
+          props.axisLabelFormatter.yAxis || {
+            style: 'currency',
+            currency: 'USD'
+          }
         );
       }
 
@@ -397,9 +395,13 @@ export default defineComponent({
         props.onAxisMoved &&
           props.onAxisMoved(props.data[seriesIndex].values[dataIndex]);
 
-        currentValue.value = numeral(
-          props.data[seriesIndex].values[dataIndex][1]
-        ).format(props.axisLabelFormatter.yAxis || '$0,0.00');
+        currentValue.value = fNum2(
+          props.data[seriesIndex].values[dataIndex][1],
+          props.axisLabelFormatter.yAxis || {
+            style: 'currency',
+            currency: 'USD'
+          }
+        );
 
         // if first point in chart, show overall change
         if (dataIndex === 0) {

--- a/src/components/cards/CreatePool/ChooseWeights.vue
+++ b/src/components/cards/CreatePool/ChooseWeights.vue
@@ -393,7 +393,7 @@ function onAlertMountChange() {
             type="warning"
             >{{
               $t('createAPool.youCanFundWithThisPoolWith', [
-                fNum2(totalLiquidity.toString(), { style: 'currency' })
+                fNum2(totalLiquidity.toString(), FNumFormats.fiat)
               ])
             }}</BalAlert
           >

--- a/src/components/cards/CreatePool/ChooseWeights.vue
+++ b/src/components/cards/CreatePool/ChooseWeights.vue
@@ -44,7 +44,7 @@ const {
   acceptedCustomTokenDisclaimer
 } = usePoolCreation();
 const { upToLargeBreakpoint } = useBreakpoints();
-const { fNum } = useNumbers();
+const { fNum2 } = useNumbers();
 const { nativeAsset, tokens } = useTokens();
 const { isWalletReady, toggleWalletSelectModal } = useWeb3();
 const { t } = useI18n();
@@ -393,7 +393,7 @@ function onAlertMountChange() {
             type="warning"
             >{{
               $t('createAPool.youCanFundWithThisPoolWith', [
-                fNum(totalLiquidity.toString(), 'usd')
+                fNum2(totalLiquidity.toString(), { style: 'currency' })
               ])
             }}</BalAlert
           >

--- a/src/components/cards/CreatePool/InitialLiquidity.vue
+++ b/src/components/cards/CreatePool/InitialLiquidity.vue
@@ -4,7 +4,7 @@ import { bnum } from '@/lib/utils';
 import useWeb3 from '@/services/web3/useWeb3';
 import useTokens from '@/composables/useTokens';
 import usePoolCreation from '@/composables/pools/usePoolCreation';
-import useNumbers from '@/composables/useNumbers';
+import useNumbers, { FNumFormats } from '@/composables/useNumbers';
 
 import TokenInput from '@/components/inputs/TokenInput/TokenInput.vue';
 import AnimatePresence from '@/components/animate/AnimatePresence.vue';
@@ -324,7 +324,7 @@ function saveAndProceed() {
             :title="
               t('createAPool.arbTitle', [
                 fNum2(arbitrageDelta.value, { style: 'currency' }),
-                fNum2(arbitrageDelta.delta, { style: 'unit', unit: 'percent' })
+                fNum2(arbitrageDelta.delta, FNumFormats.percent)
               ])
             "
           >

--- a/src/components/cards/CreatePool/InitialLiquidity.vue
+++ b/src/components/cards/CreatePool/InitialLiquidity.vue
@@ -25,7 +25,7 @@ const cardWrapper = ref<HTMLElement>();
  */
 const { userNetworkConfig } = useWeb3();
 const { balanceFor, priceFor, nativeAsset, wrappedNativeAsset } = useTokens();
-const { fNum } = useNumbers();
+const { fNum2 } = useNumbers();
 const {
   seedTokens,
   tokensList,
@@ -277,7 +277,8 @@ function saveAndProceed() {
               <h6>{{ t('total') }}</h6>
               <BalStack horizontal spacing="xs" class="font-medium">
                 <span class="text-sm">
-                  {{ t('available') }}: {{ fNum2(totalLiquidity, { style: 'currency' }) }}
+                  {{ t('available') }}:
+                  {{ fNum2(totalLiquidity, { style: 'currency' }) }}
                 </span>
                 <button
                   :disabled="areAmountsMaxed"

--- a/src/components/cards/CreatePool/InitialLiquidity.vue
+++ b/src/components/cards/CreatePool/InitialLiquidity.vue
@@ -278,7 +278,7 @@ function saveAndProceed() {
               <BalStack horizontal spacing="xs" class="font-medium">
                 <span class="text-sm">
                   {{ t('available') }}:
-                  {{ fNum2(totalLiquidity, { style: 'currency' }) }}
+                  {{ fNum2(totalLiquidity.toString(), FNumFormats.fiat) }}
                 </span>
                 <button
                   :disabled="areAmountsMaxed"
@@ -296,7 +296,9 @@ function saveAndProceed() {
               </BalStack>
             </BalStack>
             <BalStack vertical spacing="none">
-              <h6>{{ fNum2(currentLiquidity, { style: 'currency' }) }}</h6>
+              <h6>
+                {{ fNum2(currentLiquidity.toString(), FNumFormats.fiat) }}
+              </h6>
               <AnimatePresence
                 :isVisible="!isOptimised"
                 @on-presence="onAlertMountChange"
@@ -323,8 +325,8 @@ function saveAndProceed() {
             type="warning"
             :title="
               t('createAPool.arbTitle', [
-                fNum2(arbitrageDelta.value, { style: 'currency' }),
-                fNum2(arbitrageDelta.delta, FNumFormats.percent)
+                fNum2(arbitrageDelta.value.toString(), FNumFormats.fiat),
+                fNum2(arbitrageDelta.delta.toString(), FNumFormats.percent)
               ])
             "
           >

--- a/src/components/cards/CreatePool/InitialLiquidity.vue
+++ b/src/components/cards/CreatePool/InitialLiquidity.vue
@@ -277,7 +277,7 @@ function saveAndProceed() {
               <h6>{{ t('total') }}</h6>
               <BalStack horizontal spacing="xs" class="font-medium">
                 <span class="text-sm">
-                  {{ t('available') }}: {{ fNum(totalLiquidity, 'usd') }}
+                  {{ t('available') }}: {{ fNum2(totalLiquidity, { style: 'currency' }) }}
                 </span>
                 <button
                   :disabled="areAmountsMaxed"
@@ -295,7 +295,7 @@ function saveAndProceed() {
               </BalStack>
             </BalStack>
             <BalStack vertical spacing="none">
-              <h6>{{ fNum(currentLiquidity, 'usd') }}</h6>
+              <h6>{{ fNum2(currentLiquidity, { style: 'currency' }) }}</h6>
               <AnimatePresence
                 :isVisible="!isOptimised"
                 @on-presence="onAlertMountChange"
@@ -322,8 +322,8 @@ function saveAndProceed() {
             type="warning"
             :title="
               t('createAPool.arbTitle', [
-                fNum(arbitrageDelta.value, 'usd'),
-                fNum(arbitrageDelta.delta, 'percent')
+                fNum2(arbitrageDelta.value, { style: 'currency' }),
+                fNum2(arbitrageDelta.delta, { style: 'unit', unit: 'percent' })
               ])
             "
           >

--- a/src/components/cards/CreatePool/PoolFees.vue
+++ b/src/components/cards/CreatePool/PoolFees.vue
@@ -26,7 +26,7 @@ const cardWrapper = ref<HTMLElement>();
 /**
  * COMPOSABLES
  */
-const { fNum } = useNumbers();
+const { fNum2 } = useNumbers();
 const {
   initialFee,
   feeController,
@@ -69,7 +69,13 @@ const isProceedDisabled = computed(() => {
 // this does not need to be computed as it relies on a static
 const feeOptions = FIXED_FEE_OPTIONS.map(option => {
   return {
-    label: fNum(option, null, { format: '0.0%' }),
+    label: fNum2(option, {
+      style: 'unit',
+      unit: 'percent',
+      minimumFractionDigits: 1,
+      maximumFractionDigits: 1,
+      fixedFormat: true
+    }),
     value: option
   };
 });

--- a/src/components/cards/CreatePool/PoolSummary.vue
+++ b/src/components/cards/CreatePool/PoolSummary.vue
@@ -12,7 +12,7 @@ import useBreakpoints from '@/composables/useBreakpoints';
 import { prominent } from 'color.js';
 import useDarkMode from '@/composables/useDarkMode';
 import useTailwind from '@/composables/useTailwind';
-import useNumbers from '@/composables/useNumbers';
+import useNumbers, { FNumFormats } from '@/composables/useNumbers';
 
 /**
  * CONSTANTS
@@ -203,7 +203,7 @@ async function calculateColors() {
           {{ $t('createAPool.maxLiquidityTooltip') }}
         </BalTooltip>
       </BalStack>
-      <span>{{ fNum2(totalLiquidity.toString(), { style: 'currency' }) }}</span>
+      <span>{{ fNum2(totalLiquidity.toString(), FNumFormats.fiat) }}</span>
     </BalStack>
   </BalCard>
 </template>

--- a/src/components/cards/CreatePool/PoolSummary.vue
+++ b/src/components/cards/CreatePool/PoolSummary.vue
@@ -41,7 +41,7 @@ const {
 } = usePoolCreation();
 const { upToLargeBreakpoint } = useBreakpoints();
 const { darkMode } = useDarkMode();
-const { fNum } = useNumbers();
+const { fNum2 } = useNumbers();
 const tailwind = useTailwind();
 const { resolve } = useUrls();
 
@@ -203,7 +203,7 @@ async function calculateColors() {
           {{ $t('createAPool.maxLiquidityTooltip') }}
         </BalTooltip>
       </BalStack>
-      <span>{{ fNum(totalLiquidity.toString(), 'usd') }}</span>
+      <span>{{ fNum2(totalLiquidity.toString(), { style: 'currency' }) }}</span>
     </BalStack>
   </BalCard>
 </template>

--- a/src/components/cards/CreatePool/PreviewPool.vue
+++ b/src/components/cards/CreatePool/PreviewPool.vue
@@ -49,7 +49,7 @@ const {
 } = usePoolCreation();
 
 const { tokens, priceFor, nativeAsset, wrappedNativeAsset } = useTokens();
-const { fNum } = useNumbers();
+const { fNum2 } = useNumbers();
 const { t } = useI18n();
 const { userNetworkConfig, account } = useWeb3();
 
@@ -188,7 +188,14 @@ function getInitialWeightHighlightClass(tokenAddress: string) {
                   <BalAsset :address="token.tokenAddress" :size="36" />
                   <BalStack vertical spacing="none">
                     <span class="font-semibold">
-                      {{ fNum(token.weight / 100, 'percent') }}
+                      {{
+                        fNum2(token.weight / 100, {
+                          style: 'unit',
+                          unit: 'percent',
+                          minimumFractionDigits: 2,
+                          maximumFractionDigits: 2
+                        })
+                      }}
                       {{ tokens[token.tokenAddress]?.symbol }}
                     </span>
                     <span
@@ -209,15 +216,15 @@ function getInitialWeightHighlightClass(tokenAddress: string) {
                 </BalStack>
                 <BalStack vertical spacing="none" align="end">
                   <span class="font-semibold">
-                    {{ fNum(token.amount, 'token') }}
+                    {{ fNum2(token.amount, { maximumFractionDigits: 4 }) }}
                   </span>
                   <span class="text-sm text-gray-500">
                     {{
-                      fNum(
+                      fNum2(
                         bnum(token.amount)
                           .times(priceFor(token.tokenAddress))
                           .toString(),
-                        'usd'
+                        { style: 'currency' }
                       )
                     }}
                   </span>
@@ -231,7 +238,9 @@ function getInitialWeightHighlightClass(tokenAddress: string) {
             class="p-4 border-t dark:border-gray-600"
           >
             <h6>{{ $t('total') }}</h6>
-            <h6>{{ fNum(poolLiquidity.toString(), 'usd') }}</h6>
+            <h6>
+              {{ fNum2(poolLiquidity.toString(), { style: 'currency' }) }}
+            </h6>
           </BalStack>
         </BalCard>
         <BalCard shadow="none" noPad>
@@ -264,7 +273,7 @@ function getInitialWeightHighlightClass(tokenAddress: string) {
             <BalStack horizontal justify="between" class="mt-1">
               <span class="text-sm">{{ $t('swapFee') }}:</span>
               <BalStack horizontal spacing="sm">
-                <span class="text-sm">{{ fNum(initialFee, 'percent') }}</span>
+                <span class="text-sm">{{ fNum2(initialFee, { style: 'unit', unit: 'percent', minimumFractionDigits: 2, maximumFractionDigits: 2 }) }}</span>
                 <button class="hover:text-blue-500" @click="navigateToPoolFee">
                   <BalIcon name="edit" size="xs" />
                 </button>
@@ -305,8 +314,8 @@ function getInitialWeightHighlightClass(tokenAddress: string) {
           class="mb-4"
           :title="
             t('createAPool.arbTitle', [
-              fNum(arbitrageDelta.value, 'usd'),
-              fNum(arbitrageDelta.delta, 'percent')
+              fNum2(arbitrageDelta.value, { style: 'currency' }),
+              fNum2(arbitrageDelta.delta, { style: 'unit', unit: 'percent', minimumFractionDigits: 2, maximumFractionDigits: 2 })
             ])
           "
         >

--- a/src/components/cards/CreatePool/PreviewPool.vue
+++ b/src/components/cards/CreatePool/PreviewPool.vue
@@ -188,14 +188,7 @@ function getInitialWeightHighlightClass(tokenAddress: string) {
                   <BalAsset :address="token.tokenAddress" :size="36" />
                   <BalStack vertical spacing="none">
                     <span class="font-semibold">
-                      {{
-                        fNum2(token.weight / 100, {
-                          style: 'unit',
-                          unit: 'percent',
-                          minimumFractionDigits: 2,
-                          maximumFractionDigits: 2
-                        })
-                      }}
+                      {{ fNum2(token.weight / 100, FNumFormats.percent) }}
                       {{ tokens[token.tokenAddress]?.symbol }}
                     </span>
                     <span

--- a/src/components/cards/CreatePool/PreviewPool.vue
+++ b/src/components/cards/CreatePool/PreviewPool.vue
@@ -273,7 +273,14 @@ function getInitialWeightHighlightClass(tokenAddress: string) {
             <BalStack horizontal justify="between" class="mt-1">
               <span class="text-sm">{{ $t('swapFee') }}:</span>
               <BalStack horizontal spacing="sm">
-                <span class="text-sm">{{ fNum2(initialFee, { style: 'unit', unit: 'percent', minimumFractionDigits: 2, maximumFractionDigits: 2 }) }}</span>
+                <span class="text-sm">{{
+                  fNum2(initialFee, {
+                    style: 'unit',
+                    unit: 'percent',
+                    minimumFractionDigits: 2,
+                    maximumFractionDigits: 2
+                  })
+                }}</span>
                 <button class="hover:text-blue-500" @click="navigateToPoolFee">
                   <BalIcon name="edit" size="xs" />
                 </button>

--- a/src/components/cards/CreatePool/PreviewPool.vue
+++ b/src/components/cards/CreatePool/PreviewPool.vue
@@ -5,7 +5,7 @@ import AnimatePresence from '@/components/animate/AnimatePresence.vue';
 
 import usePoolCreation from '@/composables/pools/usePoolCreation';
 import useTokens from '@/composables/useTokens';
-import useNumbers from '@/composables/useNumbers';
+import useNumbers, { FNumFormats } from '@/composables/useNumbers';
 import useWeb3 from '@/services/web3/useWeb3';
 
 import { useI18n } from 'vue-i18n';
@@ -216,7 +216,7 @@ function getInitialWeightHighlightClass(tokenAddress: string) {
                 </BalStack>
                 <BalStack vertical spacing="none" align="end">
                   <span class="font-semibold">
-                    {{ fNum2(token.amount, { maximumFractionDigits: 4 }) }}
+                    {{ fNum2(token.amount, FNumFormats.token) }}
                   </span>
                   <span class="text-sm text-gray-500">
                     {{
@@ -274,12 +274,7 @@ function getInitialWeightHighlightClass(tokenAddress: string) {
               <span class="text-sm">{{ $t('swapFee') }}:</span>
               <BalStack horizontal spacing="sm">
                 <span class="text-sm">{{
-                  fNum2(initialFee, {
-                    style: 'unit',
-                    unit: 'percent',
-                    minimumFractionDigits: 2,
-                    maximumFractionDigits: 2
-                  })
+                  fNum2(initialFee, FNumFormats.percent)
                 }}</span>
                 <button class="hover:text-blue-500" @click="navigateToPoolFee">
                   <BalIcon name="edit" size="xs" />
@@ -322,7 +317,7 @@ function getInitialWeightHighlightClass(tokenAddress: string) {
           :title="
             t('createAPool.arbTitle', [
               fNum2(arbitrageDelta.value, { style: 'currency' }),
-              fNum2(arbitrageDelta.delta, { style: 'unit', unit: 'percent', minimumFractionDigits: 2, maximumFractionDigits: 2 })
+              fNum2(arbitrageDelta.delta, FNumFormats.percent)
             ])
           "
         >

--- a/src/components/cards/CreatePool/PreviewPool.vue
+++ b/src/components/cards/CreatePool/PreviewPool.vue
@@ -224,7 +224,7 @@ function getInitialWeightHighlightClass(tokenAddress: string) {
                         bnum(token.amount)
                           .times(priceFor(token.tokenAddress))
                           .toString(),
-                        { style: 'currency' }
+                        FNumFormats.fiat
                       )
                     }}
                   </span>
@@ -239,7 +239,7 @@ function getInitialWeightHighlightClass(tokenAddress: string) {
           >
             <h6>{{ $t('total') }}</h6>
             <h6>
-              {{ fNum2(poolLiquidity.toString(), { style: 'currency' }) }}
+              {{ fNum2(poolLiquidity.toString(), FNumFormats.fiat) }}
             </h6>
           </BalStack>
         </BalCard>
@@ -316,7 +316,7 @@ function getInitialWeightHighlightClass(tokenAddress: string) {
           class="mb-4"
           :title="
             t('createAPool.arbTitle', [
-              fNum2(arbitrageDelta.value, { style: 'currency' }),
+              fNum2(arbitrageDelta.value, FNumFormats.fiat),
               fNum2(arbitrageDelta.delta, FNumFormats.percent)
             ])
           "

--- a/src/components/cards/CreatePool/SimilarPools.vue
+++ b/src/components/cards/CreatePool/SimilarPools.vue
@@ -146,7 +146,12 @@ function cancel() {
                   $t('fees')
                 }}</span>
                 <span class="font-semibold">{{
-                  fNum2(pool.swapFee, { style: 'unit', unit: 'percent', minimumFractionDigits: 2, maximumFractionDigits: 2 })
+                  fNum2(pool.swapFee, {
+                    style: 'unit',
+                    unit: 'percent',
+                    minimumFractionDigits: 2,
+                    maximumFractionDigits: 2
+                  })
                 }}</span>
               </BalStack>
             </BalStack>

--- a/src/components/cards/CreatePool/SimilarPools.vue
+++ b/src/components/cards/CreatePool/SimilarPools.vue
@@ -84,7 +84,7 @@ function cancel() {
                 $t('poolValue')
               }}</span>
               <span class="font-semibold">{{
-                fNum2(existingPool.totalLiquidity, { style: 'currency' })
+                fNum2(existingPool.totalLiquidity, FNumFormats.fiat)
               }}</span>
             </BalStack>
             <BalStack vertical spacing="none">
@@ -92,7 +92,7 @@ function cancel() {
                 $t('volume24hShort')
               }}</span>
               <span class="font-semibold">{{
-                fNum2(existingPool.dynamic.volume, { style: 'currency' })
+                fNum2(existingPool.dynamic.volume, FNumFormats.fiat)
               }}</span>
             </BalStack>
             <BalStack vertical spacing="none">
@@ -125,7 +125,7 @@ function cancel() {
                   $t('poolValue')
                 }}</span>
                 <span class="font-semibold">{{
-                  fNum2(pool.totalLiquidity, { style: 'currency' })
+                  fNum2(pool.totalLiquidity, FNumFormats.fiat)
                 }}</span>
               </BalStack>
               <BalStack vertical spacing="none">
@@ -133,7 +133,7 @@ function cancel() {
                   $t('volume24hShort')
                 }}</span>
                 <span class="font-semibold">{{
-                  fNum2(pool.dynamic.volume, { style: 'currency' })
+                  fNum2(pool.dynamic.volume, FNumFormats.fiat)
                 }}</span>
               </BalStack>
               <BalStack vertical spacing="none">

--- a/src/components/cards/CreatePool/SimilarPools.vue
+++ b/src/components/cards/CreatePool/SimilarPools.vue
@@ -22,7 +22,7 @@ const {
   resetPoolCreationState,
   goBack
 } = usePoolCreation();
-const { fNum } = useNumbers();
+const { fNum2 } = useNumbers();
 const { t } = useI18n();
 
 /** COMPUTED */
@@ -84,7 +84,7 @@ function cancel() {
                 $t('poolValue')
               }}</span>
               <span class="font-semibold">{{
-                fNum(existingPool.totalLiquidity, 'usd')
+                fNum2(existingPool.totalLiquidity, { style: 'currency' })
               }}</span>
             </BalStack>
             <BalStack vertical spacing="none">
@@ -92,7 +92,7 @@ function cancel() {
                 $t('volume24hShort')
               }}</span>
               <span class="font-semibold">{{
-                fNum(existingPool.dynamic.volume, 'usd')
+                fNum2(existingPool.dynamic.volume, { style: 'currency' })
               }}</span>
             </BalStack>
             <BalStack vertical spacing="none">
@@ -100,7 +100,12 @@ function cancel() {
                 $t('fees')
               }}</span>
               <span class="font-semibold">{{
-                fNum(existingPool.swapFee, 'percent')
+                fNum2(existingPool.swapFee, {
+                  style: 'unit',
+                  unit: 'percent',
+                  minimumFractionDigits: 2,
+                  maximumFractionDigits: 2
+                })
               }}</span>
             </BalStack>
           </BalStack>
@@ -125,7 +130,7 @@ function cancel() {
                   $t('poolValue')
                 }}</span>
                 <span class="font-semibold">{{
-                  fNum(pool.totalLiquidity, 'usd')
+                  fNum2(pool.totalLiquidity, { style: 'currency' })
                 }}</span>
               </BalStack>
               <BalStack vertical spacing="none">
@@ -133,7 +138,7 @@ function cancel() {
                   $t('volume24hShort')
                 }}</span>
                 <span class="font-semibold">{{
-                  fNum(pool.dynamic.volume, 'usd')
+                  fNum2(pool.dynamic.volume, { style: 'currency' })
                 }}</span>
               </BalStack>
               <BalStack vertical spacing="none">
@@ -141,7 +146,7 @@ function cancel() {
                   $t('fees')
                 }}</span>
                 <span class="font-semibold">{{
-                  fNum(pool.swapFee, 'percent')
+                  fNum2(pool.swapFee, { style: 'unit', unit: 'percent', minimumFractionDigits: 2, maximumFractionDigits: 2 })
                 }}</span>
               </BalStack>
             </BalStack>

--- a/src/components/cards/CreatePool/SimilarPools.vue
+++ b/src/components/cards/CreatePool/SimilarPools.vue
@@ -3,7 +3,7 @@ import { computed } from 'vue';
 
 import usePoolCreation from '@/composables/pools/usePoolCreation';
 import useWeb3 from '@/services/web3/useWeb3';
-import useNumbers from '@/composables/useNumbers';
+import useNumbers, { FNumFormats } from '@/composables/useNumbers';
 
 import TokenPills from '@/components/tables/PoolsTable/TokenPills/TokenPills.vue';
 import { useI18n } from 'vue-i18n';
@@ -100,12 +100,7 @@ function cancel() {
                 $t('fees')
               }}</span>
               <span class="font-semibold">{{
-                fNum2(existingPool.swapFee, {
-                  style: 'unit',
-                  unit: 'percent',
-                  minimumFractionDigits: 2,
-                  maximumFractionDigits: 2
-                })
+                fNum2(existingPool.swapFee, FNumFormats.percent)
               }}</span>
             </BalStack>
           </BalStack>
@@ -146,12 +141,7 @@ function cancel() {
                   $t('fees')
                 }}</span>
                 <span class="font-semibold">{{
-                  fNum2(pool.swapFee, {
-                    style: 'unit',
-                    unit: 'percent',
-                    minimumFractionDigits: 2,
-                    maximumFractionDigits: 2
-                  })
+                  fNum2(pool.swapFee, FNumFormats.percent)
                 }}</span>
               </BalStack>
             </BalStack>

--- a/src/components/cards/CreatePool/SimilarPoolsCompact.vue
+++ b/src/components/cards/CreatePool/SimilarPoolsCompact.vue
@@ -1,6 +1,6 @@
 <script lang="ts" setup>
 import usePoolCreation from '@/composables/pools/usePoolCreation';
-import useNumbers from '@/composables/useNumbers';
+import useNumbers, { FNumFormats } from '@/composables/useNumbers';
 import useTokens from '@/composables/useTokens';
 
 import { Pool } from '@/services/balancer/subgraph/types';
@@ -18,20 +18,13 @@ function getPoolLabel(pool: Pool) {
   const tokensString = pool.tokens
     .map(
       t =>
-        `${tokens.value[t.address]?.symbol} ${fNum2(t.weight, {
-          style: 'unit',
-          unit: 'percent',
-          minimumFractionDigits: 2,
-          maximumFractionDigits: 2
-        })}`
+        `${tokens.value[t.address]?.symbol} ${fNum2(
+          t.weight,
+          FNumFormats.percent
+        )}`
     )
     .join(', ');
-  return `${tokensString} (${fNum2(pool.swapFee, {
-    style: 'unit',
-    unit: 'percent',
-    minimumFractionDigits: 2,
-    maximumFractionDigits: 2
-  })} fee)`;
+  return `${tokensString} (${fNum2(pool.swapFee, FNumFormats.percent)} fee)`;
 }
 </script>
 

--- a/src/components/cards/CreatePool/SimilarPoolsCompact.vue
+++ b/src/components/cards/CreatePool/SimilarPoolsCompact.vue
@@ -10,15 +10,28 @@ import { Pool } from '@/services/balancer/subgraph/types';
  */
 const { similarPools } = usePoolCreation();
 const { tokens } = useTokens();
-const { fNum } = useNumbers();
+const { fNum2 } = useNumbers();
 /**
  * FUNCTIONS
  */
 function getPoolLabel(pool: Pool) {
   const tokensString = pool.tokens
-    .map(t => `${tokens.value[t.address]?.symbol} ${fNum(t.weight, 'percent')}`)
+    .map(
+      t =>
+        `${tokens.value[t.address]?.symbol} ${fNum2(t.weight, {
+          style: 'unit',
+          unit: 'percent',
+          minimumFractionDigits: 2,
+          maximumFractionDigits: 2
+        })}`
+    )
     .join(', ');
-  return `${tokensString} (${fNum(pool.swapFee, 'percent')} fee)`;
+  return `${tokensString} (${fNum2(pool.swapFee, {
+    style: 'unit',
+    unit: 'percent',
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2
+  })} fee)`;
 }
 </script>
 

--- a/src/components/cards/CreatePool/WalletInitialLiquidity.vue
+++ b/src/components/cards/CreatePool/WalletInitialLiquidity.vue
@@ -104,7 +104,7 @@ const totalsClass = computed(() => ({
             totalsClass
           ]"
         >
-          {{ fNum2(maxInitialLiquidity, { style: 'currency' }) }}
+          {{ fNum2(maxInitialLiquidity, FNumFormats.fiat) }}
         </div>
       </div>
     </div>

--- a/src/components/cards/CreatePool/WalletInitialLiquidity.vue
+++ b/src/components/cards/CreatePool/WalletInitialLiquidity.vue
@@ -16,7 +16,7 @@ const {
   maxInitialLiquidity,
   tokenColors
 } = usePoolCreation();
-const { fNum } = useNumbers();
+const { fNum2 } = useNumbers();
 const { upToLargeBreakpoint } = useBreakpoints();
 
 /**
@@ -80,10 +80,9 @@ const totalsClass = computed(() => ({
           </div>
           <div class="col-span-6 text-sm text-right">
             {{
-              fNum(
-                optimisedLiquidity[token.tokenAddress].liquidityRequired,
-                'usd'
-              )
+              fNum2(optimisedLiquidity[token.tokenAddress].liquidityRequired, {
+                style: 'currency'
+              })
             }}
           </div>
         </template>
@@ -105,7 +104,7 @@ const totalsClass = computed(() => ({
             totalsClass
           ]"
         >
-          {{ fNum(maxInitialLiquidity, 'usd') }}
+          {{ fNum2(maxInitialLiquidity, { style: 'currency' }) }}
         </div>
       </div>
     </div>

--- a/src/components/cards/CreatePool/WalletInitialLiquidity.vue
+++ b/src/components/cards/CreatePool/WalletInitialLiquidity.vue
@@ -3,7 +3,7 @@ import useTokens from '@/composables/useTokens';
 import { computed } from 'vue';
 import { sumBy } from 'lodash';
 import usePoolCreation from '@/composables/pools/usePoolCreation';
-import useNumbers from '@/composables/useNumbers';
+import useNumbers, { FNumFormats } from '@/composables/useNumbers';
 import useBreakpoints from '@/composables/useBreakpoints';
 
 /**
@@ -80,9 +80,10 @@ const totalsClass = computed(() => ({
           </div>
           <div class="col-span-6 text-sm text-right">
             {{
-              fNum2(optimisedLiquidity[token.tokenAddress].liquidityRequired, {
-                style: 'currency'
-              })
+              fNum2(
+                optimisedLiquidity[token.tokenAddress].liquidityRequired,
+                FNumFormats.fiat
+              )
             }}
           </div>
         </template>

--- a/src/components/cards/CreatePool/WalletPoolTokens.vue
+++ b/src/components/cards/CreatePool/WalletPoolTokens.vue
@@ -31,7 +31,7 @@ const {
   priceFor
 } = useTokens();
 const { tokensList } = usePoolCreation();
-const { fNum } = useNumbers();
+const { fNum2 } = useNumbers();
 /**
  * COMPUTED
  */

--- a/src/components/cards/CreatePool/WalletPoolTokens.vue
+++ b/src/components/cards/CreatePool/WalletPoolTokens.vue
@@ -3,7 +3,7 @@ import usePoolCreation from '@/composables/pools/usePoolCreation';
 import useTokens from '@/composables/useTokens';
 import { computed } from 'vue';
 import AnimatePresence from '@/components/animate/AnimatePresence.vue';
-import useNumbers from '@/composables/useNumbers';
+import useNumbers, { FNumFormats } from '@/composables/useNumbers';
 import { sumBy } from 'lodash';
 
 /**
@@ -74,9 +74,10 @@ const totalFiat = computed(() => {
                 {{ fNum2(balanceFor(token), FNumFormats.token) }}
               </h6>
               <span class="text-sm text-gray-600">{{
-                fNum2(priceFor(token) * Number(balanceFor(token)), {
-                  style: 'currency'
-                })
+                fNum2(
+                  priceFor(token) * Number(balanceFor(token)),
+                  FNumFormats.fiat
+                )
               }}</span>
             </BalStack>
           </BalStack>
@@ -104,9 +105,10 @@ const totalFiat = computed(() => {
                   {{ fNum2(balanceFor(token), FNumFormats.token) }}
                 </h6>
                 <span class="text-sm text-gray-600">{{
-                  fNum2(priceFor(token) * Number(balanceFor(token)), {
-                    style: 'currency'
-                  })
+                  fNum2(
+                    priceFor(token) * Number(balanceFor(token)),
+                    FNumFormats.fiat
+                  )
                 }}</span>
               </BalStack>
             </BalStack>

--- a/src/components/cards/CreatePool/WalletPoolTokens.vue
+++ b/src/components/cards/CreatePool/WalletPoolTokens.vue
@@ -70,9 +70,9 @@ const totalFiat = computed(() => {
               }}</span>
             </BalStack>
             <BalStack vertical spacing="none" align="end">
-              <h6>{{ fNum(balanceFor(token), 'token') }}</h6>
+              <h6>{{ fNum2(balanceFor(token), { maximumFractionDigits: 4 }) }}</h6>
               <span class="text-sm text-gray-600">{{
-                fNum(priceFor(token) * Number(balanceFor(token)), 'usd')
+                fNum2(priceFor(token) * Number(balanceFor(token)), { style: 'currency' })
               }}</span>
             </BalStack>
           </BalStack>
@@ -96,9 +96,9 @@ const totalFiat = computed(() => {
                 }}</span>
               </BalStack>
               <BalStack vertical spacing="none" align="end">
-                <h6>{{ fNum(balanceFor(token), 'token') }}</h6>
+                <h6>{{ fNum2(balanceFor(token), { maximumFractionDigits: 4 }) }}</h6>
                 <span class="text-sm text-gray-600">{{
-                  fNum(priceFor(token) * Number(balanceFor(token)), 'usd')
+                  fNum2(priceFor(token) * Number(balanceFor(token)), { style: 'currency' })
                 }}</span>
               </BalStack>
             </BalStack>
@@ -106,7 +106,7 @@ const totalFiat = computed(() => {
         </div>
         <BalStack justify="between">
           <h6>Total</h6>
-          <h6>{{ fNum(totalFiat, 'usd') }}</h6>
+          <h6>{{ fNum2(totalFiat, { style: 'currency' }) }}</h6>
         </BalStack>
       </div>
     </BalStack>

--- a/src/components/cards/CreatePool/WalletPoolTokens.vue
+++ b/src/components/cards/CreatePool/WalletPoolTokens.vue
@@ -71,7 +71,7 @@ const totalFiat = computed(() => {
             </BalStack>
             <BalStack vertical spacing="none" align="end">
               <h6>
-                {{ fNum2(balanceFor(token), { maximumFractionDigits: 4 }) }}
+                {{ fNum2(balanceFor(token), FNumFormats.token) }}
               </h6>
               <span class="text-sm text-gray-600">{{
                 fNum2(priceFor(token) * Number(balanceFor(token)), {
@@ -101,7 +101,7 @@ const totalFiat = computed(() => {
               </BalStack>
               <BalStack vertical spacing="none" align="end">
                 <h6>
-                  {{ fNum2(balanceFor(token), { maximumFractionDigits: 4 }) }}
+                  {{ fNum2(balanceFor(token), FNumFormats.token) }}
                 </h6>
                 <span class="text-sm text-gray-600">{{
                   fNum2(priceFor(token) * Number(balanceFor(token)), {
@@ -114,7 +114,7 @@ const totalFiat = computed(() => {
         </div>
         <BalStack justify="between">
           <h6>Total</h6>
-          <h6>{{ fNum2(totalFiat, { style: 'currency' }) }}</h6>
+          <h6>{{ fNum2(totalFiat, FNumFormats.fiat) }}</h6>
         </BalStack>
       </div>
     </BalStack>

--- a/src/components/cards/CreatePool/WalletPoolTokens.vue
+++ b/src/components/cards/CreatePool/WalletPoolTokens.vue
@@ -70,9 +70,13 @@ const totalFiat = computed(() => {
               }}</span>
             </BalStack>
             <BalStack vertical spacing="none" align="end">
-              <h6>{{ fNum2(balanceFor(token), { maximumFractionDigits: 4 }) }}</h6>
+              <h6>
+                {{ fNum2(balanceFor(token), { maximumFractionDigits: 4 }) }}
+              </h6>
               <span class="text-sm text-gray-600">{{
-                fNum2(priceFor(token) * Number(balanceFor(token)), { style: 'currency' })
+                fNum2(priceFor(token) * Number(balanceFor(token)), {
+                  style: 'currency'
+                })
               }}</span>
             </BalStack>
           </BalStack>
@@ -96,9 +100,13 @@ const totalFiat = computed(() => {
                 }}</span>
               </BalStack>
               <BalStack vertical spacing="none" align="end">
-                <h6>{{ fNum2(balanceFor(token), { maximumFractionDigits: 4 }) }}</h6>
+                <h6>
+                  {{ fNum2(balanceFor(token), { maximumFractionDigits: 4 }) }}
+                </h6>
                 <span class="text-sm text-gray-600">{{
-                  fNum2(priceFor(token) * Number(balanceFor(token)), { style: 'currency' })
+                  fNum2(priceFor(token) * Number(balanceFor(token)), {
+                    style: 'currency'
+                  })
                 }}</span>
               </BalStack>
             </BalStack>

--- a/src/components/cards/MyPoolBalancesCard/MyPoolBalancesCard.vue
+++ b/src/components/cards/MyPoolBalancesCard/MyPoolBalancesCard.vue
@@ -5,7 +5,7 @@ import { bnum } from '@/lib/utils';
 import PoolCalculator from '@/services/pool/calculator/calculator.sevice';
 // Composables
 import useTokens from '@/composables/useTokens';
-import useNumbers from '@/composables/useNumbers';
+import useNumbers, { FNumFormats } from '@/composables/useNumbers';
 // Components
 import AssetRow from './components/AssetRow.vue';
 import { usePool } from '@/composables/usePool';
@@ -88,7 +88,7 @@ const fiatTotal = computed(() => {
         .plus(value)
         .toString()
     );
-  return fNum2(fiatValue, { style: 'currency' });
+  return fNum2(fiatValue, FNumFormats.fiat);
 });
 </script>
 

--- a/src/components/cards/MyPoolBalancesCard/MyPoolBalancesCard.vue
+++ b/src/components/cards/MyPoolBalancesCard/MyPoolBalancesCard.vue
@@ -6,7 +6,6 @@ import PoolCalculator from '@/services/pool/calculator/calculator.sevice';
 // Composables
 import useTokens from '@/composables/useTokens';
 import useNumbers from '@/composables/useNumbers';
-import useUserSettings from '@/composables/useUserSettings';
 // Components
 import AssetRow from './components/AssetRow.vue';
 import { usePool } from '@/composables/usePool';
@@ -29,8 +28,7 @@ const props = withDefaults(defineProps<Props>(), {
  * COMPOSABLES
  */
 const { tokens, balances, balanceFor } = useTokens();
-const { fNum, toFiat } = useNumbers();
-const { currency } = useUserSettings();
+const { fNum2, toFiat } = useNumbers();
 const { isStablePhantomPool } = usePool(toRef(props, 'pool'));
 
 /**
@@ -90,7 +88,7 @@ const fiatTotal = computed(() => {
         .plus(value)
         .toString()
     );
-  return fNum(fiatValue, currency.value);
+  return fNum2(fiatValue, { style: 'currency' });
 });
 </script>
 

--- a/src/components/cards/MyPoolBalancesCard/components/AssetRow.vue
+++ b/src/components/cards/MyPoolBalancesCard/components/AssetRow.vue
@@ -2,7 +2,6 @@
 import { computed } from 'vue';
 import useTokens from '@/composables/useTokens';
 import useNumbers from '@/composables/useNumbers';
-import useUserSettings from '@/composables/useUserSettings';
 
 /**
  * TYPES
@@ -22,14 +21,15 @@ const props = defineProps<Props>();
  */
 const { getToken } = useTokens();
 const { fNum2, toFiat } = useNumbers();
-const { currency } = useUserSettings();
 
 /**
  * COMPUTED
  */
 const token = computed(() => getToken(props.address));
 
-const balanceLabel = computed(() => fNum2(props.balance, { maximumFractionDigits: 4 }));
+const balanceLabel = computed(() =>
+  fNum2(props.balance, { maximumFractionDigits: 4 })
+);
 
 const fiatLabel = computed(() => {
   const fiatValue = toFiat(props.balance, props.address);

--- a/src/components/cards/MyPoolBalancesCard/components/AssetRow.vue
+++ b/src/components/cards/MyPoolBalancesCard/components/AssetRow.vue
@@ -21,7 +21,7 @@ const props = defineProps<Props>();
  * COMPOSABLES
  */
 const { getToken } = useTokens();
-const { fNum, toFiat } = useNumbers();
+const { fNum2, toFiat } = useNumbers();
 const { currency } = useUserSettings();
 
 /**
@@ -29,11 +29,11 @@ const { currency } = useUserSettings();
  */
 const token = computed(() => getToken(props.address));
 
-const balanceLabel = computed(() => fNum(props.balance, 'token'));
+const balanceLabel = computed(() => fNum2(props.balance, { maximumFractionDigits: 4 }));
 
 const fiatLabel = computed(() => {
   const fiatValue = toFiat(props.balance, props.address);
-  return fNum(fiatValue, currency.value);
+  return fNum2(fiatValue, { style: 'currency' });
 });
 </script>
 

--- a/src/components/cards/MyPoolBalancesCard/components/AssetRow.vue
+++ b/src/components/cards/MyPoolBalancesCard/components/AssetRow.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { computed } from 'vue';
 import useTokens from '@/composables/useTokens';
-import useNumbers from '@/composables/useNumbers';
+import useNumbers, { FNumFormats } from '@/composables/useNumbers';
 
 /**
  * TYPES
@@ -27,13 +27,11 @@ const { fNum2, toFiat } = useNumbers();
  */
 const token = computed(() => getToken(props.address));
 
-const balanceLabel = computed(() =>
-  fNum2(props.balance, { maximumFractionDigits: 4 })
-);
+const balanceLabel = computed(() => fNum2(props.balance, FNumFormats.token));
 
 const fiatLabel = computed(() => {
   const fiatValue = toFiat(props.balance, props.address);
-  return fNum2(fiatValue, { style: 'currency' });
+  return fNum2(fiatValue, FNumFormats.fiat);
 });
 </script>
 

--- a/src/components/cards/MyWalletTokensCard/MyWalletTokensCard.vue
+++ b/src/components/cards/MyWalletTokensCard/MyWalletTokensCard.vue
@@ -3,7 +3,7 @@ import { computed, toRef } from 'vue';
 import { bnum } from '@/lib/utils';
 import { FullPool } from '@/services/balancer/subgraph/types';
 // Composables
-import useNumbers from '@/composables/useNumbers';
+import useNumbers, { FNumFormats } from '@/composables/useNumbers';
 import useTokens from '@/composables/useTokens';
 // Components
 import AssetRow from './components/AssetRow.vue';
@@ -87,7 +87,7 @@ const fiatTotal = computed(() => {
         .toString()
     );
 
-  return fNum2(fiatValue, { style: 'currency' });
+  return fNum2(fiatValue, FNumFormats.fiat);
 });
 
 /**

--- a/src/components/cards/MyWalletTokensCard/MyWalletTokensCard.vue
+++ b/src/components/cards/MyWalletTokensCard/MyWalletTokensCard.vue
@@ -36,7 +36,7 @@ const emit = defineEmits<{
  */
 const { isWethPool, isStablePhantomPool } = usePool(toRef(props, 'pool'));
 const { balanceFor, nativeAsset, wrappedNativeAsset } = useTokens();
-const { fNum, toFiat } = useNumbers();
+const { fNum2, toFiat } = useNumbers();
 const { currency } = useUserSettings();
 const route = useRoute();
 
@@ -89,7 +89,7 @@ const fiatTotal = computed(() => {
         .toString()
     );
 
-  return fNum(fiatValue, currency.value);
+  return fNum2(fiatValue, { style: 'currency' });
 });
 
 /**

--- a/src/components/cards/MyWalletTokensCard/MyWalletTokensCard.vue
+++ b/src/components/cards/MyWalletTokensCard/MyWalletTokensCard.vue
@@ -4,7 +4,6 @@ import { bnum } from '@/lib/utils';
 import { FullPool } from '@/services/balancer/subgraph/types';
 // Composables
 import useNumbers from '@/composables/useNumbers';
-import useUserSettings from '@/composables/useUserSettings';
 import useTokens from '@/composables/useTokens';
 // Components
 import AssetRow from './components/AssetRow.vue';
@@ -37,7 +36,6 @@ const emit = defineEmits<{
 const { isWethPool, isStablePhantomPool } = usePool(toRef(props, 'pool'));
 const { balanceFor, nativeAsset, wrappedNativeAsset } = useTokens();
 const { fNum2, toFiat } = useNumbers();
-const { currency } = useUserSettings();
 const route = useRoute();
 
 /**

--- a/src/components/cards/MyWalletTokensCard/components/AssetRow.vue
+++ b/src/components/cards/MyWalletTokensCard/components/AssetRow.vue
@@ -2,7 +2,6 @@
 import { computed } from 'vue';
 import useTokens from '@/composables/useTokens';
 import useNumbers from '@/composables/useNumbers';
-import useUserSettings from '@/composables/useUserSettings';
 
 /**
  * TYPES

--- a/src/components/cards/MyWalletTokensCard/components/AssetRow.vue
+++ b/src/components/cards/MyWalletTokensCard/components/AssetRow.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { computed } from 'vue';
 import useTokens from '@/composables/useTokens';
-import useNumbers from '@/composables/useNumbers';
+import useNumbers, { FNumFormats } from '@/composables/useNumbers';
 
 /**
  * TYPES
@@ -28,14 +28,14 @@ const { fNum2, toFiat } = useNumbers();
 const token = computed(() => getToken(props.address));
 
 const balanceLabel = computed(() =>
-  fNum2(balanceFor(props.address), { maximumFractionDigits: 4 })
+  fNum2(balanceFor(props.address), FNumFormats.token)
 );
 
 const fiatLabel = computed(() => {
   const tokenBalance = balanceFor(props.address);
   const fiatValue = toFiat(tokenBalance, props.address);
 
-  return fNum2(fiatValue, { style: 'currency' });
+  return fNum2(fiatValue, FNumFormats.fiat);
 });
 </script>
 

--- a/src/components/cards/MyWalletTokensCard/components/AssetRow.vue
+++ b/src/components/cards/MyWalletTokensCard/components/AssetRow.vue
@@ -21,21 +21,22 @@ const props = defineProps<Props>();
  * COMPOSABLES
  */
 const { getToken, balanceFor } = useTokens();
-const { fNum, toFiat } = useNumbers();
-const { currency } = useUserSettings();
+const { fNum2, toFiat } = useNumbers();
 
 /**
  * COMPUTED
  */
 const token = computed(() => getToken(props.address));
 
-const balanceLabel = computed(() => fNum(balanceFor(props.address), 'token'));
+const balanceLabel = computed(() =>
+  fNum2(balanceFor(props.address), { maximumFractionDigits: 4 })
+);
 
 const fiatLabel = computed(() => {
   const tokenBalance = balanceFor(props.address);
   const fiatValue = toFiat(tokenBalance, props.address);
 
-  return fNum(fiatValue, currency.value);
+  return fNum2(fiatValue, { style: 'currency' });
 });
 </script>
 

--- a/src/components/cards/TradeCard/TradePair.vue
+++ b/src/components/cards/TradeCard/TradePair.vue
@@ -3,7 +3,7 @@ import { ref, watchEffect, computed } from 'vue';
 import TokenInput from '@/components/inputs/TokenInput/TokenInput.vue';
 import TradePairToggle from './TradePairToggle.vue';
 import { bnum } from '@/lib/utils';
-import useNumbers from '@/composables/useNumbers';
+import useNumbers, { FNumFormats } from '@/composables/useNumbers';
 import useTokens from '@/composables/useTokens';
 import { UseTrading } from '@/composables/trade/useTrading';
 
@@ -89,9 +89,7 @@ const rateLabel = computed(() => {
     outSymbol = tokenIn.value.symbol;
   }
 
-  return `1 ${inSymbol} = ${fNum2(rate, {
-    maximumFractionDigits: 4
-  })} ${outSymbol}`;
+  return `1 ${inSymbol} = ${fNum2(rate, FNumFormats.token)} ${outSymbol}`;
 });
 
 /**

--- a/src/components/cards/TradeCard/TradePair.vue
+++ b/src/components/cards/TradeCard/TradePair.vue
@@ -38,7 +38,7 @@ const emit = defineEmits<{
 /**
  * COMPOSABLES
  */
-const { fNum } = useNumbers();
+const { fNum2 } = useNumbers();
 const { getToken } = useTokens();
 
 /**
@@ -89,7 +89,9 @@ const rateLabel = computed(() => {
     outSymbol = tokenIn.value.symbol;
   }
 
-  return `1 ${inSymbol} = ${fNum(rate, 'token')} ${outSymbol}`;
+  return `1 ${inSymbol} = ${fNum2(rate, {
+    maximumFractionDigits: 4
+  })} ${outSymbol}`;
 });
 
 /**

--- a/src/components/cards/TradeCard/TradeRoute.vue
+++ b/src/components/cards/TradeCard/TradeRoute.vue
@@ -184,7 +184,7 @@ export default defineComponent({
     }
   },
   setup(props) {
-    const { fNum } = useNumbers();
+    const { fNum2 } = useNumbers();
     const { t } = useI18n();
 
     const { appNetworkConfig } = useWeb3();
@@ -428,7 +428,12 @@ export default defineComponent({
     }
 
     function formatShare(share: number): string {
-      return fNum(share, 'percent');
+      return fNum2(share, {
+        style: 'unit',
+        unit: 'percent',
+        minimumFractionDigits: 2,
+        maximumFractionDigits: 2
+      });
     }
 
     function getPoolLink(id: string): string {

--- a/src/components/cards/TradeCard/TradeRoute.vue
+++ b/src/components/cards/TradeCard/TradeRoute.vue
@@ -128,7 +128,7 @@ import { AddressZero } from '@ethersproject/constants';
 import { Pool, Swap } from '@balancer-labs/sor/dist/types';
 import { SwapV2, SubgraphPoolBase } from '@balancer-labs/sdk';
 
-import useNumbers from '@/composables/useNumbers';
+import useNumbers, { FNumFormats } from '@/composables/useNumbers';
 import { SorReturn } from '@/lib/utils/balancer/helpers/sor/sorManager';
 import { useI18n } from 'vue-i18n';
 import useWeb3 from '@/services/web3/useWeb3';
@@ -428,12 +428,7 @@ export default defineComponent({
     }
 
     function formatShare(share: number): string {
-      return fNum2(share, {
-        style: 'unit',
-        unit: 'percent',
-        minimumFractionDigits: 2,
-        maximumFractionDigits: 2
-      });
+      return fNum2(share, FNumFormats.percent);
     }
 
     function getPoolLink(id: string): string {

--- a/src/components/cards/TradeCardGP/TradeCardGP.vue
+++ b/src/components/cards/TradeCardGP/TradeCardGP.vue
@@ -129,7 +129,7 @@ import useTrading from '@/composables/trade/useTrading';
 import { ENABLE_LEGACY_TRADE_INTERFACE } from '@/composables/trade/constants';
 import useTokens from '@/composables/useTokens';
 import useBreakpoints from '@/composables/useBreakpoints';
-import useNumbers from '@/composables/useNumbers';
+import useNumbers, { FNumFormats } from '@/composables/useNumbers';
 
 import { TOKENS } from '@/constants/tokens';
 
@@ -267,12 +267,7 @@ export default defineComponent({
                   ),
                   { maximumFractionDigits: 4 }
                 ),
-                fNum2(trading.slippageBufferRate.value, {
-                  style: 'unit',
-                  unit: 'percent',
-                  minimumFractionDigits: 2,
-                  maximumFractionDigits: 2
-                })
+                fNum2(trading.slippageBufferRate.value, FNumFormats.percent)
               ])
             };
           } else if (validationError === ApiErrorCodes.NoLiquidity) {

--- a/src/components/cards/TradeCardGP/TradeCardGP.vue
+++ b/src/components/cards/TradeCardGP/TradeCardGP.vue
@@ -265,7 +265,7 @@ export default defineComponent({
                     trading.getQuote().maximumInAmount,
                     trading.tokenIn.value.decimals
                   ),
-                  { maximumFractionDigits: 4 }
+                  FNumFormats.token
                 ),
                 fNum2(trading.slippageBufferRate.value, FNumFormats.percent)
               ])

--- a/src/components/cards/TradeCardGP/TradeCardGP.vue
+++ b/src/components/cards/TradeCardGP/TradeCardGP.vue
@@ -162,7 +162,7 @@ export default defineComponent({
     const router = useRouter();
     const { t } = useI18n();
     const { bp } = useBreakpoints();
-    const { fNum } = useNumbers();
+    const { fNum2 } = useNumbers();
     const { appNetworkConfig } = useWeb3();
     const { nativeAsset } = useTokens();
     const {
@@ -260,14 +260,19 @@ export default defineComponent({
               ]),
               body: t('gnosisErrors.lowBalance.body', [
                 trading.tokenIn.value.symbol,
-                fNum(
+                fNum2(
                   formatUnits(
                     trading.getQuote().maximumInAmount,
                     trading.tokenIn.value.decimals
                   ),
-                  'token'
+                  { maximumFractionDigits: 4 }
                 ),
-                fNum(trading.slippageBufferRate.value, 'percent')
+                fNum2(trading.slippageBufferRate.value, {
+                  style: 'unit',
+                  unit: 'percent',
+                  minimumFractionDigits: 2,
+                  maximumFractionDigits: 2
+                })
               ])
             };
           } else if (validationError === ApiErrorCodes.NoLiquidity) {

--- a/src/components/contextual/pages/pool/MyPoolBalancesCard.vue
+++ b/src/components/contextual/pages/pool/MyPoolBalancesCard.vue
@@ -2,7 +2,7 @@
 import { toRef, computed, ref } from 'vue';
 import { FullPool } from '@/services/balancer/subgraph/types';
 import useTokens from '@/composables/useTokens';
-import useNumbers from '@/composables/useNumbers';
+import useNumbers, { FNumFormats } from '@/composables/useNumbers';
 import useWeb3 from '@/services/web3/useWeb3';
 import { usePool } from '@/composables/usePool';
 import PoolCalculator from '@/services/pool/calculator/calculator.sevice';
@@ -90,7 +90,7 @@ const fiatTotal = computed(() => {
         .plus(value)
         .toString()
     );
-  return fNum2(fiatValue, { style: 'currency' });
+  return fNum2(fiatValue, FNumFormats.fiat);
 });
 
 /**
@@ -106,7 +106,7 @@ function weightLabelFor(address: string): string {
 
 function fiatLabelFor(index: number, address: string): string {
   const fiatValue = toFiat(propTokenAmounts.value[index], address);
-  return fNum2(fiatValue, { style: 'currency' });
+  return fNum2(fiatValue, FNumFormats.fiat);
 }
 </script>
 
@@ -150,7 +150,7 @@ function fiatLabelFor(index: number, address: string): string {
         <span class="flex flex-col flex-grow text-right">
           {{
             isWalletReady
-              ? fNum2(propTokenAmounts[index], { maximumFractionDigits: 4 })
+              ? fNum2(propTokenAmounts[index], FNumFormats.token)
               : '-'
           }}
           <span class="text-gray-500 text-sm">

--- a/src/components/contextual/pages/pool/MyPoolBalancesCard.vue
+++ b/src/components/contextual/pages/pool/MyPoolBalancesCard.vue
@@ -3,7 +3,6 @@ import { toRef, computed, ref } from 'vue';
 import { FullPool } from '@/services/balancer/subgraph/types';
 import useTokens from '@/composables/useTokens';
 import useNumbers from '@/composables/useNumbers';
-import useUserSettings from '@/composables/useUserSettings';
 import useWeb3 from '@/services/web3/useWeb3';
 import { usePool } from '@/composables/usePool';
 import PoolCalculator from '@/services/pool/calculator/calculator.sevice';
@@ -27,7 +26,6 @@ const props = defineProps<Props>();
  */
 const { tokens, balances, balanceFor, getTokens } = useTokens();
 const { fNum2, toFiat } = useNumbers();
-const { currency } = useUserSettings();
 const { isWalletReady } = useWeb3();
 const { isStableLikePool, isStablePhantomPool } = usePool(toRef(props, 'pool'));
 
@@ -150,7 +148,11 @@ function fiatLabelFor(index: number, address: string): string {
         </div>
 
         <span class="flex flex-col flex-grow text-right">
-          {{ isWalletReady ? fNum2(propTokenAmounts[index], { maximumFractionDigits: 4 }) : '-' }}
+          {{
+            isWalletReady
+              ? fNum2(propTokenAmounts[index], { maximumFractionDigits: 4 })
+              : '-'
+          }}
           <span class="text-gray-500 text-sm">
             {{ isWalletReady ? fiatLabelFor(index, address) : '-' }}
           </span>

--- a/src/components/contextual/pages/pool/MyPoolBalancesCard.vue
+++ b/src/components/contextual/pages/pool/MyPoolBalancesCard.vue
@@ -26,7 +26,7 @@ const props = defineProps<Props>();
  * COMPOSABLES
  */
 const { tokens, balances, balanceFor, getTokens } = useTokens();
-const { fNum, toFiat } = useNumbers();
+const { fNum2, toFiat } = useNumbers();
 const { currency } = useUserSettings();
 const { isWalletReady } = useWeb3();
 const { isStableLikePool, isStablePhantomPool } = usePool(toRef(props, 'pool'));
@@ -92,19 +92,23 @@ const fiatTotal = computed(() => {
         .plus(value)
         .toString()
     );
-  return fNum(fiatValue, currency.value);
+  return fNum2(fiatValue, { style: 'currency' });
 });
 
 /**
  * METHODS
  */
 function weightLabelFor(address: string): string {
-  return fNum(props.pool.onchain.tokens[address].weight, 'percent_lg');
+  return fNum2(props.pool.onchain.tokens[address].weight, {
+    style: 'unit',
+    unit: 'percent',
+    maximumFractionDigits: 0
+  });
 }
 
 function fiatLabelFor(index: number, address: string): string {
   const fiatValue = toFiat(propTokenAmounts.value[index], address);
-  return fNum(fiatValue, currency.value);
+  return fNum2(fiatValue, { style: 'currency' });
 }
 </script>
 
@@ -146,7 +150,7 @@ function fiatLabelFor(index: number, address: string): string {
         </div>
 
         <span class="flex flex-col flex-grow text-right">
-          {{ isWalletReady ? fNum(propTokenAmounts[index], 'token') : '-' }}
+          {{ isWalletReady ? fNum2(propTokenAmounts[index], { maximumFractionDigits: 4 }) : '-' }}
           <span class="text-gray-500 text-sm">
             {{ isWalletReady ? fiatLabelFor(index, address) : '-' }}
           </span>

--- a/src/components/contextual/pages/pool/PoolActionsCard.vue
+++ b/src/components/contextual/pages/pool/PoolActionsCard.vue
@@ -4,7 +4,6 @@ import useWithdrawMath from '@/components/forms/pool_actions/WithdrawForm/compos
 import { FullPool } from '@/services/balancer/subgraph/types';
 import useTokens from '@/composables/useTokens';
 import useNumbers from '@/composables/useNumbers';
-import useUserSettings from '@/composables/useUserSettings';
 import { bnum } from '@/lib/utils';
 import useWeb3 from '@/services/web3/useWeb3';
 import { lpTokensFor } from '@/composables/usePool';
@@ -28,7 +27,6 @@ const props = defineProps<Props>();
 const { hasBpt } = useWithdrawMath(toRef(props, 'pool'));
 const { balanceFor, nativeAsset, wrappedNativeAsset } = useTokens();
 const { fNum2, toFiat } = useNumbers();
-const { currency } = useUserSettings();
 const { isWalletReady, toggleWalletSelectModal } = useWeb3();
 
 /**

--- a/src/components/contextual/pages/pool/PoolActionsCard.vue
+++ b/src/components/contextual/pages/pool/PoolActionsCard.vue
@@ -27,7 +27,7 @@ const props = defineProps<Props>();
  */
 const { hasBpt } = useWithdrawMath(toRef(props, 'pool'));
 const { balanceFor, nativeAsset, wrappedNativeAsset } = useTokens();
-const { fNum, toFiat } = useNumbers();
+const { fNum2, toFiat } = useNumbers();
 const { currency } = useUserSettings();
 const { isWalletReady, toggleWalletSelectModal } = useWeb3();
 
@@ -57,7 +57,7 @@ const fiatTotal = computed(() => {
         .toString()
     );
 
-  return fNum(fiatValue, currency.value);
+  return fNum2(fiatValue, { style: 'currency' });
 });
 </script>
 

--- a/src/components/contextual/pages/pool/PoolActionsCard.vue
+++ b/src/components/contextual/pages/pool/PoolActionsCard.vue
@@ -3,7 +3,7 @@ import { toRef, computed } from 'vue';
 import useWithdrawMath from '@/components/forms/pool_actions/WithdrawForm/composables/useWithdrawMath';
 import { FullPool } from '@/services/balancer/subgraph/types';
 import useTokens from '@/composables/useTokens';
-import useNumbers from '@/composables/useNumbers';
+import useNumbers, { FNumFormats } from '@/composables/useNumbers';
 import { bnum } from '@/lib/utils';
 import useWeb3 from '@/services/web3/useWeb3';
 import { lpTokensFor } from '@/composables/usePool';
@@ -55,7 +55,7 @@ const fiatTotal = computed(() => {
         .toString()
     );
 
-  return fNum2(fiatValue, { style: 'currency' });
+  return fNum2(fiatValue, FNumFormats.fiat);
 });
 </script>
 

--- a/src/components/contextual/pages/pool/PoolBalancesCard/Pool.vue
+++ b/src/components/contextual/pages/pool/PoolBalancesCard/Pool.vue
@@ -84,7 +84,7 @@ export default defineComponent({
     /**
      * COMPOSABLES
      */
-    const { fNum } = useNumbers();
+    const { fNum2 } = useNumbers();
     const { explorerLinks } = useWeb3();
     const { t } = useI18n();
     const { upToLargeBreakpoint } = useBreakpoints();
@@ -151,12 +151,19 @@ export default defineComponent({
 
     function balanceFor(address: string): string {
       if (!pool || !pool.value) return '-';
-      return fNum(pool.value.onchain.tokens[address].balance, 'token');
+      return fNum2(pool.value.onchain.tokens[address].balance, {
+        maximumFractionDigits: 4
+      });
     }
 
     function weightFor(address: string): string {
       if (!pool || !pool.value) return '-';
-      return fNum(pool.value.onchain.tokens[address].weight, 'percent');
+      return fNum2(pool.value.onchain.tokens[address].weight, {
+        style: 'unit',
+        unit: 'percent',
+        minimumFractionDigits: 2,
+        maximumFractionDigits: 2
+      });
     }
 
     function fiatValueFor(address: string): string {
@@ -164,7 +171,7 @@ export default defineComponent({
       if (!pool || !pool.value || price === 0) return '-';
 
       const balance = Number(pool.value.onchain.tokens[address].balance);
-      return fNum(balance * price, 'usd');
+      return fNum2(balance * price, { style: 'currency' });
     }
 
     return {
@@ -172,7 +179,7 @@ export default defineComponent({
       balanceFor,
       weightFor,
       fiatValueFor,
-      fNum,
+      fNum2,
       explorer: explorerLinks,
       columns,
       tableData,

--- a/src/components/contextual/pages/pool/PoolBalancesCard/Pool.vue
+++ b/src/components/contextual/pages/pool/PoolBalancesCard/Pool.vue
@@ -57,7 +57,7 @@
 
 <script lang="ts">
 import { PropType, defineComponent, toRefs, computed, Ref } from 'vue';
-import useNumbers from '@/composables/useNumbers';
+import useNumbers, { FNumFormats } from '@/composables/useNumbers';
 import { useI18n } from 'vue-i18n';
 import { FullPool } from '@/services/balancer/subgraph/types';
 import numeral from 'numeral';
@@ -158,12 +158,10 @@ export default defineComponent({
 
     function weightFor(address: string): string {
       if (!pool || !pool.value) return '-';
-      return fNum2(pool.value.onchain.tokens[address].weight, {
-        style: 'unit',
-        unit: 'percent',
-        minimumFractionDigits: 2,
-        maximumFractionDigits: 2
-      });
+      return fNum2(
+        pool.value.onchain.tokens[address].weight,
+        FNumFormats.percent
+      );
     }
 
     function fiatValueFor(address: string): string {

--- a/src/components/contextual/pages/pool/PoolBalancesCard/Pool.vue
+++ b/src/components/contextual/pages/pool/PoolBalancesCard/Pool.vue
@@ -151,9 +151,10 @@ export default defineComponent({
 
     function balanceFor(address: string): string {
       if (!pool || !pool.value) return '-';
-      return fNum2(pool.value.onchain.tokens[address].balance, {
-        maximumFractionDigits: 4
-      });
+      return fNum2(
+        pool.value.onchain.tokens[address].balance,
+        FNumFormats.token
+      );
     }
 
     function weightFor(address: string): string {

--- a/src/components/contextual/pages/pool/PoolBalancesCard/Pool.vue
+++ b/src/components/contextual/pages/pool/PoolBalancesCard/Pool.vue
@@ -169,7 +169,7 @@ export default defineComponent({
       if (!pool || !pool.value || price === 0) return '-';
 
       const balance = Number(pool.value.onchain.tokens[address].balance);
-      return fNum2(balance * price, { style: 'currency' });
+      return fNum2(balance * price, FNumFormats.fiat);
     }
 
     return {

--- a/src/components/contextual/pages/pool/PoolBalancesCard/components/AssetRow.vue
+++ b/src/components/contextual/pages/pool/PoolBalancesCard/components/AssetRow.vue
@@ -4,8 +4,6 @@ import { formatUnits } from '@ethersproject/units';
 
 import useTokens from '@/composables/useTokens';
 import useNumbers from '@/composables/useNumbers';
-import useUserSettings from '@/composables/useUserSettings';
-
 import useWeb3 from '@/services/web3/useWeb3';
 
 import { bnum } from '@/lib/utils';
@@ -31,7 +29,6 @@ const props = defineProps<Props>();
  */
 const { getToken } = useTokens();
 const { fNum2, toFiat } = useNumbers();
-const { currency } = useUserSettings();
 const { explorerLinks } = useWeb3();
 
 /**

--- a/src/components/contextual/pages/pool/PoolBalancesCard/components/AssetRow.vue
+++ b/src/components/contextual/pages/pool/PoolBalancesCard/components/AssetRow.vue
@@ -3,7 +3,7 @@ import { computed } from 'vue';
 import { formatUnits } from '@ethersproject/units';
 
 import useTokens from '@/composables/useTokens';
-import useNumbers from '@/composables/useNumbers';
+import useNumbers, { FNumFormats } from '@/composables/useNumbers';
 import useWeb3 from '@/services/web3/useWeb3';
 
 import { bnum } from '@/lib/utils';
@@ -51,10 +51,10 @@ const balanceLabel = computed(() => {
       .times(props.priceRate)
       .toString();
 
-    return fNum2(equivMainTokenBalance, { maximumFractionDigits: 4 });
+    return fNum2(equivMainTokenBalance, FNumFormats.token);
   }
 
-  return fNum2(balance.value, { maximumFractionDigits: 4 });
+  return fNum2(balance.value, FNumFormats.token);
 });
 
 const fiatLabel = computed(() => {
@@ -64,11 +64,11 @@ const fiatLabel = computed(() => {
       .toString();
 
     const fiatValue = toFiat(equivMainTokenBalance, props.mainTokenAddress);
-    return fNum2(fiatValue, { style: 'currency' });
+    return fNum2(fiatValue, FNumFormats.fiat);
   }
 
   let fiatValue = toFiat(balance.value, props.address);
-  return fNum2(fiatValue, { style: 'currency' });
+  return fNum2(fiatValue, FNumFormats.fiat);
 });
 </script>
 

--- a/src/components/contextual/pages/pool/PoolBalancesCard/components/AssetRow.vue
+++ b/src/components/contextual/pages/pool/PoolBalancesCard/components/AssetRow.vue
@@ -30,7 +30,7 @@ const props = defineProps<Props>();
  * COMPOSABLES
  */
 const { getToken } = useTokens();
-const { fNum, toFiat } = useNumbers();
+const { fNum2, toFiat } = useNumbers();
 const { currency } = useUserSettings();
 const { explorerLinks } = useWeb3();
 
@@ -54,10 +54,10 @@ const balanceLabel = computed(() => {
       .times(props.priceRate)
       .toString();
 
-    return fNum(equivMainTokenBalance, 'token');
+    return fNum2(equivMainTokenBalance, { maximumFractionDigits: 4 });
   }
 
-  return fNum(balance.value, 'token');
+  return fNum2(balance.value, { maximumFractionDigits: 4 });
 });
 
 const fiatLabel = computed(() => {
@@ -67,11 +67,11 @@ const fiatLabel = computed(() => {
       .toString();
 
     const fiatValue = toFiat(equivMainTokenBalance, props.mainTokenAddress);
-    return fNum(fiatValue, currency.value);
+    return fNum2(fiatValue, { style: 'currency' });
   }
 
   let fiatValue = toFiat(balance.value, props.address);
-  return fNum(fiatValue, currency.value);
+  return fNum2(fiatValue, { style: 'currency' });
 });
 </script>
 

--- a/src/components/contextual/pages/pool/PoolChart.vue
+++ b/src/components/contextual/pages/pool/PoolChart.vue
@@ -194,7 +194,7 @@ function getPoolValue(amounts: string[], prices: number[]) {
     <BalLineChart
       :data="series"
       :isPeriodSelectionEnabled="false"
-      :axisLabelFormatter="{ yAxis: '0.00%' }"
+      :axisLabelFormatter="{ yAxis: { style: 'unit', unit: 'percent', maximumFractionDigits: 2, minimumFractionDigits: 2 } }"
       :color="chartColors"
       height="96"
       :showLegend="true"

--- a/src/components/contextual/pages/pool/PoolChart.vue
+++ b/src/components/contextual/pages/pool/PoolChart.vue
@@ -194,7 +194,15 @@ function getPoolValue(amounts: string[], prices: number[]) {
     <BalLineChart
       :data="series"
       :isPeriodSelectionEnabled="false"
-      :axisLabelFormatter="{ yAxis: { style: 'unit', unit: 'percent', maximumFractionDigits: 2, minimumFractionDigits: 2, fixedFormat: true } }"
+      :axisLabelFormatter="{
+        yAxis: {
+          style: 'unit',
+          unit: 'percent',
+          maximumFractionDigits: 2,
+          minimumFractionDigits: 2,
+          fixedFormat: true
+        }
+      }"
       :color="chartColors"
       height="96"
       :showLegend="true"

--- a/src/components/contextual/pages/pool/PoolChart.vue
+++ b/src/components/contextual/pages/pool/PoolChart.vue
@@ -194,7 +194,7 @@ function getPoolValue(amounts: string[], prices: number[]) {
     <BalLineChart
       :data="series"
       :isPeriodSelectionEnabled="false"
-      :axisLabelFormatter="{ yAxis: { style: 'unit', unit: 'percent', maximumFractionDigits: 2, minimumFractionDigits: 2 } }"
+      :axisLabelFormatter="{ yAxis: { style: 'unit', unit: 'percent', maximumFractionDigits: 2, minimumFractionDigits: 2, fixedFormat: true } }"
       :color="chartColors"
       height="96"
       :showLegend="true"

--- a/src/components/contextual/pages/pool/PoolStatCards.vue
+++ b/src/components/contextual/pages/pool/PoolStatCards.vue
@@ -51,17 +51,17 @@ export default defineComponent({
         {
           id: 'poolValue',
           label: t('poolValue'),
-          value: fNum2(props.pool.totalLiquidity, { style: 'currency' })
+          value: fNum2(props.pool.totalLiquidity, FNumFormats.fiat)
         },
         {
           id: 'volumeTime',
           label: t('volumeTime', ['24h']),
-          value: fNum2(props.pool.dynamic.volume, { style: 'currency' })
+          value: fNum2(props.pool.dynamic.volume, FNumFormats.fiat)
         },
         {
           id: 'feesTime',
           label: t('feesTime', ['24h']),
-          value: fNum2(props.pool.dynamic.fees, { style: 'currency' })
+          value: fNum2(props.pool.dynamic.fees, FNumFormats.fiat)
         },
         {
           id: 'apr',

--- a/src/components/contextual/pages/pool/PoolStatCards.vue
+++ b/src/components/contextual/pages/pool/PoolStatCards.vue
@@ -21,7 +21,7 @@
 import { PropType, defineComponent, computed } from 'vue';
 import { useI18n } from 'vue-i18n';
 
-import useNumbers from '@/composables/useNumbers';
+import useNumbers, { FNumFormats } from '@/composables/useNumbers';
 
 import { DecoratedPool } from '@/services/balancer/subgraph/types';
 
@@ -69,12 +69,7 @@ export default defineComponent({
           value:
             Number(props.pool.dynamic.apr.total) > APR_THRESHOLD
               ? '-'
-              : fNum2(props.pool.dynamic.apr.total, {
-                  style: 'unit',
-                  unit: 'percent',
-                  minimumFractionDigits: 2,
-                  maximumFractionDigits: 2
-                })
+              : fNum2(props.pool.dynamic.apr.total, FNumFormats.percent)
         }
       ];
     });

--- a/src/components/contextual/pages/pool/PoolStatCards.vue
+++ b/src/components/contextual/pages/pool/PoolStatCards.vue
@@ -40,7 +40,7 @@ export default defineComponent({
 
   setup(props) {
     // COMPOSABLES
-    const { fNum } = useNumbers();
+    const { fNum2 } = useNumbers();
     const { t } = useI18n();
 
     // COMPUTED
@@ -51,17 +51,17 @@ export default defineComponent({
         {
           id: 'poolValue',
           label: t('poolValue'),
-          value: fNum(props.pool.totalLiquidity, 'usd')
+          value: fNum2(props.pool.totalLiquidity, { style: 'currency' })
         },
         {
           id: 'volumeTime',
           label: t('volumeTime', ['24h']),
-          value: fNum(props.pool.dynamic.volume, 'usd')
+          value: fNum2(props.pool.dynamic.volume, { style: 'currency' })
         },
         {
           id: 'feesTime',
           label: t('feesTime', ['24h']),
-          value: fNum(props.pool.dynamic.fees, 'usd')
+          value: fNum2(props.pool.dynamic.fees, { style: 'currency' })
         },
         {
           id: 'apr',
@@ -69,7 +69,12 @@ export default defineComponent({
           value:
             Number(props.pool.dynamic.apr.total) > APR_THRESHOLD
               ? '-'
-              : fNum(props.pool.dynamic.apr.total, 'percent')
+              : fNum2(props.pool.dynamic.apr.total, {
+                  style: 'unit',
+                  unit: 'percent',
+                  minimumFractionDigits: 2,
+                  maximumFractionDigits: 2
+                })
         }
       ];
     });

--- a/src/components/contextual/pages/pool/PoolTransactionsCard/BoostedPoolActivities/Table.vue
+++ b/src/components/contextual/pages/pool/PoolTransactionsCard/BoostedPoolActivities/Table.vue
@@ -315,7 +315,7 @@ function getMainTokenEquivalentAmount(address: string, amount: string) {
                   class="mr-2 flex-shrink-0"
                 />
                 <span class="font-numeric">{{
-                  fNum2(tokenAmount.amount, { maximumFractionDigits: 4 })
+                  fNum2(tokenAmount.amount, FNumFormats.token)
                 }}</span>
               </div>
             </template>

--- a/src/components/contextual/pages/pool/PoolTransactionsCard/BoostedPoolActivities/Table.vue
+++ b/src/components/contextual/pages/pool/PoolTransactionsCard/BoostedPoolActivities/Table.vue
@@ -8,7 +8,7 @@ import useWeb3 from '@/services/web3/useWeb3';
 import { FullPool, PoolSwap } from '@/services/balancer/subgraph/types';
 
 import useTokens from '@/composables/useTokens';
-import useNumbers from '@/composables/useNumbers';
+import useNumbers, { FNumFormats } from '@/composables/useNumbers';
 import useBreakpoints from '@/composables/useBreakpoints';
 
 import { ColumnDefinition } from '@/components/_global/BalTable/BalTable.vue';
@@ -286,9 +286,7 @@ function getMainTokenEquivalentAmount(address: string, amount: string) {
                 class="mr-2 flex-shrink-0"
               />
               <span class="font-numeric">{{
-                fNum2(action.tokenAmounts[0].amount, {
-                  maximumFractionDigits: 4
-                })
+                fNum2(action.tokenAmounts[0].amount, FNumFormats.token)
               }}</span>
             </div>
             <BalIcon name="arrow-right" class="mx-1" />
@@ -298,9 +296,7 @@ function getMainTokenEquivalentAmount(address: string, amount: string) {
                 class="mr-2 flex-shrink-0"
               />
               <span class="font-numeric">{{
-                fNum2(action.tokenAmounts[1].amount, {
-                  maximumFractionDigits: 4
-                })
+                fNum2(action.tokenAmounts[1].amount, FNumFormats.token)
               }}</span>
             </div>
           </template>

--- a/src/components/contextual/pages/pool/PoolTransactionsCard/BoostedPoolActivities/Table.vue
+++ b/src/components/contextual/pages/pool/PoolTransactionsCard/BoostedPoolActivities/Table.vue
@@ -140,7 +140,8 @@ const swapRows = computed<SwapRow[]>(() => {
       label,
       type,
       value,
-      formattedValue: value > 0 ? fNum2(value, { style: 'currency', abbreviate: true }) : '-',
+      formattedValue:
+        value > 0 ? fNum2(value, { style: 'currency', abbreviate: true }) : '-',
       timestamp,
       formattedDate: t('timeAgo', [formatDistanceToNow(timestamp)]),
       tx,
@@ -285,7 +286,9 @@ function getMainTokenEquivalentAmount(address: string, amount: string) {
                 class="mr-2 flex-shrink-0"
               />
               <span class="font-numeric">{{
-                fNum2(action.tokenAmounts[0].amount, { maximumFractionDigits: 4 })
+                fNum2(action.tokenAmounts[0].amount, {
+                  maximumFractionDigits: 4
+                })
               }}</span>
             </div>
             <BalIcon name="arrow-right" class="mx-1" />
@@ -295,7 +298,9 @@ function getMainTokenEquivalentAmount(address: string, amount: string) {
                 class="mr-2 flex-shrink-0"
               />
               <span class="font-numeric">{{
-                fNum2(action.tokenAmounts[1].amount, { maximumFractionDigits: 4 })
+                fNum2(action.tokenAmounts[1].amount, {
+                  maximumFractionDigits: 4
+                })
               }}</span>
             </div>
           </template>

--- a/src/components/contextual/pages/pool/PoolTransactionsCard/BoostedPoolActivities/Table.vue
+++ b/src/components/contextual/pages/pool/PoolTransactionsCard/BoostedPoolActivities/Table.vue
@@ -62,7 +62,7 @@ const emit = defineEmits(['loadMore']);
 /**
  * COMPOSABLES
  */
-const { fNum } = useNumbers();
+const { fNum2 } = useNumbers();
 const { t } = useI18n();
 const { priceFor } = useTokens();
 const { upToLargeBreakpoint } = useBreakpoints();
@@ -140,7 +140,7 @@ const swapRows = computed<SwapRow[]>(() => {
       label,
       type,
       value,
-      formattedValue: value > 0 ? fNum(fNum(value, 'usd'), 'usd_m') : '-',
+      formattedValue: value > 0 ? fNum2(value, { style: 'currency', abbreviate: true }) : '-',
       timestamp,
       formattedDate: t('timeAgo', [formatDistanceToNow(timestamp)]),
       tx,
@@ -285,7 +285,7 @@ function getMainTokenEquivalentAmount(address: string, amount: string) {
                 class="mr-2 flex-shrink-0"
               />
               <span class="font-numeric">{{
-                fNum(action.tokenAmounts[0].amount, 'token')
+                fNum2(action.tokenAmounts[0].amount, { maximumFractionDigits: 4 })
               }}</span>
             </div>
             <BalIcon name="arrow-right" class="mx-1" />
@@ -295,7 +295,7 @@ function getMainTokenEquivalentAmount(address: string, amount: string) {
                 class="mr-2 flex-shrink-0"
               />
               <span class="font-numeric">{{
-                fNum(action.tokenAmounts[1].amount, 'token')
+                fNum2(action.tokenAmounts[1].amount, { maximumFractionDigits: 4 })
               }}</span>
             </div>
           </template>
@@ -310,7 +310,7 @@ function getMainTokenEquivalentAmount(address: string, amount: string) {
                   class="mr-2 flex-shrink-0"
                 />
                 <span class="font-numeric">{{
-                  fNum(tokenAmount.amount, 'token')
+                  fNum2(tokenAmount.amount, { maximumFractionDigits: 4 })
                 }}</span>
               </div>
             </template>

--- a/src/components/contextual/pages/pool/PoolTransactionsCard/PoolActivities/Table.vue
+++ b/src/components/contextual/pages/pool/PoolTransactionsCard/PoolActivities/Table.vue
@@ -5,7 +5,7 @@ import { formatDistanceToNow } from 'date-fns';
 import { getAddress } from '@ethersproject/address';
 
 import useTokens from '@/composables/useTokens';
-import useNumbers from '@/composables/useNumbers';
+import useNumbers, { FNumFormats } from '@/composables/useNumbers';
 import useBreakpoints from '@/composables/useBreakpoints';
 
 import {
@@ -167,7 +167,7 @@ function getJoinExitDetails(amounts: PoolActivity['amounts']) {
     return {
       address,
       symbol,
-      amount: fNum2(amountNumber, { maximumFractionDigits: 4 })
+      amount: fNum2(amountNumber, FNumFormats.token)
     };
   });
 }

--- a/src/components/contextual/pages/pool/PoolTransactionsCard/PoolActivities/Table.vue
+++ b/src/components/contextual/pages/pool/PoolTransactionsCard/PoolActivities/Table.vue
@@ -120,7 +120,10 @@ const activityRows = computed<ActivityRow[]>(() =>
         return {
           label: isJoin ? t('invest') : t('withdraw.label'),
           value,
-          formattedValue: value > 0 ? fNum2(value, { style: 'currency', abbreviate: true }) : '-',
+          formattedValue:
+            value > 0
+              ? fNum2(value, { style: 'currency', abbreviate: true })
+              : '-',
           timestamp,
           formattedDate: t('timeAgo', [formatDistanceToNow(timestamp)]),
           tx,

--- a/src/components/contextual/pages/pool/PoolTransactionsCard/PoolActivities/Table.vue
+++ b/src/components/contextual/pages/pool/PoolTransactionsCard/PoolActivities/Table.vue
@@ -63,7 +63,7 @@ const emit = defineEmits(['loadMore']);
 /**
  * COMPOSABLES
  */
-const { fNum } = useNumbers();
+const { fNum2 } = useNumbers();
 const { t } = useI18n();
 const { explorerLinks } = useWeb3();
 const { tokens, priceFor } = useTokens();
@@ -120,7 +120,7 @@ const activityRows = computed<ActivityRow[]>(() =>
         return {
           label: isJoin ? t('invest') : t('withdraw.label'),
           value,
-          formattedValue: value > 0 ? fNum(fNum(value, 'usd'), 'usd_m') : '-',
+          formattedValue: value > 0 ? fNum2(value, { style: 'currency', abbreviate: true }) : '-',
           timestamp,
           formattedDate: t('timeAgo', [formatDistanceToNow(timestamp)]),
           tx,
@@ -164,7 +164,7 @@ function getJoinExitDetails(amounts: PoolActivity['amounts']) {
     return {
       address,
       symbol,
-      amount: fNum(amountNumber, 'token')
+      amount: fNum2(amountNumber, { maximumFractionDigits: 4 })
     };
   });
 }

--- a/src/components/contextual/pages/pool/PoolTransactionsCard/PoolSwaps/Table.vue
+++ b/src/components/contextual/pages/pool/PoolTransactionsCard/PoolSwaps/Table.vue
@@ -4,7 +4,7 @@ import { useI18n } from 'vue-i18n';
 import { formatDistanceToNow } from 'date-fns';
 
 import useTokens from '@/composables/useTokens';
-import useNumbers from '@/composables/useNumbers';
+import useNumbers, { FNumFormats } from '@/composables/useNumbers';
 import useBreakpoints from '@/composables/useBreakpoints';
 
 import { PoolSwap } from '@/services/balancer/subgraph/types';
@@ -170,14 +170,14 @@ const swapRows = computed<SwapRow[]>(() =>
           <div class="token-item">
             <BalAsset :address="action.tokenIn" class="mr-2 flex-shrink-0" />
             <span class="font-numeric">{{
-              fNum2(action.tokenAmountIn, { maximumFractionDigits: 4 })
+              fNum2(action.tokenAmountIn, FNumFormats.token)
             }}</span>
           </div>
           <BalIcon name="arrow-right" class="mx-1" />
           <div class="token-item">
             <BalAsset :address="action.tokenOut" class="mr-2 flex-shrink-0" />
             <span class="font-numeric">{{
-              fNum2(action.tokenAmountOut, { maximumFractionDigits: 4 })
+              fNum2(action.tokenAmountOut, FNumFormats.token)
             }}</span>
           </div>
         </div>

--- a/src/components/contextual/pages/pool/PoolTransactionsCard/PoolSwaps/Table.vue
+++ b/src/components/contextual/pages/pool/PoolTransactionsCard/PoolSwaps/Table.vue
@@ -53,7 +53,7 @@ const emit = defineEmits(['loadMore']);
 /**
  * COMPOSABLES
  */
-const { fNum } = useNumbers();
+const { fNum2 } = useNumbers();
 const { t } = useI18n();
 const { priceFor } = useTokens();
 const { upToLargeBreakpoint } = useBreakpoints();
@@ -118,7 +118,7 @@ const swapRows = computed<SwapRow[]>(() =>
 
           return {
             value,
-            formattedValue: value > 0 ? fNum(fNum(value, 'usd'), 'usd_m') : '-',
+            formattedValue: value > 0 ? fNum2(value, { style: 'currency', abbreviate: true }) : '-',
             tokenIn,
             tokenOut,
             tokenAmountIn,
@@ -167,14 +167,14 @@ const swapRows = computed<SwapRow[]>(() =>
           <div class="token-item">
             <BalAsset :address="action.tokenIn" class="mr-2 flex-shrink-0" />
             <span class="font-numeric">{{
-              fNum(action.tokenAmountIn, 'token')
+              fNum2(action.tokenAmountIn, { maximumFractionDigits: 4 })
             }}</span>
           </div>
           <BalIcon name="arrow-right" class="mx-1" />
           <div class="token-item">
             <BalAsset :address="action.tokenOut" class="mr-2 flex-shrink-0" />
             <span class="font-numeric">{{
-              fNum(action.tokenAmountOut, 'token')
+              fNum2(action.tokenAmountOut, { maximumFractionDigits: 4 })
             }}</span>
           </div>
         </div>

--- a/src/components/contextual/pages/pool/PoolTransactionsCard/PoolSwaps/Table.vue
+++ b/src/components/contextual/pages/pool/PoolTransactionsCard/PoolSwaps/Table.vue
@@ -118,7 +118,10 @@ const swapRows = computed<SwapRow[]>(() =>
 
           return {
             value,
-            formattedValue: value > 0 ? fNum2(value, { style: 'currency', abbreviate: true }) : '-',
+            formattedValue:
+              value > 0
+                ? fNum2(value, { style: 'currency', abbreviate: true })
+                : '-',
             tokenIn,
             tokenOut,
             tokenAmountIn,

--- a/src/components/forms/AppSlippageForm.vue
+++ b/src/components/forms/AppSlippageForm.vue
@@ -23,7 +23,13 @@ const state = reactive({
 
 const options = FIXED_OPTIONS.map(option => {
   return {
-    label: fNum2(option, { style: 'unit', unit: 'percent', minimumFractionDigits: 1, maximumFractionDigits: 1, fixedFormat: true }),
+    label: fNum2(option, {
+      style: 'unit',
+      unit: 'percent',
+      minimumFractionDigits: 1,
+      maximumFractionDigits: 1,
+      fixedFormat: true
+    }),
     value: option
   };
 });

--- a/src/components/forms/AppSlippageForm.vue
+++ b/src/components/forms/AppSlippageForm.vue
@@ -9,7 +9,7 @@ const FIXED_OPTIONS = ['0.005', '0.01', '0.02'];
 /**
  * COMPOSABLES
  */
-const { fNum } = useNumbers();
+const { fNum2 } = useNumbers();
 const { slippage, setSlippage } = useUserSettings();
 
 /**
@@ -23,7 +23,7 @@ const state = reactive({
 
 const options = FIXED_OPTIONS.map(option => {
   return {
-    label: fNum(option, null, { format: '0.0%' }),
+    label: fNum2(option, { style: 'unit', unit: 'percent', minimumFractionDigits: 1, maximumFractionDigits: 1, fixedFormat: true }),
     value: option
   };
 });

--- a/src/components/forms/pool_actions/InvestForm/components/InvestFormTotals.vue
+++ b/src/components/forms/pool_actions/InvestForm/components/InvestFormTotals.vue
@@ -58,7 +58,7 @@ const optimizeBtnClasses = computed(() => ({
     <div class="data-table-row total-row">
       <div class="p-2">{{ $t('total') }}</div>
       <div class="data-table-number-col">
-        {{ fNum2(fiatTotal, { style: 'currency' }) }}
+        {{ fNum2(fiatTotal, FNumFormats.fiat) }}
         <div v-if="isWalletReady && !hasNoBalances" class="text-sm">
           <span v-if="maximized" class="text-gray-400 dark:text-gray-600">
             {{ $t('maxed') }}

--- a/src/components/forms/pool_actions/InvestForm/components/InvestFormTotals.vue
+++ b/src/components/forms/pool_actions/InvestForm/components/InvestFormTotals.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { computed, toRefs } from 'vue';
-import useNumbers from '@/composables/useNumbers';
+import useNumbers, { FNumFormats } from '@/composables/useNumbers';
 import { InvestMathResponse } from '../composables/useInvestMath';
 import useWeb3 from '@/services/web3/useWeb3';
 
@@ -78,14 +78,7 @@ const optimizeBtnClasses = computed(() => ({
       <div class="data-table-number-col">
         <div class="flex">
           <span v-if="!batchSwapLoading">
-            {{
-              fNum2(priceImpact, {
-                style: 'unit',
-                unit: 'percent',
-                minimumFractionDigits: 2,
-                maximumFractionDigits: 2
-              })
-            }}
+            {{ fNum2(priceImpact, FNumFormats.percent) }}
           </span>
           <BalLoadingBlock v-else class="w-10" />
 

--- a/src/components/forms/pool_actions/InvestForm/components/InvestFormTotals.vue
+++ b/src/components/forms/pool_actions/InvestForm/components/InvestFormTotals.vue
@@ -24,7 +24,7 @@ const emit = defineEmits<{
 /**
  * COMPOSABLES
  */
-const { fNum } = useNumbers();
+const { fNum2 } = useNumbers();
 const { isWalletReady } = useWeb3();
 
 const {
@@ -58,7 +58,7 @@ const optimizeBtnClasses = computed(() => ({
     <div class="data-table-row total-row">
       <div class="p-2">{{ $t('total') }}</div>
       <div class="data-table-number-col">
-        {{ fNum(fiatTotal, 'usd') }}
+        {{ fNum2(fiatTotal, { style: 'currency' }) }}
         <div v-if="isWalletReady && !hasNoBalances" class="text-sm">
           <span v-if="maximized" class="text-gray-400 dark:text-gray-600">
             {{ $t('maxed') }}
@@ -78,7 +78,14 @@ const optimizeBtnClasses = computed(() => ({
       <div class="data-table-number-col">
         <div class="flex">
           <span v-if="!batchSwapLoading">
-            {{ fNum(priceImpact, 'percent') }}
+            {{
+              fNum2(priceImpact, {
+                style: 'unit',
+                unit: 'percent',
+                minimumFractionDigits: 2,
+                maximumFractionDigits: 2
+              })
+            }}
           </span>
           <BalLoadingBlock v-else class="w-10" />
 

--- a/src/components/forms/pool_actions/InvestForm/components/InvestPreviewModal/components/InvestActions.vue
+++ b/src/components/forms/pool_actions/InvestForm/components/InvestPreviewModal/components/InvestActions.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { toRef, toRefs, computed, reactive, watch } from 'vue';
 import PoolExchange from '@/services/pool/exchange/exchange.service';
-import { poolWeightsLabel } from '@/composables/usePool';
+import { usePool } from '@/composables/usePool';
 // Types
 import { FullPool } from '@/services/balancer/subgraph/types';
 import {
@@ -68,6 +68,7 @@ const { networkConfig } = useConfig();
 const { account, getProvider, explorerLinks, blockNumber } = useWeb3();
 const { addTransaction } = useTransactions();
 const { txListener, getTxConfirmedAt } = useEthers();
+const { poolWeightsLabel } = usePool(toRef(props, 'pool'));
 const {
   fullAmounts,
   batchSwapAmountMap,

--- a/src/components/forms/pool_actions/InvestForm/components/InvestPreviewModal/components/InvestSummary.vue
+++ b/src/components/forms/pool_actions/InvestForm/components/InvestPreviewModal/components/InvestSummary.vue
@@ -118,7 +118,14 @@ function weeklyYieldForAPR(apr: string): string {
           {{ $t('priceImpact') }}
         </div>
         <div class="summary-table-number">
-          {{ fNum2(priceImpact, { style: 'unit', unit: 'percent', minimumFractionDigits: 2, maximumFractionDigits: 2 }) }}
+          {{
+            fNum2(priceImpact, {
+              style: 'unit',
+              unit: 'percent',
+              minimumFractionDigits: 2,
+              maximumFractionDigits: 2
+            })
+          }}
           <BalTooltip
             :text="$t('tooltips.invest.priceImpact')"
             icon-size="sm"

--- a/src/components/forms/pool_actions/InvestForm/components/InvestPreviewModal/components/InvestSummary.vue
+++ b/src/components/forms/pool_actions/InvestForm/components/InvestPreviewModal/components/InvestSummary.vue
@@ -25,7 +25,7 @@ const props = defineProps<Props>();
 /**
  * COMPOSABLES
  */
-const { fNum } = useNumbers();
+const { fNum2 } = useNumbers();
 const { currency } = useUserSettings();
 const { t } = useI18n();
 const { getTokens } = useTokens();
@@ -105,7 +105,7 @@ function weeklyYieldForAPR(apr: string): string {
           {{ $t('total') }}
         </div>
         <div class="summary-table-number">
-          {{ fNum(fiatTotal, currency) }}
+          {{ fNum2(fiatTotal, { style: 'currency' }) }}
           <BalTooltip
             :text="$t('tooltips.invest.total', [currency.toUpperCase()])"
             icon-size="sm"
@@ -118,7 +118,7 @@ function weeklyYieldForAPR(apr: string): string {
           {{ $t('priceImpact') }}
         </div>
         <div class="summary-table-number">
-          {{ fNum(priceImpact, 'percent') }}
+          {{ fNum2(priceImpact, { style: 'unit', unit: 'percent', minimumFractionDigits: 2, maximumFractionDigits: 2 }) }}
           <BalTooltip
             :text="$t('tooltips.invest.priceImpact')"
             icon-size="sm"
@@ -130,7 +130,7 @@ function weeklyYieldForAPR(apr: string): string {
       <div class="summary-table-row">
         <div class="summary-table-label" v-text="$t('potentialWeeklyYield')" />
         <div class="summary-table-number">
-          {{ fNum(totalWeeklyYield, currency) }}
+          {{ fNum2(totalWeeklyYield, { style: 'currency' }) }}
           <BalTooltip icon-size="sm" width="72" noPad>
             <template v-slot:activator>
               <StarsIcon
@@ -152,13 +152,13 @@ function weeklyYieldForAPR(apr: string): string {
                 ({{ $t('basedOnLast24h') }})
               </span>
               <div class="text-base font-semibold mt-1">
-                {{ fNum(totalWeeklyYield, currency) }}
+                {{ fNum2(totalWeeklyYield, { style: 'currency' }) }}
                 {{ $t('perWeek') }}
               </div>
             </div>
             <div class="p-2">
               <div class="whitespace-nowrap flex items-center mb-1">
-                {{ fNum(swapFeeWeeklyYield, currency) }}
+                {{ fNum2(swapFeeWeeklyYield, { style: 'currency' }) }}
                 <span class="ml-1 text-gray-500 text-xs">
                   {{ $t('swapFee') }}
                 </span>
@@ -169,13 +169,13 @@ function weeklyYieldForAPR(apr: string): string {
                 :hideItems="!thirdPartyMultiRewardPool"
               >
                 <div class="flex items-center">
-                  {{ fNum(thirdPartyWeeklyYield, currency) }}
+                  {{ fNum2(thirdPartyWeeklyYield, { style: 'currency' }) }}
                   <span class="ml-1 text-gray-500 text-xs">
                     {{ thirdPartyFiatLabel }}
                   </span>
                 </div>
                 <template v-if="thirdPartyMultiRewardPool" #item="{ item }">
-                  {{ fNum(weeklyYieldForAPR(item[1]), currency) }}
+                  {{ fNum2(weeklyYieldForAPR(item[1]), { style: 'currency' }) }}
                   <span class="text-gray-500 text-xs ml-1">
                     {{ thirdPartyTokens[item[0]].symbol }}
                   </span>
@@ -187,13 +187,13 @@ function weeklyYieldForAPR(apr: string): string {
                 :hideItems="!lmMultiRewardPool"
               >
                 <div class="flex items-center">
-                  <span>{{ fNum(lmWeeklyYield, currency) }}</span>
+                  <span>{{ fNum2(lmWeeklyYield, { style: 'currency' }) }}</span>
                   <span class="ml-1 text-gray-500">
                     {{ $t('liquidityMining') }}
                   </span>
                 </div>
                 <template v-if="lmMultiRewardPool" v-slot:item="{ item }">
-                  {{ fNum(weeklyYieldForAPR(item[1]), currency) }}
+                  {{ fNum2(weeklyYieldForAPR(item[1]), { style: 'currency' }) }}
                   <span class="text-gray-500 ml-1">
                     {{ lmTokens[item[0]].symbol }}
                   </span>

--- a/src/components/forms/pool_actions/InvestForm/components/InvestPreviewModal/components/InvestSummary.vue
+++ b/src/components/forms/pool_actions/InvestForm/components/InvestPreviewModal/components/InvestSummary.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import useNumbers from '@/composables/useNumbers';
+import useNumbers, { FNumFormats } from '@/composables/useNumbers';
 import { isStablePhantom, isWstETH } from '@/composables/usePool';
 import useTokens from '@/composables/useTokens';
 import useUserSettings from '@/composables/useUserSettings';
@@ -118,14 +118,7 @@ function weeklyYieldForAPR(apr: string): string {
           {{ $t('priceImpact') }}
         </div>
         <div class="summary-table-number">
-          {{
-            fNum2(priceImpact, {
-              style: 'unit',
-              unit: 'percent',
-              minimumFractionDigits: 2,
-              maximumFractionDigits: 2
-            })
-          }}
+          {{ fNum2(priceImpact, FNumFormats.percent) }}
           <BalTooltip
             :text="$t('tooltips.invest.priceImpact')"
             icon-size="sm"

--- a/src/components/forms/pool_actions/InvestForm/components/InvestPreviewModal/components/InvestSummary.vue
+++ b/src/components/forms/pool_actions/InvestForm/components/InvestPreviewModal/components/InvestSummary.vue
@@ -105,7 +105,7 @@ function weeklyYieldForAPR(apr: string): string {
           {{ $t('total') }}
         </div>
         <div class="summary-table-number">
-          {{ fNum2(fiatTotal, { style: 'currency' }) }}
+          {{ fNum2(fiatTotal, FNumFormats.fiat) }}
           <BalTooltip
             :text="$t('tooltips.invest.total', [currency.toUpperCase()])"
             icon-size="sm"
@@ -130,7 +130,7 @@ function weeklyYieldForAPR(apr: string): string {
       <div class="summary-table-row">
         <div class="summary-table-label" v-text="$t('potentialWeeklyYield')" />
         <div class="summary-table-number">
-          {{ fNum2(totalWeeklyYield, { style: 'currency' }) }}
+          {{ fNum2(totalWeeklyYield, FNumFormats.fiat) }}
           <BalTooltip icon-size="sm" width="72" noPad>
             <template v-slot:activator>
               <StarsIcon
@@ -152,13 +152,13 @@ function weeklyYieldForAPR(apr: string): string {
                 ({{ $t('basedOnLast24h') }})
               </span>
               <div class="text-base font-semibold mt-1">
-                {{ fNum2(totalWeeklyYield, { style: 'currency' }) }}
+                {{ fNum2(totalWeeklyYield, FNumFormats.fiat) }}
                 {{ $t('perWeek') }}
               </div>
             </div>
             <div class="p-2">
               <div class="whitespace-nowrap flex items-center mb-1">
-                {{ fNum2(swapFeeWeeklyYield, { style: 'currency' }) }}
+                {{ fNum2(swapFeeWeeklyYield, FNumFormats.fiat) }}
                 <span class="ml-1 text-gray-500 text-xs">
                   {{ $t('swapFee') }}
                 </span>
@@ -169,13 +169,13 @@ function weeklyYieldForAPR(apr: string): string {
                 :hideItems="!thirdPartyMultiRewardPool"
               >
                 <div class="flex items-center">
-                  {{ fNum2(thirdPartyWeeklyYield, { style: 'currency' }) }}
+                  {{ fNum2(thirdPartyWeeklyYield, FNumFormats.fiat) }}
                   <span class="ml-1 text-gray-500 text-xs">
                     {{ thirdPartyFiatLabel }}
                   </span>
                 </div>
                 <template v-if="thirdPartyMultiRewardPool" #item="{ item }">
-                  {{ fNum2(weeklyYieldForAPR(item[1]), { style: 'currency' }) }}
+                  {{ fNum2(weeklyYieldForAPR(item[1]), FNumFormats.fiat) }}
                   <span class="text-gray-500 text-xs ml-1">
                     {{ thirdPartyTokens[item[0]].symbol }}
                   </span>
@@ -187,13 +187,13 @@ function weeklyYieldForAPR(apr: string): string {
                 :hideItems="!lmMultiRewardPool"
               >
                 <div class="flex items-center">
-                  <span>{{ fNum2(lmWeeklyYield, { style: 'currency' }) }}</span>
+                  <span>{{ fNum2(lmWeeklyYield, FNumFormats.fiat) }}</span>
                   <span class="ml-1 text-gray-500">
                     {{ $t('liquidityMining') }}
                   </span>
                 </div>
                 <template v-if="lmMultiRewardPool" v-slot:item="{ item }">
-                  {{ fNum2(weeklyYieldForAPR(item[1]), { style: 'currency' }) }}
+                  {{ fNum2(weeklyYieldForAPR(item[1]), FNumFormats.fiat) }}
                   <span class="text-gray-500 ml-1">
                     {{ lmTokens[item[0]].symbol }}
                   </span>

--- a/src/components/forms/pool_actions/InvestForm/components/InvestPreviewModal/components/TokenAmounts.vue
+++ b/src/components/forms/pool_actions/InvestForm/components/InvestPreviewModal/components/TokenAmounts.vue
@@ -1,6 +1,5 @@
 <script setup lang="ts">
 import useNumbers from '@/composables/useNumbers';
-import useUserSettings from '@/composables/useUserSettings';
 import { bnum } from '@/lib/utils';
 import { TokenInfoMap } from '@/types/TokenList';
 
@@ -26,8 +25,7 @@ const props = defineProps<Props>();
 /**
  * COMPOSABLES
  */
-const { fNum } = useNumbers();
-const { currency } = useUserSettings();
+const { fNum2 } = useNumbers();
 
 /**
  * METHODS
@@ -49,13 +47,20 @@ function amountShare(address: string): string {
         <div class="flex flex-col ml-3">
           <div class="font-medium text-lg">
             <span class="font-numeric">
-              {{ fNum(amount, 'token') }}
+              {{ fNum2(amount, { maximumFractionDigits: 4 }) }}
             </span>
             {{ tokenMap[address].symbol }}
           </div>
           <div class="text-sm text-gray-500 font-numeric">
-            {{ fNum(fiatAmountMap[address], currency) }}
-            ({{ fNum(amountShare(address), 'percent') }})
+            {{ fNum2(fiatAmountMap[address], { style: 'currency' }) }}
+            ({{
+              fNum2(amountShare(address), {
+                style: 'unit',
+                unit: 'percent',
+                minimumFractionDigits: 2,
+                maximumFractionDigits: 2
+              })
+            }})
           </div>
         </div>
       </div>

--- a/src/components/forms/pool_actions/InvestForm/components/InvestPreviewModal/components/TokenAmounts.vue
+++ b/src/components/forms/pool_actions/InvestForm/components/InvestPreviewModal/components/TokenAmounts.vue
@@ -47,12 +47,12 @@ function amountShare(address: string): string {
         <div class="flex flex-col ml-3">
           <div class="font-medium text-lg">
             <span class="font-numeric">
-              {{ fNum2(amount, { maximumFractionDigits: 4 }) }}
+              {{ fNum2(amount, FNumFormats.token) }}
             </span>
             {{ tokenMap[address].symbol }}
           </div>
           <div class="text-sm text-gray-500 font-numeric">
-            {{ fNum2(fiatAmountMap[address], { style: 'currency' }) }}
+            {{ fNum2(fiatAmountMap[address], FNumFormats.fiat) }}
             ({{ fNum2(amountShare(address), FNumFormats.percent) }})
           </div>
         </div>

--- a/src/components/forms/pool_actions/InvestForm/components/InvestPreviewModal/components/TokenAmounts.vue
+++ b/src/components/forms/pool_actions/InvestForm/components/InvestPreviewModal/components/TokenAmounts.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import useNumbers from '@/composables/useNumbers';
+import useNumbers, { FNumFormats } from '@/composables/useNumbers';
 import { bnum } from '@/lib/utils';
 import { TokenInfoMap } from '@/types/TokenList';
 
@@ -53,14 +53,7 @@ function amountShare(address: string): string {
           </div>
           <div class="text-sm text-gray-500 font-numeric">
             {{ fNum2(fiatAmountMap[address], { style: 'currency' }) }}
-            ({{
-              fNum2(amountShare(address), {
-                style: 'unit',
-                unit: 'percent',
-                minimumFractionDigits: 2,
-                maximumFractionDigits: 2
-              })
-            }})
+            ({{ fNum2(amountShare(address), FNumFormats.percent) }})
           </div>
         </div>
       </div>

--- a/src/components/forms/pool_actions/InvestForm/composables/useInvestMath.ts
+++ b/src/components/forms/pool_actions/InvestForm/composables/useInvestMath.ts
@@ -1,13 +1,12 @@
 import { computed, Ref, watch, ref } from 'vue';
 import { bnum } from '@/lib/utils';
 import { FullPool } from '@/services/balancer/subgraph/types';
-import useNumbers, { fNum } from '@/composables/useNumbers';
+import useNumbers from '@/composables/useNumbers';
 import PoolCalculator from '@/services/pool/calculator/calculator.sevice';
 import useTokens from '@/composables/useTokens';
 import { parseUnits } from '@ethersproject/units';
 import useSlippage from '@/composables/useSlippage';
 import { usePool } from '@/composables/usePool';
-import useUserSettings from '@/composables/useUserSettings';
 import { BigNumber } from 'ethers';
 import { TokenInfo } from '@/types/TokenList';
 import { queryBatchSwapTokensIn, SOR } from '@balancer-labs/sdk';
@@ -59,11 +58,10 @@ export default function useInvestFormMath(
   /**
    * COMPOSABLES
    */
-  const { toFiat } = useNumbers();
+  const { toFiat, fNum2 } = useNumbers();
   const { tokens, getToken, balances, balanceFor, nativeAsset } = useTokens();
   const { minusSlippageScaled } = useSlippage();
   const { managedPoolWithTradingHalted, isStablePhantomPool } = usePool(pool);
-  const { currency } = useUserSettings();
   const {
     promises: batchSwapPromises,
     processing: processingBatchSwaps,
@@ -130,7 +128,7 @@ export default function useInvestFormMath(
   );
 
   const fiatTotalLabel = computed((): string =>
-    fNum(fiatTotal.value, currency.value)
+    fNum2(fiatTotal.value, { style: 'currency' })
   );
 
   const hasAmounts = computed(() =>

--- a/src/components/forms/pool_actions/InvestForm/composables/useInvestMath.ts
+++ b/src/components/forms/pool_actions/InvestForm/composables/useInvestMath.ts
@@ -1,7 +1,7 @@
 import { computed, Ref, watch, ref } from 'vue';
 import { bnum } from '@/lib/utils';
 import { FullPool } from '@/services/balancer/subgraph/types';
-import useNumbers from '@/composables/useNumbers';
+import useNumbers, { FNumFormats } from '@/composables/useNumbers';
 import PoolCalculator from '@/services/pool/calculator/calculator.sevice';
 import useTokens from '@/composables/useTokens';
 import { parseUnits } from '@ethersproject/units';
@@ -128,7 +128,7 @@ export default function useInvestFormMath(
   );
 
   const fiatTotalLabel = computed((): string =>
-    fNum2(fiatTotal.value, { style: 'currency' })
+    fNum2(fiatTotal.value, FNumFormats.fiat)
   );
 
   const hasAmounts = computed(() =>

--- a/src/components/forms/pool_actions/WithdrawForm/components/ProportionalWithdrawalInput.vue
+++ b/src/components/forms/pool_actions/WithdrawForm/components/ProportionalWithdrawalInput.vue
@@ -50,7 +50,7 @@ const { isWalletReady } = useWeb3();
 const { missingPrices } = usePoolTransfers();
 const { getTokens } = useTokens();
 const { isStableLikePool } = usePool(toRef(props, 'pool'));
-const { fNum } = useNumbers();
+const { fNum2 } = useNumbers();
 
 /**
  * COMPUTED
@@ -161,7 +161,13 @@ onBeforeMount(() => {
               <span class="text-lg font-medium">
                 {{ token.symbol }}
                 <span v-if="!isStableLikePool">
-                  {{ fNum(seedTokens[i], 'percent_lg') }}
+                  {{
+                    fNum2(seedTokens[i], {
+                      style: 'unit',
+                      unit: 'percent',
+                      maximumFractionDigits: 0
+                    })
+                  }}
                 </span>
               </span>
             </div>
@@ -172,10 +178,12 @@ onBeforeMount(() => {
             <BalLoadingBlock v-if="loadingAmountsOut" class="w-20 h-12" />
             <template v-else>
               <span class="break-words text-xl">
-                {{ fNum(proportionalAmounts[i], 'token') }}
+                {{
+                  fNum2(proportionalAmounts[i], { maximumFractionDigits: 4 })
+                }}
               </span>
               <span class="text-sm text-gray-400">
-                {{ fNum(fiatAmounts[i], 'usd') }}
+                {{ fNum2(fiatAmounts[i], { style: 'currency' }) }}
               </span>
             </template>
           </div>

--- a/src/components/forms/pool_actions/WithdrawForm/components/ProportionalWithdrawalInput.vue
+++ b/src/components/forms/pool_actions/WithdrawForm/components/ProportionalWithdrawalInput.vue
@@ -178,12 +178,10 @@ onBeforeMount(() => {
             <BalLoadingBlock v-if="loadingAmountsOut" class="w-20 h-12" />
             <template v-else>
               <span class="break-words text-xl">
-                {{
-                  fNum2(proportionalAmounts[i], { maximumFractionDigits: 4 })
-                }}
+                {{ fNum2(proportionalAmounts[i], FNumFormats.token) }}
               </span>
               <span class="text-sm text-gray-400">
-                {{ fNum2(fiatAmounts[i], { style: 'currency' }) }}
+                {{ fNum2(fiatAmounts[i], FNumFormats.fiat) }}
               </span>
             </template>
           </div>

--- a/src/components/forms/pool_actions/WithdrawForm/components/WithdrawPreviewModal/components/TokenAmounts.vue
+++ b/src/components/forms/pool_actions/WithdrawForm/components/WithdrawPreviewModal/components/TokenAmounts.vue
@@ -1,6 +1,5 @@
 <script setup lang="ts">
 import useNumbers from '@/composables/useNumbers';
-import useUserSettings from '@/composables/useUserSettings';
 import { bnum } from '@/lib/utils';
 import { TokenInfoMap } from '@/types/TokenList';
 
@@ -27,7 +26,6 @@ const props = defineProps<Props>();
  * COMPOSABLES
  */
 const { fNum2 } = useNumbers();
-const { currency } = useUserSettings();
 
 /**
  * METHODS

--- a/src/components/forms/pool_actions/WithdrawForm/components/WithdrawPreviewModal/components/TokenAmounts.vue
+++ b/src/components/forms/pool_actions/WithdrawForm/components/WithdrawPreviewModal/components/TokenAmounts.vue
@@ -47,12 +47,12 @@ function amountShare(address: string): string {
         <div class="flex flex-col ml-3">
           <div class="font-medium text-lg">
             <span class="font-numeric">
-              {{ fNum2(amount, { maximumFractionDigits: 4 }) }}
+              {{ fNum2(amount, FNumFormats.token) }}
             </span>
             {{ tokenMap[address].symbol }}
           </div>
           <div class="text-sm text-gray-500 font-numeric">
-            {{ fNum2(fiatAmountMap[address], { style: 'currency' }) }}
+            {{ fNum2(fiatAmountMap[address], FNumFormats.fiat) }}
             ({{ fNum2(amountShare(address), FNumFormats.percent) }})
           </div>
         </div>

--- a/src/components/forms/pool_actions/WithdrawForm/components/WithdrawPreviewModal/components/TokenAmounts.vue
+++ b/src/components/forms/pool_actions/WithdrawForm/components/WithdrawPreviewModal/components/TokenAmounts.vue
@@ -26,7 +26,7 @@ const props = defineProps<Props>();
 /**
  * COMPOSABLES
  */
-const { fNum } = useNumbers();
+const { fNum2 } = useNumbers();
 const { currency } = useUserSettings();
 
 /**
@@ -49,13 +49,20 @@ function amountShare(address: string): string {
         <div class="flex flex-col ml-3">
           <div class="font-medium text-lg">
             <span class="font-numeric">
-              {{ fNum(amount, 'token') }}
+              {{ fNum2(amount, { maximumFractionDigits: 4 }) }}
             </span>
             {{ tokenMap[address].symbol }}
           </div>
           <div class="text-sm text-gray-500 font-numeric">
-            {{ fNum(fiatAmountMap[address], currency) }}
-            ({{ fNum(amountShare(address), 'percent') }})
+            {{ fNum2(fiatAmountMap[address], { style: 'currency' }) }}
+            ({{
+              fNum2(amountShare(address), {
+                style: 'unit',
+                unit: 'percent',
+                minimumFractionDigits: 2,
+                maximumFractionDigits: 2
+              })
+            }})
           </div>
         </div>
       </div>

--- a/src/components/forms/pool_actions/WithdrawForm/components/WithdrawPreviewModal/components/TokenAmounts.vue
+++ b/src/components/forms/pool_actions/WithdrawForm/components/WithdrawPreviewModal/components/TokenAmounts.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import useNumbers from '@/composables/useNumbers';
+import useNumbers, { FNumFormats } from '@/composables/useNumbers';
 import { bnum } from '@/lib/utils';
 import { TokenInfoMap } from '@/types/TokenList';
 
@@ -53,14 +53,7 @@ function amountShare(address: string): string {
           </div>
           <div class="text-sm text-gray-500 font-numeric">
             {{ fNum2(fiatAmountMap[address], { style: 'currency' }) }}
-            ({{
-              fNum2(amountShare(address), {
-                style: 'unit',
-                unit: 'percent',
-                minimumFractionDigits: 2,
-                maximumFractionDigits: 2
-              })
-            }})
+            ({{ fNum2(amountShare(address), FNumFormats.percent) }})
           </div>
         </div>
       </div>

--- a/src/components/forms/pool_actions/WithdrawForm/components/WithdrawPreviewModal/components/WithdrawActions.vue
+++ b/src/components/forms/pool_actions/WithdrawForm/components/WithdrawPreviewModal/components/WithdrawActions.vue
@@ -8,7 +8,7 @@ import {
   onBeforeMount,
   watch
 } from 'vue';
-import { poolWeightsLabel } from '@/composables/usePool';
+import { usePool } from '@/composables/usePool';
 // Types
 import { FullPool } from '@/services/balancer/subgraph/types';
 import {
@@ -76,6 +76,7 @@ const { networkConfig } = useConfig();
 const { account, getProvider, explorerLinks, blockNumber } = useWeb3();
 const { addTransaction } = useTransactions();
 const { txListener, getTxConfirmedAt } = useEthers();
+const { poolWeightsLabel } = usePool(toRef(props, 'pool'));
 const { tokenOutIndex, tokensOut, batchRelayerApproval } = useWithdrawalState(
   toRef(props, 'pool')
 );

--- a/src/components/forms/pool_actions/WithdrawForm/components/WithdrawPreviewModal/components/WithdrawSummary.vue
+++ b/src/components/forms/pool_actions/WithdrawForm/components/WithdrawPreviewModal/components/WithdrawSummary.vue
@@ -35,7 +35,7 @@ const { currency } = useUserSettings();
           {{ $t('total') }}
         </div>
         <div class="summary-table-number">
-          {{ fNum2(fiatTotal, { style: 'currency' }) }}
+          {{ fNum2(fiatTotal, FNumFormats.fiat) }}
           <BalTooltip
             :text="$t('tooltips.withdraw.total', [currency.toUpperCase()])"
             icon-size="sm"

--- a/src/components/forms/pool_actions/WithdrawForm/components/WithdrawPreviewModal/components/WithdrawSummary.vue
+++ b/src/components/forms/pool_actions/WithdrawForm/components/WithdrawPreviewModal/components/WithdrawSummary.vue
@@ -48,7 +48,14 @@ const { currency } = useUserSettings();
           {{ $t('priceImpact') }}
         </div>
         <div class="summary-table-number">
-          {{ fNum2(priceImpact, { style: 'unit', unit: 'percent', minimumFractionDigits: 2, maximumFractionDigits: 2 }) }}
+          {{
+            fNum2(priceImpact, {
+              style: 'unit',
+              unit: 'percent',
+              minimumFractionDigits: 2,
+              maximumFractionDigits: 2
+            })
+          }}
           <BalTooltip
             :text="$t('tooltips.withdraw.priceImpact')"
             icon-size="sm"

--- a/src/components/forms/pool_actions/WithdrawForm/components/WithdrawPreviewModal/components/WithdrawSummary.vue
+++ b/src/components/forms/pool_actions/WithdrawForm/components/WithdrawPreviewModal/components/WithdrawSummary.vue
@@ -20,7 +20,7 @@ defineProps<Props>();
 /**
  * COMPOSABLES
  */
-const { fNum } = useNumbers();
+const { fNum2 } = useNumbers();
 const { currency } = useUserSettings();
 </script>
 
@@ -35,7 +35,7 @@ const { currency } = useUserSettings();
           {{ $t('total') }}
         </div>
         <div class="summary-table-number">
-          {{ fNum(fiatTotal, currency) }}
+          {{ fNum2(fiatTotal, { style: 'currency' }) }}
           <BalTooltip
             :text="$t('tooltips.withdraw.total', [currency.toUpperCase()])"
             icon-size="sm"
@@ -48,7 +48,7 @@ const { currency } = useUserSettings();
           {{ $t('priceImpact') }}
         </div>
         <div class="summary-table-number">
-          {{ fNum(priceImpact, 'percent') }}
+          {{ fNum2(priceImpact, { style: 'unit', unit: 'percent', minimumFractionDigits: 2, maximumFractionDigits: 2 }) }}
           <BalTooltip
             :text="$t('tooltips.withdraw.priceImpact')"
             icon-size="sm"

--- a/src/components/forms/pool_actions/WithdrawForm/components/WithdrawPreviewModal/components/WithdrawSummary.vue
+++ b/src/components/forms/pool_actions/WithdrawForm/components/WithdrawPreviewModal/components/WithdrawSummary.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import useNumbers from '@/composables/useNumbers';
+import useNumbers, { FNumFormats } from '@/composables/useNumbers';
 import useUserSettings from '@/composables/useUserSettings';
 import { FullPool } from '@/services/balancer/subgraph/types';
 
@@ -48,14 +48,7 @@ const { currency } = useUserSettings();
           {{ $t('priceImpact') }}
         </div>
         <div class="summary-table-number">
-          {{
-            fNum2(priceImpact, {
-              style: 'unit',
-              unit: 'percent',
-              minimumFractionDigits: 2,
-              maximumFractionDigits: 2
-            })
-          }}
+          {{ fNum2(priceImpact, FNumFormats.percent) }}
           <BalTooltip
             :text="$t('tooltips.withdraw.priceImpact')"
             icon-size="sm"

--- a/src/components/forms/pool_actions/WithdrawForm/components/WithdrawTotals.vue
+++ b/src/components/forms/pool_actions/WithdrawForm/components/WithdrawTotals.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { computed, toRefs } from 'vue';
 import { WithdrawMathResponse } from '../composables/useWithdrawMath';
-import useNumbers from '@/composables/useNumbers';
+import useNumbers, { FNumFormats } from '@/composables/useNumbers';
 
 /**
  * TYPES
@@ -37,14 +37,7 @@ const priceImpactClasses = computed(() => ({
       <div class="data-table-number-col">
         <div class="flex items-center">
           <BalLoadingBlock v-if="loadingAmountsOut" class="w-10 h-6" />
-          <span v-else>{{
-            fNum2(priceImpact, {
-              style: 'unit',
-              unit: 'percent',
-              minimumFractionDigits: 2,
-              maximumFractionDigits: 2
-            })
-          }}</span>
+          <span v-else>{{ fNum2(priceImpact, FNumFormats.percent) }}</span>
 
           <BalTooltip :text="$t('withdraw.tooltips.priceImpact')">
             <template v-slot:activator>

--- a/src/components/forms/pool_actions/WithdrawForm/components/WithdrawTotals.vue
+++ b/src/components/forms/pool_actions/WithdrawForm/components/WithdrawTotals.vue
@@ -37,7 +37,14 @@ const priceImpactClasses = computed(() => ({
       <div class="data-table-number-col">
         <div class="flex items-center">
           <BalLoadingBlock v-if="loadingAmountsOut" class="w-10 h-6" />
-          <span v-else>{{ fNum2(priceImpact, { style: 'unit', unit: 'percent', minimumFractionDigits: 2, maximumFractionDigits: 2 }) }}</span>
+          <span v-else>{{
+            fNum2(priceImpact, {
+              style: 'unit',
+              unit: 'percent',
+              minimumFractionDigits: 2,
+              maximumFractionDigits: 2
+            })
+          }}</span>
 
           <BalTooltip :text="$t('withdraw.tooltips.priceImpact')">
             <template v-slot:activator>

--- a/src/components/forms/pool_actions/WithdrawForm/components/WithdrawTotals.vue
+++ b/src/components/forms/pool_actions/WithdrawForm/components/WithdrawTotals.vue
@@ -18,7 +18,7 @@ const props = defineProps<Props>();
 /**
  * COMPOSABLES
  */
-const { fNum } = useNumbers();
+const { fNum2 } = useNumbers();
 
 const { priceImpact, highPriceImpact, loadingAmountsOut } = toRefs(props.math);
 
@@ -37,7 +37,7 @@ const priceImpactClasses = computed(() => ({
       <div class="data-table-number-col">
         <div class="flex items-center">
           <BalLoadingBlock v-if="loadingAmountsOut" class="w-10 h-6" />
-          <span v-else>{{ fNum(priceImpact, 'percent') }}</span>
+          <span v-else>{{ fNum2(priceImpact, { style: 'unit', unit: 'percent', minimumFractionDigits: 2, maximumFractionDigits: 2 }) }}</span>
 
           <BalTooltip :text="$t('withdraw.tooltips.priceImpact')">
             <template v-slot:activator>

--- a/src/components/forms/pool_actions/WithdrawForm/composables/useWithdrawMath.ts
+++ b/src/components/forms/pool_actions/WithdrawForm/composables/useWithdrawMath.ts
@@ -17,7 +17,7 @@ import PoolCalculator from '@/services/pool/calculator/calculator.sevice';
 import useUserSettings from '@/composables/useUserSettings';
 import useSlippage from '@/composables/useSlippage';
 import useTokens from '@/composables/useTokens';
-import useNumbers from '@/composables/useNumbers';
+import useNumbers, { FNumFormats } from '@/composables/useNumbers';
 import useWeb3 from '@/services/web3/useWeb3';
 import { isStablePhantom, usePool } from '@/composables/usePool';
 import { BatchSwapOut } from '@/types';
@@ -345,7 +345,7 @@ export default function useWithdrawMath(
   );
 
   const fiatTotalLabel = computed((): string =>
-    fNum2(fiatTotal.value, { style: 'currency' })
+    fNum2(fiatTotal.value, FNumFormats.fiat)
   );
 
   const shouldFetchBatchSwap = computed(

--- a/src/components/forms/pool_actions/WithdrawForm/composables/useWithdrawMath.ts
+++ b/src/components/forms/pool_actions/WithdrawForm/composables/useWithdrawMath.ts
@@ -89,7 +89,7 @@ export default function useWithdrawMath(
    * COMPOSABLES
    */
   const { isWalletReady, account } = useWeb3();
-  const { toFiat, fNum } = useNumbers();
+  const { toFiat, fNum2 } = useNumbers();
   const {
     tokens: allTokens,
     balances,
@@ -346,7 +346,7 @@ export default function useWithdrawMath(
   );
 
   const fiatTotalLabel = computed((): string =>
-    fNum(fiatTotal.value, currency.value)
+    fNum2(fiatTotal.value, { style: 'currency' })
   );
 
   const shouldFetchBatchSwap = computed(

--- a/src/components/forms/pool_actions/WithdrawForm/composables/useWithdrawMath.ts
+++ b/src/components/forms/pool_actions/WithdrawForm/composables/useWithdrawMath.ts
@@ -102,7 +102,6 @@ export default function useWithdrawMath(
     addSlippageScaled,
     minusSlippageScaled
   } = useSlippage();
-  const { currency } = useUserSettings();
   const { isStablePhantomPool } = usePool(pool);
   const { slippageScaled } = useUserSettings();
   const {

--- a/src/components/heros/AppHero.vue
+++ b/src/components/heros/AppHero.vue
@@ -12,7 +12,12 @@
           white
         />
         <span v-else class="text-3xl font-bold text-white">
-          {{ fNum(totalInvestedAmount, 'usd', { forcePreset: true }) }}
+          {{
+            fNum2(totalInvestedAmount || '', {
+              style: 'currency',
+              fixedFormat: true
+            })
+          }}
         </span>
       </template>
       <template v-else>
@@ -62,7 +67,7 @@ export default defineComponent({
 
   setup() {
     // COMPOSABLES
-    const { fNum } = useNumbers();
+    const { fNum2 } = useNumbers();
     const { isWalletReady, toggleWalletSelectModal } = useWeb3();
     const { trackGoal, Goals } = useFathom();
     const { totalInvestedAmount, isLoadingUserPools } = usePools();
@@ -91,7 +96,7 @@ export default defineComponent({
 
       // methods
       toggleWalletSelectModal,
-      fNum,
+      fNum2,
       onClickConnect,
       trackGoal,
       // constants

--- a/src/components/inputs/TokenInput/TokenInput.vue
+++ b/src/components/inputs/TokenInput/TokenInput.vue
@@ -85,7 +85,7 @@ const _address = ref<string>('');
  */
 
 const { getToken, balanceFor, nativeAsset } = useTokens();
-const { fNum, toFiat } = useNumbers();
+const { fNum2, toFiat } = useNumbers();
 const { currency } = useUserSettings();
 const { t } = useI18n();
 const { isWalletReady } = useWeb3();
@@ -265,7 +265,7 @@ watchEffect(() => {
 
             <BalLoadingBlock v-if="balanceLoading" class="w-12 h-4 mx-2" />
             <span v-else class="mx-2">
-              {{ fNum(tokenBalance, 'token') }}
+              {{ fNum2(tokenBalance, { maximumFractionDigits: 4 }) }}
             </span>
 
             <template v-if="hasBalance && !noMax && !disableMax">
@@ -279,9 +279,17 @@ watchEffect(() => {
           </div>
           <div>
             <template v-if="hasAmount && hasToken">
-              {{ fNum(tokenValue, currency) }}
+              {{ fNum2(tokenValue, { style: 'currency' }) }}
               <span v-if="priceImpact" :class="priceImpactClass">
-                ({{ priceImpactSign + fNum(priceImpact, 'percent') }})
+                ({{
+                  priceImpactSign +
+                    fNum2(priceImpact, {
+                      style: 'unit',
+                      unit: 'percent',
+                      minimumFractionDigits: 2,
+                      maximumFractionDigits: 2
+                    })
+                }})
               </span>
             </template>
             <template v-else-if="hint">

--- a/src/components/inputs/TokenInput/TokenInput.vue
+++ b/src/components/inputs/TokenInput/TokenInput.vue
@@ -3,7 +3,7 @@ import { HtmlInputEvent } from '@/types';
 import { ref, computed, watchEffect } from 'vue';
 import { useI18n } from 'vue-i18n';
 
-import useNumbers from '@/composables/useNumbers';
+import useNumbers, { FNumFormats } from '@/composables/useNumbers';
 import useTokens from '@/composables/useTokens';
 
 import { bnum } from '@/lib/utils';
@@ -280,13 +280,7 @@ watchEffect(() => {
               {{ fNum2(tokenValue, { style: 'currency' }) }}
               <span v-if="priceImpact" :class="priceImpactClass">
                 ({{
-                  priceImpactSign +
-                    fNum2(priceImpact, {
-                      style: 'unit',
-                      unit: 'percent',
-                      minimumFractionDigits: 2,
-                      maximumFractionDigits: 2
-                    })
+                  priceImpactSign + fNum2(priceImpact, FNumFormats.percent)
                 }})
               </span>
             </template>

--- a/src/components/inputs/TokenInput/TokenInput.vue
+++ b/src/components/inputs/TokenInput/TokenInput.vue
@@ -5,7 +5,6 @@ import { useI18n } from 'vue-i18n';
 
 import useNumbers from '@/composables/useNumbers';
 import useTokens from '@/composables/useTokens';
-import useUserSettings from '@/composables/useUserSettings';
 
 import { bnum } from '@/lib/utils';
 import { isPositive, isLessThanOrEqualTo } from '@/lib/utils/validations';
@@ -86,7 +85,6 @@ const _address = ref<string>('');
 
 const { getToken, balanceFor, nativeAsset } = useTokens();
 const { fNum2, toFiat } = useNumbers();
-const { currency } = useUserSettings();
 const { t } = useI18n();
 const { isWalletReady } = useWeb3();
 

--- a/src/components/inputs/TokenInput/TokenInput.vue
+++ b/src/components/inputs/TokenInput/TokenInput.vue
@@ -263,7 +263,7 @@ watchEffect(() => {
 
             <BalLoadingBlock v-if="balanceLoading" class="w-12 h-4 mx-2" />
             <span v-else class="mx-2">
-              {{ fNum2(tokenBalance, { maximumFractionDigits: 4 }) }}
+              {{ fNum2(tokenBalance, FNumFormats.token) }}
             </span>
 
             <template v-if="hasBalance && !noMax && !disableMax">
@@ -277,7 +277,7 @@ watchEffect(() => {
           </div>
           <div>
             <template v-if="hasAmount && hasToken">
-              {{ fNum2(tokenValue, { style: 'currency' }) }}
+              {{ fNum2(tokenValue, FNumFormats.fiat) }}
               <span v-if="priceImpact" :class="priceImpactClass">
                 ({{
                   priceImpactSign + fNum2(priceImpact, FNumFormats.percent)

--- a/src/components/inputs/TokenSelectInput/TokenSelectInput.vue
+++ b/src/components/inputs/TokenSelectInput/TokenSelectInput.vue
@@ -42,7 +42,7 @@ const openTokenModal = ref(false);
  * COMPOSABLEs
  */
 const { getToken } = useTokens();
-const { fNum } = useNumbers();
+const { fNum2 } = useNumbers();
 
 /**
  * COMPUTED
@@ -80,7 +80,13 @@ function tokenFor(option: string): TokenInfo {
         {{ token?.symbol }}
       </span>
       <span v-if="Number(weight) > 0" class="text-gray-500 ml-2">
-        {{ fNum(weight, 'percent_lg') }}
+        {{
+          fNum2(weight, {
+            style: 'unit',
+            unit: 'percent',
+            maximumFractionDigits: 0
+          })
+        }}
       </span>
       <BalIcon
         v-if="!fixed"
@@ -104,7 +110,13 @@ function tokenFor(option: string): TokenInfo {
             {{ token?.symbol }}
           </span>
           <span v-if="Number(weight) > 0" class="text-gray-500 ml-2">
-            {{ fNum(weight, 'percent_lg') }}
+            {{
+              fNum2(weight, {
+                style: 'unit',
+                unit: 'percent',
+                maximumFractionDigits: 0
+              })
+            }}
           </span>
           <BalIcon
             name="chevron-down"

--- a/src/components/lists/TokenListItem.vue
+++ b/src/components/lists/TokenListItem.vue
@@ -20,7 +20,7 @@
       <template v-else>
         <template v-if="balance > 0">
           <template v-if="balance >= 0.0001">
-            {{ fNum(balance, 'token') }}
+            {{ fNum2(balance, { maximumFractionDigits: 4 }) }}
           </template>
           <template v-else>
             &#60; 0.0001
@@ -38,7 +38,7 @@
       />
       <div v-else class="text-gray-500 text-sm font-normal">
         <template v-if="value > 0">
-          {{ fNum(value, 'usd') }}
+          {{ fNum2(value, { style: 'currency', fixedFormat: true }) }}
         </template>
         <template v-else>-</template>
       </div>
@@ -66,7 +66,7 @@ export default {
     /**
      * COMPOSABLES
      */
-    const { fNum } = useNumbers();
+    const { fNum2 } = useNumbers();
     const animateRef = ref();
     const { balances, prices } = useTokens();
     const { currency } = useUserSettings();
@@ -101,7 +101,7 @@ export default {
     });
 
     return {
-      fNum,
+      fNum2,
       animateRef,
       balance,
       value

--- a/src/components/lists/TokenListItem.vue
+++ b/src/components/lists/TokenListItem.vue
@@ -20,7 +20,7 @@
       <template v-else>
         <template v-if="balance > 0">
           <template v-if="balance >= 0.0001">
-            {{ fNum2(balance, { maximumFractionDigits: 4 }) }}
+            {{ fNum2(balance, FNumFormats.token) }}
           </template>
           <template v-else>
             &#60; 0.0001

--- a/src/components/lists/TokenListsListItem.vue
+++ b/src/components/lists/TokenListsListItem.vue
@@ -9,7 +9,7 @@
     <div class="flex-auto">
       {{ tokenlist.name }}
       <div class="text-gray text-sm flex items-center">
-        {{ fNum(tokenlist.tokens.length) }} {{ $t('tokensLowerCase') }}
+        {{ fNum2(tokenlist.tokens.length, { style: 'decimal', maximumFractionDigits: 1, abbreviate: true }) }} {{ $t('tokensLowerCase') }}
         <BalLink :href="listUrl" external class="flex items-center">
           <BalIcon
             name="arrow-up-right"
@@ -57,7 +57,7 @@ export default {
     /**
      * COMPOSABLES
      */
-    const { fNum } = useNumbers();
+    const { fNum2 } = useNumbers();
     const { resolve } = useUrls();
 
     /**
@@ -70,7 +70,7 @@ export default {
 
     return {
       ...toRefs(state),
-      fNum
+      fNum2
     };
   }
 };

--- a/src/components/lists/TokenListsListItem.vue
+++ b/src/components/lists/TokenListsListItem.vue
@@ -9,7 +9,14 @@
     <div class="flex-auto">
       {{ tokenlist.name }}
       <div class="text-gray text-sm flex items-center">
-        {{ fNum2(tokenlist.tokens.length, { style: 'decimal', maximumFractionDigits: 1, abbreviate: true }) }} {{ $t('tokensLowerCase') }}
+        {{
+          fNum2(tokenlist.tokens.length, {
+            style: 'decimal',
+            maximumFractionDigits: 1,
+            abbreviate: true
+          })
+        }}
+        {{ $t('tokensLowerCase') }}
         <BalLink :href="listUrl" external class="flex items-center">
           <BalIcon
             name="arrow-up-right"

--- a/src/components/modals/TradePreviewModal.vue
+++ b/src/components/modals/TradePreviewModal.vue
@@ -11,7 +11,8 @@
         />
         <div class="flex flex-col">
           <div class="font-bold">
-            {{ fNum2(amountIn, { maximumFractionDigits: 4 }) }} {{ symbolIn }} ->
+            {{ fNum2(amountIn, { maximumFractionDigits: 4 }) }}
+            {{ symbolIn }} ->
             {{ fNum2(amountOut, { maximumFractionDigits: 4 }) }} {{ symbolOut }}
           </div>
           <div class="text-gray-500 text-sm">
@@ -64,7 +65,8 @@
               {{ totalRequiredTransactions }}
             </div>
             <div class="ml-3">
-              {{ $t('trade') }} {{ fNum2(valueIn, { style: 'currency' }) }} {{ symbolIn }} ->
+              {{ $t('trade') }} {{ fNum2(valueIn, { style: 'currency' }) }}
+              {{ symbolIn }} ->
               {{ symbolOut }}
             </div>
           </div>

--- a/src/components/modals/TradePreviewModal.vue
+++ b/src/components/modals/TradePreviewModal.vue
@@ -11,12 +11,12 @@
         />
         <div class="flex flex-col">
           <div class="font-bold">
-            {{ fNum2(amountIn, { maximumFractionDigits: 4 }) }}
-            {{ symbolIn }} ->
-            {{ fNum2(amountOut, { maximumFractionDigits: 4 }) }} {{ symbolOut }}
+            {{ fNum2(amountIn, FNumFormats.token) }}
+            {{ symbolIn }} -> {{ fNum2(amountOut, FNumFormats.token) }}
+            {{ symbolOut }}
           </div>
           <div class="text-gray-500 text-sm">
-            {{ fNum2(valueIn, { style: 'currency' }) }}
+            {{ fNum2(valueIn, FNumFormats.fiat) }}
           </div>
         </div>
       </div>
@@ -65,7 +65,7 @@
               {{ totalRequiredTransactions }}
             </div>
             <div class="ml-3">
-              {{ $t('trade') }} {{ fNum2(valueIn, { style: 'currency' }) }}
+              {{ $t('trade') }} {{ fNum2(valueIn, FNumFormats.fiat) }}
               {{ symbolIn }} ->
               {{ symbolOut }}
             </div>

--- a/src/components/modals/TradePreviewModal.vue
+++ b/src/components/modals/TradePreviewModal.vue
@@ -11,11 +11,11 @@
         />
         <div class="flex flex-col">
           <div class="font-bold">
-            {{ fNum(amountIn, 'token') }} {{ symbolIn }} ->
-            {{ fNum(amountOut, 'token') }} {{ symbolOut }}
+            {{ fNum2(amountIn, { maximumFractionDigits: 4 }) }} {{ symbolIn }} ->
+            {{ fNum2(amountOut, { maximumFractionDigits: 4 }) }} {{ symbolOut }}
           </div>
           <div class="text-gray-500 text-sm">
-            {{ fNum(valueIn, 'usd') }}
+            {{ fNum2(valueIn, { style: 'currency' }) }}
           </div>
         </div>
       </div>
@@ -64,7 +64,7 @@
               {{ totalRequiredTransactions }}
             </div>
             <div class="ml-3">
-              {{ $t('trade') }} {{ fNum(valueIn, 'usd') }} {{ symbolIn }} ->
+              {{ $t('trade') }} {{ fNum2(valueIn, { style: 'currency' }) }} {{ symbolIn }} ->
               {{ symbolOut }}
             </div>
           </div>
@@ -150,7 +150,7 @@ export default defineComponent({
     }
   },
   setup(props, { emit }) {
-    const { fNum, toFiat } = useNumbers();
+    const { fNum2, toFiat } = useNumbers();
 
     const { addressIn, amountIn, addressOut, isV1Swap } = toRefs(props);
 
@@ -272,7 +272,7 @@ export default defineComponent({
 
     return {
       // methods
-      fNum,
+      fNum2,
       onClose,
       approveLidoRelayer,
       approveToken,

--- a/src/components/modals/TradePreviewModalGP.vue
+++ b/src/components/modals/TradePreviewModalGP.vue
@@ -482,7 +482,7 @@ export default defineComponent({
           props.trading.tokenInAmountInput.value,
           props.trading.tokenIn.value.address
         ),
-        { style: 'currency' }
+        FNumFormats.fiat
       )
     );
 
@@ -492,14 +492,14 @@ export default defineComponent({
           props.trading.tokenOutAmountInput.value,
           props.trading.tokenOut.value.address
         ),
-        { style: 'currency' }
+        FNumFormats.fiat
       )
     );
 
     const showTradeRoute = computed(() => props.trading.isBalancerTrade.value);
 
     const zeroFee = computed(() =>
-      showSummaryInFiat.value ? fNum2('0', { style: 'currency' }) : '0.0 ETH'
+      showSummaryInFiat.value ? fNum2('0', FNumFormats.fiat) : '0.0 ETH'
     );
 
     const summary = computed(() => {
@@ -565,14 +565,14 @@ export default defineComponent({
           itemValue =>
             `${fNum2(
               toFiat(itemValue, exactIn ? tokenOut.address : tokenIn.address),
-              { style: 'currency' }
+              FNumFormats.fiat
             )}`
         );
       } else {
         return mapValues(
           summaryItems,
           itemValue =>
-            `${fNum2(itemValue, { maximumFractionDigits: 4 })} ${
+            `${fNum2(itemValue, FNumFormats.token)} ${
               exactIn || props.trading.isWrapUnwrapTrade.value
                 ? tokenOut.symbol
                 : tokenIn.symbol

--- a/src/components/modals/TradePreviewModalGP.vue
+++ b/src/components/modals/TradePreviewModalGP.vue
@@ -26,7 +26,11 @@
               </div>
               <div>
                 <div class="font-medium">
-                  {{ fNum(trading.tokenInAmountInput.value, 'token') }}
+                  {{
+                    fNum2(trading.tokenInAmountInput.value, {
+                      maximumFractionDigits: 4
+                    })
+                  }}
                   {{ trading.tokenIn.value.symbol }}
                 </div>
                 <div class="text-gray-500 dark:text-gray-400 text-sm">
@@ -48,7 +52,11 @@
               </div>
               <div>
                 <div class="font-medium">
-                  {{ fNum(trading.tokenOutAmountInput.value, 'token') }}
+                  {{
+                    fNum2(trading.tokenOutAmountInput.value, {
+                      maximumFractionDigits: 4
+                    })
+                  }}
                   {{ trading.tokenOut.value.symbol }}
                 </div>
                 <div class="text-gray-500 dark:text-gray-400 text-sm">
@@ -60,7 +68,14 @@
                     "
                   >
                     / {{ $t('priceImpact') }}:
-                    {{ fNum(trading.sor.priceImpact.value, 'percent') }}
+                    {{
+                      fNum2(trading.sor.priceImpact.value, {
+                        style: 'unit',
+                        unit: 'percent',
+                        minimumFractionDigits: 2,
+                        maximumFractionDigits: 2
+                      })
+                    }}
                   </span>
                 </div>
               </div>
@@ -157,7 +172,12 @@
         :title="$t('priceUpdatedAlert.title')"
         :description="
           $t('priceUpdatedAlert.description', [
-            fNum(PRICE_UPDATE_THRESHOLD, 'percent')
+            fNum2(PRICE_UPDATE_THRESHOLD, {
+              style: 'unit',
+              unit: 'percent',
+              minimumFractionDigits: 2,
+              maximumFractionDigits: 2
+            })
           ])
         "
         :action-label="$t('priceUpdatedAlert.actionLabel')"
@@ -444,7 +464,7 @@ export default defineComponent({
   setup(props, { emit }) {
     // COMPOSABLES
     const { t } = useI18n();
-    const { fNum, toFiat } = useNumbers();
+    const { fNum2, toFiat } = useNumbers();
     const { tokens, approvalRequired } = useTokens();
     const { blockNumber } = useWeb3();
     const { slippage } = useUserSettings();
@@ -460,34 +480,41 @@ export default defineComponent({
     const showSummaryInFiat = ref(false);
 
     // COMPUTED
-    const slippageRatePercent = computed(() => fNum(slippage.value, 'percent'));
+    const slippageRatePercent = computed(() =>
+      fNum2(slippage.value, {
+        style: 'unit',
+        unit: 'percent',
+        minimumFractionDigits: 2,
+        maximumFractionDigits: 2
+      })
+    );
 
     const addressIn = computed(() => props.trading.tokenIn.value.address);
 
     const tokenInFiatValue = computed(() =>
-      fNum(
+      fNum2(
         toFiat(
           props.trading.tokenInAmountInput.value,
           props.trading.tokenIn.value.address
         ),
-        'usd'
+        { style: 'currency' }
       )
     );
 
     const tokenOutFiatValue = computed(() =>
-      fNum(
+      fNum2(
         toFiat(
           props.trading.tokenOutAmountInput.value,
           props.trading.tokenOut.value.address
         ),
-        'usd'
+        { style: 'currency' }
       )
     );
 
     const showTradeRoute = computed(() => props.trading.isBalancerTrade.value);
 
     const zeroFee = computed(() =>
-      showSummaryInFiat.value ? fNum('0', 'usd') : '0.0 ETH'
+      showSummaryInFiat.value ? fNum2('0', { style: 'currency' }) : '0.0 ETH'
     );
 
     const summary = computed(() => {
@@ -551,16 +578,16 @@ export default defineComponent({
         return mapValues(
           summaryItems,
           itemValue =>
-            `${fNum(
+            `${fNum2(
               toFiat(itemValue, exactIn ? tokenOut.address : tokenIn.address),
-              'usd'
+              { style: 'currency' }
             )}`
         );
       } else {
         return mapValues(
           summaryItems,
           itemValue =>
-            `${fNum(itemValue, 'token')} ${
+            `${fNum2(itemValue, { maximumFractionDigits: 4 })} ${
               exactIn || props.trading.isWrapUnwrapTrade.value
                 ? tokenOut.symbol
                 : tokenIn.symbol
@@ -841,7 +868,7 @@ export default defineComponent({
       FiatCurrency,
 
       // methods
-      fNum,
+      fNum2,
       onClose,
       trade,
       cofirmPriceUpdate,

--- a/src/components/modals/TradePreviewModalGP.vue
+++ b/src/components/modals/TradePreviewModalGP.vue
@@ -69,12 +69,7 @@
                   >
                     / {{ $t('priceImpact') }}:
                     {{
-                      fNum2(trading.sor.priceImpact.value, {
-                        style: 'unit',
-                        unit: 'percent',
-                        minimumFractionDigits: 2,
-                        maximumFractionDigits: 2
-                      })
+                      fNum2(trading.sor.priceImpact.value, FNumFormats.percent)
                     }}
                   </span>
                 </div>
@@ -172,12 +167,7 @@
         :title="$t('priceUpdatedAlert.title')"
         :description="
           $t('priceUpdatedAlert.description', [
-            fNum2(PRICE_UPDATE_THRESHOLD, {
-              style: 'unit',
-              unit: 'percent',
-              minimumFractionDigits: 2,
-              maximumFractionDigits: 2
-            })
+            fNum2(PRICE_UPDATE_THRESHOLD, FNumFormats.percent)
           ])
         "
         :action-label="$t('priceUpdatedAlert.actionLabel')"
@@ -430,7 +420,7 @@ import { useI18n } from 'vue-i18n';
 import { mapValues } from 'lodash';
 
 import { UseTrading } from '@/composables/trade/useTrading';
-import useNumbers from '@/composables/useNumbers';
+import useNumbers, { FNumFormats } from '@/composables/useNumbers';
 import useRelayerApproval, {
   Relayer
 } from '@/composables/trade/useRelayerApproval';
@@ -481,12 +471,7 @@ export default defineComponent({
 
     // COMPUTED
     const slippageRatePercent = computed(() =>
-      fNum2(slippage.value, {
-        style: 'unit',
-        unit: 'percent',
-        minimumFractionDigits: 2,
-        maximumFractionDigits: 2
-      })
+      fNum2(slippage.value, FNumFormats.percent)
     );
 
     const addressIn = computed(() => props.trading.tokenIn.value.address);

--- a/src/components/modals/TradePreviewModalGP.vue
+++ b/src/components/modals/TradePreviewModalGP.vue
@@ -27,9 +27,7 @@
               <div>
                 <div class="font-medium">
                   {{
-                    fNum2(trading.tokenInAmountInput.value, {
-                      maximumFractionDigits: 4
-                    })
+                    fNum2(trading.tokenInAmountInput.value, FNumFormats.token)
                   }}
                   {{ trading.tokenIn.value.symbol }}
                 </div>
@@ -53,9 +51,7 @@
               <div>
                 <div class="font-medium">
                   {{
-                    fNum2(trading.tokenOutAmountInput.value, {
-                      maximumFractionDigits: 4
-                    })
+                    fNum2(trading.tokenOutAmountInput.value, FNumFormats.token)
                   }}
                   {{ trading.tokenOut.value.symbol }}
                 </div>

--- a/src/components/navs/AppNav/AppNavClaimBtn.vue
+++ b/src/components/navs/AppNav/AppNavClaimBtn.vue
@@ -222,9 +222,10 @@ async function claimAvailableRewards() {
       const summary = claimableTokens.value
         .map(
           claimableToken =>
-            `${fNum2(claimableToken.amount, { minimumFractionDigits: 4, maximumFractionDigits: 4 })} ${
-              claimableToken.symbol
-            }`
+            `${fNum2(claimableToken.amount, {
+              minimumFractionDigits: 4,
+              maximumFractionDigits: 4
+            })} ${claimableToken.symbol}`
         )
         .join(', ');
 
@@ -308,7 +309,9 @@ async function claimAvailableRewards() {
                 />
                 <div>
                   <div class="font-medium">
-                    {{ fNum2(claimableToken.amount, { maximumFractionDigits: 4 }) }}
+                    {{
+                      fNum2(claimableToken.amount, { maximumFractionDigits: 4 })
+                    }}
                     {{ claimableToken.symbol }}
                   </div>
                   <div class="font-sm text-gray-400">
@@ -333,7 +336,9 @@ async function claimAvailableRewards() {
                 />
                 <div>
                   <div class="font-medium">
-                    {{ fNum2(claimableToken.amount, { maximumFractionDigits: 4 }) }}
+                    {{
+                      fNum2(claimableToken.amount, { maximumFractionDigits: 4 })
+                    }}
                     {{ claimableToken.symbol }}
                   </div>
                   <div class="font-sm text-gray-400">
@@ -356,7 +361,9 @@ async function claimAvailableRewards() {
           :disabled="!hasClaimableTokens"
           >{{ $t('claimAll') }}
           <template v-if="hasClaimableTokens"
-            >~{{ fNum2(totalClaimableTokensFiatValue, { style: 'currency' }) }}</template
+            >~{{
+              fNum2(totalClaimableTokensFiatValue, { style: 'currency' })
+            }}</template
           ></BalBtn
         >
         <BalAlert

--- a/src/components/navs/AppNav/AppNavClaimBtn.vue
+++ b/src/components/navs/AppNav/AppNavClaimBtn.vue
@@ -269,7 +269,7 @@ async function claimAvailableRewards() {
         />
         <BalLoadingIcon size="sm" v-if="userClaimsLoading" />
         <span class="hidden lg:block" v-else>{{
-          fNum2(totalRewardsFiatValue, { style: 'currency' })
+          fNum2(totalRewardsFiatValue, FNumFormats.fiat)
         }}</span>
       </BalBtn>
     </template>
@@ -309,13 +309,11 @@ async function claimAvailableRewards() {
                 />
                 <div>
                   <div class="font-medium">
-                    {{
-                      fNum2(claimableToken.amount, { maximumFractionDigits: 4 })
-                    }}
+                    {{ fNum2(claimableToken.amount, FNumFormats.token) }}
                     {{ claimableToken.symbol }}
                   </div>
                   <div class="font-sm text-gray-400">
-                    {{ fNum2(claimableToken.fiatValue, { style: 'currency' }) }}
+                    {{ fNum2(claimableToken.fiatValue, FNumFormats.fiat) }}
                   </div>
                 </div>
               </div>
@@ -336,13 +334,11 @@ async function claimAvailableRewards() {
                 />
                 <div>
                   <div class="font-medium">
-                    {{
-                      fNum2(claimableToken.amount, { maximumFractionDigits: 4 })
-                    }}
+                    {{ fNum2(claimableToken.amount, FNumFormats.token) }}
                     {{ claimableToken.symbol }}
                   </div>
                   <div class="font-sm text-gray-400">
-                    {{ fNum2(claimableToken.fiatValue, { style: 'currency' }) }}
+                    {{ fNum2(claimableToken.fiatValue, FNumFormats.fiat) }}
                   </div>
                 </div>
               </div>
@@ -362,7 +358,7 @@ async function claimAvailableRewards() {
           >{{ $t('claimAll') }}
           <template v-if="hasClaimableTokens"
             >~{{
-              fNum2(totalClaimableTokensFiatValue, { style: 'currency' })
+              fNum2(totalClaimableTokensFiatValue, FNumFormats.fiat)
             }}</template
           ></BalBtn
         >

--- a/src/components/navs/AppNav/AppNavClaimBtn.vue
+++ b/src/components/navs/AppNav/AppNavClaimBtn.vue
@@ -56,7 +56,7 @@ const claimError = ref<TransactionError | null>(null);
 // COMPOSABLES
 const { upToLargeBreakpoint } = useBreakpoints();
 const userClaimsQuery = useUserClaimsQuery();
-const { fNum } = useNumbers();
+const { fNum2 } = useNumbers();
 const {
   account,
   getProvider,
@@ -222,7 +222,7 @@ async function claimAvailableRewards() {
       const summary = claimableTokens.value
         .map(
           claimableToken =>
-            `${fNum(claimableToken.amount, 'token_fixed')} ${
+            `${fNum2(claimableToken.amount, { minimumFractionDigits: 4, maximumFractionDigits: 4 })} ${
               claimableToken.symbol
             }`
         )
@@ -268,7 +268,7 @@ async function claimAvailableRewards() {
         />
         <BalLoadingIcon size="sm" v-if="userClaimsLoading" />
         <span class="hidden lg:block" v-else>{{
-          fNum(totalRewardsFiatValue, 'usd')
+          fNum2(totalRewardsFiatValue, { style: 'currency' })
         }}</span>
       </BalBtn>
     </template>
@@ -308,11 +308,11 @@ async function claimAvailableRewards() {
                 />
                 <div>
                   <div class="font-medium">
-                    {{ fNum(claimableToken.amount, 'token') }}
+                    {{ fNum2(claimableToken.amount, { maximumFractionDigits: 4 }) }}
                     {{ claimableToken.symbol }}
                   </div>
                   <div class="font-sm text-gray-400">
-                    {{ fNum(claimableToken.fiatValue, 'usd') }}
+                    {{ fNum2(claimableToken.fiatValue, { style: 'currency' }) }}
                   </div>
                 </div>
               </div>
@@ -333,11 +333,11 @@ async function claimAvailableRewards() {
                 />
                 <div>
                   <div class="font-medium">
-                    {{ fNum(claimableToken.amount, 'token') }}
+                    {{ fNum2(claimableToken.amount, { maximumFractionDigits: 4 }) }}
                     {{ claimableToken.symbol }}
                   </div>
                   <div class="font-sm text-gray-400">
-                    {{ fNum(claimableToken.fiatValue, 'usd') }}
+                    {{ fNum2(claimableToken.fiatValue, { style: 'currency' }) }}
                   </div>
                 </div>
               </div>
@@ -356,7 +356,7 @@ async function claimAvailableRewards() {
           :disabled="!hasClaimableTokens"
           >{{ $t('claimAll') }}
           <template v-if="hasClaimableTokens"
-            >~{{ fNum(totalClaimableTokensFiatValue, 'usd') }}</template
+            >~{{ fNum2(totalClaimableTokensFiatValue, { style: 'currency' }) }}</template
           ></BalBtn
         >
         <BalAlert

--- a/src/components/tables/LMTable/LMTable.vue
+++ b/src/components/tables/LMTable/LMTable.vue
@@ -77,7 +77,10 @@
           >
             <span v-if="tokenIndex !== 0">+</span>&nbsp;
             <span class="font-numeric">{{
-              fNum2(tokenDist.amount, { style: 'decimal', maximumFractionDigits: 0 })
+              fNum2(tokenDist.amount, {
+                style: 'decimal',
+                maximumFractionDigits: 0
+              })
             }}</span>
             {{ tokens[getAddress(tokenDist.tokenAddress)]?.symbol || 'N/A' }}
           </span>
@@ -98,11 +101,19 @@
             class="font-semibold text-right"
           >
             <span v-if="i !== 0">+</span>&nbsp;
-            <span class="font-numeric">{{ fNum2(total, { style: 'decimal', maximumFractionDigits: 0 }) }}</span>
+            <span class="font-numeric">{{
+              fNum2(total, { style: 'decimal', maximumFractionDigits: 0 })
+            }}</span>
             {{ tokens[getAddress(token)]?.symbol || 'N/A' }}
           </span>
           <span class="mt-2 text-gray-500 font-numeric"
-            >~${{ fNum2(calculatePricesFor(totals[week.week]), { style: 'decimal', maximumFractionDigits: 1, abbreviate: true }) }}</span
+            >~${{
+              fNum2(calculatePricesFor(totals[week.week]), {
+                style: 'decimal',
+                maximumFractionDigits: 1,
+                abbreviate: true
+              })
+            }}</span
           >
         </div>
       </template>

--- a/src/components/tables/LMTable/LMTable.vue
+++ b/src/components/tables/LMTable/LMTable.vue
@@ -77,7 +77,7 @@
           >
             <span v-if="tokenIndex !== 0">+</span>&nbsp;
             <span class="font-numeric">{{
-              fNum(tokenDist.amount, 'token_lg')
+              fNum2(tokenDist.amount, { style: 'decimal', maximumFractionDigits: 0 })
             }}</span>
             {{ tokens[getAddress(tokenDist.tokenAddress)]?.symbol || 'N/A' }}
           </span>
@@ -98,11 +98,11 @@
             class="font-semibold text-right"
           >
             <span v-if="i !== 0">+</span>&nbsp;
-            <span class="font-numeric">{{ fNum(total, 'token_lg') }}</span>
+            <span class="font-numeric">{{ fNum2(total, { style: 'decimal', maximumFractionDigits: 0 }) }}</span>
             {{ tokens[getAddress(token)]?.symbol || 'N/A' }}
           </span>
           <span class="mt-2 text-gray-500 font-numeric"
-            >~${{ fNum(calculatePricesFor(totals[week.week])) }}</span
+            >~${{ fNum2(calculatePricesFor(totals[week.week]), { style: 'decimal', maximumFractionDigits: 1, abbreviate: true }) }}</span
           >
         </div>
       </template>
@@ -157,7 +157,7 @@ export default defineComponent({
     const { t } = useI18n();
     const { weeks, poolMetadata } = toRefs(props);
     const { tokens, priceFor } = useTokens();
-    const { fNum } = useNumbers();
+    const { fNum2 } = useNumbers();
     const { darkMode } = useDarkMode();
 
     const data = computed(() => {
@@ -247,7 +247,7 @@ export default defineComponent({
     return {
       orderedTokenAddressesFor,
       orderedPoolTokens,
-      fNum,
+      fNum2,
       getAddress,
       calculatePricesFor,
       isStableLike,

--- a/src/components/tables/PoolsTable/PoolsTable.vue
+++ b/src/components/tables/PoolsTable/PoolsTable.vue
@@ -69,7 +69,7 @@
           {{
             Number(pool.dynamic.apr.pool) > 10000
               ? '-'
-              : fNum(pool.dynamic.apr.total, 'percent')
+              : fNum2(pool.dynamic.apr.total, { style: 'unit', unit: 'percent', minimumFractionDigits: 2, maximumFractionDigits: 2 })
           }}
           <LiquidityAPRTooltip :pool="pool" />
         </div>
@@ -139,7 +139,7 @@ export default defineComponent({
 
   setup(props) {
     // COMPOSABLES
-    const { fNum } = useNumbers();
+    const { fNum2 } = useNumbers();
     const router = useRouter();
     const { t } = useI18n();
     const { trackGoal, Goals } = useFathom();
@@ -166,7 +166,7 @@ export default defineComponent({
       },
       {
         name: t('myBalance'),
-        accessor: pool => fNum(pool.shares, 'usd', { forcePreset: true }),
+        accessor: pool => fNum2(pool.shares, { style: 'currency', fixedFormat: true }),
         align: 'right',
         id: 'myBalance',
         hidden: !props.showPoolShares,
@@ -176,7 +176,7 @@ export default defineComponent({
       },
       {
         name: t('poolValue'),
-        accessor: pool => fNum(pool.totalLiquidity, 'usd', { noDecimals: true }),
+        accessor: pool => fNum2(pool.totalLiquidity, { style: 'currency' }),
         align: 'right',
         id: 'poolValue',
         sortKey: pool => {
@@ -189,7 +189,7 @@ export default defineComponent({
       },
       {
         name: t('volume24h', [t('hourAbbrev')]),
-        accessor: pool => fNum(pool.dynamic.volume, 'usd', { noDecimals: true }),
+        accessor: pool => fNum2(pool.dynamic.volume, { style: 'currency' }),
         align: 'right',
         id: 'poolVolume',
         sortKey: pool => {
@@ -247,7 +247,7 @@ export default defineComponent({
       // methods
       handleRowClick,
       getAddress,
-      fNum,
+      fNum2,
       orderedTokenAddressesFor,
       orderedPoolTokens,
       isStableLike

--- a/src/components/tables/PoolsTable/PoolsTable.vue
+++ b/src/components/tables/PoolsTable/PoolsTable.vue
@@ -90,7 +90,7 @@ import {
 
 import { getAddress } from '@ethersproject/address';
 
-import useNumbers from '@/composables/useNumbers';
+import useNumbers, { FNumFormats } from '@/composables/useNumbers';
 import useFathom from '@/composables/useFathom';
 
 import LiquidityAPRTooltip from '@/components/tooltips/LiquidityAPRTooltip.vue';
@@ -240,6 +240,7 @@ export default defineComponent({
     return {
       // data
       columns,
+      FNumFormats,
 
       // computed
       darkMode,

--- a/src/components/tables/PoolsTable/PoolsTable.vue
+++ b/src/components/tables/PoolsTable/PoolsTable.vue
@@ -176,7 +176,7 @@ export default defineComponent({
       },
       {
         name: t('poolValue'),
-        accessor: pool => fNum(pool.totalLiquidity, 'usd'),
+        accessor: pool => fNum(pool.totalLiquidity, 'usd', { noDecimals: true }),
         align: 'right',
         id: 'poolValue',
         sortKey: pool => {
@@ -189,7 +189,7 @@ export default defineComponent({
       },
       {
         name: t('volume24h', [t('hourAbbrev')]),
-        accessor: pool => fNum(pool.dynamic.volume, 'usd'),
+        accessor: pool => fNum(pool.dynamic.volume, 'usd', { noDecimals: true }),
         align: 'right',
         id: 'poolVolume',
         sortKey: pool => {

--- a/src/components/tables/PoolsTable/PoolsTable.vue
+++ b/src/components/tables/PoolsTable/PoolsTable.vue
@@ -69,7 +69,12 @@
           {{
             Number(pool.dynamic.apr.pool) > 10000
               ? '-'
-              : fNum2(pool.dynamic.apr.total, { style: 'unit', unit: 'percent', minimumFractionDigits: 2, maximumFractionDigits: 2 })
+              : fNum2(pool.dynamic.apr.total, {
+                  style: 'unit',
+                  unit: 'percent',
+                  minimumFractionDigits: 2,
+                  maximumFractionDigits: 2
+                })
           }}
           <LiquidityAPRTooltip :pool="pool" />
         </div>
@@ -166,7 +171,8 @@ export default defineComponent({
       },
       {
         name: t('myBalance'),
-        accessor: pool => fNum2(pool.shares, { style: 'currency', fixedFormat: true }),
+        accessor: pool =>
+          fNum2(pool.shares, { style: 'currency', fixedFormat: true }),
         align: 'right',
         id: 'myBalance',
         hidden: !props.showPoolShares,

--- a/src/components/tables/PoolsTable/PoolsTable.vue
+++ b/src/components/tables/PoolsTable/PoolsTable.vue
@@ -177,7 +177,7 @@ export default defineComponent({
       },
       {
         name: t('poolValue'),
-        accessor: pool => fNum2(pool.totalLiquidity, { style: 'currency' }),
+        accessor: pool => fNum2(pool.totalLiquidity, FNumFormats.fiat),
         align: 'right',
         id: 'poolValue',
         sortKey: pool => {
@@ -190,7 +190,7 @@ export default defineComponent({
       },
       {
         name: t('volume24h', [t('hourAbbrev')]),
-        accessor: pool => fNum2(pool.dynamic.volume, { style: 'currency' }),
+        accessor: pool => fNum2(pool.dynamic.volume, FNumFormats.fiat),
         align: 'right',
         id: 'poolVolume',
         sortKey: pool => {

--- a/src/components/tables/PoolsTable/PoolsTable.vue
+++ b/src/components/tables/PoolsTable/PoolsTable.vue
@@ -69,12 +69,7 @@
           {{
             Number(pool.dynamic.apr.pool) > 10000
               ? '-'
-              : fNum2(pool.dynamic.apr.total, {
-                  style: 'unit',
-                  unit: 'percent',
-                  minimumFractionDigits: 2,
-                  maximumFractionDigits: 2
-                })
+              : fNum2(pool.dynamic.apr.total, FNumFormats.percent)
           }}
           <LiquidityAPRTooltip :pool="pool" />
         </div>

--- a/src/components/tables/PoolsTable/TokenPills/TokenPills.vue
+++ b/src/components/tables/PoolsTable/TokenPills/TokenPills.vue
@@ -47,7 +47,11 @@ function symbolFor(token: PoolToken): string {
 }
 
 function weightFor(token: PoolToken): string {
-  return fNum2(token.weight, { style: 'unit', unit: 'percent', maximumFractionDigits: 0 });
+  return fNum2(token.weight, {
+    style: 'unit',
+    unit: 'percent',
+    maximumFractionDigits: 0
+  });
 }
 
 const MAX_PILLS = 11;

--- a/src/components/tables/PoolsTable/TokenPills/TokenPills.vue
+++ b/src/components/tables/PoolsTable/TokenPills/TokenPills.vue
@@ -21,7 +21,7 @@ const props = withDefaults(defineProps<Props>(), {
   selectedTokens: () => []
 });
 
-const { fNum } = useNumbers();
+const { fNum2 } = useNumbers();
 const { tokens, hasBalance } = useTokens();
 
 /**
@@ -47,7 +47,7 @@ function symbolFor(token: PoolToken): string {
 }
 
 function weightFor(token: PoolToken): string {
-  return fNum(token.weight, 'percent_lg');
+  return fNum2(token.weight, { style: 'unit', unit: 'percent', maximumFractionDigits: 0 });
 }
 
 const MAX_PILLS = 11;

--- a/src/components/tooltips/LiquidityAPRTooltip.vue
+++ b/src/components/tooltips/LiquidityAPRTooltip.vue
@@ -25,7 +25,7 @@ const props = defineProps<Props>();
 /**
  * COMPOSABLES
  */
-const { fNum } = useNumbers();
+const { fNum2 } = useNumbers();
 const { getTokens } = useTokens();
 const { t } = useI18n();
 
@@ -93,12 +93,12 @@ const thirdPartyAPRLabel = computed(() => {
       <div class="px-3 pt-3 pb-1 bg-gray-50 dark:bg-gray-800 rounded-t">
         <div class="text-gray-500">{{ $t('totalAPR') }}</div>
         <div class="text-lg">
-          {{ fNum(pool.dynamic.apr.total, 'percent') }}
+          {{ fNum2(pool.dynamic.apr.total, { style: 'unit', unit: 'percent', minimumFractionDigits: 2, maximumFractionDigits: 2 }) }}
         </div>
       </div>
       <div class="p-3">
         <div class="whitespace-nowrap flex items-center mb-1">
-          {{ fNum(pool.dynamic.apr.pool, 'percent') }}
+          {{ fNum2(pool.dynamic.apr.pool, { style: 'unit', unit: 'percent', minimumFractionDigits: 2, maximumFractionDigits: 2 }) }}
           <span class="ml-1 text-gray-500 text-xs">{{ $t('swapFeeAPR') }}</span>
         </div>
         <BalBreakdown
@@ -107,13 +107,13 @@ const thirdPartyAPRLabel = computed(() => {
           :hideItems="!thirdPartyMultiRewardPool"
         >
           <div class="flex items-center">
-            {{ fNum(pool.dynamic.apr.thirdParty, 'percent') }}
+            {{ fNum2(pool.dynamic.apr.thirdParty, { style: 'unit', unit: 'percent', minimumFractionDigits: 2, maximumFractionDigits: 2 }) }}
             <span class="ml-1 text-gray-500 text-xs">
               {{ thirdPartyAPRLabel }}
             </span>
           </div>
           <template v-if="thirdPartyMultiRewardPool" #item="{ item }">
-            {{ fNum(item[1], 'percent') }}
+            {{ fNum2(item[1], { style: 'unit', unit: 'percent', minimumFractionDigits: 2, maximumFractionDigits: 2 }) }}
             <span class="text-gray-500 text-xs ml-1">
               {{ thirdPartyTokens[item[0]].symbol }} {{ $t('apr') }}
             </span>
@@ -125,13 +125,13 @@ const thirdPartyAPRLabel = computed(() => {
           :hideItems="!lmMultiRewardPool"
         >
           <div class="flex items-center">
-            {{ fNum(pool.dynamic.apr.liquidityMining, 'percent') }}
+            {{ fNum2(pool.dynamic.apr.liquidityMining, { style: 'unit', unit: 'percent', minimumFractionDigits: 2, maximumFractionDigits: 2 }) }}
             <span class="ml-1 text-gray-500 text-xs flex items-center">
               {{ $t('liquidityMiningAPR') }}
             </span>
           </div>
           <template v-if="lmMultiRewardPool" #item="{ item }">
-            {{ fNum(item[1], 'percent') }}
+            {{ fNum2(item[1], { style: 'unit', unit: 'percent', minimumFractionDigits: 2, maximumFractionDigits: 2 }) }}
             <span class="text-gray-500 text-xs ml-1">
               {{ lmTokens[item[0]].symbol }} {{ $t('apr') }}
             </span>

--- a/src/components/tooltips/LiquidityAPRTooltip.vue
+++ b/src/components/tooltips/LiquidityAPRTooltip.vue
@@ -93,12 +93,26 @@ const thirdPartyAPRLabel = computed(() => {
       <div class="px-3 pt-3 pb-1 bg-gray-50 dark:bg-gray-800 rounded-t">
         <div class="text-gray-500">{{ $t('totalAPR') }}</div>
         <div class="text-lg">
-          {{ fNum2(pool.dynamic.apr.total, { style: 'unit', unit: 'percent', minimumFractionDigits: 2, maximumFractionDigits: 2 }) }}
+          {{
+            fNum2(pool.dynamic.apr.total, {
+              style: 'unit',
+              unit: 'percent',
+              minimumFractionDigits: 2,
+              maximumFractionDigits: 2
+            })
+          }}
         </div>
       </div>
       <div class="p-3">
         <div class="whitespace-nowrap flex items-center mb-1">
-          {{ fNum2(pool.dynamic.apr.pool, { style: 'unit', unit: 'percent', minimumFractionDigits: 2, maximumFractionDigits: 2 }) }}
+          {{
+            fNum2(pool.dynamic.apr.pool, {
+              style: 'unit',
+              unit: 'percent',
+              minimumFractionDigits: 2,
+              maximumFractionDigits: 2
+            })
+          }}
           <span class="ml-1 text-gray-500 text-xs">{{ $t('swapFeeAPR') }}</span>
         </div>
         <BalBreakdown
@@ -107,13 +121,27 @@ const thirdPartyAPRLabel = computed(() => {
           :hideItems="!thirdPartyMultiRewardPool"
         >
           <div class="flex items-center">
-            {{ fNum2(pool.dynamic.apr.thirdParty, { style: 'unit', unit: 'percent', minimumFractionDigits: 2, maximumFractionDigits: 2 }) }}
+            {{
+              fNum2(pool.dynamic.apr.thirdParty, {
+                style: 'unit',
+                unit: 'percent',
+                minimumFractionDigits: 2,
+                maximumFractionDigits: 2
+              })
+            }}
             <span class="ml-1 text-gray-500 text-xs">
               {{ thirdPartyAPRLabel }}
             </span>
           </div>
           <template v-if="thirdPartyMultiRewardPool" #item="{ item }">
-            {{ fNum2(item[1], { style: 'unit', unit: 'percent', minimumFractionDigits: 2, maximumFractionDigits: 2 }) }}
+            {{
+              fNum2(item[1], {
+                style: 'unit',
+                unit: 'percent',
+                minimumFractionDigits: 2,
+                maximumFractionDigits: 2
+              })
+            }}
             <span class="text-gray-500 text-xs ml-1">
               {{ thirdPartyTokens[item[0]].symbol }} {{ $t('apr') }}
             </span>
@@ -125,13 +153,27 @@ const thirdPartyAPRLabel = computed(() => {
           :hideItems="!lmMultiRewardPool"
         >
           <div class="flex items-center">
-            {{ fNum2(pool.dynamic.apr.liquidityMining, { style: 'unit', unit: 'percent', minimumFractionDigits: 2, maximumFractionDigits: 2 }) }}
+            {{
+              fNum2(pool.dynamic.apr.liquidityMining, {
+                style: 'unit',
+                unit: 'percent',
+                minimumFractionDigits: 2,
+                maximumFractionDigits: 2
+              })
+            }}
             <span class="ml-1 text-gray-500 text-xs flex items-center">
               {{ $t('liquidityMiningAPR') }}
             </span>
           </div>
           <template v-if="lmMultiRewardPool" #item="{ item }">
-            {{ fNum2(item[1], { style: 'unit', unit: 'percent', minimumFractionDigits: 2, maximumFractionDigits: 2 }) }}
+            {{
+              fNum2(item[1], {
+                style: 'unit',
+                unit: 'percent',
+                minimumFractionDigits: 2,
+                maximumFractionDigits: 2
+              })
+            }}
             <span class="text-gray-500 text-xs ml-1">
               {{ lmTokens[item[0]].symbol }} {{ $t('apr') }}
             </span>

--- a/src/components/tooltips/LiquidityAPRTooltip.vue
+++ b/src/components/tooltips/LiquidityAPRTooltip.vue
@@ -2,7 +2,7 @@
 import { computed } from 'vue';
 import { useI18n } from 'vue-i18n';
 
-import useNumbers from '@/composables/useNumbers';
+import useNumbers, { FNumFormats } from '@/composables/useNumbers';
 import useTokens from '@/composables/useTokens';
 import { isStablePhantom, isWstETH } from '@/composables/usePool';
 import { APR_THRESHOLD } from '@/constants/poolAPR';
@@ -93,26 +93,12 @@ const thirdPartyAPRLabel = computed(() => {
       <div class="px-3 pt-3 pb-1 bg-gray-50 dark:bg-gray-800 rounded-t">
         <div class="text-gray-500">{{ $t('totalAPR') }}</div>
         <div class="text-lg">
-          {{
-            fNum2(pool.dynamic.apr.total, {
-              style: 'unit',
-              unit: 'percent',
-              minimumFractionDigits: 2,
-              maximumFractionDigits: 2
-            })
-          }}
+          {{ fNum2(pool.dynamic.apr.total, FNumFormats.percent) }}
         </div>
       </div>
       <div class="p-3">
         <div class="whitespace-nowrap flex items-center mb-1">
-          {{
-            fNum2(pool.dynamic.apr.pool, {
-              style: 'unit',
-              unit: 'percent',
-              minimumFractionDigits: 2,
-              maximumFractionDigits: 2
-            })
-          }}
+          {{ fNum2(pool.dynamic.apr.pool, FNumFormats.percent) }}
           <span class="ml-1 text-gray-500 text-xs">{{ $t('swapFeeAPR') }}</span>
         </div>
         <BalBreakdown
@@ -121,27 +107,13 @@ const thirdPartyAPRLabel = computed(() => {
           :hideItems="!thirdPartyMultiRewardPool"
         >
           <div class="flex items-center">
-            {{
-              fNum2(pool.dynamic.apr.thirdParty, {
-                style: 'unit',
-                unit: 'percent',
-                minimumFractionDigits: 2,
-                maximumFractionDigits: 2
-              })
-            }}
+            {{ fNum2(pool.dynamic.apr.thirdParty, FNumFormats.percent) }}
             <span class="ml-1 text-gray-500 text-xs">
               {{ thirdPartyAPRLabel }}
             </span>
           </div>
           <template v-if="thirdPartyMultiRewardPool" #item="{ item }">
-            {{
-              fNum2(item[1], {
-                style: 'unit',
-                unit: 'percent',
-                minimumFractionDigits: 2,
-                maximumFractionDigits: 2
-              })
-            }}
+            {{ fNum2(item[1], FNumFormats.percent) }}
             <span class="text-gray-500 text-xs ml-1">
               {{ thirdPartyTokens[item[0]].symbol }} {{ $t('apr') }}
             </span>
@@ -153,27 +125,13 @@ const thirdPartyAPRLabel = computed(() => {
           :hideItems="!lmMultiRewardPool"
         >
           <div class="flex items-center">
-            {{
-              fNum2(pool.dynamic.apr.liquidityMining, {
-                style: 'unit',
-                unit: 'percent',
-                minimumFractionDigits: 2,
-                maximumFractionDigits: 2
-              })
-            }}
+            {{ fNum2(pool.dynamic.apr.liquidityMining, FNumFormats.percent) }}
             <span class="ml-1 text-gray-500 text-xs flex items-center">
               {{ $t('liquidityMiningAPR') }}
             </span>
           </div>
           <template v-if="lmMultiRewardPool" #item="{ item }">
-            {{
-              fNum2(item[1], {
-                style: 'unit',
-                unit: 'percent',
-                minimumFractionDigits: 2,
-                maximumFractionDigits: 2
-              })
-            }}
+            {{ fNum2(item[1], FNumFormats.percent) }}
             <span class="text-gray-500 text-xs ml-1">
               {{ lmTokens[item[0]].symbol }} {{ $t('apr') }}
             </span>

--- a/src/composables/__mocks__/useUserSettings.ts
+++ b/src/composables/__mocks__/useUserSettings.ts
@@ -1,0 +1,7 @@
+import { ref } from 'vue';
+
+export default function useUserSettings() {
+  return {
+    currency: ref('usd')
+  };
+}

--- a/src/composables/trade/useGnosis.ts
+++ b/src/composables/trade/useGnosis.ts
@@ -233,11 +233,11 @@ export default function useGnosis({
       const tokenInAmountEst = exactIn.value ? '' : '~';
       const tokenOutAmountEst = exactIn.value ? '~' : '';
 
-      const summary = `${tokenInAmountEst}${fNum2(sellAmount, { maximumFractionDigits: 4 })} ${
-        tokenIn.value.symbol
-      } -> ${tokenOutAmountEst}${fNum2(buyAmount, { maximumFractionDigits: 4 })} ${
-        tokenOut.value.symbol
-      }`;
+      const summary = `${tokenInAmountEst}${fNum2(sellAmount, {
+        maximumFractionDigits: 4
+      })} ${tokenIn.value.symbol} -> ${tokenOutAmountEst}${fNum2(buyAmount, {
+        maximumFractionDigits: 4
+      })} ${tokenOut.value.symbol}`;
 
       const { validTo, partiallyFillable } = unsignedOrder;
 

--- a/src/composables/trade/useGnosis.ts
+++ b/src/composables/trade/useGnosis.ts
@@ -126,7 +126,7 @@ export default function useGnosis({
   const store = useStore();
   const { account, getSigner } = useWeb3();
   const { addTransaction } = useTransactions();
-  const { fNum } = useNumbers();
+  const { fNum2 } = useNumbers();
   const { balanceFor } = useTokens();
 
   // DATA
@@ -233,9 +233,9 @@ export default function useGnosis({
       const tokenInAmountEst = exactIn.value ? '' : '~';
       const tokenOutAmountEst = exactIn.value ? '~' : '';
 
-      const summary = `${tokenInAmountEst}${fNum(sellAmount, 'token')} ${
+      const summary = `${tokenInAmountEst}${fNum2(sellAmount, { maximumFractionDigits: 4 })} ${
         tokenIn.value.symbol
-      } -> ${tokenOutAmountEst}${fNum(buyAmount, 'token')} ${
+      } -> ${tokenOutAmountEst}${fNum2(buyAmount, { maximumFractionDigits: 4 })} ${
         tokenOut.value.symbol
       }`;
 

--- a/src/composables/trade/useGnosis.ts
+++ b/src/composables/trade/useGnosis.ts
@@ -30,7 +30,7 @@ import { TokenInfo } from '@/types/TokenList';
 
 import { TradeQuote } from './types';
 
-import useNumbers from '../useNumbers';
+import useNumbers, { FNumFormats } from '../useNumbers';
 import useTokens from '../useTokens';
 import { ApiErrorCodes } from '@/services/gnosis/errors/OperatorError';
 
@@ -233,11 +233,13 @@ export default function useGnosis({
       const tokenInAmountEst = exactIn.value ? '' : '~';
       const tokenOutAmountEst = exactIn.value ? '~' : '';
 
-      const summary = `${tokenInAmountEst}${fNum2(sellAmount, {
-        maximumFractionDigits: 4
-      })} ${tokenIn.value.symbol} -> ${tokenOutAmountEst}${fNum2(buyAmount, {
-        maximumFractionDigits: 4
-      })} ${tokenOut.value.symbol}`;
+      const summary = `${tokenInAmountEst}${fNum2(
+        sellAmount,
+        FNumFormats.token
+      )} ${tokenIn.value.symbol} -> ${tokenOutAmountEst}${fNum2(
+        buyAmount,
+        FNumFormats.token
+      )} ${tokenOut.value.symbol}`;
 
       const { validTo, partiallyFillable } = unsignedOrder;
 

--- a/src/composables/trade/useSor.ts
+++ b/src/composables/trade/useSor.ts
@@ -39,7 +39,7 @@ import { TransactionResponse } from '@ethersproject/providers';
 import useEthers from '../useEthers';
 import { TradeQuote } from './types';
 import useTransactions, { TransactionAction } from '../useTransactions';
-import useNumbers from '../useNumbers';
+import useNumbers, { FNumFormats } from '../useNumbers';
 import { TokenInfo, TokenInfoMap } from '@/types/TokenList';
 import useTokens from '../useTokens';
 import { getStETHByWstETH } from '@/lib/utils/balancer/lido';
@@ -398,12 +398,14 @@ export default function useSor({
     confirming.value = false;
 
     let summary = '';
-    const tokenInAmountFormatted = fNum2(tokenInAmountInput.value, {
-      maximumFractionDigits: 4
-    });
-    const tokenOutAmountFormatted = fNum2(tokenOutAmountInput.value, {
-      maximumFractionDigits: 4
-    });
+    const tokenInAmountFormatted = fNum2(
+      tokenInAmountInput.value,
+      FNumFormats.token
+    );
+    const tokenOutAmountFormatted = fNum2(
+      tokenOutAmountInput.value,
+      FNumFormats.token
+    );
 
     const tokenInSymbol = tokenIn.value.symbol;
     const tokenOutSymbol = tokenOut.value.symbol;

--- a/src/composables/trade/useSor.ts
+++ b/src/composables/trade/useSor.ts
@@ -398,8 +398,12 @@ export default function useSor({
     confirming.value = false;
 
     let summary = '';
-    const tokenInAmountFormatted = fNum2(tokenInAmountInput.value, { maximumFractionDigits: 4 });
-    const tokenOutAmountFormatted = fNum2(tokenOutAmountInput.value, { maximumFractionDigits: 4 });
+    const tokenInAmountFormatted = fNum2(tokenInAmountInput.value, {
+      maximumFractionDigits: 4
+    });
+    const tokenOutAmountFormatted = fNum2(tokenOutAmountInput.value, {
+      maximumFractionDigits: 4
+    });
 
     const tokenInSymbol = tokenIn.value.symbol;
     const tokenOutSymbol = tokenOut.value.symbol;

--- a/src/composables/trade/useSor.ts
+++ b/src/composables/trade/useSor.ts
@@ -142,7 +142,7 @@ export default function useSor({
   const { trackGoal, Goals } = useFathom();
   const { txListener } = useEthers();
   const { addTransaction } = useTransactions();
-  const { fNum } = useNumbers();
+  const { fNum2 } = useNumbers();
   const { t } = useI18n();
   const { injectTokens, priceFor } = useTokens();
 
@@ -398,8 +398,8 @@ export default function useSor({
     confirming.value = false;
 
     let summary = '';
-    const tokenInAmountFormatted = fNum(tokenInAmountInput.value, 'token');
-    const tokenOutAmountFormatted = fNum(tokenOutAmountInput.value, 'token');
+    const tokenInAmountFormatted = fNum2(tokenInAmountInput.value, { maximumFractionDigits: 4 });
+    const tokenOutAmountFormatted = fNum2(tokenOutAmountInput.value, { maximumFractionDigits: 4 });
 
     const tokenInSymbol = tokenIn.value.symbol;
     const tokenOutSymbol = tokenOut.value.symbol;

--- a/src/composables/trade/useTrading.ts
+++ b/src/composables/trade/useTrading.ts
@@ -37,7 +37,7 @@ export default function useTrading(
 ) {
   // COMPOSABLES
   const store = useStore();
-  const { fNum } = useNumbers();
+  const { fNum2 } = useNumbers();
   const { tokens } = useTokens();
   const { blockNumber } = useWeb3();
   const { slippage } = useUserSettings();
@@ -82,17 +82,17 @@ export default function useTrading(
 
     if (tokenInAmount > 0 && tokenOutAmount > 0) {
       return {
-        tokenIn: `1 ${tokenIn.value?.symbol} = ${fNum(
+        tokenIn: `1 ${tokenIn.value?.symbol} = ${fNum2(
           bnum(tokenOutAmount)
             .div(tokenInAmount)
             .toString(),
-          'token'
+          { maximumFractionDigits: 4 }
         )} ${tokenOut.value?.symbol}`,
-        tokenOut: `1 ${tokenOut.value?.symbol} = ${fNum(
+        tokenOut: `1 ${tokenOut.value?.symbol} = ${fNum2(
           bnum(tokenInAmount)
             .div(tokenOutAmount)
             .toString(),
-          'token'
+          { maximumFractionDigits: 4 }
         )} ${tokenIn.value?.symbol}`
       };
     }

--- a/src/composables/trade/useTrading.ts
+++ b/src/composables/trade/useTrading.ts
@@ -5,7 +5,7 @@ import { parseFixed } from '@ethersproject/bignumber';
 import useWeb3 from '@/services/web3/useWeb3';
 import { GP_SUPPORTED_NETWORKS } from '@/services/gnosis/constants';
 
-import useNumbers from '../useNumbers';
+import useNumbers, { FNumFormats } from '../useNumbers';
 import useTokens from '../useTokens';
 import useUserSettings from '../useUserSettings';
 import { networkId } from '../useNetwork';
@@ -86,13 +86,13 @@ export default function useTrading(
           bnum(tokenOutAmount)
             .div(tokenInAmount)
             .toString(),
-          { maximumFractionDigits: 4 }
+          FNumFormats.token
         )} ${tokenOut.value?.symbol}`,
         tokenOut: `1 ${tokenOut.value?.symbol} = ${fNum2(
           bnum(tokenInAmount)
             .div(tokenOutAmount)
             .toString(),
-          { maximumFractionDigits: 4 }
+          FNumFormats.token
         )} ${tokenIn.value?.symbol}`
       };
     }

--- a/src/composables/useNumbers.spec.ts
+++ b/src/composables/useNumbers.spec.ts
@@ -61,6 +61,39 @@ describe('useNumbers', () => {
       '121237821371'
     ];
 
+    it('Should return 0 for an empty string', () => {
+      expect(fNum2('')).toEqual('0');
+    });
+
+    it('Should not lose any precision with numbers passed as a string', () => {
+      testNumbers.forEach(testNumber => {
+        if (testNumber === '') return; // Ignore empty string as that is converted to 0
+        if (Number(testNumber) === 0) return; // Ignore 0 numbers as it will always trim their precision.
+        const formattedNumber = fNum2(testNumber, {
+          style: 'decimal',
+          maximumFractionDigits: 20,
+          useGrouping: false,
+          fixedFormat: true
+        });
+        expect(formattedNumber).toEqual(testNumber);
+      });
+    });
+
+    it('Should not lose any precision with numbers passed as a number', () => {
+      testNumbers.forEach(testNumber => {
+        if (testNumber === '') return; // Ignore empty string as that is converted to 0
+        if (Number(testNumber) === 0) return; // Ignore 0 numbers as it will always trim their precision.
+        const testNumberAsNumber = Number(testNumber);
+        const formattedNumber = fNum2(testNumberAsNumber, {
+          style: 'decimal',
+          maximumFractionDigits: 20,
+          useGrouping: false,
+          fixedFormat: true
+        });
+        expect(formattedNumber).toEqual(testNumber);
+      });
+    });
+
     it('Should give the same result without any arguments', () => {
       testNumbers.forEach(testNumber => {
         const format1 = fNum(testNumber);

--- a/src/composables/useNumbers.spec.ts
+++ b/src/composables/useNumbers.spec.ts
@@ -1,6 +1,6 @@
 import { FiatCurrency } from '@/constants/currency';
 import { mount } from 'vue-composable-tester';
-import useNumbers from './useNumbers';
+import useNumbers, { FNumFormats } from './useNumbers';
 
 const mockTokens = {
   ETH: {

--- a/src/composables/useNumbers.spec.ts
+++ b/src/composables/useNumbers.spec.ts
@@ -103,7 +103,7 @@ describe('useNumbers', () => {
     it('Should return the same result as usd preset', () => {
       testNumbers.forEach(testNumber => {
         const format1 = fNum(testNumber, 'usd');
-        const format2 = fNum2(testNumber, { style: 'currency' });
+        const format2 = fNum2(testNumber, FNumFormats.fiat);
         expect(format2).toEqual(format1);
       });
     });
@@ -196,7 +196,7 @@ describe('useNumbers', () => {
     it('Should return the same result for token', () => {
       testNumbers.forEach(testNumber => {
         const format1 = fNum(testNumber, 'token');
-        const format2 = fNum2(testNumber, { maximumFractionDigits: 4 });
+        const format2 = fNum2(testNumber, FNumFormats.token);
         expect(format2).toEqual(format1);
       });
     });

--- a/src/composables/useNumbers.spec.ts
+++ b/src/composables/useNumbers.spec.ts
@@ -64,16 +64,25 @@ describe('useNumbers', () => {
     it('Should give the same result without any arguments', () => {
       testNumbers.forEach(testNumber => {
         const format1 = fNum(testNumber);
-        const format2 = fNum2(testNumber, { style: 'decimal', maximumFractionDigits: 1, abbreviate: true });
+        const format2 = fNum2(testNumber, {
+          style: 'decimal',
+          maximumFractionDigits: 1,
+          abbreviate: true
+        });
         expect(format2).toEqual(format1);
       });
-
     });
 
     it('Should give the same result as a formatted percentage', () => {
       testNumbers.forEach(testNumber => {
         const format1 = fNum(testNumber, null, { format: '0.00%' });
-        const format2 = fNum2(testNumber, { style: 'unit', unit: 'percent', minimumFractionDigits: 2, maximumFractionDigits: 2, fixedFormat: true });
+        const format2 = fNum2(testNumber, {
+          style: 'unit',
+          unit: 'percent',
+          minimumFractionDigits: 2,
+          maximumFractionDigits: 2,
+          fixedFormat: true
+        });
         expect(format2).toEqual(format1);
       });
     });
@@ -81,7 +90,12 @@ describe('useNumbers', () => {
     it('Should give the same result as a formatted dollar value', () => {
       testNumbers.forEach(testNumber => {
         const format1 = fNum(testNumber, null, { format: '$0,0.00' });
-        const format2 = fNum2(testNumber, { style: 'currency', minimumFractionDigits: 2, maximumFractionDigits: 2, fixedFormat: true });
+        const format2 = fNum2(testNumber, {
+          style: 'currency',
+          minimumFractionDigits: 2,
+          maximumFractionDigits: 2,
+          fixedFormat: true
+        });
         expect(format2).toEqual(format1);
       });
     });
@@ -97,7 +111,10 @@ describe('useNumbers', () => {
     it('Should return the same result as usd forced preset', () => {
       testNumbers.forEach(testNumber => {
         const format1 = fNum(testNumber, 'usd', { forcePreset: true });
-        const format2 = fNum2(testNumber, { style: 'currency', fixedFormat: true });
+        const format2 = fNum2(testNumber, {
+          style: 'currency',
+          fixedFormat: true
+        });
         expect(format2).toEqual(format1);
       });
     });
@@ -105,7 +122,10 @@ describe('useNumbers', () => {
     it('Should return the same result as usd_m preset', () => {
       testNumbers.forEach(testNumber => {
         const format1 = fNum(testNumber, 'usd_m');
-        const format2 = fNum2(testNumber, { style: 'currency', abbreviate: true });
+        const format2 = fNum2(testNumber, {
+          style: 'currency',
+          abbreviate: true
+        });
         expect(format2).toEqual(format1);
       });
     });
@@ -113,15 +133,23 @@ describe('useNumbers', () => {
     it('Should return the same result as nested usd usd_m preset', () => {
       testNumbers.forEach(testNumber => {
         const format1 = fNum(fNum(testNumber, 'usd'), 'usd_m');
-        const format2 = fNum2(testNumber, { style: 'currency', abbreviate: true });
+        const format2 = fNum2(testNumber, {
+          style: 'currency',
+          abbreviate: true
+        });
         expect(format2).toEqual(format1);
       });
-    })
+    });
 
     it('Should return the same result as percent preset', () => {
       testNumbers.forEach(testNumber => {
         const format1 = fNum(testNumber, 'percent');
-        const format2 = fNum2(testNumber, { style: 'unit', unit: 'percent', minimumFractionDigits: 2, maximumFractionDigits: 2 });
+        const format2 = fNum2(testNumber, {
+          style: 'unit',
+          unit: 'percent',
+          minimumFractionDigits: 2,
+          maximumFractionDigits: 2
+        });
         expect(format2).toEqual(format1);
       });
     });
@@ -129,7 +157,11 @@ describe('useNumbers', () => {
     it('Should return the same result as percent_lg preset', () => {
       testNumbers.forEach(testNumber => {
         const format1 = fNum(testNumber, 'percent_lg');
-        const format2 = fNum2(testNumber, { style: 'unit', unit: 'percent', maximumFractionDigits: 0 });
+        const format2 = fNum2(testNumber, {
+          style: 'unit',
+          unit: 'percent',
+          maximumFractionDigits: 0
+        });
         expect(format2).toEqual(format1);
       });
     });
@@ -137,7 +169,12 @@ describe('useNumbers', () => {
     it('Should return the same result as percent_variable preset', () => {
       testNumbers.forEach(testNumber => {
         const format1 = fNum(testNumber, 'percent_variable');
-        const format2 = fNum2(testNumber, { style: 'unit', unit: 'percent', maximumFractionDigits: 4, fixedFormat: true });
+        const format2 = fNum2(testNumber, {
+          style: 'unit',
+          unit: 'percent',
+          maximumFractionDigits: 4,
+          fixedFormat: true
+        });
         expect(format2).toEqual(format1);
       });
     });
@@ -145,7 +182,13 @@ describe('useNumbers', () => {
     it('Should return the same result as a formatted percentage unit', () => {
       testNumbers.forEach(testNumber => {
         const format1 = fNum(testNumber, null, { format: '0.0%' });
-        const format2 = fNum2(testNumber, { style: 'unit', unit: 'percent', minimumFractionDigits: 1, maximumFractionDigits: 1, fixedFormat: true });
+        const format2 = fNum2(testNumber, {
+          style: 'unit',
+          unit: 'percent',
+          minimumFractionDigits: 1,
+          maximumFractionDigits: 1,
+          fixedFormat: true
+        });
         expect(format2).toEqual(format1);
       });
     });
@@ -161,7 +204,10 @@ describe('useNumbers', () => {
     it('Should return the same result for token_fixed', () => {
       testNumbers.forEach(testNumber => {
         const format1 = fNum(testNumber, 'token_fixed');
-        const format2 = fNum2(testNumber, { minimumFractionDigits: 4, maximumFractionDigits: 4 });
+        const format2 = fNum2(testNumber, {
+          minimumFractionDigits: 4,
+          maximumFractionDigits: 4
+        });
         expect(format2).toEqual(format1);
       });
     });
@@ -169,13 +215,13 @@ describe('useNumbers', () => {
     it('Should return the same result for token_lg', () => {
       testNumbers.forEach(testNumber => {
         const format1 = fNum(testNumber, 'token_lg');
-        const format2 = fNum2(testNumber, { style: 'decimal', maximumFractionDigits: 0 });
+        const format2 = fNum2(testNumber, {
+          style: 'decimal',
+          maximumFractionDigits: 0
+        });
         expect(format2).toEqual(format1);
       });
     });
-
-
-
   });
 
   describe('toFiat', () => {

--- a/src/composables/useNumbers.spec.ts
+++ b/src/composables/useNumbers.spec.ts
@@ -1,0 +1,104 @@
+import { FiatCurrency } from '@/constants/currency';
+import { mount } from 'vue-composable-tester';
+import useNumbers from './useNumbers';
+
+const mockTokens = {
+  ETH: {
+    address: '0xEee',
+    price: {
+      usd: 3000,
+      eur: 2500
+    }
+  }
+};
+
+const mockDefaultCurrency = FiatCurrency.usd;
+
+jest.mock('@/composables/useTokens', () => {
+  return jest.fn().mockImplementation(() => {
+    return {
+      priceFor: jest
+        .fn()
+        .mockImplementation((address, currency = mockDefaultCurrency) => {
+          const token = Object.values(mockTokens).find(
+            token => address === token.address
+          );
+          return token?.price[currency];
+        })
+    };
+  });
+});
+
+describe('useNumbers', () => {
+  const { result } = mount(() => useNumbers());
+
+  it('Should load', () => {
+    expect(result).toBeTruthy();
+  });
+
+  describe('fNum', () => {
+    const { fNum } = result;
+
+    it('Should format a number with default formatter when only a number is specified', () => {
+      const number = 1234567.8912345;
+      const formattedNumber = fNum(number);
+      expect(formattedNumber).toEqual('1,234,568');
+    });
+
+    it('Should not return decimal places for numbers > 1 if usd with noDecimals is specified', () => {
+      const number = 3.28;
+      const formattedNumber = fNum(number, 'usd', { noDecimals: true });
+      expect(formattedNumber).toEqual('$3');
+    });
+
+    it('Should return 1 when the number is > 0.5 and < 1 and usd with noDecimals is specified', () => {
+      const number = 0.887;
+      const formattedNumber = fNum(number, 'usd', { noDecimals: true });
+      expect(formattedNumber).toEqual('$1');
+    });
+
+    it('Should return 0 when the number is < 0.5 and usd with noDecimals is specified', () => {
+      const number = 0.387;
+      const formattedNumber = fNum(number, 'usd', { noDecimals: true });
+      expect(formattedNumber).toEqual('$0');
+    });
+
+    it('Should return 0 when the number is 0 and usd with no decimals is specified', () => {
+      const number = 0.0;
+      const formattedNumber = fNum(number, 'usd', { noDecimals: true });
+      expect(formattedNumber).toEqual('$0');
+    });
+
+  });
+
+  describe('fNum2', () => {
+    const { fNum, fNum2 } = result;
+
+    const testNumbers = [
+      '0.001',
+      '0.123456789',
+      '1.3',
+      '13.44',
+      '188.9123'
+    ];
+
+    it('BalLineChart should give the same result', () => {
+      const format1 = fNum(5.6, null, { format: '0.00%' });
+      const format2 = fNum2(5.6, { unit: 'percent' });
+      expect(format1).toEqual(format2);
+    })
+
+
+  });
+
+  describe('toFiat', () => {
+    const { toFiat } = result;
+
+    it('Should return the value of ETH in USD, when called without a currency', () => {
+      const totalEth = 2.5;
+      const expectedValue = (totalEth * mockTokens.ETH.price.usd).toString();
+      const value = toFiat(totalEth, mockTokens.ETH.address);
+      expect(value).toEqual(expectedValue);
+    });
+  });
+});

--- a/src/composables/useNumbers.spec.ts
+++ b/src/composables/useNumbers.spec.ts
@@ -75,18 +75,63 @@ describe('useNumbers', () => {
     const { fNum, fNum2 } = result;
 
     const testNumbers = [
+      '0',
+      '0.0',
+      '0.000005',
       '0.001',
       '0.123456789',
+      '0.6',
       '1.3',
+      '8',
       '13.44',
-      '188.9123'
+      '121',
+      '188.9123',
+      '5129.199911',
+      '87654',
+      '112124.8791743',
+      '121237821371'
     ];
 
-    it('BalLineChart should give the same result', () => {
-      const format1 = fNum(5.6, null, { format: '0.00%' });
-      const format2 = fNum2(5.6, { unit: 'percent' });
-      expect(format1).toEqual(format2);
-    })
+    it('BalLineChart percent formatter should give the same result', () => {
+      testNumbers.forEach(testNumber => {
+        const format1 = fNum(testNumber, null, { format: '0.00%' });
+        const format2 = fNum2(testNumber, { style: 'unit', unit: 'percent', minimumFractionDigits: 2, maximumFractionDigits: 2 });
+        expect(format2).toEqual(format1);
+      });
+    });
+
+    it('BalLineChart USD formatter should give the same result', () => {
+      testNumbers.forEach(testNumber => {
+        const format1 = fNum(testNumber, null, { format: '$0,0.00' });
+        const format2 = fNum2(testNumber, { style: 'currency', minimumFractionDigits: 2, maximumFractionDigits: 2 });
+        expect(format2).toEqual(format1);
+      });
+    });
+
+    it('usd preset should give same result as style: currency', () => {
+      testNumbers.forEach(testNumber => {
+        const format1 = fNum(testNumber, 'usd');
+        const format2 = fNum2(testNumber, { style: 'currency' });
+        expect(format2).toEqual(format1);
+      });
+    });
+
+    it('percent preset should give same result as unit: percent', () => {
+      testNumbers.forEach(testNumber => {
+        const format1 = fNum(testNumber, 'percent');
+        const format2 = fNum2(testNumber, { style: 'unit', unit: 'percent', minimumFractionDigits: 2, maximumFractionDigits: 2 });
+        expect(format2).toEqual(format1);
+      });
+    });
+
+    it('PoolFees formatted percent should give the same result', () => {
+      testNumbers.forEach(testNumber => {
+        const format1 = fNum(testNumber, null, { format: '0.0%' });
+        const format2 = fNum2(testNumber, { style: 'unit', unit: 'percent', minimumFractionDigits: 1, maximumFractionDigits: 1 });
+        expect(format2).toEqual(format1);
+      });
+    });
+
 
 
   });

--- a/src/composables/useNumbers.ts
+++ b/src/composables/useNumbers.ts
@@ -22,6 +22,9 @@ export const FNumFormats = {
   },
   token: {
     maximumFractionDigits: 4
+  },
+  fiat: {
+    style: 'currency'
   }
 };
 

--- a/src/composables/useNumbers.ts
+++ b/src/composables/useNumbers.ts
@@ -98,10 +98,7 @@ export default function useNumbers() {
       number = Number(number || 0);
     }
 
-    const formatterOptions: Intl.NumberFormatOptions = Object.assign(
-      {},
-      options
-    );
+    const formatterOptions: Intl.NumberFormatOptions = { ...options };
     let postfixSymbol = '';
 
     if (options.abbreviate) {

--- a/src/composables/useNumbers.ts
+++ b/src/composables/useNumbers.ts
@@ -13,6 +13,18 @@ export interface FNumOptions extends Intl.NumberFormatOptions {
   abbreviate?: boolean; // If true, reduce number size and add k/M/B to end
 }
 
+export const FNumFormats = {
+  percent: {
+    style: 'unit',
+    unit: 'percent',
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2
+  },
+  token: {
+    maximumFractionDigits: 4
+  }
+};
+
 enum PresetFormats {
   default = '(0.[0]a)',
   default_lg = '(0.[0]a)',

--- a/src/composables/useNumbers.ts
+++ b/src/composables/useNumbers.ts
@@ -5,16 +5,24 @@ import useTokens from './useTokens';
 interface Options {
   format?: string;
   forcePreset?: boolean;
+  noDecimals?: boolean;
 }
+
+interface Options2 extends Intl.NumberFormatOptions {
+  noDecimals?: boolean;
+}
+
 
 enum PresetFormats {
   default = '(0.[0]a)',
   token = '0,0.[0000]',
   token_fixed = '0,0.0000',
   token_lg = '0,0',
+  token_nodecimals = '0',
   usd = '$0,0.00',
   usd_lg = '$0,0',
   usd_m = '$0,0.00a',
+  usd_nodecimals = '$0,0',
   percent = '0.00%',
   percent_variable = '0.[0000]%',
   percent_lg = '0%'
@@ -32,6 +40,10 @@ export function fNum(
   let adjustedPreset;
   if (number >= 10_000 && !options.forcePreset) {
     adjustedPreset = `${preset}_lg`;
+  }
+
+  if (options.noDecimals) {
+    adjustedPreset = `${preset}_nodecimals`;
   }
 
   if (
@@ -53,6 +65,24 @@ export function fNum(
   );
 }
 
+export function fNum2(
+  number: number | string,
+  options: Options2 = {}
+): string {
+  if (typeof number === 'string') {
+    number = new BigNumber(number).toNumber();
+  }
+
+  const formatterOptions: Intl.NumberFormatOptions = Object.assign({}, options);
+  if (options.noDecimals) {
+    formatterOptions.maximumFractionDigits = 0;
+  }
+
+  const formatter = new Intl.NumberFormat('en-US', formatterOptions);
+
+  return formatter.format(number);
+}
+
 export default function useNumbers() {
   const { priceFor } = useTokens();
 
@@ -62,5 +92,5 @@ export default function useNumbers() {
     return tokenAmount.times(price).toString();
   }
 
-  return { fNum, toFiat };
+  return { fNum, fNum2, toFiat };
 }

--- a/src/composables/useNumbers.ts
+++ b/src/composables/useNumbers.ts
@@ -8,7 +8,7 @@ interface Options {
   noDecimals?: boolean;
 }
 
-interface Options2 extends Intl.NumberFormatOptions {
+export interface FNumOptions extends Intl.NumberFormatOptions {
   noDecimals?: boolean;
 }
 
@@ -67,7 +67,7 @@ export function fNum(
 
 export function fNum2(
   number: number | string,
-  options: Options2 = {}
+  options: FNumOptions | undefined = {}
 ): string {
   if (typeof number === 'string') {
     number = new BigNumber(number).toNumber();
@@ -76,6 +76,25 @@ export function fNum2(
   const formatterOptions: Intl.NumberFormatOptions = Object.assign({}, options);
   if (options.noDecimals) {
     formatterOptions.maximumFractionDigits = 0;
+  }
+
+  if (
+    number >= 1e4 &&
+    !formatterOptions.minimumFractionDigits &&
+    !formatterOptions.maximumFractionDigits
+  ) {
+    formatterOptions.minimumFractionDigits = 0;
+    formatterOptions.maximumFractionDigits = 0;
+  }
+
+  // For consistency with numeral
+  if (options.unit === 'percent') {
+    number = number * 100;
+    formatterOptions.useGrouping = false;
+  }
+
+  if (formatterOptions.style === 'currency') {
+    formatterOptions.currency = 'USD';
   }
 
   const formatter = new Intl.NumberFormat('en-US', formatterOptions);

--- a/src/composables/useNumbers.ts
+++ b/src/composables/useNumbers.ts
@@ -95,8 +95,7 @@ export default function useNumbers() {
     options: FNumOptions | undefined = {}
   ): string {
     if (typeof number === 'string') {
-      number = number || 0;
-      number = new BigNumber(number).toNumber();
+      number = Number(number || 0);
     }
 
     const formatterOptions: Intl.NumberFormatOptions = Object.assign(

--- a/src/composables/useNumbers.ts
+++ b/src/composables/useNumbers.ts
@@ -13,7 +13,6 @@ export interface FNumOptions extends Intl.NumberFormatOptions {
   abbreviate?: boolean; // If true, reduce number size and add k/M/B to end
 }
 
-
 enum PresetFormats {
   default = '(0.[0]a)',
   default_lg = '(0.[0]a)',
@@ -39,7 +38,11 @@ export function fNum(
   if (options.format) return numeral(number).format(options.format);
 
   let adjustedPreset;
-  if (number >= 10_000 && !options.forcePreset && !preset?.match(/_(lg|m|variable)$/)) {
+  if (
+    number >= 10_000 &&
+    !options.forcePreset &&
+    !preset?.match(/_(lg|m|variable)$/)
+  ) {
     adjustedPreset = `${preset}_lg`;
   }
 
@@ -81,15 +84,18 @@ export default function useNumbers() {
       number = new BigNumber(number).toNumber();
     }
 
-    const formatterOptions: Intl.NumberFormatOptions = Object.assign({}, options);
+    const formatterOptions: Intl.NumberFormatOptions = Object.assign(
+      {},
+      options
+    );
     let postfixSymbol = '';
 
     if (options.abbreviate) {
       const lookup = [
-        { value: 1, symbol: "" },
-        { value: 1e3, symbol: "k" },
-        { value: 1e6, symbol: "m" },
-        { value: 1e9, symbol: "b" },
+        { value: 1, symbol: '' },
+        { value: 1e3, symbol: 'k' },
+        { value: 1e6, symbol: 'm' },
+        { value: 1e9, symbol: 'b' }
       ];
       const rx = /\.0+$|(\.[0-9]*[1-9])0+$/;
       const item = lookup

--- a/src/composables/usePool.ts
+++ b/src/composables/usePool.ts
@@ -7,7 +7,7 @@ import {
 import { configService } from '@/services/config/config.service';
 import { getAddress } from 'ethers/lib/utils';
 import { bnum } from '@/lib/utils';
-import { fNum } from './useNumbers';
+import useNumbers from './useNumbers';
 
 /**
  * METHODS
@@ -85,24 +85,33 @@ export function lpTokensFor(pool: AnyPool): string[] {
 }
 
 /**
- * Returns pool weights label
- */
-export function poolWeightsLabel(pool: FullPool): string {
-  if (isStableLike(pool.poolType)) {
-    return Object.values(pool.onchain.tokens)
-      .map(token => token.symbol)
-      .join(', ');
-  }
-
-  return Object.values(pool.onchain.tokens)
-    .map(token => `${fNum(token.weight, 'percent_lg')} ${token.symbol}`)
-    .join(', ');
-}
-
-/**
  * COMPOSABLE
  */
 export function usePool(pool: Ref<AnyPool> | Ref<undefined>) {
+  const { fNum2 } = useNumbers();
+
+  /**
+   * Returns pool weights label
+   */
+  function poolWeightsLabel(pool: FullPool): string {
+    if (isStableLike(pool.poolType)) {
+      return Object.values(pool.onchain.tokens)
+        .map(token => token.symbol)
+        .join(', ');
+    }
+
+    return Object.values(pool.onchain.tokens)
+      .map(
+        token =>
+          `${fNum2(token.weight, {
+            style: 'unit',
+            unit: 'percent',
+            maximumFractionDigits: 0
+          })} ${token.symbol}`
+      )
+      .join(', ');
+  }
+
   /**
    * COMPUTED
    */
@@ -176,6 +185,7 @@ export function usePool(pool: Ref<AnyPool> | Ref<undefined>) {
     isTradingHaltable,
     isWeth,
     noInitLiquidity,
-    lpTokensFor
+    lpTokensFor,
+    poolWeightsLabel
   };
 }

--- a/src/composables/useTransactions.ts
+++ b/src/composables/useTransactions.ts
@@ -254,7 +254,7 @@ export default function useTransactions() {
   } = useWeb3();
   const { addNotification } = useNotifications();
   const { t } = useI18n();
-  const { fNum } = useNumbers();
+  const { fNum2 } = useNumbers();
 
   // COMPUTED
   const provider = computed(() => getWeb3Provider());
@@ -279,9 +279,9 @@ export default function useTransactions() {
         tokenOut.decimals
       );
 
-      return `${fNum(tokenInAmount, 'token')} ${tokenIn.symbol} -> ${fNum(
+      return `${fNum2(tokenInAmount, { maximumFractionDigits: 4 })} ${tokenIn.symbol} -> ${fNum2(
         tokenOutAmount,
-        'token'
+        { maximumFractionDigits: 4 }
       )} ${tokenOut.symbol}`;
     }
 

--- a/src/composables/useTransactions.ts
+++ b/src/composables/useTransactions.ts
@@ -16,7 +16,7 @@ import { lsGet, lsSet } from '@/lib/utils';
 
 import useNotifications from './useNotifications';
 import { processedTxs } from './useEthers';
-import useNumbers from './useNumbers';
+import useNumbers, { FNumFormats } from './useNumbers';
 
 import { GnosisTransactionDetails } from './trade/useGnosis';
 
@@ -279,11 +279,9 @@ export default function useTransactions() {
         tokenOut.decimals
       );
 
-      return `${fNum2(tokenInAmount, { maximumFractionDigits: 4 })} ${
+      return `${fNum2(tokenInAmount, FNumFormats.token)} ${
         tokenIn.symbol
-      } -> ${fNum2(tokenOutAmount, { maximumFractionDigits: 4 })} ${
-        tokenOut.symbol
-      }`;
+      } -> ${fNum2(tokenOutAmount, FNumFormats.token)} ${tokenOut.symbol}`;
     }
 
     return transaction.summary;

--- a/src/composables/useTransactions.ts
+++ b/src/composables/useTransactions.ts
@@ -279,10 +279,11 @@ export default function useTransactions() {
         tokenOut.decimals
       );
 
-      return `${fNum2(tokenInAmount, { maximumFractionDigits: 4 })} ${tokenIn.symbol} -> ${fNum2(
-        tokenOutAmount,
-        { maximumFractionDigits: 4 }
-      )} ${tokenOut.symbol}`;
+      return `${fNum2(tokenInAmount, { maximumFractionDigits: 4 })} ${
+        tokenIn.symbol
+      } -> ${fNum2(tokenOutAmount, { maximumFractionDigits: 4 })} ${
+        tokenOut.symbol
+      }`;
     }
 
     return transaction.summary;

--- a/src/pages/liquidity-mining.vue
+++ b/src/pages/liquidity-mining.vue
@@ -5,7 +5,7 @@
         >Week {{ currentWeek }} Liquidity mining incentives</span
       >
       <h1 class="font-body mt-2 text-white font-semi bold">
-        ~{{ fNum2(currentWeekTotalFiat, { style: 'currency' }) }}
+        ~{{ fNum2(currentWeekTotalFiat, FNumFormats.fiat) }}
       </h1>
     </div>
     <div class="lg:container lg:mx-auto pt-10 md:pt-12">

--- a/src/pages/liquidity-mining.vue
+++ b/src/pages/liquidity-mining.vue
@@ -5,7 +5,7 @@
         >Week {{ currentWeek }} Liquidity mining incentives</span
       >
       <h1 class="font-body mt-2 text-white font-semi bold">
-        ~{{ fNum(currentWeekTotalFiat, 'usd') }}
+        ~{{ fNum2(currentWeekTotalFiat, { style: 'currency' }) }}
       </h1>
     </div>
     <div class="lg:container lg:mx-auto pt-10 md:pt-12">
@@ -110,7 +110,7 @@ export default defineComponent({
     LMTable
   },
   setup() {
-    const { fNum } = useNumbers();
+    const { fNum2 } = useNumbers();
     const { priceFor } = useTokens();
     const { networkConfig } = useConfig();
 
@@ -234,7 +234,7 @@ export default defineComponent({
       isLoadingPoolsIdle,
       currentWeek,
       currentWeekTotalFiat,
-      fNum,
+      fNum2,
       otherNetwork,
       otherNetworkLink
     };

--- a/src/pages/pool/_id.vue
+++ b/src/pages/pool/_id.vue
@@ -21,7 +21,13 @@
                 v-if="!isStableLikePool"
                 class="font-medium text-gray-400 text-xs mt-px ml-1"
               >
-                {{ fNum2(tokenMeta.weight, { style: 'unit', unit: 'percent', maximumFractionDigits: 0 }) }}
+                {{
+                  fNum2(tokenMeta.weight, {
+                    style: 'unit',
+                    unit: 'percent',
+                    maximumFractionDigits: 0
+                  })
+                }}
               </span>
             </div>
             <BalChip
@@ -307,10 +313,12 @@ export default defineComponent({
 
     const poolFeeLabel = computed(() => {
       if (!pool.value) return '';
-      const feeLabel = `${fNum2(
-        pool.value.onchain.swapFee,
-        { style: 'unit', unit: 'percent', maximumFractionDigits: 4, fixedFormat: true }
-      )}`;
+      const feeLabel = `${fNum2(pool.value.onchain.swapFee, {
+        style: 'unit',
+        unit: 'percent',
+        maximumFractionDigits: 4,
+        fixedFormat: true
+      })}`;
 
       if (feesFixed.value) {
         return t('fixedSwapFeeLabel', [feeLabel]);

--- a/src/pages/pool/_id.vue
+++ b/src/pages/pool/_id.vue
@@ -21,7 +21,7 @@
                 v-if="!isStableLikePool"
                 class="font-medium text-gray-400 text-xs mt-px ml-1"
               >
-                {{ fNum(tokenMeta.weight, 'percent_lg') }}
+                {{ fNum2(tokenMeta.weight, { style: 'unit', unit: 'percent', maximumFractionDigits: 0 }) }}
               </span>
             </div>
             <BalChip
@@ -211,7 +211,7 @@ export default defineComponent({
     const { appLoading } = useApp();
     const { t } = useI18n();
     const route = useRoute();
-    const { fNum } = useNumbers();
+    const { fNum2 } = useNumbers();
     const { isWalletReady } = useWeb3();
     const { prices } = useTokens();
     const { blockNumber, isKovan, isMainnet, isPolygon } = useWeb3();
@@ -307,9 +307,9 @@ export default defineComponent({
 
     const poolFeeLabel = computed(() => {
       if (!pool.value) return '';
-      const feeLabel = `${fNum(
+      const feeLabel = `${fNum2(
         pool.value.onchain.swapFee,
-        'percent_variable'
+        { style: 'unit', unit: 'percent', maximumFractionDigits: 4, fixedFormat: true }
       )}`;
 
       if (feesFixed.value) {
@@ -434,7 +434,7 @@ export default defineComponent({
       copperNetworkPrefix,
       hasCustomToken,
       // methods
-      fNum,
+      fNum2,
       onNewTx
     };
   }

--- a/src/services/pool/pool.helper.ts
+++ b/src/services/pool/pool.helper.ts
@@ -4,6 +4,13 @@ import { FullPool } from '../balancer/subgraph/types';
 
 export function getPoolWeights(pool: FullPool) {
   return Object.values(pool.onchain.tokens)
-    .map(token => `${fNum2(token.weight, { style: 'unit', unit: 'percent', maximumFractionDigits: 0 })} ${token.symbol}`)
+    .map(
+      token =>
+        `${fNum2(token.weight, {
+          style: 'unit',
+          unit: 'percent',
+          maximumFractionDigits: 0
+        })} ${token.symbol}`
+    )
     .join(', ');
 }

--- a/src/services/pool/pool.helper.ts
+++ b/src/services/pool/pool.helper.ts
@@ -1,9 +1,9 @@
-import { fNum } from '@/composables/useNumbers';
+import { fNum2 } from '@/composables/useNumbers';
 
 import { FullPool } from '../balancer/subgraph/types';
 
 export function getPoolWeights(pool: FullPool) {
   return Object.values(pool.onchain.tokens)
-    .map(token => `${fNum(token.weight, 'percent_lg')} ${token.symbol}`)
+    .map(token => `${fNum2(token.weight, { style: 'unit', unit: 'percent', maximumFractionDigits: 0 })} ${token.symbol}`)
     .join(', ');
 }


### PR DESCRIPTION
# Description

I've created a new function [fNum2](https://github.com/balancer-labs/frontend-v2/pull/1321/files#diff-8b279947dd8a9ce4af0f314eab942df05750b46dbc2aa4fe71b65d00d33c46a6R90) that uses Javascripts native [Intl.NumberFormat](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/NumberFormat) to format numbers instead of the old numeral package. 

Nothing should be changed UX wise in this PR. It's purely a code refactor. To ensure nothing has changed I created a series of tests that have an old fNum call and an fNum2 equivalent that runs through many test cases to ensure the results are always the same. 

fNum2 has several advantages over the old fNum:

- Users can change their locale and have both numbers and values show the correct format
- Users can change currency and have it show in the correct format for that currency
- Users can combine any locale / currency they wish. 
- We don't have custom formats that change based on the size of the number, it can auto-adjust on the fly.
- Because each usage has it's own specification and the same presets aren't used all over the place, it's more easy to change the formatting of one section of Balancer without accidentally breaking other areas. 

In a future PR I'll remove fNum and rename fNum2 to fNum. I didn't want to do it in this PR so that we can ensure all changes are correct first. 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [x] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## How should this be tested?

- For each code change, have a look at the relevant unit test and ensure that the new code is the correct equivalent code. 
- Use Balancer and ensure all 

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have requested at least 2 reviews (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] If package-lock.json has changes, it was intentional.
- [x] The base of this PR is `master` if hotfix, `develop` if not
