### PR TITLE
Fix console errors on trade page

### DIFF
--- a/src/components/cards/PairPriceGraph/PairPriceGraph.vue
+++ b/src/components/cards/PairPriceGraph/PairPriceGraph.vue
@@ -112,7 +112,7 @@ const props = defineProps<Props>();
 const { upToLargeBreakpoint } = useBreakpoints();
 const store = useStore();
 const { tokens, wrappedNativeAsset, nativeAsset } = useTokens();
-const { tokenInAddress, tokenOutAddress } = useTradeState();
+const { tokenInAddress, tokenOutAddress, initialized } = useTradeState();
 const tailwind = useTailwind();
 const { chainId: userNetworkId } = useWeb3();
 
@@ -162,6 +162,7 @@ const {
       true
     ),
   reactive({
+    enabled: initialized,
     retry: false,
     // when refetch on window focus in enabled, it causes a flash
     // in the loading state of the card which is jarring. disabling it

--- a/src/components/cards/TradeCardGP/TradeCardGP.vue
+++ b/src/components/cards/TradeCardGP/TradeCardGP.vue
@@ -125,7 +125,7 @@
 </template>
 
 <script lang="ts">
-import { ref, defineComponent, computed } from 'vue';
+import { ref, defineComponent, computed, onBeforeMount } from 'vue';
 import { useStore } from 'vuex';
 import { useRouter } from 'vue-router';
 
@@ -184,7 +184,8 @@ export default defineComponent({
       tokenInAmount,
       tokenOutAmount,
       setTokenInAddress,
-      setTokenOutAddress
+      setTokenOutAddress,
+      setInitialized
     } = useTradeState();
 
     // DATA
@@ -355,7 +356,6 @@ export default defineComponent({
       } else if (isAddress(assetOut)) {
         assetOut = getAddress(assetOut);
       }
-
       setTokenInAddress(assetIn || store.state.trade.inputAsset);
       setTokenOutAddress(assetOut || store.state.trade.outputAsset);
     }
@@ -377,7 +377,10 @@ export default defineComponent({
     }
 
     // INIT
-    populateInitialTokens();
+    onBeforeMount(() => {
+      populateInitialTokens();
+      setInitialized(true);
+    });
 
     return {
       // constants

--- a/src/composables/trade/useTradeState.ts
+++ b/src/composables/trade/useTradeState.ts
@@ -2,11 +2,16 @@ import { reactive, toRefs } from 'vue';
 
 // globals
 const tradeState = reactive({
+  initialized: false,
   tokenInAddress: '',
   tokenOutAddress: '',
   tokenInAmount: '',
   tokenOutAmount: ''
 });
+
+function setInitialized(val: boolean) {
+  tradeState.initialized = val;
+}
 
 function setTokenInAddress(address: string) {
   tradeState.tokenInAddress = address;
@@ -30,6 +35,7 @@ export function useTradeState() {
     setTokenInAddress,
     setTokenOutAddress,
     setTokenInAmount,
-    setTokenOutAmount
+    setTokenOutAmount,
+    setInitialized
   };
 }

--- a/src/services/coingecko/api/price.service.ts
+++ b/src/services/coingecko/api/price.service.ts
@@ -114,7 +114,7 @@ export class PriceService {
     days: number,
     addressesPerRequest = 1,
     aggregateBy: 'hour' | 'day' = 'day'
-  ) {
+  ): Promise<HistoricalPrices> {
     try {
       if (addresses.length / addressesPerRequest > 10)
         throw new Error('To many requests for rate limit.');


### PR DESCRIPTION
# Description

Loading the trade page with a fresh state (localstorage cleared etc) results in a bunch of console errors coming from the `PairPriceGraph` component's query being run before the initial trade state pair has been set. This PR adds a conditional `initialized` to the trade state and sets the pair price query enabled flag to wait for this conditional to be true.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## How should this be tested?

- [ ] Load [kovan.balancer.fi/#/trade](https://kovan.balancer.fi/#/trade) and check console for errors.
- [ ] Load this PR's kovan preview and check the console for errors.

## Visual context

n/a

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have requested at least 2 reviews (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] If package-lock.json has changes, it was intentional.
- [x] The base of this PR is `master` if hotfix, `develop` if not
