### PR TITLE
Change all style 'unit' to 'percent' in fNum2 usage

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.39.0",
+  "version": "1.39.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@balancer-labs/frontend-v2",
-      "version": "1.39.0",
+      "version": "1.39.1",
       "license": "MIT",
       "devDependencies": {
         "@aave/protocol-js": "^4.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.39.0",
+  "version": "1.39.1",
   "engines": {
     "node": "14.x",
     "npm": ">=7"

--- a/src/components/cards/CreatePool/PoolFees.vue
+++ b/src/components/cards/CreatePool/PoolFees.vue
@@ -70,8 +70,7 @@ const isProceedDisabled = computed(() => {
 const feeOptions = FIXED_FEE_OPTIONS.map(option => {
   return {
     label: fNum2(option, {
-      style: 'unit',
-      unit: 'percent',
+      style: 'percent',
       minimumFractionDigits: 1,
       maximumFractionDigits: 1,
       fixedFormat: true

--- a/src/components/contextual/pages/pool/MyPoolBalancesCard.vue
+++ b/src/components/contextual/pages/pool/MyPoolBalancesCard.vue
@@ -98,8 +98,7 @@ const fiatTotal = computed(() => {
  */
 function weightLabelFor(address: string): string {
   return fNum2(props.pool.onchain.tokens[address].weight, {
-    style: 'unit',
-    unit: 'percent',
+    style: 'percent',
     maximumFractionDigits: 0
   });
 }

--- a/src/components/contextual/pages/pool/PoolChart.vue
+++ b/src/components/contextual/pages/pool/PoolChart.vue
@@ -196,8 +196,7 @@ function getPoolValue(amounts: string[], prices: number[]) {
       :isPeriodSelectionEnabled="false"
       :axisLabelFormatter="{
         yAxis: {
-          style: 'unit',
-          unit: 'percent',
+          style: 'percent',
           maximumFractionDigits: 2,
           minimumFractionDigits: 2,
           fixedFormat: true

--- a/src/components/forms/AppSlippageForm.vue
+++ b/src/components/forms/AppSlippageForm.vue
@@ -24,8 +24,7 @@ const state = reactive({
 const options = FIXED_OPTIONS.map(option => {
   return {
     label: fNum2(option, {
-      style: 'unit',
-      unit: 'percent',
+      style: 'percent',
       minimumFractionDigits: 1,
       maximumFractionDigits: 1,
       fixedFormat: true

--- a/src/components/forms/pool_actions/WithdrawForm/components/ProportionalWithdrawalInput.vue
+++ b/src/components/forms/pool_actions/WithdrawForm/components/ProportionalWithdrawalInput.vue
@@ -163,8 +163,7 @@ onBeforeMount(() => {
                 <span v-if="!isStableLikePool">
                   {{
                     fNum2(seedTokens[i], {
-                      style: 'unit',
-                      unit: 'percent',
+                      style: 'percent',
                       maximumFractionDigits: 0
                     })
                   }}

--- a/src/components/inputs/TokenSelectInput/TokenSelectInput.vue
+++ b/src/components/inputs/TokenSelectInput/TokenSelectInput.vue
@@ -82,8 +82,7 @@ function tokenFor(option: string): TokenInfo {
       <span v-if="Number(weight) > 0" class="text-gray-500 ml-2">
         {{
           fNum2(weight, {
-            style: 'unit',
-            unit: 'percent',
+            style: 'percent',
             maximumFractionDigits: 0
           })
         }}
@@ -112,8 +111,7 @@ function tokenFor(option: string): TokenInfo {
           <span v-if="Number(weight) > 0" class="text-gray-500 ml-2">
             {{
               fNum2(weight, {
-                style: 'unit',
-                unit: 'percent',
+                style: 'percent',
                 maximumFractionDigits: 0
               })
             }}

--- a/src/components/tables/PoolsTable/TokenPills/TokenPills.vue
+++ b/src/components/tables/PoolsTable/TokenPills/TokenPills.vue
@@ -48,8 +48,7 @@ function symbolFor(token: PoolToken): string {
 
 function weightFor(token: PoolToken): string {
   return fNum2(token.weight, {
-    style: 'unit',
-    unit: 'percent',
+    style: 'percent',
     maximumFractionDigits: 0
   });
 }

--- a/src/composables/useNumbers.spec.ts
+++ b/src/composables/useNumbers.spec.ts
@@ -110,8 +110,7 @@ describe('useNumbers', () => {
       testNumbers.forEach(testNumber => {
         const format1 = fNum(testNumber, null, { format: '0.00%' });
         const format2 = fNum2(testNumber, {
-          style: 'unit',
-          unit: 'percent',
+          style: 'percent',
           minimumFractionDigits: 2,
           maximumFractionDigits: 2,
           fixedFormat: true
@@ -178,8 +177,7 @@ describe('useNumbers', () => {
       testNumbers.forEach(testNumber => {
         const format1 = fNum(testNumber, 'percent');
         const format2 = fNum2(testNumber, {
-          style: 'unit',
-          unit: 'percent',
+          style: 'percent',
           minimumFractionDigits: 2,
           maximumFractionDigits: 2
         });
@@ -191,8 +189,7 @@ describe('useNumbers', () => {
       testNumbers.forEach(testNumber => {
         const format1 = fNum(testNumber, 'percent_lg');
         const format2 = fNum2(testNumber, {
-          style: 'unit',
-          unit: 'percent',
+          style: 'percent',
           maximumFractionDigits: 0
         });
         expect(format2).toEqual(format1);
@@ -203,8 +200,7 @@ describe('useNumbers', () => {
       testNumbers.forEach(testNumber => {
         const format1 = fNum(testNumber, 'percent_variable');
         const format2 = fNum2(testNumber, {
-          style: 'unit',
-          unit: 'percent',
+          style: 'percent',
           maximumFractionDigits: 4,
           fixedFormat: true
         });
@@ -216,8 +212,7 @@ describe('useNumbers', () => {
       testNumbers.forEach(testNumber => {
         const format1 = fNum(testNumber, null, { format: '0.0%' });
         const format2 = fNum2(testNumber, {
-          style: 'unit',
-          unit: 'percent',
+          style: 'percent',
           minimumFractionDigits: 1,
           maximumFractionDigits: 1,
           fixedFormat: true

--- a/src/composables/useNumbers.spec.ts
+++ b/src/composables/useNumbers.spec.ts
@@ -58,7 +58,8 @@ describe('useNumbers', () => {
       '87654',
       '112124.3791743',
       '1883234',
-      '121237821371'
+      '121237821371',
+      'NaN'
     ];
 
     it('Should return 0 for an empty string', () => {
@@ -68,6 +69,7 @@ describe('useNumbers', () => {
     it('Should not lose any precision with numbers passed as a string', () => {
       testNumbers.forEach(testNumber => {
         if (testNumber === '') return; // Ignore empty string as that is converted to 0
+        if (testNumber === 'NaN') return; // Ignore NaN as that is converted to 0
         if (Number(testNumber) === 0) return; // Ignore 0 numbers as it will always trim their precision.
         const formattedNumber = fNum2(testNumber, {
           style: 'decimal',

--- a/src/composables/useNumbers.ts
+++ b/src/composables/useNumbers.ts
@@ -15,8 +15,7 @@ export interface FNumOptions extends Intl.NumberFormatOptions {
 
 export const FNumFormats = {
   percent: {
-    style: 'unit',
-    unit: 'percent',
+    style: 'percent',
     minimumFractionDigits: 2,
     maximumFractionDigits: 2
   },
@@ -132,6 +131,10 @@ export default function useNumbers() {
     // For consistency with numeral
     if (options.unit === 'percent') {
       number = number * 100;
+      formatterOptions.useGrouping = false;
+    }
+
+    if (options.style === 'percent') {
       formatterOptions.useGrouping = false;
     }
 

--- a/src/composables/useNumbers.ts
+++ b/src/composables/useNumbers.ts
@@ -94,6 +94,7 @@ export default function useNumbers() {
     options: FNumOptions | undefined = {}
   ): string {
     if (typeof number === 'string') {
+      if (number === 'NaN') number = 0;
       number = Number(number || 0);
     }
 

--- a/src/composables/usePool.ts
+++ b/src/composables/usePool.ts
@@ -104,8 +104,7 @@ export function usePool(pool: Ref<AnyPool> | Ref<undefined>) {
       .map(
         token =>
           `${fNum2(token.weight, {
-            style: 'unit',
-            unit: 'percent',
+            style: 'percent',
             maximumFractionDigits: 0
           })} ${token.symbol}`
       )

--- a/src/pages/pool/_id.vue
+++ b/src/pages/pool/_id.vue
@@ -23,8 +23,7 @@
               >
                 {{
                   fNum2(tokenMeta.weight, {
-                    style: 'unit',
-                    unit: 'percent',
+                    style: 'percent',
                     maximumFractionDigits: 0
                   })
                 }}
@@ -314,8 +313,7 @@ export default defineComponent({
     const poolFeeLabel = computed(() => {
       if (!pool.value) return '';
       const feeLabel = `${fNum2(pool.value.onchain.swapFee, {
-        style: 'unit',
-        unit: 'percent',
+        style: 'percent',
         maximumFractionDigits: 4,
         fixedFormat: true
       })}`;

--- a/src/services/pool/pool.helper.ts
+++ b/src/services/pool/pool.helper.ts
@@ -7,8 +7,7 @@ export function getPoolWeights(pool: FullPool) {
     .map(
       token =>
         `${fNum2(token.weight, {
-          style: 'unit',
-          unit: 'percent',
+          style: 'percent',
           maximumFractionDigits: 0
         })} ${token.symbol}`
     )


### PR DESCRIPTION
# Description

- style: 'unit' isn't supported by iOS mobile browsers (see https://sentry.io/share/issue/68705b2059ae4056a301b7ea9171acc3/)
- I updated the unit tests and it looks like 'percent' works exactly the same, so changed all instances of `style: 'unit', unit: 'percent'` to `style: percent`.
- Add a fix if 'NaN' is passed into fNum2, it should default to 0 to be equivalent to fNum. 


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## How should this be tested?

- Look through all changes and ensure that they are changed from `style: 'unit', unit: 'percent'` to just `style: 'percent'`
- Load website on mobile safari / chrome browser and ensure no errors occur. 

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have requested at least 2 reviews (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] If package-lock.json has changes, it was intentional.
- [x] The base of this PR is `master` if hotfix, `develop` if not
