### PR TITLE
Add PICKLE, TUSD liquidity mining distributors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.39.1",
+  "version": "1.39.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@balancer-labs/frontend-v2",
-      "version": "1.39.1",
+      "version": "1.39.2",
       "license": "MIT",
       "devDependencies": {
         "@aave/protocol-js": "^4.3.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.39.3",
+  "version": "1.39.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@balancer-labs/frontend-v2",
-      "version": "1.39.3",
+      "version": "1.39.4",
       "license": "MIT",
       "devDependencies": {
         "@aave/protocol-js": "^4.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.39.1",
+  "version": "1.39.2",
   "engines": {
     "node": "14.x",
     "npm": ">=7"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.39.3",
+  "version": "1.39.4",
   "engines": {
     "node": "14.x",
     "npm": ">=7"

--- a/src/services/claim/MultiTokenClaim.json
+++ b/src/services/claim/MultiTokenClaim.json
@@ -94,13 +94,6 @@
             "token": "0x2e1ad108ff1d8c782fcbbb89aad783ac49586756",
             "manifest": "https://raw.githubusercontent.com/balancer-labs/bal-mining-scripts/master/reports/_current-tusd-polygon.json",
             "weekStart": 10
-        },
-        {
-            "label": "TEL",
-            "distributor": "0xc38c5f97B34E175FFd35407fc91a937300E33860",
-            "token": "0xdf7837de1f2fa4631d716cf2502f8b230f1dcc32",
-            "manifest": "https://raw.githubusercontent.com/balancer-labs/bal-mining-scripts/master/reports/_current-tel-polygon.json",
-            "weekStart": 17
         }
       ],
     "42161": [

--- a/src/services/claim/MultiTokenClaim.json
+++ b/src/services/claim/MultiTokenClaim.json
@@ -87,6 +87,20 @@
             "token": "0x2e1ad108ff1d8c782fcbbb89aad783ac49586756",
             "manifest": "https://raw.githubusercontent.com/balancer-labs/bal-mining-scripts/master/reports/_current-tusd-polygon.json",
             "weekStart": 1
+        },
+        {
+            "label": "TUSD",
+            "distributor": "0xc38c5f97B34E175FFd35407fc91a937300E33860",
+            "token": "0x2e1ad108ff1d8c782fcbbb89aad783ac49586756",
+            "manifest": "https://raw.githubusercontent.com/balancer-labs/bal-mining-scripts/master/reports/_current-tusd-polygon.json",
+            "weekStart": 10
+        },
+        {
+            "label": "TEL",
+            "distributor": "0xc38c5f97B34E175FFd35407fc91a937300E33860",
+            "token": "0xdf7837de1f2fa4631d716cf2502f8b230f1dcc32",
+            "manifest": "https://raw.githubusercontent.com/balancer-labs/bal-mining-scripts/master/reports/_current-tel-polygon.json",
+            "weekStart": 17
         }
       ],
     "42161": [

--- a/src/services/claim/MultiTokenClaim.json
+++ b/src/services/claim/MultiTokenClaim.json
@@ -124,6 +124,13 @@
             "token": "0x965772e0e9c84b6f359c8597c891108dcf1c5b1a",
             "manifest": "https://raw.githubusercontent.com/balancer-labs/bal-mining-scripts/master/reports/_current-pickle-arbitrum.json",
             "weekStart": 4
+        },
+        {
+            "label": "PICKLE",
+            "distributor": "0xc38c5f97B34E175FFd35407fc91a937300E33860",
+            "token": "0x965772e0e9c84b6f359c8597c891108dcf1c5b1a",
+            "manifest": "https://raw.githubusercontent.com/balancer-labs/bal-mining-scripts/master/reports/_current-pickle-arbitrum.json",
+            "weekStart": 18
         }
     ]
   }


### PR DESCRIPTION
# Description

Ballers have taken over the process of seeding the merkle orchard for TUSD and PICKLE incentives. This adds their safe address to the list of distributors used by the claim UI.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [X] Other

## How should this be tested?

- [x] TUSD and PICKLE for week 87 should be claimable from the UI once the orchard has been seeded. 

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have requested at least 2 reviews (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] If package-lock.json has changes, it was intentional.
- [x] The base of this PR is `master` if hotfix, `develop` if not
