### PR TITLE
Fix return route for veBAL investment

### DIFF
--- a/src/components/contextual/pages/vebal/MyVeBAL/components/MyVeBalCards.vue
+++ b/src/components/contextual/pages/vebal/MyVeBAL/components/MyVeBalCards.vue
@@ -99,7 +99,8 @@ const cards = computed(() => {
       showPlusIcon: isWalletReady.value ? true : false,
       plusIconTo: {
         name: 'invest',
-        params: { id: lockablePoolId.value }
+        params: { id: lockablePoolId.value },
+        query: { returnRoute: 'vebal' }
       }
     },
     {

--- a/src/composables/useReturnRoute.ts
+++ b/src/composables/useReturnRoute.ts
@@ -1,0 +1,26 @@
+import { RouteLocationRaw, useRoute } from 'vue-router';
+
+export function useReturnRoute() {
+  const route = useRoute();
+
+  function getReturnRoute(to?: RouteLocationRaw): RouteLocationRaw {
+    const queryReturnRoute = route.query?.returnRoute as string;
+
+    if (queryReturnRoute) {
+      const queryReturnParams = route.query?.returnParams as string;
+
+      if (queryReturnParams) {
+        return {
+          name: queryReturnRoute,
+          params: JSON.parse(queryReturnParams)
+        };
+      }
+
+      return { name: queryReturnRoute };
+    } else if (to) return to;
+
+    return { name: 'home' };
+  }
+
+  return { getReturnRoute };
+}

--- a/src/pages/_layouts/FocusedLayout.vue
+++ b/src/pages/_layouts/FocusedLayout.vue
@@ -1,23 +1,7 @@
 <script setup lang="ts">
-import { useRoute } from 'vue-router';
+import { useReturnRoute } from '@/composables/useReturnRoute';
 
-const route = useRoute();
-
-function getReturnRoute() {
-  const queryReturnRoute = route.query?.returnRoute as string;
-
-  if (queryReturnRoute) {
-    const queryReturnParams = route.query?.returnParams as string;
-
-    if (queryReturnParams) {
-      return { name: queryReturnRoute, params: JSON.parse(queryReturnParams) };
-    }
-
-    return { name: queryReturnRoute };
-  }
-
-  return { name: 'home' };
-}
+const { getReturnRoute } = useReturnRoute();
 </script>
 <template>
   <div class="pb-16">

--- a/src/pages/_layouts/PoolTransferLayout.vue
+++ b/src/pages/_layouts/PoolTransferLayout.vue
@@ -4,6 +4,7 @@ import { ref } from 'vue';
 import useBreakpoints from '@/composables/useBreakpoints';
 import usePoolTransfers from '@/composables/contextual/pool-transfers/usePoolTransfers';
 import { useRoute } from 'vue-router';
+import { useReturnRoute } from '@/composables/useReturnRoute';
 // Components
 import MyPoolBalancesCard from '@/components/cards/MyPoolBalancesCard/MyPoolBalancesCard.vue';
 import MyWalletTokensCard from '@/components/cards/MyWalletTokensCard/MyWalletTokensCard.vue';
@@ -20,6 +21,7 @@ const id = ref<string>(route.params.id as string);
 /**
  * COMPOSABLES
  */
+const { getReturnRoute } = useReturnRoute();
 const { upToLargeBreakpoint } = useBreakpoints();
 const {
   pool,
@@ -34,7 +36,7 @@ usePoolTransfersGuard();
   <div class="pb-16">
     <div class="layout-header mb-12">
       <div></div>
-      <router-link :to="{ name: 'pool', params: { id } }">
+      <router-link :to="getReturnRoute({ name: 'pool', params: { id } })">
         <BalIcon name="x" size="lg" />
       </router-link>
     </div>


### PR DESCRIPTION
# Description

Fixes #1569 
- When navigating to the invest flow from the veBAL page, should redirect back to veBAL page on clicking to close
- Refactors handling of return route into it's own composable

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## How should this be tested?

Please provide instructions so we can test. Please also list any relevant details for your test configuration.

- [ ] Test that you are returned to the veBAL page if you try to invest in BAL/WETH from there
- [ ] Test that you are returned to the pool page if you click invest from there

## Visual context

n/a

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have requested at least 2 reviews (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] If package-lock.json has changes, it was intentional.
- [x] The base of this PR is `master` if hotfix, `develop` if not
