### PR TITLE
Update SOR. Changed to handle SDK Relayer error throwing.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.42.4",
+  "version": "1.42.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@balancer-labs/frontend-v2",
-      "version": "1.42.4",
+      "version": "1.42.6",
       "license": "MIT",
       "devDependencies": {
         "@aave/protocol-js": "^4.3.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@babel/plugin-proposal-numeric-separator": "^7.14.5",
         "@balancer-labs/assets": "github:balancer-labs/assets#master",
         "@balancer-labs/balancer-js": "^1.0.1",
-        "@balancer-labs/sdk": "^0.1.1",
+        "@balancer-labs/sdk": "^0.1.2",
         "@balancer-labs/sor": "^1.1.0",
         "@balancer-labs/typechain": "^1.0.0",
         "@ensdomains/content-hash": "^2.5.3",
@@ -2002,12 +2002,12 @@
       }
     },
     "node_modules/@balancer-labs/sdk": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/@balancer-labs/sdk/-/sdk-0.1.1.tgz",
-      "integrity": "sha512-CqwGVbb6OORF/GmQHgx01sfbGAz8cXCfCUDpNhYjXGj0GO6q9GqBmc6jWIl6GF1DYBuQiPwvi2q3TsFhlUe+PA==",
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@balancer-labs/sdk/-/sdk-0.1.2.tgz",
+      "integrity": "sha512-A5GC7HbRMSQZ/Sz/L5kt7fHswHTxN7G4076dTOcPTxLDt28mbz6YPGOxPi9zBLDvAR5bEn2jLHEhwECJVXGeZw==",
       "dev": true,
       "dependencies": {
-        "@balancer-labs/sor": "3.0.0-beta.0",
+        "@balancer-labs/sor": "3.0.0-beta.1",
         "@ethersproject/abi": "^5.5.0",
         "@ethersproject/abstract-signer": "^5.5.0",
         "@ethersproject/contracts": "^5.5.0",
@@ -2028,9 +2028,9 @@
       }
     },
     "node_modules/@balancer-labs/sdk/node_modules/@balancer-labs/sor": {
-      "version": "3.0.0-beta.0",
-      "resolved": "https://registry.npmjs.org/@balancer-labs/sor/-/sor-3.0.0-beta.0.tgz",
-      "integrity": "sha512-Yp8FDjj0KJtaxyZIbktRZ1ECyd3THVrzgi32RtPwDeGAqWssbCCR130eAZdtJwm/og6BF7FdwBkbQI9N4J5wyQ==",
+      "version": "3.0.0-beta.1",
+      "resolved": "https://registry.npmjs.org/@balancer-labs/sor/-/sor-3.0.0-beta.1.tgz",
+      "integrity": "sha512-mtB6EO/qJj1OSFbMezoQ55ciLv/sCe4oR9i0I3MbfGucMMxkEewOmsy4ZUvMexHteYBto8B+OlY+7MxxigDGjg==",
       "dev": true,
       "dependencies": {
         "@georgeroman/balancer-v2-pools": "0.0.7",
@@ -2317,9 +2317,9 @@
       }
     },
     "node_modules/@balancer-labs/sdk/node_modules/@ethersproject/providers": {
-      "version": "5.5.2",
-      "resolved": "https://registry.npmjs.org/@ethersproject/providers/-/providers-5.5.2.tgz",
-      "integrity": "sha512-hkbx7x/MKcRjyrO4StKXCzCpWer6s97xnm34xkfPiarhtEUVAN4TBBpamM+z66WcTt7H5B53YwbRj1n7i8pZoQ==",
+      "version": "5.5.3",
+      "resolved": "https://registry.npmjs.org/@ethersproject/providers/-/providers-5.5.3.tgz",
+      "integrity": "sha512-ZHXxXXXWHuwCQKrgdpIkbzMNJMvs+9YWemanwp1fA7XZEv7QlilseysPvQe0D7Q7DlkJX/w/bGA1MdgK2TbGvA==",
       "dev": true,
       "funding": [
         {
@@ -37295,12 +37295,12 @@
       }
     },
     "@balancer-labs/sdk": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/@balancer-labs/sdk/-/sdk-0.1.1.tgz",
-      "integrity": "sha512-CqwGVbb6OORF/GmQHgx01sfbGAz8cXCfCUDpNhYjXGj0GO6q9GqBmc6jWIl6GF1DYBuQiPwvi2q3TsFhlUe+PA==",
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@balancer-labs/sdk/-/sdk-0.1.2.tgz",
+      "integrity": "sha512-A5GC7HbRMSQZ/Sz/L5kt7fHswHTxN7G4076dTOcPTxLDt28mbz6YPGOxPi9zBLDvAR5bEn2jLHEhwECJVXGeZw==",
       "dev": true,
       "requires": {
-        "@balancer-labs/sor": "3.0.0-beta.0",
+        "@balancer-labs/sor": "3.0.0-beta.1",
         "@ethersproject/abi": "^5.5.0",
         "@ethersproject/abstract-signer": "^5.5.0",
         "@ethersproject/contracts": "^5.5.0",
@@ -37312,9 +37312,9 @@
       },
       "dependencies": {
         "@balancer-labs/sor": {
-          "version": "3.0.0-beta.0",
-          "resolved": "https://registry.npmjs.org/@balancer-labs/sor/-/sor-3.0.0-beta.0.tgz",
-          "integrity": "sha512-Yp8FDjj0KJtaxyZIbktRZ1ECyd3THVrzgi32RtPwDeGAqWssbCCR130eAZdtJwm/og6BF7FdwBkbQI9N4J5wyQ==",
+          "version": "3.0.0-beta.1",
+          "resolved": "https://registry.npmjs.org/@balancer-labs/sor/-/sor-3.0.0-beta.1.tgz",
+          "integrity": "sha512-mtB6EO/qJj1OSFbMezoQ55ciLv/sCe4oR9i0I3MbfGucMMxkEewOmsy4ZUvMexHteYBto8B+OlY+7MxxigDGjg==",
           "dev": true,
           "requires": {
             "@georgeroman/balancer-v2-pools": "0.0.7",
@@ -37481,9 +37481,9 @@
           }
         },
         "@ethersproject/providers": {
-          "version": "5.5.2",
-          "resolved": "https://registry.npmjs.org/@ethersproject/providers/-/providers-5.5.2.tgz",
-          "integrity": "sha512-hkbx7x/MKcRjyrO4StKXCzCpWer6s97xnm34xkfPiarhtEUVAN4TBBpamM+z66WcTt7H5B53YwbRj1n7i8pZoQ==",
+          "version": "5.5.3",
+          "resolved": "https://registry.npmjs.org/@ethersproject/providers/-/providers-5.5.3.tgz",
+          "integrity": "sha512-ZHXxXXXWHuwCQKrgdpIkbzMNJMvs+9YWemanwp1fA7XZEv7QlilseysPvQe0D7Q7DlkJX/w/bGA1MdgK2TbGvA==",
           "dev": true,
           "requires": {
             "@ethersproject/abstract-provider": "^5.5.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.42.6",
+  "version": "1.43.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@balancer-labs/frontend-v2",
-      "version": "1.42.6",
+      "version": "1.43.2",
       "license": "MIT",
       "devDependencies": {
         "@aave/protocol-js": "^4.3.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.42.3",
+  "version": "1.42.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@balancer-labs/frontend-v2",
-      "version": "1.42.3",
+      "version": "1.42.4",
       "license": "MIT",
       "devDependencies": {
         "@aave/protocol-js": "^4.3.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@babel/plugin-proposal-numeric-separator": "^7.14.5",
         "@balancer-labs/assets": "github:balancer-labs/assets#master",
         "@balancer-labs/balancer-js": "^1.0.1",
-        "@balancer-labs/sdk": "^0.1.2",
+        "@balancer-labs/sdk": "^0.1.3",
         "@balancer-labs/sor": "^1.1.0",
         "@balancer-labs/typechain": "^1.0.0",
         "@ensdomains/content-hash": "^2.5.3",
@@ -2002,9 +2002,9 @@
       }
     },
     "node_modules/@balancer-labs/sdk": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/@balancer-labs/sdk/-/sdk-0.1.2.tgz",
-      "integrity": "sha512-A5GC7HbRMSQZ/Sz/L5kt7fHswHTxN7G4076dTOcPTxLDt28mbz6YPGOxPi9zBLDvAR5bEn2jLHEhwECJVXGeZw==",
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@balancer-labs/sdk/-/sdk-0.1.3.tgz",
+      "integrity": "sha512-4fg7a2RorjQXPTniDmCJr81PaRGWnEu1/wktfoBTEIZkDbx4OxnfHhYg3IdO62Ljba1x1r6IBrttdnTQf4F98g==",
       "dev": true,
       "dependencies": {
         "@balancer-labs/sor": "3.0.0-beta.1",
@@ -37295,9 +37295,9 @@
       }
     },
     "@balancer-labs/sdk": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/@balancer-labs/sdk/-/sdk-0.1.2.tgz",
-      "integrity": "sha512-A5GC7HbRMSQZ/Sz/L5kt7fHswHTxN7G4076dTOcPTxLDt28mbz6YPGOxPi9zBLDvAR5bEn2jLHEhwECJVXGeZw==",
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@balancer-labs/sdk/-/sdk-0.1.3.tgz",
+      "integrity": "sha512-4fg7a2RorjQXPTniDmCJr81PaRGWnEu1/wktfoBTEIZkDbx4OxnfHhYg3IdO62Ljba1x1r6IBrttdnTQf4F98g==",
       "dev": true,
       "requires": {
         "@balancer-labs/sor": "3.0.0-beta.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.42.3",
+  "version": "1.42.4",
   "engines": {
     "node": "14.x",
     "npm": ">=7"

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "@babel/plugin-proposal-numeric-separator": "^7.14.5",
     "@balancer-labs/assets": "github:balancer-labs/assets#master",
     "@balancer-labs/balancer-js": "^1.0.1",
-    "@balancer-labs/sdk": "^0.1.2",
+    "@balancer-labs/sdk": "^0.1.3",
     "@balancer-labs/sor": "^1.1.0",
     "@balancer-labs/typechain": "^1.0.0",
     "@ensdomains/content-hash": "^2.5.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.42.4",
+  "version": "1.42.6",
   "engines": {
     "node": "14.x",
     "npm": ">=7"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.42.6",
+  "version": "1.43.2",
   "engines": {
     "node": "14.x",
     "npm": ">=7"

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "@babel/plugin-proposal-numeric-separator": "^7.14.5",
     "@balancer-labs/assets": "github:balancer-labs/assets#master",
     "@balancer-labs/balancer-js": "^1.0.1",
-    "@balancer-labs/sdk": "^0.1.1",
+    "@balancer-labs/sdk": "^0.1.2",
     "@balancer-labs/sor": "^1.1.0",
     "@balancer-labs/typechain": "^1.0.0",
     "@ensdomains/content-hash": "^2.5.3",

--- a/src/components/forms/pool_actions/WithdrawForm/WithdrawForm.vue
+++ b/src/components/forms/pool_actions/WithdrawForm/WithdrawForm.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { toRef, computed, ref, onBeforeMount } from 'vue';
+import { toRef, computed, ref, onBeforeMount, watch } from 'vue';
 import { FullPool } from '@/services/balancer/subgraph/types';
 import { isLessThanOrEqualTo, isRequired } from '@/lib/utils/validations';
 // Composables
@@ -85,12 +85,24 @@ const singleAssetRules = computed(() => [
 ]);
 
 /**
+ * WATCHERS
+ */
+watch(isProportional, newVal => {
+  // If user selects to withdraw all tokens proportionally
+  // reset the slider to max.
+  if (newVal) {
+    initMath();
+    maxSlider();
+  }
+});
+
+/**
  * CALLBACKS
  */
 onBeforeMount(() => {
   isProportional.value = true;
-  maxSlider();
   initMath();
+  maxSlider();
 });
 </script>
 

--- a/src/components/forms/pool_actions/WithdrawForm/composables/useWithdrawMath.ts
+++ b/src/components/forms/pool_actions/WithdrawForm/composables/useWithdrawMath.ts
@@ -25,7 +25,12 @@ import { balancerContractsService } from '@/services/balancer/contracts/balancer
 import OldBigNumber from 'bignumber.js';
 import { TokenInfo } from '@/types/TokenList';
 import { balancer } from '@/lib/balancer.sdk';
-import { SwapType, TransactionData } from '@balancer-labs/sdk';
+import {
+  SwapType,
+  TransactionData,
+  BalancerError,
+  BalancerErrorCode
+} from '@balancer-labs/sdk';
 import { SwapKind } from '@balancer-labs/balancer-js';
 import usePromiseSequence from '@/composables/usePromiseSequence';
 import { setError, WithdrawalError } from './useWithdrawalState';
@@ -503,7 +508,10 @@ export default function useWithdrawMath(
       batchSwapLoading.value = false;
       return result;
     } catch (error) {
-      if ((error as Error).message.includes('SOR Swap returned 0 amount')) {
+      if (
+        (error as BalancerError).code ===
+        BalancerErrorCode.SWAP_ZERO_RETURN_AMOUNT
+      ) {
         // The batch swap can fail if amounts are greater than supported by pool balances
         // in this case we can return 0 amounts which will lead to an attempt via getBatchRelayerSwap()
         batchSwapLoading.value = false;

--- a/src/components/forms/pool_actions/WithdrawForm/composables/useWithdrawMath.ts
+++ b/src/components/forms/pool_actions/WithdrawForm/composables/useWithdrawMath.ts
@@ -509,8 +509,9 @@ export default function useWithdrawMath(
       return result;
     } catch (error) {
       if (
-        (error as BalancerError).code ===
-        BalancerErrorCode.SWAP_ZERO_RETURN_AMOUNT
+        error instanceof BalancerError &&
+        (error as BalancerError)?.code ===
+          BalancerErrorCode.SWAP_ZERO_RETURN_AMOUNT
       ) {
         // The batch swap can fail if amounts are greater than supported by pool balances
         // in this case we can return 0 amounts which will lead to an attempt via getBatchRelayerSwap()

--- a/src/components/forms/pool_actions/WithdrawForm/composables/useWithdrawMath.ts
+++ b/src/components/forms/pool_actions/WithdrawForm/composables/useWithdrawMath.ts
@@ -502,15 +502,19 @@ export default function useWithdrawMath(
       });
       batchSwapLoading.value = false;
       return result;
-    } catch (err) {
-      // queryBatchSwapWithSor can fail if amounts are greater than supported by pool balances
-      // in this case we can return 0 amounts which will lead to an attempt via getBatchRelayerSwap()
-      batchSwapLoading.value = false;
-      return {
-        returnAmounts: Array(amounts.length).fill('0'),
-        swaps: [],
-        assets: []
-      };
+    } catch (error) {
+      if ((error as Error).message.includes('SOR Swap returned 0 amount')) {
+        // The batch swap can fail if amounts are greater than supported by pool balances
+        // in this case we can return 0 amounts which will lead to an attempt via getBatchRelayerSwap()
+        batchSwapLoading.value = false;
+        return {
+          returnAmounts: Array(amounts.length).fill('0'),
+          swaps: [],
+          assets: []
+        };
+      } else {
+        throw error;
+      }
     }
   }
 


### PR DESCRIPTION
# Description
- Update SOR. Fixed limit in Linear Pool BPT>wrapped. This should allow bbausd exit with unwrapped aTokens via Relayer.
- SDK changed to make Relayer throw errors. SDK should not be handling error cases for consumer but will exit and throw early. Updated `useWithdrawMath` to catch error and set returnAmounts to 0 which will trigger relayer exit flow as before.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## How should this be tested?

bbausd exit functionality should be same as before.
Should allow exit via Relayer - hard to test as Kovan pools are unbalanced. Tested by artifically forcing `getBatchSwap()` to throw error which triggers flow via `getBatchRelayerSwap()`.

## Visual context

Please provide any relevant visual context for UI changes or additions. This could be static screenshots or a loom screencast.

## Checklist:

- [X] I have performed a self-review of my own code
- [ ] I have requested at least 2 reviews (If the PR is significant enough, use best judgement here)
- [X] I have commented my code where relevant, particularly in hard-to-understand areas
- [X] If package-lock.json has changes, it was intentional.
- [X] The base of this PR is `master` if hotfix, `develop` if not
