### PR TITLE
always show trade route if storage key is set

### DIFF
--- a/src/components/cards/TradeCardGP/TradeCardGP.vue
+++ b/src/components/cards/TradeCardGP/TradeCardGP.vue
@@ -102,6 +102,18 @@
           <div v-html="$t('tradeGaslessToggle.tooltip')" />
         </BalTooltip>
       </div>
+      <div>
+        <TradeRoute
+          v-if="alwaysShowRoutes"
+          :address-in="trading.tokenIn.value.address"
+          :amount-in="trading.tokenInAmountInput.value"
+          :address-out="trading.tokenOut.value.address"
+          :amount-out="trading.tokenOutAmountInput.value"
+          :pools="trading.sor.pools.value"
+          :sor-return="trading.sor.sorReturn.value"
+          class="mt-5"
+        />
+      </div>
     </div>
   </BalCard>
   <teleport to="#modal">
@@ -135,6 +147,7 @@ import { TOKENS } from '@/constants/tokens';
 
 import { isRequired } from '@/lib/utils/validations';
 import { WrapType } from '@/lib/utils/balancer/wrapper';
+import { lsGet } from '@/lib/utils';
 
 import TradePreviewModalGP from '@/components/modals/TradePreviewModalGP.vue';
 import TradeSettingsPopover, {
@@ -145,6 +158,7 @@ import { ApiErrorCodes } from '@/services/gnosis/errors/OperatorError';
 
 import GasReimbursement from '../TradeCard/GasReimbursement.vue';
 import TradePair from '../TradeCard/TradePair.vue';
+import TradeRoute from '../TradeCard/TradeRoute.vue';
 import useWeb3 from '@/services/web3/useWeb3';
 import { useTradeState } from '@/composables/trade/useTradeState';
 
@@ -152,6 +166,7 @@ export default defineComponent({
   components: {
     TradePair,
     TradePreviewModalGP,
+    TradeRoute,
     TradeSettingsPopover,
     GasReimbursement
   },
@@ -180,6 +195,7 @@ export default defineComponent({
     const dismissedErrors = ref({
       highPriceImpact: false
     });
+    const alwaysShowRoutes = lsGet('alwaysShowRoutes', false);
 
     const tradeCardShadow = computed(() => {
       switch (bp.value) {
@@ -378,6 +394,7 @@ export default defineComponent({
       tokenOutAddress,
       tokenOutAmount,
       modalTradePreviewIsOpen,
+      alwaysShowRoutes,
       exactIn,
       trading,
 

--- a/src/components/cards/TradeCardGP/TradeCardGP.vue
+++ b/src/components/cards/TradeCardGP/TradeCardGP.vue
@@ -102,18 +102,16 @@
           <div v-html="$t('tradeGaslessToggle.tooltip')" />
         </BalTooltip>
       </div>
-      <div>
-        <TradeRoute
-          v-if="alwaysShowRoutes"
-          :address-in="trading.tokenIn.value.address"
-          :amount-in="trading.tokenInAmountInput.value"
-          :address-out="trading.tokenOut.value.address"
-          :amount-out="trading.tokenOutAmountInput.value"
-          :pools="trading.sor.pools.value"
-          :sor-return="trading.sor.sorReturn.value"
-          class="mt-5"
-        />
-      </div>
+      <TradeRoute
+        v-if="alwaysShowRoutes"
+        :address-in="trading.tokenIn.value.address"
+        :amount-in="trading.tokenInAmountInput.value"
+        :address-out="trading.tokenOut.value.address"
+        :amount-out="trading.tokenOutAmountInput.value"
+        :pools="trading.sor.pools.value"
+        :sor-return="trading.sor.sorReturn.value"
+        class="mt-4"
+      />
     </div>
   </BalCard>
   <teleport to="#modal">


### PR DESCRIPTION
# Description

Adds logic so that if a localStorage `alwaysShowRoutes` key is set, the Trade Route card can be seen on the main page even if the wallet doesn't have enough balances. No need to allow users to set this flag in the UI, this is just a nice to have that can be shared with pro users.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## How should this be tested?

Please provide instructions so we can test. Please also list any relevant details for your test configuration.

- [ ] In Chrome developer tools create a key `@balancer-labs/frontend-v2.alwaysShowRoutes` and set to true. Try entering trade amounts on the swap page

## Visual context

Please provide any relevant visual context for UI changes or additions. This could be static screenshots or a loom screencast.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have requested at least 2 reviews (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] If package-lock.json has changes, it was intentional.
- [x] The base of this PR is `master` if hotfix, `develop` if not
