### PR TITLE
Add more recoverability to pool creation due to Polygon slowness

### DIFF
--- a/src/components/_global/BalActionSteps/BalActionSteps.vue
+++ b/src/components/_global/BalActionSteps/BalActionSteps.vue
@@ -160,7 +160,7 @@ async function handleTransaction(
       // need to explicity wait for a number of confirmations
       // on polygon
       if (Number(configService.network.chainId) === ChainId.polygon) {
-        await tx.wait(7);
+        await tx.wait(10);
       }
 
       const confirmedAt = await getTxConfirmedAt(receipt);

--- a/src/composables/pools/usePoolCreation.ts
+++ b/src/composables/pools/usePoolCreation.ts
@@ -415,14 +415,7 @@ export default function usePoolCreation() {
       1;
       txListener(tx, {
         onTxConfirmed: async () => {
-          const poolDetails = await balancerService.pools.weighted.details(
-            provider,
-            tx
-          );
-          poolCreationState.poolId = poolDetails.id;
-          poolCreationState.poolAddress = poolDetails.address;
-          poolCreationState.needsSeeding = true;
-          saveState();
+          retrievePoolDetails(tx.hash);
         },
         onTxFailed: () => {
           console.log('Create failed');
@@ -513,6 +506,18 @@ export default function usePoolCreation() {
     hasRestoredFromSavedState.value = value;
   }
 
+  async function retrievePoolDetails(hash: string) {
+    const provider = getProvider();
+    const poolDetails = await balancerService.pools.weighted.details(
+      provider,
+      hash
+    );
+    poolCreationState.poolId = poolDetails.id;
+    poolCreationState.poolAddress = poolDetails.address;
+    poolCreationState.needsSeeding = true;
+    saveState();
+  }
+
   return {
     ...toRefs(poolCreationState),
     updateTokenWeights,
@@ -540,6 +545,7 @@ export default function usePoolCreation() {
     importState,
     setRestoredState,
     setTokensList,
+    retrievePoolDetails,
     currentLiquidity,
     optimisedLiquidity,
     scaledLiquidity,

--- a/src/composables/useEthers.ts
+++ b/src/composables/useEthers.ts
@@ -66,7 +66,6 @@ export default function useEthers() {
   ): Promise<boolean> {
     let confirmed = false;
     const retries = shouldRetry ? 5 : 1;
-    console.log('dingodng', retries);
     processedTxs.value.add(tx.hash);
 
     try {

--- a/src/lib/utils/index.ts
+++ b/src/lib/utils/index.ts
@@ -45,7 +45,6 @@ export function lsGet<T = any>(
   if (rawValue != null) {
     try {
       const value = JSON.parse(rawValue);
-
       if (version != null) {
         return value._version === version ? value.data : defaultValue;
       }

--- a/src/providers/tokens.provider.ts
+++ b/src/providers/tokens.provider.ts
@@ -360,7 +360,7 @@ export default {
       if (tokenAddress === nativeAsset.address) return false;
 
       const allowance = bnum(
-        allowances.value[contractAddress][getAddress(tokenAddress)]
+        (allowances.value[contractAddress] || {})[getAddress(tokenAddress)]
       );
       return allowance.lt(amount);
     }

--- a/src/services/balancer/pools/weighted-pool.service.ts
+++ b/src/services/balancer/pools/weighted-pool.service.ts
@@ -73,9 +73,9 @@ export default class WeightedPoolService {
 
   public async details(
     provider: Web3Provider,
-    createPoolTransaction: TransactionResponse
+    createHash: string
   ): Promise<CreatePoolReturn> {
-    const receipt: any = await createPoolTransaction.wait();
+    const receipt: any = await provider.getTransactionReceipt(createHash);
     let poolAddress;
     if (receipt.events) {
       const events = receipt.events.filter(e => e.event === 'PoolCreated');

--- a/src/services/config/config.service.ts
+++ b/src/services/config/config.service.ts
@@ -15,7 +15,6 @@ interface Env {
   PORTIS_DAPP_ID: string;
   ENABLE_STABLE_POOLS: boolean;
 }
-
 export default class ConfigService {
   public get env(): Env {
     return {
@@ -43,7 +42,7 @@ export default class ConfigService {
   }
 
   public getNetworkConfig(key: Network): Config {
-    if (!Object.keys(configs).includes(key.toString()))
+    if (!Object.keys(configs).includes(key?.toString()))
       throw new Error(`No config for network key: ${key}`);
     return configs[key];
   }


### PR DESCRIPTION
# Description

Polygon is getting even more slow. With transactions showing `confirmed` way before they actually are confirmed. This causes a race condition with pool creation where we retrieve the pool address from the contract. Since the pool technically isn't created until the tx is properly confirmed, we attempt to retrieve the pool address anyways and this causes a chain of pain.

To combat this I've done two things:
1. Increased the wait time for tx confirmations on polygon FURTHER.
2. Added recoverability to the state where it attempts to retrieve those pool details on restore, this should alleviate some headache for sure.

Other things included:
1. Allowances always broke on a whim sometimes, I added a guard for when the contract vault is still undefined (we attempt to load allowances sometimes onBeforeMount which causes issues here)
2. Guard on config service where the key (coming from the users wallet) may not be available yet.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## How should this be tested?

Working pool creation. I've tested

## Visual context

N/A

## Checklist:

- [X] I have performed a self-review of my own code
- [X] I have requested at least 2 reviews (If the PR is significant enough, use best judgement here)
- [X] I have commented my code where relevant, particularly in hard-to-understand areas
- [X] If package-lock.json has changes, it was intentional.
- [X] The base of this PR is `master` if hotfix, `develop` if not
