### PR TITLE
Gauge vote testing

### DIFF
--- a/src/components/_global/BalLoadingBlock/BalLoadingBlock.vue
+++ b/src/components/_global/BalLoadingBlock/BalLoadingBlock.vue
@@ -1,47 +1,56 @@
+<script lang="ts" setup>
+import useDarkMode from '@/composables/useDarkMode';
+import { computed } from 'vue';
+
+/**
+ * TYPES
+ */
+type RoundedOpts = 'sm' | 'md' | 'lg';
+
+type Props = {
+  white: boolean;
+  darker: boolean;
+  square: boolean;
+  rounded: RoundedOpts;
+};
+
+/**
+ * PROPS & EMITS
+ */
+const props = withDefaults(defineProps<Props>(), {
+  white: false,
+  darker: false,
+  square: false,
+  rounded: 'lg'
+});
+
+/**
+ * COMPOSABLES
+ */
+const { darkMode } = useDarkMode();
+
+/**
+ * COMPUTED
+ */
+const bgClass = computed(() => {
+  if (props.white) return 'shimmer-white';
+  if (darkMode.value) {
+    return props.darker ? 'shimmer-dark-mode-darker' : 'shimmer-dark-mode';
+  }
+  return props.darker ? 'shimmer-light-mode-darker' : 'shimmer-light-mode';
+});
+
+const classes = computed(() => {
+  return {
+    [`rounded-${props.rounded}`]: !props.square,
+    [bgClass.value]: true
+  };
+});
+</script>
+
 <template>
   <div :class="['bal-loading-block', classes]" />
 </template>
-
-<script lang="ts">
-import useDarkMode from '@/composables/useDarkMode';
-import { defineComponent, computed } from 'vue';
-
-export default defineComponent({
-  name: 'BalLoadingBlock',
-
-  props: {
-    white: { type: Boolean, default: false },
-    darker: { type: Boolean, default: false },
-    square: { type: Boolean, default: false },
-    rounded: {
-      type: String,
-      default: 'lg',
-      validator: (val: string): boolean => ['sm', 'md', 'lg'].includes(val)
-    }
-  },
-
-  setup(props) {
-    const { darkMode } = useDarkMode();
-
-    const bgClass = computed(() => {
-      if (props.white) return 'shimmer-white';
-      if (darkMode.value) {
-        return props.darker ? 'shimmer-dark-mode-darker' : 'shimmer-dark-mode';
-      }
-      return props.darker ? 'shimmer-light-mode-darker' : 'shimmer-light-mode';
-    });
-
-    const classes = computed(() => {
-      return {
-        [`rounded-${props.rounded}`]: !props.square,
-        [bgClass.value]: true
-      };
-    });
-
-    return { classes };
-  }
-});
-</script>
 
 <style>
 .bal-loading-block {


### PR DESCRIPTION
# Description

This PR is to describe how the gauge voting flow can be tested and to collect feedback.

## How should this be tested?

Pre-condition: To be able to vote you need to have veBAL by locking the BPT of the 80/20 pool.

First navigate to the [veBAL page in the kovan preview URL](https://beta-kovan-git-testing-voting-balancer.vercel.app/#/vebal).

- [ ] Test the /vebal page loads and causes no errors with wallet disconnected
- [ ] Test connecting wallet on page, vebal stats should load, voting buttons should appear.
- [ ] Test voting on gauges by clicking on 'Vote' and completing the flow.

## Visual context

Demo: [https://www.loom.com/share/67271b990989411d9c6b9e3848077772](https://www.loom.com/share/67271b990989411d9c6b9e3848077772)

<img width="1215" alt="Screenshot 2022-03-16 at 19 28 21" src="https://user-images.githubusercontent.com/2406506/158676081-68d7a008-1589-4e2a-8f94-e87ae642b535.png">
<img width="507" alt="Screenshot 2022-03-16 at 19 38 47" src="https://user-images.githubusercontent.com/2406506/158676108-015c6a4a-187e-42cc-b2a2-4c4adbaa265f.png">

