### PR TITLE
Fix background color not being applied to HTML tag on dark mode

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.38.2",
+  "version": "1.38.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@balancer-labs/frontend-v2",
-      "version": "1.38.2",
+      "version": "1.38.3",
       "license": "MIT",
       "devDependencies": {
         "@aave/protocol-js": "^4.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.38.2",
+  "version": "1.38.3",
   "engines": {
     "node": "14.x",
     "npm": ">=7"

--- a/src/assets/css/global/all.css
+++ b/src/assets/css/global/all.css
@@ -10,6 +10,10 @@ body {
   -moz-osx-font-smoothing: grayscale;
 }
 
+html.dark {
+  background-color: rgba(15, 23, 42)
+}
+
 @media only screen and (max-width: 600px) {
   html {
     font-size: 14px;

--- a/src/components/cards/CreatePool/PreviewPool.vue
+++ b/src/components/cards/CreatePool/PreviewPool.vue
@@ -136,8 +136,8 @@ function getSwapFeeManager() {
 
 function getInitialWeightHighlightClass(tokenAddress: string) {
   return {
-    'text-gray-500': initialWeights[tokenAddress].gte(0.01),
-    'text-yellow-500': initialWeights[tokenAddress].lt(0.01)
+    'text-gray-500': initialWeights[tokenAddress]?.gte(0.01),
+    'text-yellow-500': initialWeights[tokenAddress]?.lt(0.01)
   };
 }
 </script>


### PR DESCRIPTION
# Description

On dark mode around the app we get extra whitespace at the bottom if content overflows the HTML height. This is because even though it is darkmode and the 'dark' class gets applied to the HTML tag it doesn't actually apply any background color.

This hotfix applies that style manually.

Also included: Typescript lint fix

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## How should this be tested?

Go through pool creation (with a lot of tokens) or any other UI which overflows and test that there is no extra white space at the bottom

## Visual context

Covered in test.

## Checklist:

- [X] I have performed a self-review of my own code
- [X] I have requested at least 2 reviews (If the PR is significant enough, use best judgement here)
- [X] I have commented my code where relevant, particularly in hard-to-understand areas
- [X] If package-lock.json has changes, it was intentional.
- [X] The base of this PR is `master` if hotfix, `develop` if not
