### PR TITLE
Add extra week to countdown for first week of LM

### DIFF
--- a/src/components/contextual/pages/vebal/LMVoting/LMVoting.vue
+++ b/src/components/contextual/pages/vebal/LMVoting/LMVoting.vue
@@ -96,7 +96,11 @@ function handleVoteSuccess() {
 }
 
 function getVotePeriodEndTime(): number {
-  const n = nextThursday(new Date());
+  let n = nextThursday(new Date());
+  // April 5th 2022, for launch, remove after this date
+  if (n.getTime() < 1649116800000) {
+    n = nextThursday(n);
+  }
   const epochEndTime = Date.UTC(
     n.getFullYear(),
     n.getMonth(),


### PR DESCRIPTION
# Description

- Adding an additional week to the countdown timer for the first week. Adds another week if the end date is before April 5th (first week is April 7th so this will be fine for all timezones). 