### PR TITLE
hotfix/1.41.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.41.2",
+  "version": "1.41.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@balancer-labs/frontend-v2",
-      "version": "1.41.2",
+      "version": "1.41.3",
       "license": "MIT",
       "devDependencies": {
         "@aave/protocol-js": "^4.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.41.2",
+  "version": "1.41.3",
   "engines": {
     "node": "14.x",
     "npm": ">=7"

--- a/src/components/cards/TradeCard/TradePair.vue
+++ b/src/components/cards/TradeCard/TradePair.vue
@@ -175,6 +175,7 @@ watchEffect(() => {
       noRules
       noMax
       :disabled="tradeLoading"
+      disableNativeAssetBuffer
     />
   </div>
 </template>

--- a/src/services/gas-price/gas-price.service.ts
+++ b/src/services/gas-price/gas-price.service.ts
@@ -57,8 +57,8 @@ export default class GasPriceService {
       if (gasPrice != null) {
         if (
           ethereumTxType.value === EthereumTxType.EIP1559 &&
-          options.maxFeePerGas != null &&
-          options.maxPriorityFeePerGas != null &&
+          gasPrice.maxFeePerGas != null &&
+          gasPrice.maxPriorityFeePerGas != null &&
           !forceEthereumLegacyTxType
         ) {
           gasSettings.maxFeePerGas = gasPrice.maxFeePerGas;


### PR DESCRIPTION
# Description

This PR addressed 2 of the bugs @timjrobinson reported:
1. Showing ETH warning when trading to ETH
2. When turning off trade gasless it sets the priority fee to same as gas fee

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## How should this be tested?

Please provide instructions so we can test. Please also list any relevant details for your test configuration.

- [ ] Trade DAI to ETH (shouldn't show buffer message)
- [ ] Trade ETH to DAI (should show the buffer message)
- [ ] Turn off gasless and trade normally - should use EIP1559 (`maxFeePerGas` and `maxPriorityFeePerGas`) will be used.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have requested at least 2 reviews (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] If package-lock.json has changes, it was intentional.
- [x] The base of this PR is `master` if hotfix, `develop` if not
