### PR TITLE
Fix staking values

### DIFF
--- a/src/components/contextual/pages/pools/UnstakedPoolsTable.vue
+++ b/src/components/contextual/pages/pools/UnstakedPoolsTable.vue
@@ -131,6 +131,7 @@ function handleModalClose() {
       :hiddenColumns="['poolVolume', 'poolValue', 'migrate']"
       @triggerStake="handleStake"
       showPoolShares
+      :stakeablePoolIds="stakedPools.map(pool => pool.id)"
     />
   </BalStack>
   <StakePreviewModal

--- a/src/components/contextual/stake/StakePreview.vue
+++ b/src/components/contextual/stake/StakePreview.vue
@@ -8,7 +8,7 @@ import useStaking from '@/composables/staking/useStaking';
 import { useI18n } from 'vue-i18n';
 
 import { bnum } from '@/lib/utils';
-import { DecoratedPoolWithStakedShares } from '@/services/balancer/subgraph/types';
+import { DecoratedPoolWithShares } from '@/services/balancer/subgraph/types';
 import { TransactionActionInfo } from '@/types/transactions';
 import { TransactionReceipt } from '@ethersproject/abstract-provider';
 
@@ -19,7 +19,7 @@ import { useQueryClient } from 'vue-query';
 
 export type StakeAction = 'stake' | 'unstake';
 type Props = {
-  pool: DecoratedPoolWithStakedShares;
+  pool: DecoratedPoolWithShares;
   action: StakeAction;
 };
 

--- a/src/components/contextual/stake/StakePreviewModal.vue
+++ b/src/components/contextual/stake/StakePreviewModal.vue
@@ -1,11 +1,11 @@
 <script setup lang="ts">
 import { ref } from 'vue';
-import { DecoratedPoolWithStakedShares } from '@/services/balancer/subgraph/types';
+import { DecoratedPoolWithShares } from '@/services/balancer/subgraph/types';
 import StakePreview, { StakeAction } from './StakePreview.vue';
 
 type Props = {
   isVisible: boolean;
-  pool: DecoratedPoolWithStakedShares;
+  pool: DecoratedPoolWithShares;
   action: StakeAction;
 };
 

--- a/src/components/heros/AppHero.vue
+++ b/src/components/heros/AppHero.vue
@@ -47,8 +47,9 @@ const totalVeBalLabel = computed((): string =>
   fNum2(lockFiatValue.value, FNumFormats.fiat)
 );
 
-const isLoadingTotalValue = computed((): boolean =>
-  isLoadingUserPools.value || isLoadingLock.value || isStakingLoading.value
+const isLoadingTotalValue = computed(
+  (): boolean =>
+    isLoadingUserPools.value || isLoadingLock.value || isStakingLoading.value
 );
 
 /**

--- a/src/components/heros/AppHero.vue
+++ b/src/components/heros/AppHero.vue
@@ -9,6 +9,7 @@ import useDarkMode from '@/composables/useDarkMode';
 import { useLock } from '@/composables/useLock';
 import { bnum } from '@/lib/utils';
 import { useRouter } from 'vue-router';
+import useStaking from '@/composables/staking/useStaking';
 
 /**
  * COMPOSABLES
@@ -24,6 +25,7 @@ const { trackGoal, Goals } = useFathom();
 const { totalInvestedAmount, isLoadingUserPools } = usePools();
 const { darkMode } = useDarkMode();
 const { lockFiatValue, isLoadingLock } = useLock();
+const { totalStakedFiatValue, isLoading: isStakingLoading } = useStaking();
 
 /**
  * COMPUTED
@@ -36,12 +38,17 @@ const classes = computed(() => ({
 const totalInvestedLabel = computed((): string => {
   const value = bnum(totalInvestedAmount.value || '0')
     .plus(lockFiatValue.value)
+    .plus(totalStakedFiatValue.value)
     .toString();
   return fNum2(value, FNumFormats.fiat);
 });
 
 const totalVeBalLabel = computed((): string =>
   fNum2(lockFiatValue.value, FNumFormats.fiat)
+);
+
+const isLoadingTotalValue = computed((): boolean =>
+  isLoadingUserPools.value || isLoadingLock.value || isStakingLoading.value
 );
 
 /**
@@ -62,7 +69,7 @@ function onClickConnect() {
           class="text-base font-medium text-white opacity-90 font-body mb-2"
         />
         <BalLoadingBlock
-          v-if="isLoadingUserPools || isLoadingLock"
+          v-if="isLoadingTotalValue"
           class="h-10 w-40 mx-auto"
           white
         />
@@ -71,7 +78,7 @@ function onClickConnect() {
         </div>
         <div class="mt-2 inline-block">
           <BalLoadingBlock
-            v-if="isLoadingUserPools || isLoadingLock"
+            v-if="isLoadingTotalValue"
             class="h-8 w-40 mx-auto"
             white
           />

--- a/src/components/tables/PoolsTable/PoolsTable.vue
+++ b/src/components/tables/PoolsTable/PoolsTable.vue
@@ -3,10 +3,7 @@ import { computed } from 'vue';
 import { useRouter } from 'vue-router';
 import { useI18n } from 'vue-i18n';
 
-import {
-  DecoratedPoolWithShares,
-  DecoratedPoolWithStakedShares
-} from '@/services/balancer/subgraph/types';
+import { DecoratedPoolWithShares } from '@/services/balancer/subgraph/types';
 
 import useNumbers, { FNumFormats } from '@/composables/useNumbers';
 import useFathom from '@/composables/useFathom';
@@ -30,7 +27,7 @@ import TokenPills from './TokenPills/TokenPills.vue';
  * TYPES
  */
 type Props = {
-  data?: DecoratedPoolWithShares[] | DecoratedPoolWithStakedShares[];
+  data?: DecoratedPoolWithShares[];
   isLoading?: boolean;
   isLoadingMore?: boolean;
   showPoolShares?: boolean;

--- a/src/composables/staking/useStaking.ts
+++ b/src/composables/staking/useStaking.ts
@@ -1,21 +1,5 @@
-import { DecoratedPoolWithStakedShares } from '@/services/balancer/subgraph/types';
 import { inject } from 'vue';
 import { StakingProviderSymbol } from '@/providers/local/staking.provider';
-
-export enum StakeState {
-  CanStake = 'can_stake',
-  MaxStaked = 'max_staked',
-  NoGuage = 'no_guage'
-}
-
-export function getStakeState(pool: DecoratedPoolWithStakedShares) {
-  // just random logic for differentiating between stake states // TODO REPLACE
-  if (pool.stakedPct === '1') {
-    return StakeState.MaxStaked;
-  } else if (pool.stakedPct !== undefined) {
-    return StakeState.CanStake;
-  }
-}
 
 export default function useStaking() {
   const providedData = inject(StakingProviderSymbol);

--- a/src/pages/_layouts/DefaultLayout.vue
+++ b/src/pages/_layouts/DefaultLayout.vue
@@ -4,6 +4,7 @@ import { useRoute } from 'vue-router';
 import AppNav from '@/components/navs/AppNav/AppNav.vue';
 import AppHero from '@/components/heros/AppHero.vue';
 import useBreakpoints from '@/composables/useBreakpoints';
+import StakingProvider from '@/providers/local/staking.provider';
 
 /**
  * COMPOSABLES
@@ -20,7 +21,11 @@ const isHomePage = computed(() => route.path === '/');
 <template>
   <div>
     <AppNav />
-    <AppHero v-if="isHomePage" />
+    <template v-if="isHomePage">
+      <StakingProvider>
+        <AppHero />
+      </StakingProvider>
+    </template>
     <div class="pb-16">
       <router-view :key="$route.path" />
     </div>

--- a/src/providers/local/staking.provider.ts
+++ b/src/providers/local/staking.provider.ts
@@ -79,7 +79,6 @@ export type StakingProvider = {
   unstakeBPT: () => Promise<TransactionResponse>;
   getStakedShares: () => Promise<string>;
   setPoolAddress: (address: string) => void;
-  canStake: (poolAddress: string) => boolean;
   refetchStakingData: Ref<
     (options?: RefetchOptions) => Promise<QueryObserverResult>
   >;
@@ -362,13 +361,6 @@ export default defineComponent({
       _poolAddress.value = address;
     }
 
-    /**
-     * @summary Check if a pool is stakeable.
-     */
-    function canStake(poolAddress: string): boolean {
-      return stakedPools.value.map(pool => pool.id).includes(poolAddress);
-    }
-
     provide(StakingProviderSymbol, {
       userGaugeShares,
       userLiquidityGauges,
@@ -394,7 +386,6 @@ export default defineComponent({
       unstakeBPT,
       getStakedShares,
       setPoolAddress,
-      canStake,
       refetchStakingData
     });
   },

--- a/src/services/balancer/subgraph/types.ts
+++ b/src/services/balancer/subgraph/types.ts
@@ -173,13 +173,6 @@ export interface DecoratedPoolWithShares extends DecoratedPool {
   bpt: string;
 }
 
-export interface DecoratedPoolWithStakedShares extends DecoratedPoolWithShares {
-  shares: string;
-  bpt: string;
-  stakedPct: string;
-  stakedShares: string;
-}
-
 export type PoolActivityType = 'Join' | 'Exit';
 
 export interface PoolActivity {


### PR DESCRIPTION
# Description

Fixes: #1559 & #1533 
- The 'My balance' number in 'Unstaked pools' table. It shouldn't include the staked balance for that pool.
- The 'My balancer investments' total value to include all staked balances.

More work could be done in the future to clean up here. We don't need to change the pool schema to include staked and unstaked balances. We also no longer need to know anything about the percentage of a pool that's staked an unstaked.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## How should this be tested?

Please provide instructions so we can test. Please also list any relevant details for your test configuration.

- [ ] Test that the total value includes staked balances
- [ ] Test that unstaked balances only include the actual unstaked balance and not the combination of staked and unstaked.

## Visual context

See related issues.

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have requested at least 2 reviews (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] If package-lock.json has changes, it was intentional.
- [x] The base of this PR is `master` if hotfix, `develop` if not
