### PR TITLE
Fix boosted pool chart values

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.40.2",
+  "version": "1.40.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@balancer-labs/frontend-v2",
-      "version": "1.40.2",
+      "version": "1.40.3",
       "license": "MIT",
       "devDependencies": {
         "@aave/protocol-js": "^4.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.40.2",
+  "version": "1.40.3",
   "engines": {
     "node": "14.x",
     "npm": ">=7"

--- a/src/components/contextual/pages/pool/PoolChart.vue
+++ b/src/components/contextual/pages/pool/PoolChart.vue
@@ -70,8 +70,6 @@ const history = computed(() => {
     return [];
   }
 
-  if (supportsPoolLiquidity.value) return [];
-
   // Prices are required when not using pool liquidity
   if (!supportsPoolLiquidity.value && pricesTimestamps.length === 0) {
     return [];

--- a/src/services/balancer/subgraph/entities/poolSnapshots/query.ts
+++ b/src/services/balancer/subgraph/entities/poolSnapshots/query.ts
@@ -12,7 +12,7 @@ const defaultAttrs = {
   swapFees: true
 };
 
-if (!isPolygon) {
+if (!isPolygon.value) {
   defaultAttrs['liquidity'] = true;
 }
 


### PR DESCRIPTION
# Description

The `isPolygon` variable used to decide whether or not to request the `liquidity` attribute from the poolSnapshots subgraph entity was changed to a computed property but the `.value` attribute was not used.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## How should this be tested?

- [ ] Test the the pool chart works for the boosted pool on mainnet

## Visual context

n/a

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have requested at least 2 reviews (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] If package-lock.json has changes, it was intentional.
- [x] The base of this PR is `master` if hotfix, `develop` if not
