### PR TITLE
Hotfix/1.43.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.43.2",
+  "version": "1.43.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@balancer-labs/frontend-v2",
-      "version": "1.43.2",
+      "version": "1.43.3",
       "license": "MIT",
       "devDependencies": {
         "@aave/protocol-js": "^4.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.43.2",
+  "version": "1.43.3",
   "engines": {
     "node": "14.x",
     "npm": ">=7"

--- a/src/services/pool/calculator/stable-phantom.ts
+++ b/src/services/pool/calculator/stable-phantom.ts
@@ -58,9 +58,9 @@ export default class StablePhantom {
       tokenAmounts,
       this.calc.poolTokenDecimals
     );
-
+    // This function should use pool balances (i.e. without rate conversion)
     const bptZeroImpact = _bptForTokensZeroPriceImpact(
-      this.scaledBalances,
+      this.calc.poolTokenBalances,
       this.calc.poolTokenDecimals,
       denormAmounts,
       this.calc.poolTotalSupply,


### PR DESCRIPTION
# Description

Fixes priceImpact issue for bbausd single asset join.
_bptForTokensZeroPriceImpact should use pool balances. Was previously using balances converted with rates.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## How should this be tested?

Test bbausd single asset join.

## Visual context

Please provide any relevant visual context for UI changes or additions. This could be static screenshots or a loom screencast.

## Checklist:

- [X] I have performed a self-review of my own code
- [ ] I have requested at least 2 reviews (If the PR is significant enough, use best judgement here)
- [X] I have commented my code where relevant, particularly in hard-to-understand areas
- [X] If package-lock.json has changes, it was intentional.
- [X] The base of this PR is `master` if hotfix, `develop` if not
