### PR TITLE
Fix stable single asset withdrawals

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.40.1",
+  "version": "1.40.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@balancer-labs/frontend-v2",
-      "version": "1.40.1",
+      "version": "1.40.2",
       "license": "MIT",
       "devDependencies": {
         "@aave/protocol-js": "^4.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.40.1",
+  "version": "1.40.2",
   "engines": {
     "node": "14.x",
     "npm": ">=7"

--- a/src/services/pool/calculator/stable.ts
+++ b/src/services/pool/calculator/stable.ts
@@ -119,7 +119,8 @@ export default class Stable {
 
     const amp = bnum(this.calc.pool.value.onchain.amp?.toString() || '0');
     const ampAdjusted = this.adjustAmp(amp);
-    const bptAmountIn = this.scaleInput(bptAmount);
+    const normalizedAmountIn = formatUnits(bptAmount, this.calc.poolDecimals);
+    const bptAmountIn = this.scaleInput(normalizedAmountIn);
 
     const tokenAmountOut = SDK.StableMath._calcTokenOutGivenExactBptIn(
       ampAdjusted,
@@ -161,7 +162,7 @@ export default class Stable {
         tokenAmounts = this.calc.pool.value.tokensList.map((_, i) => {
           if (i !== opts.tokenIndex) return '0';
           const tokenAmount = this.exactBPTInForTokenOut(
-            this.calc.bptBalance,
+            bptAmount.toString(),
             opts.tokenIndex
           ).toString();
           return formatUnits(


### PR DESCRIPTION
# Description

To support cases where the LP owns a majority of a pool and tries to withdraw a single asset some changes were made to the weighted pool math. This involved passing in a scaled BPT balance rather than a normalised value. Since the pool calculator acts as an adapter for the same function in the weighted & stable pool math, the scaling was missed for stable pools. This PR fixes scaling issues in the stable math class.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## How should this be tested?

- [ ] Test single asset withdrawals work for stable pools
- [ ] Test single asset withdrawals still work for weighted pools.

## Visual context

n/a

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have requested at least 2 reviews (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] If package-lock.json has changes, it was intentional.
- [x] The base of this PR is `master` if hotfix, `develop` if not
