### PR TITLE
Hotfix: re-add token approval

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.44.4",
+  "version": "1.44.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@balancer-labs/frontend-v2",
-      "version": "1.44.4",
+      "version": "1.44.5",
       "license": "MIT",
       "devDependencies": {
         "@aave/protocol-js": "^4.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.44.4",
+  "version": "1.44.5",
   "engines": {
     "node": "14.x",
     "npm": ">=7"

--- a/src/components/modals/TradePreviewModalGP.vue
+++ b/src/components/modals/TradePreviewModalGP.vue
@@ -677,10 +677,7 @@ export default defineComponent({
           props.trading.tokenOut.value.address
         );
       } else if (props.trading.requiresTokenApproval.value) {
-        return (
-          props.trading.isBalancerTrade.value &&
-          !tokenApproval.isUnlockedV2.value
-        );
+        return !tokenApproval.isUnlockedV2.value;
       }
       return false;
     });


### PR DESCRIPTION
# Description

Fixes token approvals actions not showing when trading via Gnosis. 

In #1415 in https://github.com/balancer-labs/frontend-v2/pull/1415/files#diff-9ba385aaaa1dd79048d5b04f24c55f3519dd75890e2770596abd620e7fa3dad7L680 The logic for approving tokens was changed from:

```
return props.trading.isBalancerTrade.value &&
          props.trading.sor.sorReturn.value.isV1swap
          ? !tokenApproval.isUnlockedV1.value
          : !tokenApproval.isUnlockedV2.value;
```

to

```
return (
          props.trading.isBalancerTrade.value &&
          !tokenApproval.isUnlockedV2.value
        );
```

The bug was that when `props.trading.isBalancerTrade.value` is false, when doing a gnosis trade, in the old code it would return `!tokenApproval.isUnlockedV2.value` while in the new code it always returns false. 

This removes the isBalancerTrade check because we always want to check that the token is approved regardless of the trade type. 


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## How should this be tested?

- Test swapping a token via gnosis that you've never traded before. 
- Ensure it asks for token approval before the trade step. 

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have requested at least 2 reviews (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] If package-lock.json has changes, it was intentional.
- [x] The base of this PR is `master` if hotfix, `develop` if not
