### PR TITLE
Fix pool creation name issue and fund issue on polygon

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.42.3",
+  "version": "1.42.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@balancer-labs/frontend-v2",
-      "version": "1.42.3",
+      "version": "1.42.4",
       "license": "MIT",
       "devDependencies": {
         "@aave/protocol-js": "^4.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.42.3",
+  "version": "1.42.4",
   "engines": {
     "node": "14.x",
     "npm": ">=7"

--- a/src/components/_global/BalActionSteps/BalActionSteps.vue
+++ b/src/components/_global/BalActionSteps/BalActionSteps.vue
@@ -21,6 +21,8 @@ import {
 import useEthers from '@/composables/useEthers';
 import { dateTimeLabelFor } from '@/composables/useTime';
 import useTransactionErrors from '@/composables/useTransactionErrors';
+import { configService } from '@/services/config/config.service';
+import { ChainId } from '@aave/protocol-js';
 
 /**
  * TYPES
@@ -154,6 +156,12 @@ async function handleTransaction(
   state.confirmed = await txListener(tx, {
     onTxConfirmed: async (receipt: TransactionReceipt) => {
       state.receipt = receipt;
+
+      // need to explicity wait for a number of confirmations
+      // on polygon
+      if (Number(configService.network.chainId) === ChainId.polygon) {
+        await tx.wait(7)
+      }
 
       const confirmedAt = await getTxConfirmedAt(receipt);
       state.confirmedAt = dateTimeLabelFor(confirmedAt);

--- a/src/components/_global/BalActionSteps/BalActionSteps.vue
+++ b/src/components/_global/BalActionSteps/BalActionSteps.vue
@@ -160,7 +160,7 @@ async function handleTransaction(
       // need to explicity wait for a number of confirmations
       // on polygon
       if (Number(configService.network.chainId) === ChainId.polygon) {
-        await tx.wait(7)
+        await tx.wait(7);
       }
 
       const confirmedAt = await getTxConfirmedAt(receipt);

--- a/src/components/cards/CreatePool/ChooseWeights.vue
+++ b/src/components/cards/CreatePool/ChooseWeights.vue
@@ -144,17 +144,15 @@ const weightColor = computed(() => {
 /**
  * WATCHERS
  */
-  watch(
-    () => seedTokens,
-    () => {
-      setTokensList(seedTokens.value.map(
-        w => w.tokenAddress
-      ));
-    },
-    {
-      deep: true
-    }
-  );
+watch(
+  () => seedTokens,
+  () => {
+    setTokensList(seedTokens.value.map(w => w.tokenAddress));
+  },
+  {
+    deep: true
+  }
+);
 
 /**
  * LIFECYCLE

--- a/src/components/cards/CreatePool/ChooseWeights.vue
+++ b/src/components/cards/CreatePool/ChooseWeights.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, onMounted, ref, nextTick, onBeforeUpdate } from 'vue';
+import { computed, onMounted, ref, nextTick, onBeforeUpdate, watch } from 'vue';
 
 import TokenWeightInput from '@/components/inputs/TokenInput/TokenWeightInput.vue';
 
@@ -34,13 +34,14 @@ const emptyTokenWeight: PoolSeedToken = {
  * COMPOSABLES
  */
 const {
-  seedTokens,
   updateTokenWeights,
   proceed,
+  acceptCustomTokenDisclaimer,
+  setTokensList,
+  seedTokens,
   tokensList,
   totalLiquidity,
   hasInjectedToken,
-  acceptCustomTokenDisclaimer,
   acceptedCustomTokenDisclaimer
 } = usePoolCreation();
 const { upToLargeBreakpoint } = useBreakpoints();
@@ -139,6 +140,21 @@ const weightColor = computed(() => {
   }
   return darkMode.value ? 'text-gray-300' : 'text-gray-800';
 });
+
+/**
+ * WATCHERS
+ */
+  watch(
+    () => seedTokens,
+    () => {
+      setTokensList(seedTokens.value.map(
+        w => w.tokenAddress
+      ));
+    },
+    {
+      deep: true
+    }
+  );
 
 /**
  * LIFECYCLE

--- a/src/components/cards/CreatePool/PreviewPool.vue
+++ b/src/components/cards/CreatePool/PreviewPool.vue
@@ -45,7 +45,8 @@ const {
   setActiveStep,
   sortSeedTokens,
   getScaledAmounts,
-  saveState
+  saveState,
+  getPoolSymbol
 } = usePoolCreation();
 
 const { tokens, priceFor, nativeAsset, wrappedNativeAsset } = useTokens();
@@ -58,6 +59,9 @@ const { userNetworkConfig, account } = useWeb3();
  */
 onBeforeMount(() => {
   sortSeedTokens();
+
+  poolName.value = poolName.value || getPoolSymbol();
+  poolSymbol.value = poolSymbol.value || getPoolSymbol();
 });
 
 /**

--- a/src/composables/pools/usePoolCreation.ts
+++ b/src/composables/pools/usePoolCreation.ts
@@ -1,4 +1,4 @@
-import { ref, reactive, toRefs, watch, computed } from 'vue';
+import { ref, reactive, toRefs, computed } from 'vue';
 
 import { useI18n } from 'vue-i18n';
 import usePoolsQuery from '@/composables/queries/usePoolsQuery';
@@ -412,7 +412,7 @@ export default function usePoolCreation() {
           name: poolCreationState.name
         }
       });
-1
+      1;
       txListener(tx, {
         onTxConfirmed: async () => {
           const poolDetails = await balancerService.pools.weighted.details(

--- a/src/composables/pools/usePoolCreation.ts
+++ b/src/composables/pools/usePoolCreation.ts
@@ -38,7 +38,7 @@ type FeeType = 'fixed' | 'dynamic';
 type FeeController = 'self' | 'other';
 
 const emptyPoolCreationState = {
-  name: 'MyPool',
+  name: '',
   seedTokens: [] as PoolSeedToken[],
   activeStep: 0,
   initialFee: '0.003',
@@ -81,24 +81,6 @@ export default function usePoolCreation() {
   const { txListener } = useEthers();
   const { addTransaction } = useTransactions();
   const { t } = useI18n();
-
-  /**
-   * WATCHERS
-   */
-  watch(
-    () => poolCreationState.seedTokens,
-    () => {
-      poolCreationState.tokensList = poolCreationState.seedTokens.map(
-        w => w.tokenAddress
-      );
-
-      poolCreationState.name = poolCreationState.name || getPoolSymbol();
-      poolCreationState.symbol = poolCreationState.symbol || getPoolSymbol();
-    },
-    {
-      deep: true
-    }
-  );
 
   /**
    * COMPUTED
@@ -353,6 +335,10 @@ export default function usePoolCreation() {
     }
   }
 
+  function setTokensList(newList: string[]) {
+    poolCreationState.tokensList = newList;
+  }
+
   function getTokensScaledByBIP(
     bip: BigNumber
   ): Record<string, OptimisedLiquidity> {
@@ -426,7 +412,7 @@ export default function usePoolCreation() {
           name: poolCreationState.name
         }
       });
-
+1
       txListener(tx, {
         onTxConfirmed: async () => {
           const poolDetails = await balancerService.pools.weighted.details(
@@ -553,6 +539,7 @@ export default function usePoolCreation() {
     resetState,
     importState,
     setRestoredState,
+    setTokensList,
     currentLiquidity,
     optimisedLiquidity,
     scaledLiquidity,


### PR DESCRIPTION
# Description

On polygon for some reason the blocknative library reflects the create transaction as confirmed before it actually is. The fix was to simply explicitly ask the transaction to go through 7 confirmations before proceeding to the fund step. 

Another issue was the name for the pool not being reflected or set correctly, adjusting a watcher should fix that.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## How should this be tested?

Go through pool creation with no problems

## Visual context
None applicable, prod issue.

## Checklist:

- [X] I have performed a self-review of my own code
- [X] I have requested at least 2 reviews (If the PR is significant enough, use best judgement here)
- [X] I have commented my code where relevant, particularly in hard-to-understand areas
- [X] If package-lock.json has changes, it was intentional.
- [X] The base of this PR is `master` if hotfix, `develop` if not
