### PR TITLE
Add legacy claims to claim page

### DIFF
--- a/src/components/contextual/pages/claim/LegacyClaims.vue
+++ b/src/components/contextual/pages/claim/LegacyClaims.vue
@@ -1,0 +1,382 @@
+<script setup lang="ts">
+import { computed, ref, watch } from 'vue';
+import { useI18n } from 'vue-i18n';
+import { getAddress } from 'ethers/lib/utils';
+import { differenceInSeconds } from 'date-fns';
+import { useIntervalFn } from '@vueuse/core';
+
+import useNumbers, { FNumFormats } from '@/composables/useNumbers';
+import useUserClaimsQuery from '@/composables/queries/useUserClaimsQuery';
+import useEthers from '@/composables/useEthers';
+import useTransactions from '@/composables/useTransactions';
+import useTokens from '@/composables/useTokens';
+import { networkId } from '@/composables/useNetwork';
+import { oneSecondInMs } from '@/composables/useTime';
+
+import { bnum } from '@/lib/utils';
+
+import { claimService } from '@/services/claim/claim.service';
+import useWeb3 from '@/services/web3/useWeb3';
+
+import BalLink from '@/components/_global/BalLink/BalLink.vue';
+
+import { TOKENS } from '@/constants/tokens';
+import useTranasactionErrors, {
+  TransactionError
+} from '@/composables/useTransactionErrors';
+
+type ClaimableToken = {
+  token: string;
+  symbol: string;
+  amount: string;
+  fiatValue: string;
+};
+
+enum Tabs {
+  CLAIMABLE = 'claimable',
+  CURRENT_ESTIMATE = 'currentEstimate'
+}
+
+const { t } = useI18n();
+
+const tabs = [
+  { value: Tabs.CLAIMABLE, label: t('liquidityMiningPopover.tabs.claimable') },
+  {
+    value: Tabs.CURRENT_ESTIMATE,
+    label: t('liquidityMiningPopover.tabs.currentEstimate')
+  }
+];
+
+const activeTab = ref(tabs[0].value);
+const isClaiming = ref(false);
+const elapstedTimeSinceEstimateTimestamp = ref(0);
+const claimError = ref<TransactionError | null>(null);
+
+// COMPOSABLES
+const userClaimsQuery = useUserClaimsQuery();
+const { fNum2 } = useNumbers();
+const {
+  account,
+  getProvider,
+  isArbitrum,
+  isMainnet,
+  isKovan,
+  isPolygon,
+  isMismatchedNetwork
+} = useWeb3();
+const { txListener } = useEthers();
+const { addTransaction } = useTransactions();
+const { priceFor, tokens } = useTokens();
+const { parseError } = useTranasactionErrors();
+
+const BALTokenAddress = getAddress(TOKENS.AddressMap[networkId.value].BAL);
+
+// COMPUTED
+const BALTokenPlaceholder = computed<ClaimableToken>(() => ({
+  token: BALTokenAddress,
+  symbol: tokens.value[BALTokenAddress]?.symbol,
+  amount: '0',
+  fiatValue: '0'
+}));
+
+// Polygon used to be an airdrop, now its claimable - leaving it here in case new networks will need to be airdropped first.
+const isAirdrop = false;
+
+const legacyClaimUI = computed(() => {
+  if (isMainnet.value || isKovan.value) {
+    return [
+      { token: '$BAL', subdomain: 'claim' },
+      { token: '$VITA', subdomain: 'claim-vita' },
+      { token: '$LDO', subdomain: 'claim-lido' }
+    ];
+  } else if (isArbitrum.value) {
+    return [
+      { token: '$BAL', subdomain: 'claim-arbitrum' },
+      { token: '$MCDEX', subdomain: 'claim-mcdex' },
+      { token: '$PICKLE', subdomain: 'claim-pickle' }
+    ];
+  }
+
+  return [];
+});
+
+const userClaims = computed(() =>
+  userClaimsQuery.isSuccess.value ? userClaimsQuery.data?.value : null
+);
+
+const claimableTokens = computed<ClaimableToken[]>(() => {
+  if (
+    userClaims.value != null &&
+    userClaims.value.multiTokenPendingClaims.length > 0
+  ) {
+    return userClaims.value.multiTokenPendingClaims.map(
+      ({ availableToClaim, tokenClaimInfo }) => ({
+        token: tokenClaimInfo.token,
+        symbol: tokens.value[tokenClaimInfo.token]?.symbol,
+        amount: availableToClaim,
+        fiatValue: bnum(availableToClaim)
+          .times(priceFor(tokenClaimInfo.token))
+          .toString()
+      })
+    );
+  }
+  return [BALTokenPlaceholder.value];
+});
+
+const currentEstimateClaimableTokens = computed<ClaimableToken[]>(() => {
+  if (
+    userClaims.value != null &&
+    userClaims.value.multiTokenCurrentRewardsEstimate.length > 0
+  ) {
+    return userClaims.value.multiTokenCurrentRewardsEstimate.map(
+      ({ token, rewards, velocity }) => {
+        const rewardsSinceTimestamp = bnum(velocity).times(
+          elapstedTimeSinceEstimateTimestamp.value
+        );
+        const totalRewards = bnum(rewards).plus(rewardsSinceTimestamp);
+
+        return {
+          token,
+          symbol: tokens.value[token]?.symbol,
+          amount: totalRewards.toString(),
+          fiatValue: totalRewards.times(priceFor(token)).toString()
+        };
+      }
+    );
+  }
+  return [BALTokenPlaceholder.value];
+});
+
+const totalClaimableTokensFiatValue = computed(() =>
+  claimableTokens.value
+    .reduce((totalValue, { fiatValue }) => totalValue.plus(fiatValue), bnum(0))
+    .toString()
+);
+
+const hasClaimableTokens = computed(() =>
+  claimableTokens.value.some(
+    claimableToken => Number(claimableToken.amount) > 0
+  )
+);
+
+useIntervalFn(async () => {
+  if (userClaims.value != null && userClaims.value.timestamp != null) {
+    const diffInSeconds = differenceInSeconds(
+      new Date(),
+      new Date(userClaims.value.timestamp)
+    );
+    elapstedTimeSinceEstimateTimestamp.value = diffInSeconds;
+  }
+}, oneSecondInMs);
+
+watch(isMismatchedNetwork, () => {
+  userClaimsQuery.refetch.value();
+});
+
+// METHODS
+async function claimAvailableRewards() {
+  if (userClaims.value != null) {
+    isClaiming.value = true;
+    claimError.value = null;
+
+    try {
+      const tx = await claimService.multiTokenClaimRewards(
+        getProvider(),
+        account.value,
+        userClaims.value.multiTokenPendingClaims
+      );
+
+      const summary = claimableTokens.value
+        .map(
+          claimableToken =>
+            `${fNum2(claimableToken.amount, {
+              minimumFractionDigits: 4,
+              maximumFractionDigits: 4
+            })} ${claimableToken.symbol}`
+        )
+        .join(', ');
+
+      addTransaction({
+        id: tx.hash,
+        type: 'tx',
+        action: 'claim',
+        summary
+      });
+
+      txListener(tx, {
+        onTxConfirmed: () => {
+          isClaiming.value = false;
+          userClaimsQuery.refetch.value();
+        },
+        onTxFailed: () => {
+          isClaiming.value = false;
+        }
+      });
+    } catch (e) {
+      console.log(e);
+      claimError.value = parseError(e);
+      isClaiming.value = false;
+    }
+  }
+}
+</script>
+
+<template>
+  <div class="w-full sm:w-3/4 md:w-1/2 mt-4" v-if="userClaims != null">
+    <div class="text-sm text-gray-600 mb-1" v-if="isAirdrop">
+      {{ $t('liquidityMiningPopover.airdropExplainer', ['Polygon']) }}
+    </div>
+    <div v-if="!isAirdrop" class="">
+      <BalCard no-pad class="mb-4">
+        <template v-slot:header>
+          <div
+            class="w-full px-3 border-b dark:border-gray-900 bg-gray-50 dark:bg-gray-800"
+          >
+            <BalTabs
+              v-model="activeTab"
+              :tabs="tabs"
+              class="whitespace-nowrap p-0 m-0"
+              no-pad
+            />
+          </div>
+        </template>
+        <template v-if="activeTab === Tabs.CLAIMABLE">
+          <template
+            v-for="claimableToken in claimableTokens"
+            :key="`token-${claimableToken.token}`"
+          >
+            <div
+              class="px-3 py-2 flex items-center mb-2 border-b dark:border-gray-900 last:border-0"
+            >
+              <BalAsset
+                :address="claimableToken.token"
+                :size="36"
+                class="mr-3"
+              />
+              <div>
+                <div class="font-medium">
+                  {{ fNum2(claimableToken.amount, FNumFormats.token) }}
+                  {{ claimableToken.symbol }}
+                </div>
+                <div class="font-sm text-gray-400">
+                  {{ fNum2(claimableToken.fiatValue, FNumFormats.fiat) }}
+                </div>
+              </div>
+            </div>
+          </template>
+        </template>
+        <template v-if="activeTab === Tabs.CURRENT_ESTIMATE">
+          <template
+            v-for="claimableToken in currentEstimateClaimableTokens"
+            :key="`token-${claimableToken.token}`"
+          >
+            <div
+              class="px-3 py-2 flex items-center mb-2 border-b dark:border-gray-900 last:border-0"
+            >
+              <BalAsset
+                :address="claimableToken.token"
+                :size="36"
+                class="mr-3"
+              />
+              <div>
+                <div class="font-medium">
+                  {{ fNum2(claimableToken.amount, FNumFormats.token) }}
+                  {{ claimableToken.symbol }}
+                </div>
+                <div class="font-sm text-gray-400">
+                  {{ fNum2(claimableToken.fiatValue, FNumFormats.fiat) }}
+                </div>
+              </div>
+            </div>
+          </template>
+        </template>
+      </BalCard>
+      <BalBtn
+        v-if="!isAirdrop"
+        color="gradient"
+        size="md"
+        block
+        class="mb-6"
+        :loading="isClaiming"
+        :loading-label="$t('claiming')"
+        @click="claimAvailableRewards"
+        :disabled="!hasClaimableTokens"
+        >{{ $t('claimAll') }}
+        <template v-if="hasClaimableTokens"
+          >~{{
+            fNum2(totalClaimableTokensFiatValue, FNumFormats.fiat)
+          }}</template
+        ></BalBtn
+      >
+      <BalAlert
+        v-if="claimError != null"
+        class="mb-6 -mt-4"
+        type="error"
+        size="md"
+        :title="claimError.title"
+        :description="claimError.description"
+        block
+        action-label="Dismiss"
+        @actionClick="claimError = null"
+      />
+    </div>
+    <div v-if="!isAirdrop">
+      <div class="mb-4">
+        <div class="font-semibold mb-2">
+          Looking for other claimable tokens?
+        </div>
+        <ul class="pl-8 list-disc">
+          <li class="mt-2" v-if="legacyClaimUI.length > 0">
+            Claim
+            <span class="inline-grid grid-flow-col gap-1">
+              <BalLink
+                v-for="legacyClaim in legacyClaimUI"
+                :key="`token-${legacyClaim.token}`"
+                :href="
+                  `https://${legacyClaim.subdomain}.balancer.fi/#/${account}`
+                "
+                external
+                >{{ legacyClaim.token }}</BalLink
+              >
+            </span>
+            from legacy liquidity mining contracts distributed before 20 Oct,
+            2021.
+          </li>
+          <li class="mt-2">
+            Claim BAL on other networks
+            <template v-if="isArbitrum">
+              <BalLink href="https://app.balancer.fi" external>
+                Ethereum
+              </BalLink>
+              and
+              <BalLink href="https://polygon.balancer.fi" external
+                >Polygon</BalLink
+              >.
+            </template>
+            <template v-else-if="isPolygon">
+              <BalLink href="https://app.balancer.fi" external>
+                Ethereum
+              </BalLink>
+              and
+              <BalLink href="https://arbitrum.balancer.fi" external
+                >Arbitrum</BalLink
+              >.
+            </template>
+            <template v-else-if="isMainnet || isKovan">
+              <BalLink href="https://polygon.balancer.fi" external>
+                Polygon
+              </BalLink>
+              and
+              <BalLink href="https://arbitrum.balancer.fi" external
+                >Arbitrum</BalLink
+              >.
+            </template>
+          </li>
+        </ul>
+      </div>
+    </div>
+    <div v-else class="mt-4 text-sm px-3 pb-3">
+      <div>{{ $t('liquidityMiningPopover.airdropEligibility') }}</div>
+    </div>
+  </div>
+</template>

