### PR TITLE
LM page improvement

### DIFF
--- a/src/pages/liquidity-mining.vue
+++ b/src/pages/liquidity-mining.vue
@@ -157,10 +157,15 @@ export default defineComponent({
       return totalFiat;
     });
 
+    const weekNumbers = Object.keys(weeksJSON)
+      .map(key => parseInt(key.replace('week_', '')))
+      .sort(function(a, b) {
+        return a - b;
+      });
     // only concerned with past 3 weeks
-    const weeks = takeRight(Object.keys(weeksJSON), 3).map(week => ({
-      week: week,
-      distributions: weeksJSON[week]
+    const weeks = takeRight(weekNumbers, 3).map(weekNumber => ({
+      week: 'week_' + weekNumber,
+      distributions: weeksJSON['week_' + weekNumber]
         .filter(d => d.chainId === networkConfig.chainId)
         .map(d => d.pools)[0]
     }));


### PR DESCRIPTION
# Description

Sort week numbers before selecting the last 3, to avoid issues like #1454

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## How should this be tested?

Even if the weeks in the JSON are not sorted, the /liquidity-mining page should still display them in the right order

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have requested at least 2 reviews (If the PR is significant enough, use best judgement here)
- [ ] I have commented my code where relevant, particularly in hard-to-understand areas
- [ ] If package-lock.json has changes, it was intentional.
- [ ] The base of this PR is `master` if hotfix, `develop` if not
