### PR TITLE
Add gauges query

### DIFF
--- a/src/composables/queries/useGaugesQuery.ts
+++ b/src/composables/queries/useGaugesQuery.ts
@@ -1,0 +1,40 @@
+import { reactive } from 'vue';
+import { useQuery } from 'vue-query';
+import { UseQueryOptions } from 'react-query/types';
+import QUERY_KEYS from '@/constants/queryKeys';
+import { gaugesSubgraphService } from '@/services/balancer/gauges/gauges-subgraph.service';
+import { SubgraphGauge } from '@/services/balancer/gauges/types';
+
+/**
+ * TYPES
+ */
+type QueryResponse = SubgraphGauge[];
+
+/**
+ * @summary Fetches guages list from subgraph
+ */
+export default function useGaugesQuery(
+  options: UseQueryOptions<QueryResponse> = {}
+) {
+  /**
+   * QUERY KEY
+   */
+  const queryKey = reactive(QUERY_KEYS.Gauges.All());
+
+  /**
+   * QUERY FUNCTION
+   */
+  const queryFn = async () => {
+    return await gaugesSubgraphService.gauges.get();
+  };
+
+  /**
+   * QUERY OPTIONS
+   */
+  const queryOptions = reactive({
+    enabled: true,
+    ...options
+  });
+
+  return useQuery<QueryResponse>(queryKey, queryFn, queryOptions);
+}

--- a/src/constants/queryKeys.ts
+++ b/src/constants/queryKeys.ts
@@ -111,6 +111,9 @@ const QUERY_KEYS = {
       account: Ref<string>,
       chainId: Ref<number | undefined>
     ) => ['account', 'profile', { networkId, account, chainId }]
+  },
+  Gauges: {
+    All: () => ['gauges', 'all']
   }
 };
 

--- a/src/jest.setup.ts
+++ b/src/jest.setup.ts
@@ -1,5 +1,15 @@
 import nock from 'nock';
+import axios from 'axios';
 import '@testing-library/jest-dom';
