### PR TITLE
Fix countdown timer to vote period end time

### DIFF
--- a/src/components/contextual/pages/vebal/LMVoting/LMVoting.vue
+++ b/src/components/contextual/pages/vebal/LMVoting/LMVoting.vue
@@ -1,7 +1,7 @@
 <script lang="ts" setup>
 import { computed, ref } from 'vue';
 import { scale, bnum } from '@/lib/utils';
-import { intervalToDuration, Interval, Duration } from 'date-fns';
+import { intervalToDuration, Interval, Duration, add } from 'date-fns';
 
 import useNumbers, { FNumFormats } from '@/composables/useNumbers';
 import useVotingGauges from '@/composables/useVotingGauges';
@@ -46,8 +46,7 @@ const unallocatedVotesFormatted = computed<string>(() =>
 
 const votingPeriodEnd = computed<number[]>(() => {
   if (!veBalLockInfoQuery.data.value) return [];
-  const currentEpoch = Number(veBalLockInfoQuery.data.value.epoch);
-  const periodEnd = EPOCH_GENESIS + currentEpoch * WEEK_IN_MS;
+  const periodEnd = getVotePeriodEndTime();
   const interval: Interval = { start: now.value, end: periodEnd };
   const timeUntilEnd: Duration = intervalToDuration(interval);
   const formattedTime = [
@@ -58,6 +57,30 @@ const votingPeriodEnd = computed<number[]>(() => {
   ];
   return formattedTime;
 });
+
+/**
+ * METHODS
+ **/
+
+function getVotePeriodEndTime(): number {
+  var d = new Date();
+  const dayOfWeek = d.getDay();
+  let daysUntilThursday = 4 - dayOfWeek;
+  if (daysUntilThursday <= 0) {
+    daysUntilThursday += 7;
+  }
+  const nextThursdayTimestamp = add(d, { days: daysUntilThursday });
+  const n = new Date(nextThursdayTimestamp);
+  const epochEndTime = Date.UTC(
+    n.getFullYear(),
+    n.getMonth(),
+    n.getDate(),
+    0,
+    0,
+    0
+  );
+  return epochEndTime;
+}
 </script>
 
 <template>

--- a/src/components/contextual/pages/vebal/LMVoting/LMVoting.vue
+++ b/src/components/contextual/pages/vebal/LMVoting/LMVoting.vue
@@ -10,13 +10,6 @@ import useVeBalLockInfoQuery from '@/composables/queries/useVeBalLockInfoQuery';
 import GaugesTable from './GaugesTable.vue';
 
 /**
- * CONSTANTS
- */
-
-const EPOCH_GENESIS = 1596636000000;
-const WEEK_IN_MS = 86_400_000 * 7;
-
-/**
  * DATA
  */
 const now = ref(Date.now());


### PR DESCRIPTION
# Description

- Add a new method that calculates when the current vote period should end by finding next thursday and getting the UTC time of 00:00. 
- Tested by changing my system clock to various timezones and it always shows the same time remaining. 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## How should this be tested?

- Open `/#/vebal` 
- Check the Voting Period Ends time, it should be the time remaining until 00:00 on next Thursday morning UTC time. 

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have requested at least 2 reviews (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] If package-lock.json has changes, it was intentional.
- [x] The base of this PR is `master` if hotfix, `develop` if not
