### PR TITLE
Add missing FNumFormat requires

### DIFF
--- a/src/components/cards/CreatePool/ChooseWeights.vue
+++ b/src/components/cards/CreatePool/ChooseWeights.vue
@@ -3,7 +3,7 @@ import { computed, onMounted, ref, nextTick, onBeforeUpdate } from 'vue';
 
 import TokenWeightInput from '@/components/inputs/TokenInput/TokenWeightInput.vue';
 
-import useNumbers from '@/composables/useNumbers';
+import useNumbers, { FNumFormats } from '@/composables/useNumbers';
 import useBreakpoints from '@/composables/useBreakpoints';
 import usePoolCreation, {
   PoolSeedToken

--- a/src/components/forms/pool_actions/WithdrawForm/components/ProportionalWithdrawalInput.vue
+++ b/src/components/forms/pool_actions/WithdrawForm/components/ProportionalWithdrawalInput.vue
@@ -6,7 +6,7 @@ import BigNumber from 'bignumber.js';
 import { FullPool } from '@/services/balancer/subgraph/types';
 import { TokenInfoMap } from '@/types/TokenList';
 // Composables
-import useNumbers from '@/composables/useNumbers';
+import useNumbers, { FNumFormats } from '@/composables/useNumbers';
 import { isStablePhantom, usePool } from '@/composables/usePool';
 import useTokens from '@/composables/useTokens';
 import { WithdrawMathResponse } from '../composables/useWithdrawMath';

--- a/src/components/lists/TokenListItem.vue
+++ b/src/components/lists/TokenListItem.vue
@@ -47,7 +47,7 @@
 </template>
 
 <script lang="ts">
-import useNumbers from '@/composables/useNumbers';
+import useNumbers, { FNumFormats } from '@/composables/useNumbers';
 import anime from 'animejs';
 import { onMounted, onUnmounted, PropType, ref, computed } from 'vue';
 import { TokenInfo } from '@/types/TokenList';
@@ -102,6 +102,7 @@ export default {
 
     return {
       fNum2,
+      FNumFormats,
       animateRef,
       balance,
       value

--- a/src/components/modals/TradePreviewModal.vue
+++ b/src/components/modals/TradePreviewModal.vue
@@ -108,7 +108,7 @@
 
 <script lang="ts">
 import { defineComponent, toRefs, computed } from 'vue';
-import useNumbers from '@/composables/useNumbers';
+import useNumbers, { FNumFormats } from '@/composables/useNumbers';
 import useTokenApproval from '@/composables/trade/useTokenApproval';
 import useRelayerApproval, {
   Relayer
@@ -273,6 +273,8 @@ export default defineComponent({
     }
 
     return {
+      // constants
+      FNumFormats,
       // methods
       fNum2,
       onClose,

--- a/src/components/modals/TradePreviewModalGP.vue
+++ b/src/components/modals/TradePreviewModalGP.vue
@@ -847,6 +847,7 @@ export default defineComponent({
     return {
       // constants
       FiatCurrency,
+      FNumFormats,
 
       // methods
       fNum2,

--- a/src/components/navs/AppNav/AppNavClaimBtn.vue
+++ b/src/components/navs/AppNav/AppNavClaimBtn.vue
@@ -5,7 +5,7 @@ import { getAddress } from 'ethers/lib/utils';
 import { differenceInSeconds } from 'date-fns';
 import { useIntervalFn } from '@vueuse/core';
 
-import useNumbers from '@/composables/useNumbers';
+import useNumbers, { FNumFormats } from '@/composables/useNumbers';
 import useUserClaimsQuery from '@/composables/queries/useUserClaimsQuery';
 import useBreakpoints from '@/composables/useBreakpoints';
 import useEthers from '@/composables/useEthers';

--- a/src/components/tables/PoolsTable/PoolsTable.vue
+++ b/src/components/tables/PoolsTable/PoolsTable.vue
@@ -240,6 +240,8 @@ export default defineComponent({
     return {
       // data
       columns,
+
+      // constants
       FNumFormats,
 
       // computed

--- a/src/pages/liquidity-mining.vue
+++ b/src/pages/liquidity-mining.vue
@@ -81,7 +81,7 @@ import LiquidityMiningDistributions from '@/lib/utils/liquidityMining/MultiToken
 import usePoolsQuery from '@/composables/queries/usePoolsQuery';
 import { flatten, last, takeRight, uniq } from 'lodash';
 import { Network } from '@balancer-labs/sdk';
-import useNumbers from '@/composables/useNumbers';
+import useNumbers, { FNumFormats } from '@/composables/useNumbers';
 import useTokens from '@/composables/useTokens';
 import { getAddress } from '@ethersproject/address';
 import useConfig from '@/composables/useConfig';
@@ -235,6 +235,7 @@ export default defineComponent({
       currentWeek,
       currentWeekTotalFiat,
       fNum2,
+      FNumFormats,
       otherNetwork,
       otherNetworkLink
     };


### PR DESCRIPTION
After merging #1321 I discovered there were a few templates where FNumFormats was used but not imported. This imports it to all files correctly. 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## How should this be tested?

Test each page of the app and ensure there are no errors about missing FNumFormats in console. 

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have requested at least 2 reviews (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] If package-lock.json has changes, it was intentional.
- [x] The base of this PR is `master` if hotfix, `develop` if not
