### PR TITLE
Allow setting of bg color via route meta

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -20,6 +20,7 @@ import useAlerts, {
 } from './composables/useAlerts';
 import { useI18n } from 'vue-i18n';
 import useExploitWatcher from './composables/watchers/useExploitWatcher';
+import useBackgroundColor from './composables/useBackgroundColor';
 
 BigNumber.config({ DECIMAL_PLACES: DEFAULT_TOKEN_DECIMALS });
 
@@ -55,6 +56,7 @@ export default defineComponent({
     const router = useRouter();
     const { addAlert } = useAlerts();
     const { t } = useI18n();
+    const { newRouteHandler: updateBgColorFor } = useBackgroundColor();
 
     // Temporary feature alert for Balancer boosted pools.
     if (isMainnet.value) {
@@ -93,6 +95,7 @@ export default defineComponent({
      * WATCHERS
      */
     watch(route, newRoute => {
+      updateBgColorFor(newRoute);
       if (newRoute.meta.layout) {
         layout.value = newRoute.meta.layout as string;
       } else {

--- a/src/assets/css/global/all.css
+++ b/src/assets/css/global/all.css
@@ -25,7 +25,6 @@ input {
 }
 
 #app {
-  @apply bg-white dark:bg-gray-900;
   @apply text-gray-900 dark:text-gray-50;
   min-height: calc(100vh + 1px);
 }

--- a/src/composables/useBackgroundColor.ts
+++ b/src/composables/useBackgroundColor.ts
@@ -1,0 +1,70 @@
+/**
+ * useBackgroundColor
+ *
+ * @description Adds ability to change page background color via route meta.
+ * This composable should only be imported once at the app component level
+ * because it watches dark mode and toggles the background color. We don't
+ * want that happening in multiple places.
+ *
+ * @dev to use, set route meta.bgColors attribute in router.ts for page.
+ */
+import { ref, watch } from 'vue';
+import useDarkMode from '@/composables/useDarkMode';
+import { RouteLocationNormalizedLoaded, useRoute } from 'vue-router';
+
+/**
+ * CONSTANTS
+ */
+const defaultBgColor = 'bg-white';
+const defaultDarkBgColor = 'bg-gray-900';
+
+/**
+ * STATE
+ */
+const bgColor = ref(defaultBgColor);
+
+/**
+ * COMPOSABLES
+ */
+const { darkMode } = useDarkMode();
+
+/**
+ * METHODS
+ */
+function setBackgroundColor(color: string): void {
+  document.documentElement.classList.remove(bgColor.value);
+  bgColor.value = color;
+  document.documentElement.classList.add(bgColor.value);
+}
+
+function setDefaultBgColor(): void {
+  if (darkMode.value) {
+    setBackgroundColor(defaultDarkBgColor);
+  } else {
+    setBackgroundColor(defaultBgColor);
+  }
+}
+
+export function newRouteHandler(newRoute: RouteLocationNormalizedLoaded): void {
+  if (darkMode.value && newRoute.meta.bgColors?.dark) {
+    setBackgroundColor(newRoute.meta.bgColors.dark);
+  } else if (!darkMode.value && newRoute.meta.bgColors?.light) {
+    setBackgroundColor(newRoute.meta.bgColors.light);
+  } else {
+    setDefaultBgColor();
+  }
+}
+
+/**
+ * INIT
+ */
+setDefaultBgColor();
+
+export default function useBackgroundColor() {
+  const route = useRoute();
+  watch(darkMode, () => newRouteHandler(route));
+
+  return {
+    newRouteHandler
+  };
+}

--- a/src/composables/useDarkMode.ts
+++ b/src/composables/useDarkMode.ts
@@ -14,9 +14,9 @@ function setDarkMode(val: boolean): void {
   darkMode.value = val;
   lsSet(LS_KEYS.App.DarkMode, darkMode.value.toString());
   if (darkMode.value) {
-    document.documentElement.classList.add('dark', 'bg-gray-900');
+    document.documentElement.classList.add('dark');
   } else {
-    document.documentElement.classList.remove('dark', 'bg-gray-900');
+    document.documentElement.classList.remove('dark');
   }
 }
 

--- a/src/plugins/router.ts
+++ b/src/plugins/router.ts
@@ -11,6 +11,16 @@ import TermsOfUsePage from '@/pages/terms-of-use.vue';
 import PrivacyPolicyPage from '@/pages/privacy-policy.vue';
 import CookiesPolicyPage from '@/pages/cookies-policy.vue';
 
+declare module 'vue-router' {
+  interface RouteMeta {
+    layout?: string;
+    bgColors?: {
+      dark: string;
+      light: string;
+    };
+  }
+}
+
 const routes: RouteRecordRaw[] = [
   {
     path: '/',


### PR DESCRIPTION
# Description

Adds background color attributes to route meta so that different pages can have different background colors on the HTML tag.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## How should this be tested?

- [ ] Set a background color for a page locally and click through and refresh pages to check background color is always correct.

## Visual context

n/a

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have requested at least 2 reviews (If the PR is significant enough, use best judgement here)
- [ ] I have commented my code where relevant, particularly in hard-to-understand areas
- [ ] If package-lock.json has changes, it was intentional.
- [ ] The base of this PR is `master` if hotfix, `develop` if not
