### PR TITLE
Tokenomics/Fix home page staking

### DIFF
--- a/src/components/contextual/pages/pools/StakedPoolsTable.vue
+++ b/src/components/contextual/pages/pools/StakedPoolsTable.vue
@@ -25,11 +25,11 @@ const {
   userGaugeShares,
   userLiquidityGauges,
   stakedPools,
-  isLoading: isLoadingStakingData
+  isLoading: isLoadingStakingData,
+  setPoolAddress
 } = useStaking();
 
 /** COMPUTED */
-
 // a map of poolId-stakedBPT for the connected user
 const stakedBalanceMap = computed(() => {
   const map: Record<string, string> = {};
@@ -117,6 +117,7 @@ const allStakedPools = computed(() => {
 
 /** METHODS */
 function handleStake(pool: FullPool) {
+  setPoolAddress(pool.address);
   showStakeModal.value = true;
   stakePool.value = pool;
 }


### PR DESCRIPTION
# Description

Users could not stake from the home page since the stake action would complain about the 'useStaking' composable not being initalised with a pool address.

This pull request fixes that by allowing the pool address to be set manually on the provider as well. The provider will prefer to use any manual address set compared to the one provided to it in props.

Also removes some unused code in the provider.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## How should this be tested?

You should be able to stake your BPT from the home page table

## Visual context

Available on base branch.

## Checklist:

- [X] I have performed a self-review of my own code
- [X] I have requested at least 2 reviews (If the PR is significant enough, use best judgement here)
- [X] I have commented my code where relevant, particularly in hard-to-understand areas
- [X] If package-lock.json has changes, it was intentional.
- [X] The base of this PR is `master` if hotfix, `develop` if not
