### PR TITLE
Remember alert closure

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -63,6 +63,7 @@ export default defineComponent({
         priority: AlertPriority.LOW,
         label: t('alerts.boostedPools'),
         type: AlertType.FEATURE,
+        rememberClose: true,
         actionOnClick: true,
         action: () =>
           router.push({

--- a/src/composables/useAlerts.ts
+++ b/src/composables/useAlerts.ts
@@ -1,5 +1,6 @@
 import { computed, ref } from 'vue';
 import { orderBy } from 'lodash';
+import { lsGet, lsSet } from '@/lib/utils';
 
 export enum AlertType {
   ERROR = 'error',
@@ -22,6 +23,7 @@ export type Alert = {
   action?: () => void;
   actionOnClick?: boolean;
   persistent?: boolean;
+  rememberClose?: boolean;
 };
 
 export const alertsState = ref<Record<string, Alert>>({});
@@ -40,6 +42,9 @@ const currentAlert = computed(() =>
  * METHODS
  */
 function addAlert(alert: Alert) {
+  const wasClosed = lsGet(`alerts.${alert.id}.closed`);
+  if (wasClosed && alert?.rememberClose) return;
+
   alertsState.value[alert.id] = {
     ...alert,
     priority: alert.priority ?? AlertPriority.LOW
@@ -47,6 +52,9 @@ function addAlert(alert: Alert) {
 }
 
 function removeAlert(alertId: string) {
+  const alert = alertsState.value[alertId];
+  if (alert?.rememberClose) lsSet(`alerts.${alertId}.closed`, true);
+
   delete alertsState.value[alertId];
 }
 


### PR DESCRIPTION
# Description

Adds conditional to Alert schema, `rememberClose`, which uses local storage to remember if an alert was closed and prevents it from being shown again. This has then been applied to the boosted pools banner.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## How should this be tested?

- [ ] Test on mainnet that when you close the boosted pool banner and refresh it doesn't show again.

## Visual context

n/a

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have requested at least 2 reviews (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] If package-lock.json has changes, it was intentional.
- [x] The base of this PR is `master` if hotfix, `develop` if not
