### PR TITLE
Tokenomics - Add skeleton claims page

### DIFF
--- a/src/components/cards/StatCard/StatCard.spec.ts
+++ b/src/components/cards/StatCard/StatCard.spec.ts
@@ -1,0 +1,34 @@
+import { render } from '@testing-library/vue';
+import StatCard from './StatCard.vue';
+import BalCard from '@/components/_global/BalCard/BalCard.vue';
+
+StatCard.components = { BalCard };
+
+describe.only('StatCard', () => {
+  describe('When using StatCard', () => {
+    it('should render props', () => {
+      const { getByText } = render(StatCard, {
+        props: {
+          label: 'Prop label',
+          value: '$10,000'
+        }
+      });
+
+      // check that elements are actually rendered as children
+      expect(getByText('Prop label')).toBeVisible();
+      expect(getByText('$10,000')).toBeVisible();
+    });
+
+    it('Should render slots', () => {
+      const { getByText } = render(StatCard, {
+        slots: {
+          label: '<span>Slot label</span>',
+          value: '<span>$100,000</span>'
+        }
+      });
+
+      expect(getByText('Slot label')).toBeVisible();
+      expect(getByText('$100,000')).toBeVisible();
+    });
+  });
+});

--- a/src/components/cards/StatCard/StatCard.vue
+++ b/src/components/cards/StatCard/StatCard.vue
@@ -1,0 +1,23 @@
+<script lang="ts" setup>
+type Props = {
+  label?: string;
+  value?: string;
+};
+
+defineProps<Props>();
+</script>
+
+<template>
+  <BalCard>
+    <div class="text-sm text-gray-500 font-medium mb-2">
+      <slot name="label">
+        {{ label }}
+      </slot>
+    </div>
+    <div class="text-xl font-medium truncate flex items-center">
+      <slot name="value">
+        {{ value }}
+      </slot>
+    </div>
+  </BalCard>
+</template>

--- a/src/locales/default.json
+++ b/src/locales/default.json
@@ -331,6 +331,7 @@
     "learnMore": "Learn more",
     "light": "Light",
     "liquidityBootstrappingPool": "Liquidity Bootstrapping Pool",
