### PR TITLE
Change votes to show next period. Add tooltip with further info

### DIFF
--- a/src/components/_global/BalHorizSteps/BalHorizSteps.vue
+++ b/src/components/_global/BalHorizSteps/BalHorizSteps.vue
@@ -66,7 +66,7 @@ function stateClasses(state: StepState): string {
         v-if="i !== 0"
         :class="['h-px bg-gray-100 dark:bg-gray-700', `w-${spacerWidth}`]"
       />
-      <BalTooltip :text="step.tooltip" width="44" textCenter>
+      <BalTooltip :text="step.tooltip" width="44" textAlign="center">
         <template v-slot:activator>
           <div :class="['step', stateClasses(step.state)]">
             <BalIcon v-if="step.state === stepState.Success" name="check" />

--- a/src/components/_global/BalTooltip/BalTooltip.vue
+++ b/src/components/_global/BalTooltip/BalTooltip.vue
@@ -5,7 +5,7 @@ import { createPopper, Instance as PopperInstance } from '@popperjs/core';
 import BalIcon, { IconSize } from '../BalIcon/BalIcon.vue';
 
 type Placement = 'top' | 'left' | 'bottom' | 'right';
-type TextAlign = 'left' | 'center' | 'right';
+type TextAlign = 'left' | 'center' | 'right' | '';
 
 type Props = {
   text?: string;
@@ -27,7 +27,7 @@ const props = withDefaults(defineProps<Props>(), {
   noPad: false,
   disabled: false,
   width: '52',
-  textAlign: 'left',
+  textAlign: '',
   iconName: 'info',
   iconSize: 'md',
   iconClass: 'text-gray-300'
@@ -41,7 +41,7 @@ const tooltipClasses = computed(() => {
   return {
     'p-3': !props.noPad,
     [`w-${props.width}`]: true,
-    [`text-${props.textAlign}`]: true
+    [`text-${props.textAlign}`]: props.textAlign !== ''
   };
 });
 

--- a/src/components/_global/BalTooltip/BalTooltip.vue
+++ b/src/components/_global/BalTooltip/BalTooltip.vue
@@ -5,6 +5,7 @@ import { createPopper, Instance as PopperInstance } from '@popperjs/core';
 import BalIcon, { IconSize } from '../BalIcon/BalIcon.vue';
 
 type Placement = 'top' | 'left' | 'bottom' | 'right';
+type TextAlign = 'left' | 'center' | 'right';
 
 type Props = {
   text?: string;
@@ -17,7 +18,7 @@ type Props = {
   iconName?: string;
   iconClass?: string;
   width?: string;
-  textCenter?: boolean;
+  textAlign?: TextAlign;
 };
 
 const props = withDefaults(defineProps<Props>(), {
@@ -26,7 +27,7 @@ const props = withDefaults(defineProps<Props>(), {
   noPad: false,
   disabled: false,
   width: '52',
-  textCenter: false,
+  textAlign: 'left',
   iconName: 'info',
   iconSize: 'md',
   iconClass: 'text-gray-300'
@@ -40,7 +41,7 @@ const tooltipClasses = computed(() => {
   return {
     'p-3': !props.noPad,
     [`w-${props.width}`]: true,
-    'text-center': props.textCenter
+    [`text-${props.textAlign}`]: true
   };
 });
 

--- a/src/components/contextual/pages/vebal/LMVoting/GaugeVoteInfo.vue
+++ b/src/components/contextual/pages/vebal/LMVoting/GaugeVoteInfo.vue
@@ -1,0 +1,88 @@
+<script setup lang="ts">
+import { computed } from 'vue';
+import { scale, bnum } from '@/lib/utils';
+
+import useNumbers from '@/composables/useNumbers';
+
+import { VotingGaugeWithVotes } from '@/services/balancer/gauges/gauge-controller.decorator';
+
+/**
+ * TYPES
+ */
+type Props = {
+  gauge: VotingGaugeWithVotes;
+};
+
+/**
+ * PROPS & EMITS
+ */
+const props = withDefaults(defineProps<Props>(), {});
+
+/**
+ * COMPOSABLES
+ */
+const { fNum2 } = useNumbers();
+
+/**
+ * COMPUTED
+ */
+
+const votesThisPeriod = computed<string>(() =>
+  formatVotesAsPercent(props.gauge.votes)
+);
+
+const votesNextPeriod = computed<string>(() =>
+  formatVotesAsPercent(props.gauge.votesNextPeriod)
+);
+
+const voteDifference = computed<number>(() => {
+  return Number(props.gauge.votesNextPeriod) - Number(props.gauge.votes);
+});
+
+const voteDifferenceText = computed<string>(() => {
+  const text = formatVotesAsPercent(voteDifference.value.toString());
+  const prefix = voteDifference.value > 0 ? '+' : '';
+  return `${prefix}${text}`;
+});
+
+const voteTextClass = computed(() => {
+  return {
+    'text-green-600': voteDifference.value > 0,
+    'text-red-600': voteDifference.value < 0
+  };
+});
+
+/**
+ * METHODS
+ */
+function formatVotesAsPercent(votes: string): string {
+  const normalizedVotes = scale(bnum(votes), -18);
+  return fNum2(normalizedVotes.toString(), {
+    style: 'percent',
+    maximumFractionDigits: 2,
+    fixedFormat: true
+  });
+}
+</script>
+
+<template>
+  <BalTooltip>
+    <template v-slot:activator>
+      <span :class="voteTextClass">{{ votesNextPeriod }}</span>
+    </template>
+    <div class="p-1">
+      <h5>{{ $t('veBAL.liquidityMining.votesTooltip.title') }}</h5>
+      <div>
+        {{
+          $t('veBAL.liquidityMining.votesTooltip.thisPeriod', [votesThisPeriod])
+        }}
+      </div>
+      <div>
+        {{
+          $t('veBAL.liquidityMining.votesTooltip.nextPeriod', [votesNextPeriod])
+        }}
+        <span :class="voteTextClass">{{ voteDifferenceText }}</span>
+      </div>
+    </div>
+  </BalTooltip>
+</template>

--- a/src/components/contextual/pages/vebal/LMVoting/GaugeVoteInfo.vue
+++ b/src/components/contextual/pages/vebal/LMVoting/GaugeVoteInfo.vue
@@ -70,18 +70,26 @@ function formatVotesAsPercent(votes: string): string {
     <template v-slot:activator>
       <span :class="voteTextClass">{{ votesNextPeriod }}</span>
     </template>
-    <div class="p-1">
-      <h5>{{ $t('veBAL.liquidityMining.votesTooltip.title') }}</h5>
-      <div>
-        {{
-          $t('veBAL.liquidityMining.votesTooltip.thisPeriod', [votesThisPeriod])
-        }}
+    <div>
+      <div class="mb-2 text-sm font-semibold">
+        {{ $t('veBAL.liquidityMining.votesTooltip.title') }}
       </div>
-      <div>
-        {{
-          $t('veBAL.liquidityMining.votesTooltip.nextPeriod', [votesNextPeriod])
-        }}
-        <span :class="voteTextClass">{{ voteDifferenceText }}</span>
+      <div class="text-xs font-normal">
+        <div class="mb-2">
+          {{
+            $t('veBAL.liquidityMining.votesTooltip.thisPeriod', [
+              votesThisPeriod
+            ])
+          }}
+        </div>
+        <div class="mb-2">
+          {{
+            $t('veBAL.liquidityMining.votesTooltip.nextPeriod', [
+              votesNextPeriod
+            ])
+          }}
+          <span :class="voteTextClass">{{ voteDifferenceText }}</span>
+        </div>
       </div>
     </div>
   </BalTooltip>

--- a/src/components/contextual/pages/vebal/LMVoting/GaugeVoteInfo.vue
+++ b/src/components/contextual/pages/vebal/LMVoting/GaugeVoteInfo.vue
@@ -66,7 +66,7 @@ function formatVotesAsPercent(votes: string): string {
 </script>
 
 <template>
-  <BalTooltip>
+  <BalTooltip textAlign="left">
     <template v-slot:activator>
       <span :class="voteTextClass">{{ votesNextPeriod }}</span>
     </template>

--- a/src/components/contextual/pages/vebal/LMVoting/GaugeVoteModal.vue
+++ b/src/components/contextual/pages/vebal/LMVoting/GaugeVoteModal.vue
@@ -95,10 +95,10 @@ const voteButtonText = computed(() =>
 
 const votedToRecentlyWarning = computed(() => {
   const timestampSeconds = Date.now() / 1000;
-  const lastUserVote = props.gauge.lastUserVote;
-  if (timestampSeconds < lastUserVote + WEIGHT_VOTE_DELAY) {
+  const lastUserVoteTime = props.gauge.lastUserVoteTime;
+  if (timestampSeconds < lastUserVoteTime + WEIGHT_VOTE_DELAY) {
     const remainingTime = formatDistanceToNow(
-      (lastUserVote + WEIGHT_VOTE_DELAY) * 1000
+      (lastUserVoteTime + WEIGHT_VOTE_DELAY) * 1000
     );
     return {
       title: t('veBAL.liquidityMining.popover.warnings.votedTooRecently.title'),

--- a/src/components/contextual/pages/vebal/LMVoting/GaugesTable.vue
+++ b/src/components/contextual/pages/vebal/LMVoting/GaugesTable.vue
@@ -8,7 +8,6 @@ import useBreakpoints from '@/composables/useBreakpoints';
 import { ColumnDefinition } from '@/components/_global/BalTable/BalTable.vue';
 import TokenPills from '@/components/tables/PoolsTable/TokenPills/TokenPills.vue';
 
-import GaugeVoteModal from './GaugeVoteModal.vue';
 import GaugeVoteInfo from './GaugeVoteInfo.vue';
 
 import { VotingGaugeWithVotes } from '@/services/balancer/gauges/gauge-controller.decorator';

--- a/src/components/contextual/pages/vebal/LMVoting/GaugesTable.vue
+++ b/src/components/contextual/pages/vebal/LMVoting/GaugesTable.vue
@@ -7,6 +7,10 @@ import useNumbers from '@/composables/useNumbers';
 import useBreakpoints from '@/composables/useBreakpoints';
 import { ColumnDefinition } from '@/components/_global/BalTable/BalTable.vue';
 import TokenPills from '@/components/tables/PoolsTable/TokenPills/TokenPills.vue';
+
+import GaugeVoteModal from './GaugeVoteModal.vue';
+import GaugeVoteInfo from './GaugeVoteInfo.vue';
+
 import { VotingGaugeWithVotes } from '@/services/balancer/gauges/gauge-controller.decorator';
 import { Network } from '@balancer-labs/sdk';
 import { networkNameFor } from '@/composables/useNetwork';
@@ -79,16 +83,11 @@ const columns = ref<ColumnDefinition<VotingGaugeWithVotes>[]>([
   },
   {
     name: t('veBAL.liquidityMining.table.nextPeriodVotes'),
-    accessor(gauge) {
-      const normalizedVotes = scale(new BigNumber(gauge.votes), -18);
-      return fNum2(normalizedVotes.toString(), {
-        style: 'percent',
-        maximumFractionDigits: 2
-      });
-    },
+    acessor: 'id',
     align: 'right',
-    id: 'poolGaugeVotes',
-    sortKey: gauge => Number(gauge.votes),
+    id: 'nextPeriodVotes',
+    Cell: 'nextPeriodVotesCell',
+    sortKey: gauge => Number(gauge.votesNextWeek),
     width: 150,
     cellClassName: 'font-numeric'
   },
@@ -197,6 +196,11 @@ function redirectToPool(gauge: VotingGaugeWithVotes) {
             "
             :isStablePool="isStableLike(pool.poolType)"
           />
+        </div>
+      </template>
+      <template #nextPeriodVotesCell="gauge">
+        <div v-if="!isLoading" class="px-6 py-4">
+          <GaugeVoteInfo :gauge="gauge" />
         </div>
       </template>
       <template #voteColumnCell="gauge">

--- a/src/components/contextual/pages/vebal/LMVoting/GaugesTable.vue
+++ b/src/components/contextual/pages/vebal/LMVoting/GaugesTable.vue
@@ -83,11 +83,11 @@ const columns = ref<ColumnDefinition<VotingGaugeWithVotes>[]>([
   },
   {
     name: t('veBAL.liquidityMining.table.nextPeriodVotes'),
-    acessor: 'id',
+    accessor: 'id',
     align: 'right',
     id: 'nextPeriodVotes',
     Cell: 'nextPeriodVotesCell',
-    sortKey: gauge => Number(gauge.votesNextWeek),
+    sortKey: gauge => Number(gauge.votesNextPeriod),
     width: 150,
     cellClassName: 'font-numeric'
   },
@@ -199,7 +199,7 @@ function redirectToPool(gauge: VotingGaugeWithVotes) {
         </div>
       </template>
       <template #nextPeriodVotesCell="gauge">
-        <div v-if="!isLoading" class="px-6 py-4">
+        <div v-if="!isLoading" class="px-6 py-4 text-right">
           <GaugeVoteInfo :gauge="gauge" />
         </div>
       </template>

--- a/src/components/contextual/stake/StakePreview.vue
+++ b/src/components/contextual/stake/StakePreview.vue
@@ -187,7 +187,7 @@ function handleClose() {
             <span class="text-sm capitalize">
               ~{{ fNum2(fiatValueOfModifiedShares, FNumFormats.fiat) }}
             </span>
-            <BalTooltip text="s" width="20" textCenter />
+            <BalTooltip text="s" width="20" textAlign="center" />
           </BalStack>
         </BalStack>
         <BalStack horizontal justify="between">
@@ -196,7 +196,7 @@ function handleClose() {
             <span class="text-sm capitalize">
               ~{{ fNum2(totalUserPoolSharePct, FNumFormats.percent) }}
             </span>
-            <BalTooltip text="s" width="20" textCenter />
+            <BalTooltip text="s" width="20" textAlign="center" />
           </BalStack>
         </BalStack>
         <BalStack horizontal justify="between">
@@ -206,7 +206,7 @@ function handleClose() {
           </span>
           <BalStack horizontal spacing="base">
             <span class="text-sm capitalize">0</span>
-            <BalTooltip text="s" width="20" textCenter />
+            <BalTooltip text="s" width="20" textAlign="center" />
           </BalStack>
         </BalStack>
         <BalStack horizontal justify="between">
@@ -216,7 +216,7 @@ function handleClose() {
           </span>
           <BalStack horizontal spacing="base">
             <span class="text-sm capitalize">0</span>
-            <BalTooltip text="s" width="20" textCenter />
+            <BalTooltip text="s" width="20" textAlign="center" />
           </BalStack>
         </BalStack>
       </BalStack>

--- a/src/composables/useTime.ts
+++ b/src/composables/useTime.ts
@@ -3,6 +3,8 @@ import { sub } from 'date-fns';
 export const oneSecondInMs = 1000;
 export const oneMinInMs = 60 * oneSecondInMs;
 export const oneHourInMs = 60 * oneMinInMs;
+export const oneDayInMs = 24 * oneHourInMs;
+export const oneWeekInMs = 7 * oneDayInMs;
 
 export const twentyFourHoursInMs = 24 * oneHourInMs;
 export const twentyFourHoursInSecs = twentyFourHoursInMs / oneSecondInMs;
@@ -26,6 +28,10 @@ export function dateTimeLabelFor(date: Date): string {
 
 export function toJsTimestamp(unixTimestamp: number): number {
   return unixTimestamp * oneSecondInMs;
+}
+
+export function toUnixTimestamp(jsTimestamp: number): number {
+  return Math.round(jsTimestamp / oneSecondInMs);
 }
 
 export function getPreviousThursday(date: Date): Date {

--- a/src/lib/abi/GaugeController.json
+++ b/src/lib/abi/GaugeController.json
@@ -277,6 +277,10 @@
       {
         "name": "addr",
         "type": "address"
+      },
+      {
+        "name": "time",
+        "type": "uint256"
       }
     ],
     "outputs": [

--- a/src/locales/default.json
+++ b/src/locales/default.json
@@ -619,6 +619,11 @@
                 "myVotes": "My votes",
                 "vote": "Vote"
             },
+            "votesTooltip": {
+                "title": "Voting breakdown",
+                "thisPeriod": "This period: {0}",
+                "nextPeriod": "Next period: {0}"
+            },
             "popover": {
                 "title": {
                     "vote": "Gauge vote",

--- a/src/services/balancer/gauges/gauge-controller.decorator.ts
+++ b/src/services/balancer/gauges/gauge-controller.decorator.ts
@@ -132,7 +132,7 @@ export class GaugeControllerDecorator {
   ) {
     votingGauges.forEach(gauge => {
       this.multicaller.call(
-        `${gauge.address}.lastUserVote`,
+        `${gauge.address}.lastUserVoteTime`,
         this.config.network.addresses.gaugeController,
         'last_user_vote',
         [userAddress, gauge.address]

--- a/src/services/balancer/gauges/gauge-controller.decorator.ts
+++ b/src/services/balancer/gauges/gauge-controller.decorator.ts
@@ -6,6 +6,7 @@ import { BigNumber } from '@ethersproject/bignumber';
 import { JsonRpcProvider } from '@ethersproject/providers';
 import { Network } from '@balancer-labs/sdk';
 import { VotingGauge } from '@/constants/voting-gauges';
+import { oneWeekInMs, toUnixTimestamp } from '@/composables/useTime';
 
 export interface UserVotesData {
   end: BigNumber;
@@ -15,14 +16,16 @@ export interface UserVotesData {
 
 export interface RawVotesData {
   votes: number;
+  votesNextPeriod: number;
   userVotes: UserVotesData;
-  lastUserVote: BigNumber;
+  lastUserVoteTime: BigNumber;
 }
 
 export interface VotesData {
   votes: string;
+  votesNextPeriod: string;
   userVotes: string;
-  lastUserVote: number;
+  lastUserVoteTime: number;
 }
 
 export type RawVotesDataMap = Record<string, RawVotesData>;
@@ -52,6 +55,7 @@ export class GaugeControllerDecorator {
   ): Promise<VotingGaugeWithVotes[]> {
     this.multicaller = this.resetMulticaller();
     this.callGaugeVotes(votingGauges);
+    this.callGaugeVotesNextPeriod(votingGauges);
     if (userAddress) {
       this.callUserGaugeVotes(votingGauges, userAddress);
       this.callUserGaugeVoteTime(votingGauges, userAddress);
@@ -70,8 +74,9 @@ export class GaugeControllerDecorator {
   private formatVotes(votesData: RawVotesData): VotesData {
     return {
       votes: votesData.votes.toString(),
+      votesNextPeriod: votesData.votesNextPeriod.toString(),
       userVotes: votesData?.userVotes?.power.toString() || '0',
-      lastUserVote: votesData?.lastUserVote?.toNumber() || 0
+      lastUserVoteTime: votesData?.lastUserVoteTime?.toNumber() || 0
     };
   }
 
@@ -84,7 +89,22 @@ export class GaugeControllerDecorator {
         `${gauge.address}.votes`,
         this.config.network.addresses.gaugeController,
         'gauge_relative_weight',
-        [gauge.address]
+        [gauge.address, toUnixTimestamp(Date.now())]
+      );
+    });
+  }
+
+  /**
+   * @summary Fetch relative vote weight of each gauge for next period (1 week)
+   */
+  private callGaugeVotesNextPeriod(votingGauges: VotingGauge[]) {
+    const oneWeekFromNow = toUnixTimestamp(Date.now() + oneWeekInMs);
+    votingGauges.forEach(gauge => {
+      this.multicaller.call(
+        `${gauge.address}.votesNextPeriod`,
+        this.config.network.addresses.gaugeController,
+        'gauge_relative_weight',
+        [gauge.address, oneWeekFromNow]
       );
     });
   }


### PR DESCRIPTION
# Description

- Add new vue for Vote Information in the Gauge Voting table. 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## How should this be tested?

- Open Gauge Voting table at `/#/vebal`
- Check that tooltip looks correct and has this week + next weeks votes + change in votes, and is the correct color. 

## Visual context

https://www.loom.com/share/19a19f4ecea34d4995326db09e15c883

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have requested at least 2 reviews (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] If package-lock.json has changes, it was intentional.
- [x] The base of this PR is `master` if hotfix, `develop` if not
