### PR TITLE
<BalActionSteps> to accept dynamic actions

### DIFF
--- a/src/components/_global/BalActionSteps/BalActionSteps.vue
+++ b/src/components/_global/BalActionSteps/BalActionSteps.vue
@@ -60,7 +60,7 @@ const defaultActionState: TransactionActionState = {
  * STATE
  */
 const currentActionIndex = ref(0);
-const _actions = ref<TransactionActionInfo[]>([]);
+const _actions = ref<TransactionActionInfo[]>(props.actions);
 
 const actionStates = ref(
   _actions.value.map(() => ({
@@ -231,7 +231,7 @@ async function handleTransaction(
         block
         @click="currentAction.promise()"
       >
-        {{ currentAction.label }}
+        {{ currentAction?.label }}
       </BalBtn>
     </BalStack>
   </AnimatePresence>

--- a/src/components/_global/BalActionSteps/BalActionSteps.vue
+++ b/src/components/_global/BalActionSteps/BalActionSteps.vue
@@ -202,37 +202,39 @@ async function handleTransaction(
 </script>
 
 <template>
-  <AnimatePresence isVisible>
-    <BalAlert
-      v-if="currentActionState?.error && !isLoading"
-      type="error"
-      :title="currentActionState?.error?.title"
-      :description="currentActionState?.error?.description"
-      block
-      class="mb-4"
-    />
-    <BalStack vertical>
-      <BalHorizSteps
-        v-if="actions.length > 1 && !lastActionState?.confirmed"
-        :steps="steps"
-        :spacerWidth="spacerWidth"
-        class="flex justify-center"
-      />
-      <BalBtn
-        v-if="!lastActionState?.confirmed"
-        :disabled="props.disabled"
-        color="gradient"
-        :loading="currentAction?.pending || isLoading"
-        :loading-label="
-          isLoading
-            ? loadingLabel || $t('loading')
-            : currentAction?.loadingLabel
-        "
+  <div>
+    <AnimatePresence isVisible>
+      <BalAlert
+        v-if="currentActionState?.error && !isLoading"
+        type="error"
+        :title="currentActionState?.error?.title"
+        :description="currentActionState?.error?.description"
         block
-        @click="currentAction.promise()"
-      >
-        {{ currentAction?.label }}
-      </BalBtn>
-    </BalStack>
-  </AnimatePresence>
+        class="mb-4"
+      />
+      <BalStack vertical>
+        <BalHorizSteps
+          v-if="actions.length > 1 && !lastActionState?.confirmed"
+          :steps="steps"
+          :spacerWidth="spacerWidth"
+          class="flex justify-center"
+        />
+        <BalBtn
+          v-if="!lastActionState?.confirmed"
+          :disabled="props.disabled"
+          color="gradient"
+          :loading="currentAction?.pending || isLoading"
+          :loading-label="
+            isLoading
+              ? loadingLabel || $t('loading')
+              : currentAction?.loadingLabel
+          "
+          block
+          @click="currentAction.promise()"
+        >
+          {{ currentAction?.label }}
+        </BalBtn>
+      </BalStack>
+    </AnimatePresence>
+  </div>
 </template>

--- a/src/components/_global/BalActionSteps/BalActionSteps.vue
+++ b/src/components/_global/BalActionSteps/BalActionSteps.vue
@@ -7,7 +7,7 @@
  * Useful if there are an arbitrary number of actions the user must take such as
  * "approve n tokens, then invest in a pool.""
  */
-import { ref, computed, reactive } from 'vue';
+import { ref, computed, watch } from 'vue';
 import {
   TransactionReceipt,
   TransactionResponse
@@ -23,6 +23,7 @@ import { dateTimeLabelFor } from '@/composables/useTime';
 import useTransactionErrors from '@/composables/useTransactionErrors';
 import { configService } from '@/services/config/config.service';
 import { ChainId } from '@aave/protocol-js';
+import AnimatePresence from '@/components/animate/AnimatePresence.vue';
 
 /**
  * TYPES
@@ -59,12 +60,29 @@ const defaultActionState: TransactionActionState = {
  * STATE
  */
 const currentActionIndex = ref(0);
+const _actions = ref<TransactionActionInfo[]>([]);
 
-const actionStates = props.actions.map(() => {
-  return reactive<TransactionActionState>({
+const actionStates = ref(
+  _actions.value.map(() => ({
     ...defaultActionState
-  });
-});
+  }))
+);
+
+/**
+ * WATCHERS
+ */
+watch(
+  () => [props.actions, props.isLoading],
+  () => {
+    _actions.value = props.actions;
+    actionStates.value = _actions.value.map(() => ({
+      ...defaultActionState
+    }));
+  },
+  {
+    deep: true
+  }
+);
 
 /**
  * COMPOSABLES
@@ -77,8 +95,8 @@ const { parseError } = useTransactionErrors();
  */
 
 const actions = computed((): TransactionAction[] => {
-  return props.actions.map((actionInfo, idx) => {
-    const actionState = actionStates[idx];
+  return _actions.value.map((actionInfo, idx) => {
+    const actionState = actionStates.value[idx];
     return {
       label: actionInfo.label,
       loadingLabel: actionState.init
@@ -99,11 +117,12 @@ const currentAction = computed(
 );
 
 const currentActionState = computed(
-  (): TransactionActionState => actionStates[currentActionIndex.value]
+  (): TransactionActionState => actionStates.value[currentActionIndex.value]
 );
 
 const lastActionState = computed(
-  (): TransactionActionState => actionStates[actionStates.length - 1]
+  (): TransactionActionState =>
+    actionStates.value[actionStates.value.length - 1]
 );
 
 const steps = computed((): Step[] => actions.value.map(action => action.step));
@@ -183,33 +202,37 @@ async function handleTransaction(
 </script>
 
 <template>
-  <div>
+  <AnimatePresence isVisible>
     <BalAlert
-      v-if="currentActionState.error"
+      v-if="currentActionState?.error && !isLoading"
       type="error"
-      :title="currentActionState.error.title"
-      :description="currentActionState.error.description"
+      :title="currentActionState?.error?.title"
+      :description="currentActionState?.error?.description"
       block
       class="mb-4"
     />
     <BalStack vertical>
       <BalHorizSteps
-        v-if="actions.length > 1 && !lastActionState.confirmed"
+        v-if="actions.length > 1 && !lastActionState?.confirmed"
         :steps="steps"
         :spacerWidth="spacerWidth"
         class="flex justify-center"
       />
       <BalBtn
-        v-if="!lastActionState.confirmed"
+        v-if="!lastActionState?.confirmed"
         :disabled="props.disabled"
         color="gradient"
-        :loading="currentAction.pending || isLoading"
-        :loading-label="isLoading ? loadingLabel : currentAction.loadingLabel"
+        :loading="currentAction?.pending || isLoading"
+        :loading-label="
+          isLoading
+            ? loadingLabel || $t('loading')
+            : currentAction?.loadingLabel
+        "
         block
         @click="currentAction.promise()"
       >
         {{ currentAction.label }}
       </BalBtn>
     </BalStack>
-  </div>
+  </AnimatePresence>
 </template>


### PR DESCRIPTION
# Description

Currently `<BalActionSteps>` doesn't support the list of actions being supplied to it, changing. This pull request changes that by allowing the component to receive a changing list of actions, if needed. Use cases where this is needed are where one of the steps (or all) rely on an async call while the component is mounted - for this, the component will show the loading flag and then when the action steps are ready: the steps.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [X] Other

## How should this be tested?

This is mainly a code change. However this should be tested by re-testing the invest and other flows which rely on `<BalActionSteps>`

## Visual context

https://www.loom.com/share/ab22d8f2b6344135a64b9e99f832bd2f

## Checklist:

- [X] I have performed a self-review of my own code
- [X] I have requested at least 2 reviews (If the PR is significant enough, use best judgement here)
- [X] I have commented my code where relevant, particularly in hard-to-understand areas
- [X] If package-lock.json has changes, it was intentional.
- [X] The base of this PR is `master` if hotfix, `develop` if not
