### PR TITLE
Tokenomics/Fix home page staking

### DIFF
--- a/src/components/contextual/pages/pools/StakedPoolsTable.vue
+++ b/src/components/contextual/pages/pools/StakedPoolsTable.vue
@@ -25,11 +25,11 @@ const {
   userGaugeShares,
   userLiquidityGauges,
   stakedPools,
-  isLoading: isLoadingStakingData
+  isLoading: isLoadingStakingData,
+  setPoolAddress
 } = useStaking();
 
 /** COMPUTED */
-
 // a map of poolId-stakedBPT for the connected user
 const stakedBalanceMap = computed(() => {
   const map: Record<string, string> = {};
@@ -117,6 +117,7 @@ const allStakedPools = computed(() => {
 
 /** METHODS */
 function handleStake(pool: FullPool) {
+  setPoolAddress(pool.address);
   showStakeModal.value = true;
   stakePool.value = pool;
 }

--- a/src/components/contextual/stake/StakePreview.vue
+++ b/src/components/contextual/stake/StakePreview.vue
@@ -37,7 +37,8 @@ const {
   unstakeBPT,
   getGaugeAddress,
   stakedShares,
-  refetchStakedShares
+  refetchStakedShares,
+  refetchStakingData
 } = useStaking();
 const { getTokenApprovalActionsForSpender } = useTokenApprovalActions(
   [props.pool.address],
@@ -123,6 +124,7 @@ async function handleSuccess({ receipt }) {
   isActionConfirmed.value = true;
   confirmationReceipt.value = receipt;
   await refetchStakedShares.value();
+  await refetchStakingData.value();
   emit('success');
 }
 

--- a/src/providers/staking.provider.ts
+++ b/src/providers/staking.provider.ts
@@ -32,6 +32,7 @@ import {
 import { DecoratedPool } from '@/services/balancer/subgraph/types';
 import { TransactionResponse } from '@ethersproject/abstract-provider';
 import { useQuery } from 'vue-query';
+import { QueryObserverResult, RefetchOptions } from 'react-query';
 
 /**
  * TYPES
@@ -56,6 +57,9 @@ export type StakingProvider = {
   unstakeBPT: () => Promise<TransactionResponse>;
   getStakedShares: () => Promise<string>;
   setPoolAddress: (address: string) => void;
+  refetchStakingData: Ref<
+    (options?: RefetchOptions) => Promise<QueryObserverResult>
+  >;
 };
 
 /**
@@ -106,7 +110,8 @@ export default defineComponent({
     const {
       data: stakingData,
       isLoading: isLoadingStakingData,
-      isIdle: isStakeDataIdle
+      isIdle: isStakeDataIdle,
+      refetch: refetchStakingData
     } = useGraphQuery<UserGuageSharesResponse>(
       subgraphs.gauge,
       ['staking', 'data', { account, userPoolIds }],
@@ -303,7 +308,8 @@ export default defineComponent({
       stakeBPT,
       unstakeBPT,
       getStakedShares,
-      setPoolAddress
+      setPoolAddress,
+      refetchStakingData
     });
   },
 


### PR DESCRIPTION
# Description

After staking on the home page refetch user staked balances so the table updates.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## How should this be tested?

Stake on the home page, it should the table to show 100% instead of the stake button

## Visual context

N/A

## Checklist:

- [X] I have performed a self-review of my own code
- [X] I have requested at least 2 reviews (If the PR is significant enough, use best judgement here)
- [X] I have commented my code where relevant, particularly in hard-to-understand areas
- [X] If package-lock.json has changes, it was intentional.
- [X] The base of this PR is `master` if hotfix, `develop` if not
