### PR TITLE
fix: use production path for excluded addresses for LM

### DIFF
--- a/src/services/balancer/subgraph/entities/pools/index.ts
+++ b/src/services/balancer/subgraph/entities/pools/index.ts
@@ -187,7 +187,7 @@ export default class Pools {
   private async getExcludedAddresses() {
     try {
       const { data } = await axios.get<ExcludedAddressesResponse>(
-        'https://raw.githubusercontent.com/balancer-labs/bal-mining-scripts/frontend-exclude-test/config/exclude.json'
+        'https://raw.githubusercontent.com/balancer-labs/bal-mining-scripts/master/config/exclude.json'
       );
 
       if (data[networkId.value]) {


### PR DESCRIPTION
# Description

I forgot to update the excluded addresses path to the prod one.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## How should this be tested?

Please provide instructions so we can test. Please also list any relevant details for your test configuration.

- [ ] The new URL should load correctly

## Visual context

Please provide any relevant visual context for UI changes or additions. This could be static screenshots or a loom screencast.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have requested at least 2 reviews (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] If package-lock.json has changes, it was intentional.
- [x] The base of this PR is `master` if hotfix, `develop` if not