+
+// If you are using jsdom, axios will default to using the XHR adapter which
+// can't be intercepted by nock. So, configure axios to use the node adapter.
+//
+// References:
+// https://github.com/nock/nock/issues/699#issuecomment-272708264
+// https://github.com/axios/axios/issues/305
+axios.defaults.adapter = require('axios/lib/adapters/http');
+
 /**
  * HTTP Requests
  *

--- a/src/services/balancer/gauges/__mocks__/gauges.schema.json
+++ b/src/services/balancer/gauges/__mocks__/gauges.schema.json
@@ -1,0 +1,22 @@
+{
+    "many": [
+        {
+            "id": "0x5be3bbb5d7497138b9e623506d8b6c6cd72daceb",
+            "symbol": "B-50USDC-50WETH-gauge",
+            "pool": "0x3a19030ed746bd1c3f2b0f996ff9479af04c5f0a",
+            "totalSupply": "2.098686656699031571",
+            "factory": {
+                "id": "0xa333c704e96fe7117055e56ce95525d1ef11c006"
+            }
+        },
+        {
+            "id": "0xf5e1f2ae2a4ceeeb1786c650856fda2a27796f87",
+            "symbol": "17WBTC-50BAL-33USDC-gauge",
+            "pool": "0xf767f0a3fcf1eafec2180b7de79d0c559d7e7e37",
+            "totalSupply": "0",
+            "factory": {
+                "id": "0xa333c704e96fe7117055e56ce95525d1ef11c006"
+            }
+        }
+    ]      
+}

--- a/src/services/balancer/gauges/entities/gauges/index.ts
+++ b/src/services/balancer/gauges/entities/gauges/index.ts
@@ -1,0 +1,16 @@
+import Service from '../../gauges-subgraph.service';
+import { gaugeQueryBuilder } from './query';
+import { SubgraphGauge, QueryBuilder } from '../../types';
+
+export default class Gauges {
+  constructor(
+    private readonly service: Service,
+    private readonly query: QueryBuilder = gaugeQueryBuilder
+  ) {}
+
+  public async get(args = {}, attrs = {}): Promise<SubgraphGauge[]> {
+    const query = this.query(args, attrs);
+    const data = await this.service.client.get(query);
+    return data.liquidityGauges;
+  }
+}

--- a/src/services/balancer/gauges/entities/gauges/query.ts
+++ b/src/services/balancer/gauges/entities/gauges/query.ts
@@ -1,0 +1,22 @@
+import { merge } from 'lodash';
+
+const defaultArgs = {
+  first: 20
+};
+
+const defaultAttrs = {
+  id: true,
+  symbol: true,
+  pool: true,
+  totalSupply: true,
+  factory: {
+    id: true
+  }
+};
+
+export const gaugeQueryBuilder = (args = {}, attrs = {}) => ({
+  liquidityGauges: {
+    __args: merge({}, defaultArgs, args),
+    ...merge({}, defaultAttrs, attrs)
+  }
+});

--- a/src/services/balancer/gauges/gauges-subgraph.client.spec.ts
+++ b/src/services/balancer/gauges/gauges-subgraph.client.spec.ts
@@ -1,0 +1,21 @@
+import { gaugeQueryBuilder } from './entities/gauges/query';
+import { gaugesSubgraphClient } from './gauges-subgraph.client';
+import gaugesSchema from './__mocks__/gauges.schema.json';
+import nock from 'nock';
+
+describe('GaugesSubgraphClient', () => {
+  beforeEach(() => {
+    nock('https://api.thegraph.com')
+      .post('/subgraphs/name/mendesfabio/balancer-gauges')
+      .reply(200, { data: gaugesSchema.many });
+  });
+
+  describe('#get', () => {
+    it('returns array of gauges when called with default query', async () => {
+      const query = gaugeQueryBuilder();
+      const response = await gaugesSubgraphClient.get(query);
+
+      expect(response).toEqual(gaugesSchema.many);
+    });
+  });
+});

--- a/src/services/balancer/gauges/gauges-subgraph.client.ts
+++ b/src/services/balancer/gauges/gauges-subgraph.client.ts
@@ -1,0 +1,28 @@
+import axios from 'axios';
+import { jsonToGraphQLQuery } from 'json-to-graphql-query';
+
+const BALANCER_GAUGES_SUBGRAPH =
+  'https://api.thegraph.com/subgraphs/name/mendesfabio/balancer-gauges';
+
+export default class GaugesSubgraphClient {
+  constructor(public readonly url: string = BALANCER_GAUGES_SUBGRAPH) {}
+
+  public async get(query) {
+    try {
+      const payload = this.payloadFor(query);
+      const {
+        data: { data }
+      } = await axios.post(this.url, payload);
+      return data;
+    } catch (error) {
+      console.error('GaugesSubgraphClient request failed', error);
+      throw error;
+    }
+  }
+
+  public payloadFor(query) {
+    return JSON.stringify({ query: jsonToGraphQLQuery({ query }) });
+  }
+}
+
+export const gaugesSubgraphClient = new GaugesSubgraphClient();

--- a/src/services/balancer/gauges/gauges-subgraph.service.ts
+++ b/src/services/balancer/gauges/gauges-subgraph.service.ts
@@ -1,0 +1,16 @@
+import { gaugesSubgraphClient } from './gauges-subgraph.client';
+import { rpcProviderService as _rpcProviderService } from '@/services/rpc-provider/rpc-provider.service';
+import Gauges from './entities/gauges';
+
+export default class GaugesSubgraphService {
+  gauges: Gauges;
+
+  constructor(
+    readonly client = gaugesSubgraphClient,
+    readonly rpcProviderService = _rpcProviderService
+  ) {
+    this.gauges = new Gauges(this);
+  }
+}
+
+export const gaugesSubgraphService = new GaugesSubgraphService();

--- a/src/services/balancer/gauges/types.ts
+++ b/src/services/balancer/gauges/types.ts
@@ -1,0 +1,19 @@
+import { BigNumber } from 'ethers';
+
+export type Address = string;
+export type QueryArgs = Record<string, any>;
+export type QueryAttrs = Record<string, any>;
+export type QueryBuilder = (
+  args?: QueryArgs,
+  attrs?: QueryAttrs
+) => Record<string, any>;
+
+export type SubgraphGauge = {
+  id: string;
+  symbol: string;
+  pool: string;
+  totalSupply: BigNumber;
+  factory: {
+    id: string;
+  };
+};


### PR DESCRIPTION
# Description

Adds a subgraph service for fetching gauges.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## How should this be tested?

- [ ] Pull branch, import `useGaugesQuery` on a page and log the response.

## Visual context

n/a

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have requested at least 2 reviews (If the PR is significant enough, use best judgement here)
- [ ] I have commented my code where relevant, particularly in hard-to-understand areas
- [ ] If package-lock.json has changes, it was intentional.
- [ ] The base of this PR is `master` if hotfix, `develop` if not
