### PR TITLE
Resolve ENS names/avatars on Polygon/Arbitrum

### DIFF
--- a/src/services/rpc-provider/__mocks__/rpc-provider.service.ts
+++ b/src/services/rpc-provider/__mocks__/rpc-provider.service.ts
@@ -9,7 +9,8 @@ const RpcProviderService = jest.fn().mockImplementation(() => {
         })
       };
     },
-    initBlockListener: jest.fn().mockImplementation()
+    initBlockListener: jest.fn().mockImplementation(),
+    getJsonProvider: jest.fn().mockImplementation()
   };
 });
 

--- a/src/services/rpc-provider/rpc-provider.service.ts
+++ b/src/services/rpc-provider/rpc-provider.service.ts
@@ -1,6 +1,7 @@
 import { WebSocketProvider, JsonRpcProvider } from '@ethersproject/providers';
 import ConfigService, { configService } from '@/services/config/config.service';
 import { Network } from '@balancer-labs/sdk';
+import template from '@/lib/utils/template';
 
 type NewBlockHandler = (blockNumber: number) => any;
 
@@ -28,9 +29,10 @@ export default class RpcProviderService {
   }
 
   public getJsonProvider(networkKey: Network): JsonRpcProvider {
-    const rpcUrl = `${this.config.getNetworkConfig(networkKey).rpc}/${
-      this.config.env.INFURA_PROJECT_ID
-    }`;
+    const rpcUrl = template(this.config.getNetworkConfig(networkKey).rpc, {
+      INFURA_KEY: this.config.env.INFURA_PROJECT_ID,
+      ALCHEMY_KEY: this.config.env.ALCHEMY_KEY
+    });
     return new JsonRpcProvider(rpcUrl);
   }
 }

--- a/src/services/web3/web3.service.ts
+++ b/src/services/web3/web3.service.ts
@@ -12,6 +12,7 @@ import { logFailedTx } from '@/lib/utils/logging';
 import { gasPriceService } from '@/services/gas-price/gas-price.service';
 import ConfigService, { configService } from '@/services/config/config.service';
 import { WalletError } from '@/types';
+import { Network } from '@balancer-labs/sdk';
 
 interface Web3Profile {
   ens: string | null;
@@ -23,6 +24,7 @@ const EIP1559_UNSUPPORTED_REGEX = /network does not support EIP-1559/i;
 
 export default class Web3Service {
   appProvider: JsonRpcProvider;
+  ensProvider: JsonRpcProvider;
   userProvider!: ComputedRef<Web3Provider>;
 
   constructor(
@@ -30,6 +32,7 @@ export default class Web3Service {
     private readonly config: ConfigService = configService
   ) {
     this.appProvider = this.rpcProviderService.jsonProvider;
+    this.ensProvider = this.rpcProviderService.getJsonProvider(Network.MAINNET);
   }
 
   public setUserProvider(provider: ComputedRef<Web3Provider>) {
@@ -38,7 +41,7 @@ export default class Web3Service {
 
   async getEnsName(address: string): Promise<string | null> {
     try {
-      return await this.appProvider.lookupAddress(address);
+      return await this.ensProvider.lookupAddress(address);
     } catch (error) {
       return null;
     }
@@ -46,7 +49,7 @@ export default class Web3Service {
 
   async getEnsAvatar(address: string): Promise<string | null> {
     try {
-      return await resolveENSAvatar(this.appProvider, address);
+      return await resolveENSAvatar(this.ensProvider, address);
     } catch (error) {
       return null;
     }


### PR DESCRIPTION
# Description

We're currently trying to resolve ENS names using the provider for whichever network we're on even if ENS isn't deployed there. This PR maintains a mainnet provider for the purposes of querying ENS.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## How should this be tested?

Load an address with an ENS name/avatar (nick.eth, brantly.eth) on Polygon/Arbitrum:

- [ ] Check that name and avatar display correctly

## Visual context

N/A

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have requested at least 2 reviews (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] If package-lock.json has changes, it was intentional.
- [x] The base of this PR is `master` if hotfix, `develop` if not
