### PR TITLE
useTokenApprovals/Actions to support a custom spender

### DIFF
--- a/src/composables/pools/useTokenApprovals.ts
+++ b/src/composables/pools/useTokenApprovals.ts
@@ -12,7 +12,6 @@ import { MaxUint256 } from '@ethersproject/constants';
 import { TransactionResponse } from '@ethersproject/abstract-provider';
 import { sendTransaction } from '@/lib/utils/balancer/web3';
 import { default as ERC20ABI } from '@/lib/abi/ERC20.json';
-import { TokenInfoMap } from '@/types/TokenList';
 import { getAddress } from '@ethersproject/address';
 import { bnum } from '@/lib/utils';
 
@@ -38,7 +37,7 @@ export default function useTokenApprovals(
     tokens,
     refetchAllowances,
     approvalsRequired,
-    getToken
+    getTokens
   } = useTokens();
   const { txListener } = useEthers();
   const { addTransaction } = useTransactions();
@@ -124,10 +123,7 @@ export default function useTokenApprovals(
   }
 
   async function getApprovalForSpender(spender: string) {
-    const customTokenMap: TokenInfoMap = {};
-    for (const token of tokenAddresses) {
-      customTokenMap[getAddress(token)] = getToken(getAddress(token));
-    }
+    const customTokenMap = getTokens(tokenAddresses);
 
     const allowances = await tokenService.allowances.get(
       account.value,

--- a/src/composables/pools/useTokenApprovals.ts
+++ b/src/composables/pools/useTokenApprovals.ts
@@ -1,13 +1,20 @@
 import { ref, computed, Ref } from 'vue';
 import { useI18n } from 'vue-i18n';
+
 import useWeb3 from '@/services/web3/useWeb3';
 import useTokens from '@/composables/useTokens';
 import useEthers from '@/composables/useEthers';
 import useTransactions from '../useTransactions';
+
+import { tokenService } from '@/services/token/token.service';
+
 import { MaxUint256 } from '@ethersproject/constants';
 import { TransactionResponse } from '@ethersproject/abstract-provider';
 import { sendTransaction } from '@/lib/utils/balancer/web3';
 import { default as ERC20ABI } from '@/lib/abi/ERC20.json';
+import { TokenInfoMap } from '@/types/TokenList';
+import { getAddress } from '@ethersproject/address';
+import { bnum } from '@/lib/utils';
 
 export type ApprovalState = {
   init: boolean;
@@ -26,8 +33,13 @@ export default function useTokenApprovals(
   /**
    * COMPOSABLES
    */
-  const { getProvider, appNetworkConfig } = useWeb3();
-  const { tokens, refetchAllowances, approvalsRequired } = useTokens();
+  const { getProvider, appNetworkConfig, account } = useWeb3();
+  const {
+    tokens,
+    refetchAllowances,
+    approvalsRequired,
+    getToken
+  } = useTokens();
   const { txListener } = useEthers();
   const { addTransaction } = useTransactions();
   const { t } = useI18n();
@@ -57,8 +69,12 @@ export default function useTokenApprovals(
   /**
    * METHODS
    */
-  async function approveToken(address: string): Promise<TransactionResponse> {
-    const state = requiredApprovalState.value[address];
+  async function approveToken(
+    address: string,
+    spender?: string,
+    customApprovalState?: Record<string, ApprovalState>
+  ): Promise<TransactionResponse> {
+    const state = customApprovalState || requiredApprovalState.value[address];
 
     try {
       state.init = true;
@@ -68,7 +84,7 @@ export default function useTokenApprovals(
         address,
         ERC20ABI,
         'approve',
-        [appNetworkConfig.addresses.vault, MaxUint256.toString()]
+        [spender || appNetworkConfig.addresses.vault, MaxUint256.toString()]
       );
 
       state.init = false;
@@ -83,7 +99,7 @@ export default function useTokenApprovals(
         ]),
         details: {
           contractAddress: address,
-          spender: appNetworkConfig.addresses.vault
+          spender: spender || appNetworkConfig.addresses.vault
         }
       });
 
@@ -107,6 +123,34 @@ export default function useTokenApprovals(
     }
   }
 
+  async function getApprovalForSpender(spender: string) {
+    const customTokenMap: TokenInfoMap = {};
+    for (const token of tokenAddresses) {
+      customTokenMap[getAddress(token)] = getToken(getAddress(token));
+    }
+
+    const allowances = await tokenService.allowances.get(
+      account.value,
+      [spender],
+      customTokenMap
+    );
+
+    const requiredApprovals = tokenAddresses
+      .filter((tokenAddress, i) => {
+        const allowance = bnum(
+          allowances[getAddress(spender)][getAddress(tokenAddress)]
+        );
+        return allowance.lt(amounts.value[i]);
+      })
+      .map(tokenAddress => [
+        tokenAddress,
+        { init: false, confirming: false, approved: false }
+      ]);
+
+    const approvalMap = Object.fromEntries(requiredApprovals);
+    return approvalMap;
+  }
+
   return {
     // state
     requiredApprovalState,
@@ -114,6 +158,7 @@ export default function useTokenApprovals(
     // computed
     requiredApprovals,
     // methods
-    approveToken
+    approveToken,
+    getApprovalForSpender
   };
 }


### PR DESCRIPTION
# Description

Currently our token approvals architecture only takes into account two main spenders (The vault, and wstETH [Here](https://github.com/balancer-labs/frontend-v2/blob/develop/src/providers/tokens.provider.ts#L136-L139) ).
How it works is that it checks the allowances for all tokens in the store for approvals against those contracts. 
Adding new spenders is fine to the list of spenders above is fine - if we know those spenders are pretty static.

However, for the upcoming tokenomics pull requests we need to have the ability to approve against many different spenders as the spender is the gauge contract - which is dynamic based on the pool. We could just keep a static list and have it imported but I feel that we should have support for custom or dynamic spenders.

This pull request adds support for checking token approvals/allowances against a custom spender via the `useTokenApprovals` and `useTokenApprovalActions` composables. 
Instead of modifying the entire allowance architecture from the ground up (from the tokens provider), I've simplified it down to just modifying those above composables. All existing behaviour is maintained, just that we have additional parameters and functions to support the custom spender usecase.

Usage
```
const { getTokenApprovalActionsForSpender } = useTokenApprovalActions(
  [props.pool.address],
  ref([balanceFor(props.pool.address).toString()])
);

const actions = ref<TransactionActionInfo[]>([]);

 const approvalActions = await getTokenApprovalActionsForSpender('mySpenderAddress');
 actions.value.unshift(...approvalActions);

<BalActionSteps
  :actions="actions"
/>
```


## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [X] Other

## How should this be tested?

You will be able to test this with the tokenomics pull request. But make sure that any existing approval flows for pool creation, trading and investing are not broken.

## Visual context

N/A

## Checklist:

- [X] I have performed a self-review of my own code
- [X] I have requested at least 2 reviews (If the PR is significant enough, use best judgement here)
- [X] I have commented my code where relevant, particularly in hard-to-understand areas
- [X] If package-lock.json has changes, it was intentional.
- [X] The base of this PR is `master` if hotfix, `develop` if not
