### PR TITLE
Tokenomics- Staking tables always visible

### DIFF
--- a/src/components/contextual/pages/pools/StakedPoolsTable.vue
+++ b/src/components/contextual/pages/pools/StakedPoolsTable.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref } from 'vue';
+import { computed, ref } from 'vue';
 
 import useStaking from '@/composables/staking/useStaking';
 
@@ -18,8 +18,19 @@ const {
   isLoadingStakingData,
   isLoadingStakedPools,
   setPoolAddress,
-  isStakeDataIdle
+  isLoadingUserPools,
+  isUserPoolsIdle
 } = useStaking();
+
+/** COMPUTED */
+const isLoading = computed(() => {
+  return (
+    isLoadingStakingData.value ||
+    isLoadingStakedPools.value ||
+    isLoadingUserPools.value ||
+    isUserPoolsIdle.value
+  );
+});
 
 /** METHODS */
 function handleStake(pool: FullPool) {
@@ -43,9 +54,7 @@ function handleModalClose() {
         :noPoolsLabel="$t('noInvestments')"
         :hiddenColumns="['poolVolume', 'poolValue', 'migrate']"
         @triggerStake="handleStake"
-        :isLoading="
-          isLoadingStakingData || isStakeDataIdle || isLoadingStakedPools
-        "
+        :isLoading="isLoading"
         showPoolShares
         onlyStakedPct
       />

--- a/src/components/contextual/pages/pools/StakedPoolsTable.vue
+++ b/src/components/contextual/pages/pools/StakedPoolsTable.vue
@@ -7,7 +7,6 @@ import { FullPool } from '@/services/balancer/subgraph/types';
 
 import PoolsTable from '@/components/tables/PoolsTable/PoolsTable.vue';
 import StakePreviewModal from '../../stake/StakePreviewModal.vue';
-import AnimatePresence from '@/components/animate/AnimatePresence.vue';
 
 /** STATE */
 const showStakeModal = ref(false);
@@ -16,8 +15,10 @@ const stakePool = ref<FullPool | undefined>();
 /** COMPOSABLES */
 const {
   stakedPools,
-  isLoading: isLoadingStakingData,
-  setPoolAddress
+  isLoadingStakingData,
+  isLoadingStakedPools,
+  setPoolAddress,
+  isStakeDataIdle
 } = useStaking();
 
 /** METHODS */
@@ -33,31 +34,27 @@ function handleModalClose() {
 </script>
 
 <template>
-  <AnimatePresence :isVisible="!isLoadingStakingData && stakedPools.length > 0">
-    <div class="mt-8">
-      <BalStack vertical spacing="sm">
-        <h5>{{ $t('staking.stakedPools') }}</h5>
-        <PoolsTable
-          :key="stakedPools"
-          :data="stakedPools"
-          :noPoolsLabel="$t('noInvestments')"
-          :hiddenColumns="['poolVolume', 'poolValue', 'migrate']"
-          @triggerStake="handleStake"
-          showPoolShares
-          onlyStakedPct
-        />
-      </BalStack>
-    </div>
-    <StakePreviewModal
-      :pool="stakePool"
-      :isVisible="showStakeModal"
-      @close="handleModalClose"
-      action="stake"
-    />
-  </AnimatePresence>
-  <AnimatePresence :isVisible="isLoadingStakingData">
-    <div class="mt-8">
-      <BalLoadingBlock class="h-32" />
-    </div>
-  </AnimatePresence>
+  <div class="mt-8">
+    <BalStack vertical spacing="sm">
+      <h5>{{ $t('staking.stakedPools') }}</h5>
+      <PoolsTable
+        :key="stakedPools"
+        :data="stakedPools"
+        :noPoolsLabel="$t('noInvestments')"
+        :hiddenColumns="['poolVolume', 'poolValue', 'migrate']"
+        @triggerStake="handleStake"
+        :isLoading="
+          isLoadingStakingData || isStakeDataIdle || isLoadingStakedPools
+        "
+        showPoolShares
+        onlyStakedPct
+      />
+    </BalStack>
+  </div>
+  <StakePreviewModal
+    :pool="stakePool"
+    :isVisible="showStakeModal"
+    @close="handleModalClose"
+    action="stake"
+  />
 </template>

--- a/src/components/contextual/pages/pools/UnstakedPoolsTable.vue
+++ b/src/components/contextual/pages/pools/UnstakedPoolsTable.vue
@@ -13,7 +13,6 @@ import { bnum } from '@/lib/utils';
 
 import PoolsTable from '@/components/tables/PoolsTable/PoolsTable.vue';
 import StakePreviewModal from '../../stake/StakePreviewModal.vue';
-import AnimatePresence from '@/components/animate/AnimatePresence.vue';
 
 import { uniqBy } from 'lodash';
 import { isMigratablePool } from '@/composables/usePool';
@@ -27,8 +26,7 @@ const {
   userGaugeShares,
   userLiquidityGauges,
   stakedPools,
-  isLoading: isLoadingStakingData,
-  isStakeDataIdle,
+  isLoadingStakingData,
   setPoolAddress
 } = useStaking();
 
@@ -47,7 +45,7 @@ const stakedBalanceMap = computed(() => {
 const {
   data: userPools,
   isLoading: isLoadingUserPools,
-  isIdle: isUserPoolsQueryIdle
+  isIdle: isUserPoolsIdle
 } = useUserPoolsQuery();
 
 const partiallyStakedPools = computed(() => {
@@ -123,34 +121,18 @@ function handleModalClose() {
 </script>
 
 <template>
-  <AnimatePresence
-    :isVisible="!isLoadingStakingData && poolsToRender.length > 0"
-  >
-    <BalStack vertical spacing="sm">
-      <h5>{{ $t('staking.unstakedPools') }}</h5>
-      <PoolsTable
-        :key="poolsToRender"
-        :isLoading="isLoadingStakingData"
-        :data="poolsToRender"
-        :noPoolsLabel="$t('noInvestments')"
-        :hiddenColumns="['poolVolume', 'poolValue', 'migrate']"
-        @triggerStake="handleStake"
-        showPoolShares
-      />
-    </BalStack>
-  </AnimatePresence>
-  <AnimatePresence
-    :isVisible="
-      isLoadingStakingData ||
-        isStakeDataIdle ||
-        isLoadingUserPools ||
-        isUserPoolsQueryIdle
-    "
-  >
-    <div class="mb-8">
-      <BalLoadingBlock class="h-32" />
-    </div>
-  </AnimatePresence>
+  <BalStack vertical spacing="sm">
+    <h5>{{ $t('staking.unstakedPools') }}</h5>
+    <PoolsTable
+      :key="poolsToRender"
+      :isLoading="isLoadingStakingData || isLoadingUserPools || isUserPoolsIdle"
+      :data="poolsToRender"
+      :noPoolsLabel="$t('noInvestments')"
+      :hiddenColumns="['poolVolume', 'poolValue', 'migrate']"
+      @triggerStake="handleStake"
+      showPoolShares
+    />
+  </BalStack>
   <StakePreviewModal
     :pool="stakePool"
     :isVisible="showStakeModal"

--- a/src/providers/staking.provider.ts
+++ b/src/providers/staking.provider.ts
@@ -58,6 +58,8 @@ export type StakingProvider = {
   isLoadingPoolEligibility: Ref<boolean>;
   isPoolEligibleForStaking: Ref<boolean>;
   isStakedPoolsQueryEnabled: Ref<boolean>;
+  isLoadingUserPools: Ref<boolean>;
+  isUserPoolsIdle: Ref<boolean>;
   refetchStakedShares: Ref<() => void>;
   hideAprInfo: boolean;
   getGaugeAddress: (poolAddress: string) => Promise<string>;
@@ -111,7 +113,11 @@ export default defineComponent({
     /**
      * QUERIES
      */
-    const { data: userPoolsResponse } = useUserPoolsQuery();
+    const {
+      data: userPoolsResponse,
+      isLoading: isLoadingUserPools,
+      isIdle: isUserPoolsIdle
+    } = useUserPoolsQuery();
 
     const userPools = computed(() => userPoolsResponse.value?.pools || []);
 
@@ -350,6 +356,8 @@ export default defineComponent({
       refetchStakedShares,
       isStakedPoolsQueryEnabled,
       hideAprInfo: true,
+      isLoadingUserPools,
+      isUserPoolsIdle,
       getGaugeAddress,
       stakeBPT,
       unstakeBPT,


### PR DESCRIPTION
# Description

Makes the staked/unstaked tables always visible.
Fixes tables not loading when user has no investments.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [X] Other

## How should this be tested?

Pools should load when no investments are present.
Both tables should be visible and load appropriately.

## Visual context

https://www.loom.com/share/1095079deef44aab9a67b3b6e341574f

## Checklist:

- [X] I have performed a self-review of my own code
- [X] I have requested at least 2 reviews (If the PR is significant enough, use best judgement here)
- [X] I have commented my code where relevant, particularly in hard-to-understand areas
- [X] If package-lock.json has changes, it was intentional.
- [X] The base of this PR is `master` if hotfix, `develop` if not
