### PR TITLE
Numbers Improvements - Remove Decimals, 6 Significant digits

### DIFF
--- a/src/components/tables/PoolsTable/PoolsTable.vue
+++ b/src/components/tables/PoolsTable/PoolsTable.vue
@@ -88,7 +88,11 @@ const columns = ref<ColumnDefinition<DecoratedPoolWithShares>[]>([
   {
     name: t('myBalance'),
     accessor: pool =>
-      fNum2(pool.shares, { style: 'currency', fixedFormat: true }),
+      fNum2(pool.shares, {
+        style: 'currency',
+        maximumFractionDigits: 0,
+        fixedFormat: true
+      }),
     align: 'right',
     id: 'myBalance',
     hidden: !props.showPoolShares,
@@ -98,7 +102,11 @@ const columns = ref<ColumnDefinition<DecoratedPoolWithShares>[]>([
   },
   {
     name: t('poolValue'),
-    accessor: pool => fNum2(pool.totalLiquidity, FNumFormats.fiat),
+    accessor: pool =>
+      fNum2(pool.totalLiquidity, {
+        style: 'currency',
+        maximumFractionDigits: 0
+      }),
     align: 'right',
     id: 'poolValue',
     sortKey: pool => {
@@ -111,7 +119,11 @@ const columns = ref<ColumnDefinition<DecoratedPoolWithShares>[]>([
   },
   {
     name: t('volume24h', [t('hourAbbrev')]),
-    accessor: pool => fNum2(pool.dynamic.volume, FNumFormats.fiat),
+    accessor: pool =>
+      fNum2(pool.dynamic.volume, {
+        style: 'currency',
+        maximumFractionDigits: 0
+      }),
     align: 'right',
     id: 'poolVolume',
     sortKey: pool => {

--- a/src/components/tables/PoolsTable/PoolsTable.vue
+++ b/src/components/tables/PoolsTable/PoolsTable.vue
@@ -167,7 +167,11 @@ export default defineComponent({
       {
         name: t('myBalance'),
         accessor: pool =>
-          fNum2(pool.shares, { style: 'currency', fixedFormat: true }),
+          fNum2(pool.shares, {
+            style: 'currency',
+            maximumFractionDigits: 0,
+            fixedFormat: true
+          }),
         align: 'right',
         id: 'myBalance',
         hidden: !props.showPoolShares,
@@ -177,7 +181,11 @@ export default defineComponent({
       },
       {
         name: t('poolValue'),
-        accessor: pool => fNum2(pool.totalLiquidity, FNumFormats.fiat),
+        accessor: pool =>
+          fNum2(pool.totalLiquidity, {
+            style: 'currency',
+            maximumFractionDigits: 0
+          }),
         align: 'right',
         id: 'poolValue',
         sortKey: pool => {
@@ -190,7 +198,10 @@ export default defineComponent({
       },
       {
         name: t('volume24h', [t('hourAbbrev')]),
-        accessor: pool => fNum2(pool.dynamic.volume, FNumFormats.fiat),
+        accessor: pool => fNum2(pool.dynamic.volume, {
+            style: 'currency',
+            maximumFractionDigits: 0
+          }),
         align: 'right',
         id: 'poolVolume',
         sortKey: pool => {

--- a/src/components/tables/PoolsTable/PoolsTable.vue
+++ b/src/components/tables/PoolsTable/PoolsTable.vue
@@ -198,7 +198,8 @@ export default defineComponent({
       },
       {
         name: t('volume24h', [t('hourAbbrev')]),
-        accessor: pool => fNum2(pool.dynamic.volume, {
+        accessor: pool =>
+          fNum2(pool.dynamic.volume, {
             style: 'currency',
             maximumFractionDigits: 0
           }),

--- a/src/composables/trade/useSor.ts
+++ b/src/composables/trade/useSor.ts
@@ -308,7 +308,11 @@ export default function useSor({
       );
       tokenOutAmountInput.value =
         tokenOutAmountNormalised.toNumber() > 0
-          ? tokenOutAmountNormalised.toFixed(6, OldBigNumber.ROUND_DOWN)
+          ? fNum2(tokenOutAmountNormalised.toString(), {
+              maximumSignificantDigits: 6,
+              useGrouping: false,
+              fixedFormat: true
+            })
           : '';
 
       if (!sorReturn.value.hasSwaps) {
@@ -362,7 +366,11 @@ export default function useSor({
       );
       tokenInAmountInput.value =
         tokenInAmountNormalised.toNumber() > 0
-          ? tokenInAmountNormalised.toFixed(6, OldBigNumber.ROUND_UP)
+          ? fNum2(tokenInAmountNormalised.toString(), {
+              maximumSignificantDigits: 6,
+              useGrouping: false,
+              fixedFormat: true
+            })
           : '';
 
       if (!sorReturn.value.hasSwaps) {
@@ -398,14 +406,14 @@ export default function useSor({
     confirming.value = false;
 
     let summary = '';
-    const tokenInAmountFormatted = fNum2(
-      tokenInAmountInput.value,
-      FNumFormats.token
-    );
-    const tokenOutAmountFormatted = fNum2(
-      tokenOutAmountInput.value,
-      FNumFormats.token
-    );
+    const tokenInAmountFormatted = fNum2(tokenInAmountInput.value, {
+      ...FNumFormats.token,
+      maximumSignificantDigits: 6
+    });
+    const tokenOutAmountFormatted = fNum2(tokenOutAmountInput.value, {
+      ...FNumFormats.token,
+      maximumSignificantDigits: 6
+    });
 
     const tokenInSymbol = tokenIn.value.symbol;
     const tokenOutSymbol = tokenOut.value.symbol;

--- a/src/composables/useNumbers.spec.ts
+++ b/src/composables/useNumbers.spec.ts
@@ -255,6 +255,15 @@ describe('useNumbers', () => {
         expect(format2).toEqual(format1);
       });
     });
+
+    it('Should not return < 0.0001 if fixedFormat is true', () => {
+      const testNumber = '0.00000123';
+      const formattedNumber = fNum2(testNumber, {
+        maximumSignificantDigits: 6,
+        fixedFormat: true
+      });
+      expect(formattedNumber).toEqual(testNumber);
+    });
   });
 
   describe('toFiat', () => {

--- a/src/composables/useNumbers.ts
+++ b/src/composables/useNumbers.ts
@@ -13,7 +13,7 @@ export interface FNumOptions extends Intl.NumberFormatOptions {
   abbreviate?: boolean; // If true, reduce number size and add k/M/B to end
 }
 
-export const FNumFormats = {
+export const FNumFormats: Record<string, FNumOptions> = {
   percent: {
     style: 'unit',
     unit: 'percent',
@@ -139,7 +139,12 @@ export default function useNumbers() {
       formatterOptions.currency = currency.value;
     }
 
-    if (!options.style && number > 0 && number < 0.0001) {
+    if (
+      !options.fixedFormat &&
+      !options.style &&
+      number > 0 &&
+      number < 0.0001
+    ) {
       return '< 0.0001';
     }
 

--- a/src/lib/config/kovan.json
+++ b/src/lib/config/kovan.json
@@ -11,7 +11,7 @@
   "loggingRpc": "https://eth-kovan.alchemyapi.io/v2/{{ALCHEMY_KEY}}",
   "explorer": "https://kovan.etherscan.io",
   "explorerName": "Etherscan",
-  "subgraph": "https://api.thegraph.com/subgraphs/name/balancer-labs/balancer-kovan-v2-beta",
+  "subgraph": "https://api.thegraph.com/subgraphs/name/balancer-labs/balancer-kovan-v2",
   "poolsUrlV1": "https://storageapi.fleek.co/balancer-bucket/balancer-exchange-kovan/pools",
   "poolsUrlV2": "https://storageapi.fleek.co/johngrantuk-team-bucket/poolsRc02.json",
   "subgraphs": {

--- a/src/lib/config/kovan.json
+++ b/src/lib/config/kovan.json
@@ -11,7 +11,7 @@
   "loggingRpc": "https://eth-kovan.alchemyapi.io/v2/{{ALCHEMY_KEY}}",
   "explorer": "https://kovan.etherscan.io",
   "explorerName": "Etherscan",
-  "subgraph": "https://api.thegraph.com/subgraphs/name/balancer-labs/balancer-kovan-v2",
+  "subgraph": "https://api.thegraph.com/subgraphs/name/balancer-labs/balancer-kovan-v2-beta",
   "poolsUrlV1": "https://storageapi.fleek.co/balancer-bucket/balancer-exchange-kovan/pools",
   "poolsUrlV2": "https://storageapi.fleek.co/johngrantuk-team-bucket/poolsRc02.json",
   "subgraphs": {


### PR DESCRIPTION
# Description

- Remove decimals from tables 
- When trading, limit values to 6 significant digits

I originally changed `FNumFormats.token` to have 6 significant digits, but I'm not sure if any part of Balancer is supposed to have more and didn't want to accidentally break anything. 


## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## How should this be tested?

- Look at the pools table and ensure values look correct.
- Perform a trade with various assets and ensure values look correct

## Visual context

Loom Demo: https://www.loom.com/share/80feb37d026641d6a459968285f1f84c

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have requested at least 2 reviews (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] If package-lock.json has changes, it was intentional.
- [x] The base of this PR is `master` if hotfix, `develop` if not