+    "liquidityIncentives": "liquidity incentives",
     "liquidityMining": "Liquidity mining",
     "liquidityMiningAPR": "Liquidity Mining APR",
     "liquidityMiningPopover": {
@@ -423,6 +424,18 @@
     "overview": "Overview",
     "ownerFeesTooltip": "Liquidity providers earn dynamic swap fees on every trade utilizing the liquidity in this pool. Dynamic swap fees are controlled by the pool owner.",
     "payload": "Payload",
+    "pages": {
+        "claim": {
+            "title": "Claim all of your liquidity incentives",
+            "description": "The Balancer protocol provides incentives to attract liquidity in eligible pools.",
+            "titles": {
+                "incentivesOnOtherNetworks": "Incentives on other networks"
+            },
+            "btns": {
+                "claimOn": "Claim on"
+            }
+        }
+    },
     "pendingClaims": "Pending claims",
     "pendingEstimate": "Pending: (estimate)",
     "perWeek": "per week",

--- a/src/pages/claim.vue
+++ b/src/pages/claim.vue
@@ -10,7 +10,8 @@ import StatCard from '@/components/cards/StatCard/StatCard.vue';
           Claim all of your liquidity incentives
         </h1>
         <p class="text-lg text-gray-600 mt-2">
-          The Balancer protocol provides incentives to attract liquidity in eligible pools.
+          The Balancer protocol provides incentives to attract liquidity in
+          eligible pools.
         </p>
         <BalBtn outline class="mt-4">
           Learn more

--- a/src/pages/claim.vue
+++ b/src/pages/claim.vue
@@ -79,7 +79,6 @@ const networkBtns = computed(() => {
           Claim on {{ network.name }}
         </BalBtn>
       </div>
-
     </div>
   </div>
 </template>

--- a/src/pages/claim.vue
+++ b/src/pages/claim.vue
@@ -1,9 +1,36 @@
 <script lang="ts" setup>
+import { computed } from 'vue';
 import StatCard from '@/components/cards/StatCard/StatCard.vue';
+import { configService } from '@/services/config/config.service';
+
+const networks = [
+  {
+    id: 'ethereum',
+    name: 'Ethereum',
+    subdomain: 'app',
+    key: '1'
+  },
+  {
+    id: 'polygon',
+    name: 'Polygon',
+    subdomain: 'polygon',
+    key: '137'
+  },
+  {
+    id: 'arbitrum',
+    name: 'Arbitrum',
+    subdomain: 'arbitrum',
+    key: '42161'
+  }
+];
+
+const networkBtns = computed(() => {
+  return networks.filter(network => network.key !== configService.network.key);
+});
 </script>
 
 <template>
-  <div class="lg:container lg:mx-auto pt-10 md:pt-12">
+  <div class="lg:container lg:mx-auto py-12">
     <div class="grid gap-24 grid-cols-2 grid-rows-1">
       <div class="">
         <h1 class="font-body font-bold text-4xl">
@@ -24,6 +51,35 @@ import StatCard from '@/components/cards/StatCard/StatCard.vue';
         <StatCard label="My 24h yield" value="$12.6845" />
         <StatCard label="My 24h APR" value="12.46%" />
       </div>
+    </div>
+  </div>
+  <div class="bg-gray-50">
+    <div class="lg:container lg:mx-auto py-12">
+      <h2 class="font-body font-bold text-2xl">
+        {{ configService.network.chainName }} liquidity incentives
+      </h2>
+
+      <h2 class="font-body font-bold text-2xl">
+        Incentives on other networks
+      </h2>
+      <div class="flex mt-4">
+        <BalBtn
+          tag="a"
+          :href="`https://${network.subdomain}.balancer.fi/#/claims`"
+          v-for="network in networkBtns"
+          :key="network.id"
+          color="white"
+          class="mr-4"
+        >
+          <img
+            :src="require(`@/assets/images/icons/networks/${network.id}.svg`)"
+            alt="Arbitrum"
+            class="w-6 h-6 rounded-full shadow-sm mr-2"
+          />
+          Claim on {{ network.name }}
+        </BalBtn>
+      </div>
+
     </div>
   </div>
 </template>

--- a/src/pages/claim.vue
+++ b/src/pages/claim.vue
@@ -1,0 +1,28 @@
+<script lang="ts" setup>
+import StatCard from '@/components/cards/StatCard/StatCard.vue';
+</script>
+
+<template>
+  <div class="lg:container lg:mx-auto pt-10 md:pt-12">
+    <div class="grid gap-24 grid-cols-2 grid-rows-1">
+      <div class="">
+        <h1 class="font-body font-bold text-4xl">
+          Claim all of your liquidity incentives
+        </h1>
+        <p class="text-lg text-gray-600 mt-2">
+          The Balancer protocol provides incentives to attract liquidity in eligible pools.
+        </p>
+        <BalBtn outline class="mt-4">
+          Learn more
+          <BalIcon name="arrow-up-right" class="ml-2" />
+        </BalBtn>
+      </div>
+      <div class="grid gap-4 grid-cols-2 grid-rows-2">
+        <StatCard label="My claimable incentives" value="$10,400.00" />
+        <StatCard label="My 30d yield" value="$480.56" />
+        <StatCard label="My 24h yield" value="$12.6845" />
+        <StatCard label="My 24h APR" value="12.46%" />
+      </div>
+    </div>
+  </div>
+</template>

--- a/src/pages/claim.vue
+++ b/src/pages/claim.vue
@@ -34,14 +34,13 @@ const networkBtns = computed(() => {
     <div class="grid gap-24 grid-cols-2 grid-rows-1">
       <div class="">
         <h1 class="font-body font-bold text-4xl">
-          Claim all of your liquidity incentives
+          {{ $t('pages.claim.title') }}
         </h1>
         <p class="text-lg text-gray-600 mt-2">
-          The Balancer protocol provides incentives to attract liquidity in
-          eligible pools.
+          {{ $t('pages.claim.description') }}
         </p>
         <BalBtn outline class="mt-4">
-          Learn more
+          {{ $t('learnMore') }}
           <BalIcon name="arrow-up-right" class="ml-2" />
         </BalBtn>
       </div>
@@ -56,11 +55,11 @@ const networkBtns = computed(() => {
   <div class="bg-gray-50">
     <div class="lg:container lg:mx-auto py-12">
       <h2 class="font-body font-bold text-2xl">
-        {{ configService.network.chainName }} liquidity incentives
+        {{ configService.network.chainName }} {{ $t('liquidityIncentives') }}
       </h2>
 
       <h2 class="font-body font-bold text-2xl">
-        Incentives on other networks
+        {{ $t('pages.claim.titles.incentivesOnOtherNetworks') }}
       </h2>
       <div class="flex mt-4">
         <BalBtn
@@ -76,7 +75,7 @@ const networkBtns = computed(() => {
             alt="Arbitrum"
             class="w-6 h-6 rounded-full shadow-sm mr-2"
           />
-          Claim on {{ network.name }}
+          {{ $t('pages.claim.btns.claimOn') }} {{ network.name }}
         </BalBtn>
       </div>
     </div>

--- a/src/pages/claim.vue
+++ b/src/pages/claim.vue
@@ -45,10 +45,10 @@ const networkBtns = computed(() => {
         </BalBtn>
       </div>
       <div class="grid gap-4 grid-cols-2 grid-rows-2">
-        <StatCard label="My claimable incentives" value="$10,400.00" />
-        <StatCard label="My 30d yield" value="$480.56" />
-        <StatCard label="My 24h yield" value="$12.6845" />
-        <StatCard label="My 24h APR" value="12.46%" />
+        <StatCard label="My claimable incentives" value="-" />
+        <StatCard label="My 30d yield" value="-" />
+        <StatCard label="My 24h yield" value="-" />
+        <StatCard label="My 24h APR" value="-" />
       </div>
     </div>
   </div>

--- a/src/plugins/router.ts
+++ b/src/plugins/router.ts
@@ -10,6 +10,7 @@ import MigratePoolPage from '@/pages/pool/migrate.vue';
 import TermsOfUsePage from '@/pages/terms-of-use.vue';
 import PrivacyPolicyPage from '@/pages/privacy-policy.vue';
 import CookiesPolicyPage from '@/pages/cookies-policy.vue';
+import ClaimPage from '@/pages/claim.vue';
 
 declare module 'vue-router' {
   interface RouteMeta {
@@ -31,6 +32,11 @@ const routes: RouteRecordRaw[] = [
     path: '/trade/:assetIn?/:assetOut?',
     name: 'trade',
     component: TradePage
+  },
+  {
+    path: '/claim',
+    name: 'claim',
+    component: ClaimPage
   },
   {
     path: '/swap/:assetIn?/:assetOut?',

--- a/src/plugins/router.ts
+++ b/src/plugins/router.ts
@@ -34,11 +34,6 @@ const routes: RouteRecordRaw[] = [
     component: TradePage
   },
   {
-    path: '/claim',
-    name: 'claim',
-    component: ClaimPage
-  },
-  {
     path: '/swap/:assetIn?/:assetOut?',
     redirect: to => {
       return `/trade${to.path.split('/swap')[1]}`;
@@ -109,7 +104,17 @@ const routes: RouteRecordRaw[] = [
 if (
   ['development', 'staging'].includes(process.env.VUE_APP_ENV || 'development')
 ) {
-  // routes.push();
+  routes.push({
+    path: '/claim',
+    name: 'claim',
+    component: ClaimPage,
+    meta: {
+      bgColors: {
+        light: 'bg-gray-50',
+        dark: 'bg-gray-800'
+      }
+    }
+  });
 }
 
 const router = createRouter({


### PR DESCRIPTION
# Description

Adds skeleton for claim page under dev/staging guard in routes. Will only be accessible via beta apps or locally.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## How should this be tested?

- [ ] Check that you can access a page at /claim on beta apps but not on production apps.

## Visual context

n/a

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have requested at least 2 reviews (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] If package-lock.json has changes, it was intentional.
- [x] The base of this PR is `master` if hotfix, `develop` if not
