### PR TITLE
Fix pool chart display

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.40.0",
+  "version": "1.40.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@balancer-labs/frontend-v2",
-      "version": "1.40.0",
+      "version": "1.40.1",
       "license": "MIT",
       "devDependencies": {
         "@aave/protocol-js": "^4.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.40.0",
+  "version": "1.40.1",
   "engines": {
     "node": "14.x",
     "npm": ">=7"

--- a/src/components/contextual/pages/pool/PoolChart.vue
+++ b/src/components/contextual/pages/pool/PoolChart.vue
@@ -70,6 +70,8 @@ const history = computed(() => {
     return [];
   }
 
+  if (supportsPoolLiquidity.value) return [];
+
   // Prices are required when not using pool liquidity
   if (!supportsPoolLiquidity.value && pricesTimestamps.length === 0) {
     return [];

--- a/src/components/contextual/pages/pool/PoolChart.vue
+++ b/src/components/contextual/pages/pool/PoolChart.vue
@@ -100,7 +100,8 @@ const history = computed(() => {
         return false;
       }
       return totalShares > 0 && amounts.length > 0;
-    });
+    })
+    .reverse();
 });
 
 const timestamps = computed(() =>


### PR DESCRIPTION
# Description

The array of values used to generate the pool chart seems to be coming out of the subgraph in the opposite order which caused a function guard to return 0 for all values. This PR reverses the order of the chart history so that they are in the same order as before.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## How should this be tested?

- [ ] Test pool charts are working for all pool types on all networks.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have requested at least 2 reviews (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] If package-lock.json has changes, it was intentional.
- [x] The base of this PR is `master` if hotfix, `develop` if not
