### PR TITLE
Smoother success transition

### DIFF
--- a/src/components/_global/BalActionSteps/BalActionSteps.vue
+++ b/src/components/_global/BalActionSteps/BalActionSteps.vue
@@ -153,7 +153,7 @@ async function handleTransaction(
   tx: TransactionResponse,
   state: TransactionActionState
 ): Promise<void> {
-  state.confirmed = await txListener(tx, {
+  await txListener(tx, {
     onTxConfirmed: async (receipt: TransactionReceipt) => {
       state.receipt = receipt;
 
@@ -173,6 +173,7 @@ async function handleTransaction(
       }
 
       state.confirming = false;
+      state.confirmed = true;
     },
     onTxFailed: () => {
       state.confirming = false;

--- a/src/components/forms/pool_actions/InvestForm/components/InvestPreviewModal/components/InvestActions.vue
+++ b/src/components/forms/pool_actions/InvestForm/components/InvestPreviewModal/components/InvestActions.vue
@@ -23,6 +23,7 @@ import useTokenApprovalActions from '@/composables/useTokenApprovalActions';
 import { TransactionActionInfo } from '@/types/transactions';
 import BalActionSteps from '@/components/_global/BalActionSteps/BalActionSteps.vue';
 import { boostedJoinBatchSwap } from '@/lib/utils/balancer/swapper';
+
 /**
  * TYPES
  */
@@ -198,9 +199,9 @@ watch(blockNumber, async () => {
 </script>
 
 <template>
-  <div>
-    <BalActionSteps :actions="actions" />
-    <template v-if="investmentState.confirmed">
+  <transition>
+    <BalActionSteps v-if="!investmentState.confirmed" :actions="actions" />
+    <div v-else>
       <div
         class="flex items-center justify-between text-gray-400 dark:text-gray-600 mt-4 text-sm"
       >
@@ -234,6 +235,6 @@ watch(blockNumber, async () => {
       >
         {{ $t('returnToPool') }}
       </BalBtn>
-    </template>
-  </div>
+    </div>
+  </transition>
 </template>

--- a/src/components/forms/pool_actions/WithdrawForm/components/WithdrawPreviewModal/components/WithdrawActions.vue
+++ b/src/components/forms/pool_actions/WithdrawForm/components/WithdrawPreviewModal/components/WithdrawActions.vue
@@ -226,9 +226,9 @@ watch(blockNumber, async () => {
 </script>
 
 <template>
-  <div>
+  <transition>
     <BalActionSteps v-if="!withdrawalState.confirmed" :actions="actions" />
-    <template v-else>
+    <div v-else>
       <div
         class="flex items-center justify-between text-gray-400 dark:text-gray-600 mt-4 text-sm"
       >
@@ -262,6 +262,6 @@ watch(blockNumber, async () => {
       >
         {{ $t('returnToPool') }}
       </BalBtn>
-    </template>
-  </div>
+    </div>
+  </transition>
 </template>


### PR DESCRIPTION
# Description

At the moment when an investment or withdrawal is successful the transition to the success state is really janky. This PR makes that transition a bit smoother for a nicer UX.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [x] Other

## How should this be tested?

- [ ] Try an investment on this PR preview URL Kovan and then on the existing kovan app and notice the difference in success state transition.

## Visual context

Old transition - https://www.loom.com/share/8a57ff0f1d674b0994c8d90dc63f0729
New transition - https://www.loom.com/share/8bdb07e2d5e8421ba3919744f68a68f1

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have requested at least 2 reviews (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] If package-lock.json has changes, it was intentional.
- [x] The base of this PR is `master` if hotfix, `develop` if not
