### PR TITLE
Hotfix: Fix gnosis / cowswap explorer link

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.41.4",
+  "version": "1.42.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@balancer-labs/frontend-v2",
-      "version": "1.41.4",
+      "version": "1.42.1",
       "license": "MIT",
       "devDependencies": {
         "@aave/protocol-js": "^4.3.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.41.3",
+  "version": "1.41.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@balancer-labs/frontend-v2",
-      "version": "1.41.3",
+      "version": "1.41.4",
       "license": "MIT",
       "devDependencies": {
         "@aave/protocol-js": "^4.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.41.3",
+  "version": "1.41.4",
   "engines": {
     "node": "14.x",
     "npm": ">=7"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.41.4",
+  "version": "1.42.1",
   "engines": {
     "node": "14.x",
     "npm": ">=7"

--- a/src/services/gnosis/explorer.service.ts
+++ b/src/services/gnosis/explorer.service.ts
@@ -11,7 +11,7 @@ export default class GnosisExplorerService {
     } else if (IS_STAGING) {
       this.baseURL = 'https://protocol-explorer.staging.gnosisdev.com';
     } else {
-      this.baseURL = 'https://gnosis-protocol.io';
+      this.baseURL = 'https://explorer.cow.fi';
     }
   }
 


### PR DESCRIPTION
# Description

Gnosis has moved their explorer domain to https://explorer.cow.fi, without redirection from the old domain, so all transaction links are just going to the explorer homepage at the moment. 

Example of old link: https://gnosis-protocol.io/orders/0xaea6aee87af7c77b96855aaa26459f89a2771a67e6c84836ce199d46a5202389ad66946538e4b03b1910dade713febb8b59cff606219c21c

Notice when you go to it it redirects to the new domain homepage

New link for same transaction: https://explorer.cow.fi/orders/0xaea6aee87af7c77b96855aaa26459f89a2771a67e6c84836ce199d46a5202389ad66946538e4b03b1910dade713febb8b59cff606219c21c

I couldn't find the development domains to replace them, not sure what they should be. 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## How should this be tested?

- Perform a trade on Balancer
- Click the activities link in the top right
- Click the link on the transaction to go to the Gnosis / Cowswap explorer for it. 

## Visual context

Please provide any relevant visual context for UI changes or additions. This could be static screenshots or a loom screencast.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have requested at least 2 reviews (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] If package-lock.json has changes, it was intentional.
- [x] The base of this PR is `master` if hotfix, `develop` if not
