### PR TITLE
Fix css deep combinator deprecation warnings

### DIFF
--- a/src/pages/_layouts/ContentLayout.vue
+++ b/src/pages/_layouts/ContentLayout.vue
@@ -17,60 +17,60 @@ import AppNav from '@/components/navs/AppNav/AppNav.vue';
   min-height: calc(100vh - 140px);
 }
 
-.content-container >>> h1 {
+.content-container :deep(h1) {
   @apply pb-6;
 }
 
-.content-container >>> h2,
-.content-container >>> h3,
-.content-container >>> p,
-.content-container >>> ul,
-.content-container >>> ol,
-.content-container >>> em {
+.content-container :deep(h2),
+.content-container :deep(h3),
+.content-container :deep(p),
+.content-container :deep(ul),
+.content-container :deep(ol),
+.content-container :deep(em) {
   @apply pb-3;
 }
 
-.content-container >>> .subsection {
+.content-container :deep(.subsection) {
   @apply mb-8;
 }
 
-.content-container >>> h1,
-.content-container >>> h2,
-.content-container >>> h3 {
+.content-container :deep(h1),
+.content-container :deep(h2),
+.content-container :deep(h3) {
   @apply font-body tracking-tight;
   font-variation-settings: 'wght' 500;
 }
 
-.content-container >>> h3 {
+.content-container :deep(h3) {
   @apply font-body tracking-tight;
   font-variation-settings: 'wght' 600;
 }
 
-.content-container >>> li {
+.content-container :deep(li) {
   @apply list-disc ml-8 pb-2;
 }
 
-.content-container >>> ol > li {
+.content-container :deep(ol > li) {
   @apply list-decimal;
 }
 
-.content-container >>> em {
+.content-container :deep(em) {
   font-style: italic;
   font-variation-settings: 'ital' 1;
   font-synthesis: none;
 }
 
-.content-container >>> em.font-medium {
+.content-container :deep(em.font-medium) {
   font-variation-settings: 'ital' 1, 'wght' 500;
 }
 
-.content-container >>> table,
-.content-container >>> th,
-.content-container >>> td {
+.content-container :deep(table),
+.content-container :deep(th),
+.content-container :deep(td) {
   @apply p-4 border-gray-500 border text-left align-top;
 }
 
-.content-container >>> table {
+.content-container :deep(table) {
   @apply mt-4 mb-8;
 }
 </style>


### PR DESCRIPTION
# Description

Fixes warnings thrown about deprecated CSS combinator in vue compiler.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [x] Other

## How should this be tested?

Please provide instructions so we can test. Please also list any relevant details for your test configuration.

- [ ] Test content pages like Terms of service page, display as expected
- [ ] Test that on dev startup of server no warnings are shown

## Visual context

<img width="798" alt="Screenshot 2022-03-03 at 15 41 45" src="https://user-images.githubusercontent.com/2406506/156598812-167d2f40-2b9b-4ac8-afd2-b1a03f20512e.png">

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have requested at least 2 reviews (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] If package-lock.json has changes, it was intentional.
- [x] The base of this PR is `master` if hotfix, `develop` if not
