### PR TITLE
Remove animation of BalAccordion for mobile on pool creation

### DIFF
--- a/src/components/animate/AnimatePresence.vue
+++ b/src/components/animate/AnimatePresence.vue
@@ -46,7 +46,7 @@ export default defineComponent({
       default: () => true
     },
     onComplete: {
-      type: Function
+      type: Function as PropType<(el: HTMLElement) => void>
     }
   },
   setup(props, { emit }) {

--- a/src/components/animate/AnimatePresence.vue
+++ b/src/components/animate/AnimatePresence.vue
@@ -44,6 +44,9 @@ export default defineComponent({
     isVisible: {
       type: Boolean,
       default: () => true
+    },
+    onComplete: {
+      type: Function
     }
   },
   setup(props, { emit }) {
@@ -85,6 +88,7 @@ export default defineComponent({
             easing: 'spring(0.2, 80, 10, 0)',
             complete: () => {
               done();
+              if (props.onComplete) props.onComplete(el);
               emit('on-presence', { isCompleted: true });
             }
           }),

--- a/src/components/cards/CreatePool/ChooseWeights.vue
+++ b/src/components/cards/CreatePool/ChooseWeights.vue
@@ -41,8 +41,7 @@ const {
   totalLiquidity,
   hasInjectedToken,
   acceptCustomTokenDisclaimer,
-  acceptedCustomTokenDisclaimer,
-  goBack
+  acceptedCustomTokenDisclaimer
 } = usePoolCreation();
 const { upToLargeBreakpoint } = useBreakpoints();
 const { fNum2 } = useNumbers();

--- a/src/components/cards/CreatePool/ChooseWeights.vue
+++ b/src/components/cards/CreatePool/ChooseWeights.vue
@@ -310,17 +310,9 @@ function onAlertMountChange() {
           <span class="text-xs text-gray-700 dark:text-gray-500">{{
             networkName
           }}</span>
-          <BalStack horizontal align="center" spacing="xs">
-            <button
-              @click="goBack"
-              class="text-blue-500 hover:text-blue-700 flex"
-            >
-              <BalIcon class="flex" name="chevron-left" />
-            </button>
-            <h5 class="font-bold dark:text-gray-300">
-              {{ $t('createAPool.setPoolFees') }}
-            </h5>
-          </BalStack>
+          <h5 class="font-bold dark:text-gray-300">
+            {{ $t('createAPool.chooseTokenWeights') }}
+          </h5>
         </BalStack>
         <BalCard shadow="none" noPad>
           <div ref="tokenWeightListWrapper">

--- a/src/components/cards/CreatePool/ChooseWeights.vue
+++ b/src/components/cards/CreatePool/ChooseWeights.vue
@@ -41,7 +41,8 @@ const {
   totalLiquidity,
   hasInjectedToken,
   acceptCustomTokenDisclaimer,
-  acceptedCustomTokenDisclaimer
+  acceptedCustomTokenDisclaimer,
+  goBack
 } = usePoolCreation();
 const { upToLargeBreakpoint } = useBreakpoints();
 const { fNum2 } = useNumbers();
@@ -302,16 +303,24 @@ function onAlertMountChange() {
 </script>
 
 <template>
-  <div ref="cardWrapper" class="mb-16">
+  <div ref="cardWrapper" class="lg:mb-16">
     <BalCard shadow="xl" noBorder>
       <BalStack vertical spacing="sm">
         <BalStack vertical spacing="xs">
           <span class="text-xs text-gray-700 dark:text-gray-500">{{
             networkName
           }}</span>
-          <h5 class="font-bold dark:text-gray-300">
-            {{ $t('createAPool.chooseTokenWeights') }}
-          </h5>
+          <BalStack horizontal align="center" spacing="xs">
+            <button
+              @click="goBack"
+              class="text-blue-500 hover:text-blue-700 flex"
+            >
+              <BalIcon class="flex" name="chevron-left" />
+            </button>
+            <h5 class="font-bold dark:text-gray-300">
+              {{ $t('createAPool.setPoolFees') }}
+            </h5>
+          </BalStack>
         </BalStack>
         <BalCard shadow="none" noPad>
           <div ref="tokenWeightListWrapper">


### PR DESCRIPTION
# Description

Right now the accordion which contains the Pool Summary and Token Prices cards for pool creation is animated based on a couple different factors and alerts showing etc, just so the accordion can always remain in place during layout changes. This is REALLY inefficient as I've come to realise and there was a super simple and obvious solution that I didn't realise.

TLDR: Just make the main content a relative element once its finished animating.

Also included: Cleanup the create.vue page and lessen the lines of code.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [X] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## How should this be tested?

Please provide instructions so we can test. Please also list any relevant details for your test configuration.

This test is mainly for mobile but:
1. Test the pool creation flow on desktop. Nothing should be different
2. Test the pool creation flow on mobile, the accordion should always be below the main content (might take half a second to show). No janky, jittering anything weird should be happening.

## Visual context
https://www.loom.com/share/45615311e9c04e5bb2aeda4af01fe3f3

## Checklist:

- [X] I have performed a self-review of my own code
- [X] I have requested at least 2 reviews (If the PR is significant enough, use best judgement here)
- [X] I have commented my code where relevant, particularly in hard-to-understand areas
- [X] If package-lock.json has changes, it was intentional.
- [X] The base of this PR is `master` if hotfix, `develop` if not
