### PR TITLE
Don't format numbers the user entered into trade

### DIFF
--- a/src/composables/trade/useSor.ts
+++ b/src/composables/trade/useSor.ts
@@ -191,8 +191,12 @@ export default function useSor({
     if (sorReturn.value.hasSwaps) {
       const { result } = sorReturn.value;
 
+      const swapType: SwapType = exactIn.value
+        ? SwapType.SwapExactIn
+        : SwapType.SwapExactOut;
+
       const deltas = await balancer.swaps.queryBatchSwap({
-        kind: exactIn.value ? SwapType.SwapExactIn : SwapType.SwapExactOut,
+        kind: swapType,
         swaps: result.swaps,
         assets: result.tokenAddresses
       });
@@ -219,15 +223,19 @@ export default function useSor({
           )
         );
 
-        tokenInAmountInput.value =
-          tokenInAmountNormalised.toNumber() > 0
-            ? formatAmount(tokenInAmountNormalised.toString())
-            : '';
+        if (swapType === SwapType.SwapExactOut) {
+          tokenInAmountInput.value =
+            tokenInAmountNormalised.toNumber() > 0
+              ? formatAmount(tokenInAmountNormalised.toString())
+              : '';
+        }
 
-        tokenOutAmountInput.value =
-          tokenOutAmountNormalised.toNumber() > 0
-            ? formatAmount(tokenOutAmountNormalised.toString())
-            : '';
+        if (swapType === SwapType.SwapExactIn) {
+          tokenOutAmountInput.value =
+            tokenOutAmountNormalised.toNumber() > 0
+              ? formatAmount(tokenOutAmountNormalised.toString())
+              : '';
+        }
       }
     }
   }


### PR DESCRIPTION
# Description

Fixes: #1527 

The `updateTradeAmounts` function is called whenever a new block is received. It re-calculates the swap value and updates the numbers in the trade view. It is currently calling `formatAmount` on these values before re-writing them to the page. This is causing issues because it re-formats the number the user just entered to only have 6 significant digits. 

This fix makes it only reformat + display the value that the user did not enter. 

@evgenyboxer This also means `formatFixed` with the deltas is not run on the number the user entered, does that seem fine to you? 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## How should this be tested?

Refer to issue #1527 and attempt to replicate

- Load the Trade UI
- Perform a trade between any two assets. 
- Specify a large number or a number with a large number of decimals 
- Ensure that the number you are entering is not rounded or changed at all. 

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have requested at least 2 reviews (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] If package-lock.json has changes, it was intentional.
- [x] The base of this PR is `master` if hotfix, `develop` if not
