### PR TITLE
Hotfix/1.39.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.39.1",
+  "version": "1.39.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@balancer-labs/frontend-v2",
-      "version": "1.39.1",
+      "version": "1.39.2",
       "license": "MIT",
       "devDependencies": {
         "@aave/protocol-js": "^4.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.39.1",
+  "version": "1.39.2",
   "engines": {
     "node": "14.x",
     "npm": ">=7"

--- a/src/components/_global/BalAccordion/BalAccordion.vue
+++ b/src/components/_global/BalAccordion/BalAccordion.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, nextTick, onMounted } from 'vue';
+import { ref, nextTick, onMounted, watch, Ref } from 'vue';
 import anime from 'animejs';
 import { takeRight } from 'lodash';
 
@@ -10,6 +10,10 @@ type Section = {
 
 type Props = {
   sections: Section[];
+  // changing variables which can be used to
+  // determine whether to re-render the height
+  // of an accordion section
+  dependencies: Ref<unknown>;
 };
 
 const props = defineProps<Props>();
@@ -30,8 +34,8 @@ const totalHeight = ref(0);
 
 const easing = 'spring(0.2, 150, 18, 0)';
 
-async function toggleSection(section: string) {
-  const collapseCurrentSection = activeSection.value === section;
+async function toggleSection(section: string, collapse = true) {
+  const collapseCurrentSection = activeSection.value === section && collapse;
   if (collapseCurrentSection) {
     activeSection.value = '';
     isContentVisible.value = false;
@@ -140,6 +144,16 @@ function setHandleBars(el: HTMLElement) {
     handleBarElements.value.push(el);
   }
 }
+
+/**
+ * WATCHERS
+ */
+watch(
+  () => props.dependencies,
+  () => {
+    toggleSection(activeSection.value, false);
+  }
+);
 </script>
 
 <template>

--- a/src/components/cards/CreatePool/ChooseWeights.vue
+++ b/src/components/cards/CreatePool/ChooseWeights.vue
@@ -376,6 +376,7 @@ function onAlertMountChange() {
                 <BalProgressBar
                   :color="progressBarColor"
                   :width="totalAllocatedWeight"
+                  :bufferWidth="0"
                   class="my-2"
                 />
               </div>

--- a/src/components/cards/CreatePool/TokenPrices.vue
+++ b/src/components/cards/CreatePool/TokenPrices.vue
@@ -7,7 +7,7 @@ import useTokens from '@/composables/useTokens';
 import { computed } from 'vue';
 
 type Props = {
-  toggleUnknownPriceModal: () => void;
+  toggleUnknownPriceModal?: () => void;
 };
 
 defineProps<Props>();

--- a/src/pages/pool/create.vue
+++ b/src/pages/pool/create.vue
@@ -338,8 +338,9 @@ watch(isLoadingTokens, () => {
       </AnimatePresence>
       <div v-if="upToLargeBreakpoint" ref="accordionWrapper" class="pb-24">
         <BalAccordion
+          :dependencies="validTokens"
           :sections="[
-            { title: t('poolSummary'), id: 'pool-summary' },
+            { title: t('createAPool.poolSummary'), id: 'pool-summary' },
             { title: t('tokenPrices'), id: 'token-prices' }
           ]"
         >


### PR DESCRIPTION
# Description

1. On mobile when adding / removing tokens for pool creation, the accordion section height for 'Token Prices' doesn't update as BalAccordion works off transforms. This change adds a dependencies array that BalAccordion can use to track any dependencies and update the section height from that.

2. Missing TL key on mobile

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## How should this be tested?

On pool creation mobile, open up the token prices section on the accordion. Add / change tokens to the first step, the token prices section should have all the chosen tokens.

## Visual context
https://www.loom.com/share/133afddbf877457399cfcbcf32fc1f6f

## Checklist:

- [X] I have performed a self-review of my own code
- [X] I have requested at least 2 reviews (If the PR is significant enough, use best judgement here)
- [X] I have commented my code where relevant, particularly in hard-to-understand areas
- [X] If package-lock.json has changes, it was intentional.
- [X] The base of this PR is `master` if hotfix, `develop` if not
