### PR TITLE
Handle withdrawal abs max

### DIFF
--- a/src/components/forms/pool_actions/WithdrawForm/WithdrawForm.vue
+++ b/src/components/forms/pool_actions/WithdrawForm/WithdrawForm.vue
@@ -40,7 +40,10 @@ const {
   highPriceImpactAccepted,
   validInput,
   maxSlider,
-  tokensOut
+  tokensOut,
+  error,
+  parseError,
+  setError
 } = useWithdrawalState(toRef(props, 'pool'));
 
 const withdrawMath = useWithdrawMath(
@@ -105,6 +108,7 @@ onBeforeMount(() => {
       :address="tokenOut"
       v-model:amount="tokenOutAmount"
       v-model:isValid="validInput"
+      :disableBalance="singleAssetMaxes[tokenOutIndex] === '-'"
       :customBalance="singleAssetMaxes[tokenOutIndex] || '0'"
       :rules="singleAssetRules"
       :balanceLabel="$t('singleTokenMax')"
@@ -131,6 +135,17 @@ onBeforeMount(() => {
         :label="$t('priceImpactAccept', [$t('withdrawing')])"
       />
     </div>
+
+    <BalAlert
+      v-if="error !== null"
+      type="error"
+      title="Error"
+      :description="parseError(error)"
+      class="mt-4"
+      block
+      actionLabel="Dismiss"
+      @actionClick="setError(null)"
+    />
 
     <div class="mt-4">
       <BalBtn

--- a/src/components/forms/pool_actions/WithdrawForm/WithdrawForm.vue
+++ b/src/components/forms/pool_actions/WithdrawForm/WithdrawForm.vue
@@ -139,8 +139,8 @@ onBeforeMount(() => {
     <BalAlert
       v-if="error !== null"
       type="error"
-      title="Error"
-      :description="parseError(error)"
+      :title="parseError(error).title"
+      :description="parseError(error).description"
       class="mt-4"
       block
       actionLabel="Dismiss"

--- a/src/components/forms/pool_actions/WithdrawForm/composables/useWithdrawMath.ts
+++ b/src/components/forms/pool_actions/WithdrawForm/composables/useWithdrawMath.ts
@@ -136,11 +136,10 @@ export default function useWithdrawMath(
     if (!isWeightedPool.value) return bptBalance.value;
     // Maximum BPT allowed from weighted pool is 30%
     const poolMax = bnum(pool.value.totalShares)
-      .times(0.25)
+      .times(0.3)
       .toFixed(poolDecimals.value, OldBigNumber.ROUND_DOWN);
     // If the user's bpt balance is greater than the withdrawal limit for
     // weighted pools we need to return the poolMax bpt value.
-    console.log('maxes', bptBalance.value, poolMax);
     return OldBigNumber.min(bptBalance.value, poolMax).toString();
   });
 
@@ -273,7 +272,7 @@ export default function useWithdrawMath(
       return poolTokens.value.map((token, tokenIndex) => {
         return formatUnits(
           poolCalculator
-            .exactBPTInForTokenOut(bptBalance.value, tokenIndex)
+            .exactBPTInForTokenOut(bptBalanceScaled.value, tokenIndex)
             .toString(),
           token.decimals
         );
@@ -320,7 +319,6 @@ export default function useWithdrawMath(
     if (amountExceedsPoolBalance.value) return 1;
     if (!hasAmounts.value || isProportional.value) return 0;
 
-    console.log('fullBPTIn.value', fullBPTIn.value);
     return poolCalculator
       .priceImpact(fullAmounts.value, {
         exactOut: exactOut.value,

--- a/src/components/forms/pool_actions/WithdrawForm/composables/useWithdrawMath.ts
+++ b/src/components/forms/pool_actions/WithdrawForm/composables/useWithdrawMath.ts
@@ -280,12 +280,17 @@ export default function useWithdrawMath(
     } catch (error) {
       if ((error as Error).message.includes('MIN_BPT_IN_FOR_TOKEN_OUT')) {
         setError(WithdrawalError.SINGLE_ASSET_WITHDRAWAL_MIN_BPT_LIMIT);
-        const { receive } = poolCalculator.propAmountsGiven(
-          absMaxBpt.value,
-          0,
-          'send'
-        );
-        return receive;
+        return poolTokens.value.map((token, tokenIndex) => {
+          return formatUnits(
+            poolCalculator
+              .exactBPTInForTokenOut(
+                parseUnits(absMaxBpt.value, poolDecimals.value).toString(),
+                tokenIndex
+              )
+              .toString(),
+            token.decimals
+          );
+        });
       }
       return [];
     }

--- a/src/components/forms/pool_actions/WithdrawForm/composables/useWithdrawMath.ts
+++ b/src/components/forms/pool_actions/WithdrawForm/composables/useWithdrawMath.ts
@@ -28,6 +28,7 @@ import { balancer } from '@/lib/balancer.sdk';
 import { SwapType, TransactionData } from '@balancer-labs/sdk';
 import { SwapKind } from '@balancer-labs/balancer-js';
 import usePromiseSequence from '@/composables/usePromiseSequence';
+import { setError, WithdrawalError } from './useWithdrawalState';
 
 /**
  * TYPES
@@ -73,7 +74,7 @@ export default function useWithdrawMath(
     addSlippageScaled,
     minusSlippageScaled
   } = useSlippage();
-  const { isStablePhantomPool } = usePool(pool);
+  const { isStablePhantomPool, isWeightedPool } = usePool(pool);
   const { slippageScaled } = useUserSettings();
   const {
     promises: swapPromises,
@@ -118,10 +119,29 @@ export default function useWithdrawMath(
     tokenAddresses.value.map(address => getToken(address))
   );
 
-  const bptBalance = computed(() => balanceFor(pool.value.address));
+  const bptBalance = computed((): string => balanceFor(pool.value.address));
+
   const bptBalanceScaled = computed((): string =>
     parseUnits(bptBalance.value, poolDecimals.value).toString()
   );
+
+  /**
+   * Returns the absolute max BPT withdrawable from a pool.
+   * In most cases this is just the user's BPT balance.
+   *
+   * However, for weighted pools, if the user is a majority LP they may
+   * only be able to withdraw up to the 30% limit.
+   */
+  const bptMax = computed((): string => {
+    if (!isWeightedPool.value) return bptBalance.value;
+    // Maximum BPT allowed from weighted pool is 30%
+    const poolMax = bnum(pool.value.totalShares)
+      .times(0.3)
+      .toFixed(poolDecimals.value, OldBigNumber.ROUND_DOWN);
+    // If the user's bpt balance is greater than the withdrawal limit for
+    // weighted pools we need to return the poolMax bpt value.
+    return OldBigNumber.min(bptBalance.value, poolMax).toString();
+  });
 
   const hasBpt = computed(() => bnum(bptBalance.value).gt(0));
 
@@ -248,14 +268,27 @@ export default function useWithdrawMath(
   const singleAssetMaxes = computed((): string[] => {
     if (isStablePhantomPool.value) return batchSwapSingleAssetMaxes.value;
 
-    return poolTokens.value.map((token, tokenIndex) => {
-      return formatUnits(
-        poolCalculator
-          .exactBPTInForTokenOut(bptBalance.value, tokenIndex)
-          .toString(),
-        token.decimals
-      );
-    });
+    try {
+      return poolTokens.value.map((token, tokenIndex) => {
+        return formatUnits(
+          poolCalculator
+            .exactBPTInForTokenOut(bptBalance.value, tokenIndex)
+            .toString(),
+          token.decimals
+        );
+      });
+    } catch (error) {
+      if ((error as Error).message.includes('MIN_BPT_IN_FOR_TOKEN_OUT')) {
+        setError(WithdrawalError.SINGLE_ASSET_WITHDRAWAL_MIN_BPT_LIMIT);
+        const { receive } = poolCalculator.propAmountsGiven(
+          bptMax.value,
+          0,
+          'send'
+        );
+        return receive;
+      }
+      return [];
+    }
   });
 
   // Checks if the single asset withdrawal is maxed out.

--- a/src/components/forms/pool_actions/WithdrawForm/composables/useWithdrawMath.ts
+++ b/src/components/forms/pool_actions/WithdrawForm/composables/useWithdrawMath.ts
@@ -140,7 +140,7 @@ export default function useWithdrawMath(
       .toFixed(poolDecimals.value, OldBigNumber.ROUND_DOWN);
     // If the user's bpt balance is greater than the withdrawal limit for
     // weighted pools we need to return the poolMax bpt value.
-    console.log('maxes', bptBalance.value, poolMax)
+    console.log('maxes', bptBalance.value, poolMax);
     return OldBigNumber.min(bptBalance.value, poolMax).toString();
   });
 
@@ -320,7 +320,7 @@ export default function useWithdrawMath(
     if (amountExceedsPoolBalance.value) return 1;
     if (!hasAmounts.value || isProportional.value) return 0;
 
-    console.log('fullBPTIn.value', fullBPTIn.value)
+    console.log('fullBPTIn.value', fullBPTIn.value);
     return poolCalculator
       .priceImpact(fullAmounts.value, {
         exactOut: exactOut.value,

--- a/src/components/forms/pool_actions/WithdrawForm/composables/useWithdrawalState.ts
+++ b/src/components/forms/pool_actions/WithdrawForm/composables/useWithdrawalState.ts
@@ -6,10 +6,30 @@ import useRelayerApproval, {
   Relayer
 } from '@/composables/trade/useRelayerApproval';
 
+export enum WithdrawalError {
+  SINGLE_ASSET_WITHDRAWAL_MIN_BPT_LIMIT
+}
+
+type WithdrawalState = {
+  isProportional: boolean;
+  tokenOut: string;
+  validInput: boolean;
+  highPriceImpactAccepted: boolean;
+  submitting: boolean;
+  sorReady: boolean;
+  slider: {
+    val: number;
+    max: number;
+    min: number;
+    interval: number;
+  };
+  error: WithdrawalError | null;
+};
+
 /**
  * STATE
  */
-const state = reactive({
+const state = reactive<WithdrawalState>({
   isProportional: true,
   tokenOut: '',
   validInput: true,
@@ -21,8 +41,25 @@ const state = reactive({
     max: 1000,
     min: 0,
     interval: 1
-  }
+  },
+  error: null
 });
+
+/**
+ * METHODS
+ */
+export function setError(error: WithdrawalError | null): void {
+  state.error = error;
+}
+
+export function parseError(error: WithdrawalError): string {
+  switch (error) {
+    case WithdrawalError.SINGLE_ASSET_WITHDRAWAL_MIN_BPT_LIMIT:
+      return 'Min BPT error';
+    default:
+      return 'Something went wrong';
+  }
+}
 
 export default function useWithdrawalState(pool: Ref<FullPool | undefined>) {
   /**
@@ -69,6 +106,8 @@ export default function useWithdrawalState(pool: Ref<FullPool | undefined>) {
     tokenOutIndex,
     batchRelayerApproval,
     // methods
-    maxSlider
+    maxSlider,
+    setError,
+    parseError
   };
 }

--- a/src/components/forms/pool_actions/WithdrawForm/composables/useWithdrawalState.ts
+++ b/src/components/forms/pool_actions/WithdrawForm/composables/useWithdrawalState.ts
@@ -5,6 +5,7 @@ import { isStablePhantom } from '@/composables/usePool';
 import useRelayerApproval, {
   Relayer
 } from '@/composables/trade/useRelayerApproval';
+import { BasicContent } from '@/types';
 
 export enum WithdrawalError {
   SINGLE_ASSET_WITHDRAWAL_MIN_BPT_LIMIT
@@ -52,12 +53,19 @@ export function setError(error: WithdrawalError | null): void {
   state.error = error;
 }
 
-export function parseError(error: WithdrawalError): string {
+export function parseError(error: WithdrawalError): BasicContent {
   switch (error) {
     case WithdrawalError.SINGLE_ASSET_WITHDRAWAL_MIN_BPT_LIMIT:
-      return 'Min BPT error';
+      return {
+        title: 'Warning',
+        description:
+          "You can only withdraw 30% of the pool's value in single asset withdrawals"
+      };
     default:
-      return 'Something went wrong';
+      return {
+        title: 'Oops',
+        description: 'Something went wrong.'
+      };
   }
 }
 

--- a/src/components/forms/pool_actions/WithdrawForm/composables/useWithdrawalState.ts
+++ b/src/components/forms/pool_actions/WithdrawForm/composables/useWithdrawalState.ts
@@ -5,7 +5,7 @@ import { isStablePhantom } from '@/composables/usePool';
 import useRelayerApproval, {
   Relayer
 } from '@/composables/trade/useRelayerApproval';
-import { BasicContent } from '@/types';
+import { BaseContent } from '@/types';
 
 /**
  * TYPES
@@ -56,7 +56,7 @@ export function setError(error: WithdrawalError | null): void {
   state.error = error;
 }
 
-export function parseError(error: WithdrawalError): BasicContent {
+export function parseError(error: WithdrawalError): BaseContent {
   switch (error) {
     case WithdrawalError.SINGLE_ASSET_WITHDRAWAL_MIN_BPT_LIMIT:
       return {

--- a/src/components/forms/pool_actions/WithdrawForm/composables/useWithdrawalState.ts
+++ b/src/components/forms/pool_actions/WithdrawForm/composables/useWithdrawalState.ts
@@ -6,12 +6,13 @@ import useRelayerApproval, {
   Relayer
 } from '@/composables/trade/useRelayerApproval';
 import { BaseContent } from '@/types';
+import i18n from '@/plugins/i18n';
 
 /**
  * TYPES
  */
 export enum WithdrawalError {
-  SINGLE_ASSET_WITHDRAWAL_MIN_BPT_LIMIT
+  SINGLE_ASSET_WITHDRAWAL_MIN_BPT_LIMIT = 'SINGLE_ASSET_WITHDRAWAL_MIN_BPT_LIMIT'
 }
 
 type WithdrawalState = {
@@ -60,14 +61,15 @@ export function parseError(error: WithdrawalError): BaseContent {
   switch (error) {
     case WithdrawalError.SINGLE_ASSET_WITHDRAWAL_MIN_BPT_LIMIT:
       return {
-        title: 'Warning',
-        description:
-          "You can only withdraw 30% of the pool's value in single asset withdrawals"
+        title: i18n.global.t('warning'),
+        description: i18n.global.t(
+          `withdraw.errors.${WithdrawalError.SINGLE_ASSET_WITHDRAWAL_MIN_BPT_LIMIT}`
+        )
       };
     default:
       return {
-        title: 'Oops',
-        description: 'Something went wrong.'
+        title: i18n.global.t('Ooops'),
+        description: i18n.global.t('somethingWentWrong')
       };
   }
 }

--- a/src/components/forms/pool_actions/WithdrawForm/composables/useWithdrawalState.ts
+++ b/src/components/forms/pool_actions/WithdrawForm/composables/useWithdrawalState.ts
@@ -7,6 +7,9 @@ import useRelayerApproval, {
 } from '@/composables/trade/useRelayerApproval';
 import { BasicContent } from '@/types';
 
+/**
+ * TYPES
+ */
 export enum WithdrawalError {
   SINGLE_ASSET_WITHDRAWAL_MIN_BPT_LIMIT
 }

--- a/src/components/inputs/TokenInput/TokenInput.vue
+++ b/src/components/inputs/TokenInput/TokenInput.vue
@@ -33,6 +33,7 @@ type Props = {
   customBalance?: string;
   balanceLabel?: string;
   disableMax?: boolean;
+  disableBalance?: boolean;
   balanceLoading?: boolean;
   hint?: string;
   hintAmount?: string;
@@ -55,6 +56,7 @@ const props = withDefaults(defineProps<Props>(), {
   noMax: false,
   fixedToken: false,
   disableMax: false,
+  disableBalance: false,
   balanceLoading: false,
   hintAmount: '',
   disableNativeAssetBuffer: false,
@@ -82,7 +84,6 @@ const _address = ref<string>('');
 /**
  * COMPOSABLEs
  */
-
 const { getToken, balanceFor, nativeAsset } = useTokens();
 const { fNum2, toFiat } = useNumbers();
 const { t } = useI18n();
@@ -257,7 +258,7 @@ watchEffect(() => {
         <div
           class="flex items-center justify-between text-sm text-gray-500 leading-none"
         >
-          <div v-if="!isWalletReady" />
+          <div v-if="!isWalletReady || disableBalance" />
           <div v-else class="cursor-pointer flex items-center" @click="setMax">
             {{ balanceLabel ? balanceLabel : $t('balance') }}:
 

--- a/src/locales/default.json
+++ b/src/locales/default.json
@@ -418,6 +418,7 @@
     "optimize": "Optimize",
     "optimized": "Optimized",
     "optimizedPrefilled": "Optimized amounts have been pre-filled",
+    "oops": "Oops",
     "oracleWeightedPool": "Oracle Weighted Pool",
     "overview": "Overview",
     "ownerFeesTooltip": "Liquidity providers earn dynamic swap fees on every trade utilizing the liquidity in this pool. Dynamic swap fees are controlled by the pool owner.",
@@ -516,6 +517,7 @@
     "singleToken": "Single token",
     "singleTokenMax": "Single token max",
     "slippageTolerance": "Slippage tolerance",
+    "somethingWentWrong": "Something went wrong",
     "stablePool": "Stable pool",
     "strategy": "Strategy",
     "submit": "Submit",
@@ -725,6 +727,7 @@
     "volume24hShort": "Vol (24h)",
     "volumeTime": "Volume ({0})",
     "wallet": "Wallet",
+    "warning": "Warning",
     "week": "Week",
     "weekAbbrev": "w",
     "weight": "Weight",
@@ -746,6 +749,9 @@
             "tooltips": {
                 "withdrawStep": "Confirm withdrawal from this pool"
             }
+        },
+        "errors": {
+            "SINGLE_ASSET_WITHDRAWAL_MIN_BPT_LIMIT": "You can only withdraw 30% of the pool's value in single asset withdrawals"
         }
     },
     "withdrawal": "Withdrawal",

--- a/src/services/pool/calculator/weighted.ts
+++ b/src/services/pool/calculator/weighted.ts
@@ -89,7 +89,7 @@ export default class Weighted {
     return SDK.WeightedMath._calcTokenOutGivenExactBptIn(
       tokenBalance,
       tokenNormalizedWeight,
-      bnum(bptAmount), // TODO - check if bpt amount is correctly scaled for all pool types
+      bnum(bptAmount),
       bnum(this.calc.poolTotalSupply.toString()),
       bnum(this.calc.poolSwapFee.toString())
     );

--- a/src/services/pool/calculator/weighted.ts
+++ b/src/services/pool/calculator/weighted.ts
@@ -85,14 +85,11 @@ export default class Weighted {
     const tokenNormalizedWeight = bnum(
       this.calc.poolTokenWeights[tokenIndex].toString()
     );
-    const bptAmountIn = bnum(
-      parseUnits(bptAmount, this.calc.poolDecimals).toString()
-    );
 
     return SDK.WeightedMath._calcTokenOutGivenExactBptIn(
       tokenBalance,
       tokenNormalizedWeight,
-      bptAmountIn,
+      bnum(bptAmount), // TODO - check if bpt amount is correctly scaled for all pool types
       bnum(this.calc.poolTotalSupply.toString()),
       bnum(this.calc.poolSwapFee.toString())
     );
@@ -113,14 +110,13 @@ export default class Weighted {
         bptAmount = this.bptInForExactTokensOut(tokenAmounts);
         bptZeroPriceImpact = this.bptForTokensZeroPriceImpact(tokenAmounts);
       } else {
-        bptAmount = parseUnits(
-          this.calc.bptBalance,
-          this.calc.poolDecimals
-        ).toString();
+        bptAmount =
+          opts.queryBPT ||
+          parseUnits(this.calc.bptBalance, this.calc.poolDecimals).toString();
         tokenAmounts = this.calc.pool.value.tokensList.map((_, i) => {
           if (i !== opts.tokenIndex) return '0';
           const tokenAmount = this.exactBPTInForTokenOut(
-            this.calc.bptBalance,
+            bptAmount,
             opts.tokenIndex
           ).toString();
           return formatUnits(

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -76,7 +76,7 @@ export type QueryBuilder = (
   attrs?: QueryAttrs
 ) => Record<string, any>;
 
-export type BasicContent = {
+export type BaseContent = {
   title: string;
   description: string;
 };

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -75,3 +75,8 @@ export type QueryBuilder = (
   args?: QueryArgs,
   attrs?: QueryAttrs
 ) => Record<string, any>;
+
+export type BasicContent = {
+  title: string;
+  description: string;
+};


### PR DESCRIPTION
# Description

If the user trying to withdraw from a pool is a significant LP, i.e. they can withdraw more than 30% of the BPT in a pool, then currently the withdrawal form fails on selecting a single asset to withdraw.

This PR fixes the call to fetch the single asset max withdrawal by using the minimum of either the user's full balance or 30% of the BPT in the chosen token as the max value. It also adds a warning to explain why the maximum withdrawable amount is less than the user might be expecting.

This issue was less relevant before we launched pool creation. However, with pool creation live it's likely more users will run into this problem.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## How should this be tested?

- [ ] Create a pool so you are the sole LP (or go to a pool you have previously created) and try to withdraw in a single asset. You should notice that the max withdrawable amount is not the full pool balance and you should see a warning.
- [ ] Ensure that single asset maxes work as expected for other pools where you are not the majority LP

## Visual context

[Demo](https://www.loom.com/share/10c507663a504503990065c20f82acbe)

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have requested at least 2 reviews (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] If package-lock.json has changes, it was intentional.
- [x] The base of this PR is `master` if hotfix, `develop` if not
