### PR TITLE
Tokenomics/Fix no staked pools

### DIFF
--- a/src/components/contextual/pages/pools/StakedPoolsTable.vue
+++ b/src/components/contextual/pages/pools/StakedPoolsTable.vue
@@ -13,6 +13,7 @@ import { bnum } from '@/lib/utils';
 
 import PoolsTable from '@/components/tables/PoolsTable/PoolsTable.vue';
 import StakePreviewModal from '../../stake/StakePreviewModal.vue';
+import AnimatePresence from '@/components/animate/AnimatePresence.vue';
 
 import { uniqBy } from 'lodash';
 
@@ -138,7 +139,7 @@ function calculateFiatValueOfShares(
 </script>
 
 <template>
-  <div>
+  <AnimatePresence :isVisible="!isLoadingStakingData">
     <BalStack vertical spacing="sm">
       <h5>{{ $t('myStakedPools') }}</h5>
       <PoolsTable
@@ -157,5 +158,5 @@ function calculateFiatValueOfShares(
       @close="handleModalClose"
       action="stake"
     />
-  </div>
+  </AnimatePresence>
 </template>

--- a/src/components/tables/PoolsTable/PoolsTable.vue
+++ b/src/components/tables/PoolsTable/PoolsTable.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, ref } from 'vue';
+import { computed } from 'vue';
 import { useRouter } from 'vue-router';
 import { useI18n } from 'vue-i18n';
 

--- a/src/components/tables/PoolsTable/PoolsTable.vue
+++ b/src/components/tables/PoolsTable/PoolsTable.vue
@@ -64,12 +64,16 @@ const router = useRouter();
 const { t } = useI18n();
 const { trackGoal, Goals } = useFathom();
 const { darkMode } = useDarkMode();
-const { upToLargeBreakpoint } = useBreakpoints();
+const { upToLargeBreakpoint, upToMediumBreakpoint } = useBreakpoints();
+
+const wideCompositionWidth = computed(() =>
+  upToMediumBreakpoint.value ? 900 : undefined
+);
 
 /**
  * DATA
  */
-const columns = ref<ColumnDefinition<DecoratedPoolWithShares>[]>([
+const columns = computed<ColumnDefinition<DecoratedPoolWithShares>[]>(() => [
   {
     name: 'Icons',
     id: 'icons',
@@ -84,7 +88,7 @@ const columns = ref<ColumnDefinition<DecoratedPoolWithShares>[]>([
     id: 'poolName',
     accessor: 'id',
     Cell: 'poolNameCell',
-    width: props.hiddenColumns.length >= 2 ? 900 : 350
+    width: props.hiddenColumns.length >= 2 ? wideCompositionWidth.value : 350
   },
   {
     name: t('myBalance'),

--- a/src/composables/queries/usePoolsQuery.ts
+++ b/src/composables/queries/usePoolsQuery.ts
@@ -250,9 +250,9 @@ export default function usePoolsQuery(
   };
 
   const queryOptions = reactive({
-    enabled,
+    ...options,
     getNextPageParam: (lastPage: PoolsQueryResponse) => lastPage.skip,
-    ...options
+    enabled
   });
 
   return useInfiniteQuery<PoolsQueryResponse>(queryKey, queryFn, queryOptions);

--- a/src/providers/staking.provider.ts
+++ b/src/providers/staking.provider.ts
@@ -51,6 +51,7 @@ export type StakingProvider = {
   isRefetchingStakedShares: Ref<boolean>;
   isLoadingPoolEligibility: Ref<boolean>;
   isPoolEligibleForStaking: Ref<boolean>;
+  isStakedPoolsQueryEnabled: Ref<boolean>;
   refetchStakedShares: Ref<() => void>;
   getGaugeAddress: (poolAddress: string) => Promise<string>;
   stakeBPT: () => Promise<TransactionResponse>;
@@ -89,7 +90,7 @@ export default defineComponent({
 
     /** QUERY ARGS */
     const userPoolIds = computed(() => {
-      return userPools.value.map(pool => pool.address.toLowerCase());
+      return userPools.value.map(pool => pool.id);
     });
 
     const poolAddress = computed(() => {
@@ -208,14 +209,19 @@ export default defineComponent({
         undefined
     );
 
+    const isStakedPoolsQueryEnabled = computed(
+      () => stakedPoolIds.value.length > 0
+    );
+
     /** QUERY */
     const {
       data: stakedPoolsResponse,
-      isLoading: isLoadingStakedPools,
-      isIdle: isPoolsQueryIdle
+      isLoading: isLoadingStakedPools
     } = usePoolsQuery(
       ref([]),
-      {},
+      reactive({
+        enabled: isStakedPoolsQueryEnabled
+      }),
       {
         poolIds: stakedPoolIds
       }
@@ -225,8 +231,7 @@ export default defineComponent({
       () =>
         isLoadingStakedPools.value ||
         isLoadingStakingData.value ||
-        isStakeDataIdle.value ||
-        isPoolsQueryIdle.value
+        isStakeDataIdle.value
     );
 
     const stakedPools = computed(
@@ -304,6 +309,7 @@ export default defineComponent({
       isRefetchingStakedShares,
       isPoolEligibleForStaking,
       refetchStakedShares,
+      isStakedPoolsQueryEnabled,
       getGaugeAddress,
       stakeBPT,
       unstakeBPT,


### PR DESCRIPTION
# Description

When the user has no staked pools, it makes a graphql query with an empty filter which returns all available pools. This is a problem so this PR fixes that by disabling the query if there are no staked pools.
## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## How should this be tested?

Normal staking flow should be still working. Pools which you are not staked in should not be visible

## Visual context

Refer to the base branch preview.

## Checklist:

- [X] I have performed a self-review of my own code
- [X] I have requested at least 2 reviews (If the PR is significant enough, use best judgement here)
- [X] I have commented my code where relevant, particularly in hard-to-understand areas
- [X] If package-lock.json has changes, it was intentional.
- [X] The base of this PR is `master` if hotfix, `develop` if not