--- a/src/locales/default.json
+++ b/src/locales/default.json
@@ -429,7 +429,8 @@
             "title": "Claim all of your liquidity incentives",
             "description": "The Balancer protocol provides incentives to attract liquidity in eligible pools.",
             "titles": {
-                "incentivesOnOtherNetworks": "Incentives on other networks"
+                "incentivesOnOtherNetworks": "Incentives on other networks",
+                "legacyIncentives": "Legacy incentives"
             },
             "btns": {
                 "claimOn": "Claim on"

--- a/src/pages/claim.vue
+++ b/src/pages/claim.vue
@@ -2,6 +2,7 @@
 import { computed } from 'vue';
 import StatCard from '@/components/cards/StatCard/StatCard.vue';
 import { configService } from '@/services/config/config.service';
+import LegacyClaims from '@/components/contextual/pages/claim/LegacyClaims.vue';
 
 const networks = [
   {
@@ -30,7 +31,7 @@ const networkBtns = computed(() => {
 </script>
 
 <template>
-  <div class="lg:container lg:mx-auto py-12">
+  <div class="lg:container lg:mx-auto py-12 px-2 lg:px-0">
     <div class="grid gap-24 grid-cols-2 grid-rows-1">
       <div class="">
         <h1 class="font-body font-bold text-4xl">
@@ -52,13 +53,13 @@ const networkBtns = computed(() => {
       </div>
     </div>
   </div>
-  <div class="bg-gray-50">
+  <div class="px-2 lg:px-0">
     <div class="lg:container lg:mx-auto py-12">
       <h2 class="font-body font-bold text-2xl">
         {{ configService.network.chainName }} {{ $t('liquidityIncentives') }}
       </h2>
 
-      <h2 class="font-body font-bold text-2xl">
+      <h2 class="font-body font-bold text-2xl mt-8">
         {{ $t('pages.claim.titles.incentivesOnOtherNetworks') }}
       </h2>
       <div class="flex mt-4">
@@ -78,6 +79,11 @@ const networkBtns = computed(() => {
           {{ $t('pages.claim.btns.claimOn') }} {{ network.name }}
         </BalBtn>
       </div>
+
+      <h2 class="font-body font-bold text-2xl mt-8">
+        {{ $t('pages.claim.titles.legacyIncentives') }}
+      </h2>
+      <LegacyClaims />
     </div>
   </div>
 </template>


### PR DESCRIPTION
# Description

Moves all the functionality from the navbar claims widget to the 'Legacy incentives' section of the new claim page.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## How should this be tested?

- [ ] Got to /claim and check that merkle orchard claims work as they do in the navbar claim popover.

## Visual context

<img width="940" alt="Screenshot 2022-03-04 at 16 38 17" src="https://user-images.githubusercontent.com/2406506/156803181-b13fc084-deb3-404a-affd-e4177736f260.png">

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have requested at least 2 reviews (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] If package-lock.json has changes, it was intentional.
- [x] The base of this PR is `master` if hotfix, `develop` if not
