### PR TITLE
Hotfix - lock approvals

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.46.1",
+  "version": "1.46.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@balancer-labs/frontend-v2",
-      "version": "1.46.1",
+      "version": "1.46.6",
       "license": "MIT",
       "devDependencies": {
         "@aave/protocol-js": "^4.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.46.1",
+  "version": "1.46.6",
   "engines": {
     "node": "14.x",
     "npm": ">=7"

--- a/src/components/forms/lock_actions/LockForm/components/LockPreviewModal/components/LockActions.vue
+++ b/src/components/forms/lock_actions/LockForm/components/LockPreviewModal/components/LockActions.vue
@@ -191,10 +191,16 @@ watch(lockActionStatesConfirmed, () => {
  * LIFECYCLE
  */
 onBeforeMount(async () => {
+  const approvalAmount = parseUnits(
+    props.lockAmount,
+    props.lockablePoolTokenInfo.decimals
+  ).toString();
+
   const approvalActions = await getTokenApprovalActionsForSpender(
     configService.network.addresses.veBAL,
-    parseUnits(props.lockAmount, 18).toString()
+    approvalAmount
   );
+
   actions.value.unshift(...approvalActions);
 });
 </script>

--- a/src/components/forms/lock_actions/LockForm/components/LockPreviewModal/components/LockActions.vue
+++ b/src/components/forms/lock_actions/LockForm/components/LockPreviewModal/components/LockActions.vue
@@ -25,6 +25,7 @@ import { PRETTY_DATE_FORMAT } from '@/components/forms/lock_actions/constants';
 
 import { LockType } from '@/components/forms/lock_actions/LockForm/types';
 import { configService } from '@/services/config/config.service';
+import { parseUnits } from '@ethersproject/units';
 
 /**
  * TYPES
@@ -191,7 +192,8 @@ watch(lockActionStatesConfirmed, () => {
  */
 onBeforeMount(async () => {
   const approvalActions = await getTokenApprovalActionsForSpender(
-    configService.network.addresses.veBAL
+    configService.network.addresses.veBAL,
+    parseUnits(props.lockAmount, 18).toString()
   );
   actions.value.unshift(...approvalActions);
 });

--- a/src/composables/pools/useTokenApprovals.ts
+++ b/src/composables/pools/useTokenApprovals.ts
@@ -25,6 +25,12 @@ export type ApprovalStateMap = {
   [address: string]: ApprovalState;
 };
 
+export type ApprovalOptions = {
+  spender: string;
+  amount: string;
+  state: ApprovalState;
+};
+
 export default function useTokenApprovals(
   tokenAddresses: string[],
   amounts: Ref<string[]>
@@ -72,15 +78,20 @@ export default function useTokenApprovals(
       appNetworkConfig.addresses.vault
     )
   );
+
   /**
    * METHODS
    */
   async function approveToken(
     address: string,
-    spender?: string,
-    customApprovalState?: Record<string, ApprovalState>
+    options: Partial<ApprovalOptions> = {}
   ): Promise<TransactionResponse> {
-    const state = customApprovalState || requiredApprovalState.value[address];
+    const defaultOptions: ApprovalOptions = {
+      spender: appNetworkConfig.addresses.vault,
+      amount: MaxUint256.toString(),
+      state: requiredApprovalState.value[address]
+    };
+    const { spender, amount, state } = Object.assign(defaultOptions, options);
 
     try {
       state.init = true;
@@ -90,7 +101,7 @@ export default function useTokenApprovals(
         address,
         ERC20ABI,
         'approve',
-        [spender || appNetworkConfig.addresses.vault, MaxUint256.toString()]
+        [spender || appNetworkConfig.addresses.vault, amount]
       );
 
       state.init = false;

--- a/src/composables/pools/useTokenApprovals.ts
+++ b/src/composables/pools/useTokenApprovals.ts
@@ -101,7 +101,7 @@ export default function useTokenApprovals(
         address,
         ERC20ABI,
         'approve',
-        [spender || appNetworkConfig.addresses.vault, amount]
+        [spender, amount]
       );
 
       state.init = false;
@@ -119,7 +119,7 @@ export default function useTokenApprovals(
         ),
         details: {
           contractAddress: address,
-          spender: spender || appNetworkConfig.addresses.vault
+          spender: spender
         }
       });
 

--- a/src/composables/useTokenApprovalActions.ts
+++ b/src/composables/useTokenApprovalActions.ts
@@ -9,6 +9,7 @@ import useTokens from '@/composables/useTokens';
 import useWeb3 from '@/services/web3/useWeb3';
 
 import { TransactionActionInfo } from '@/types/transactions';
+import { MaxUint256 } from '@ethersproject/constants';
 
 export default function useTokenApprovalActions(
   tokenAddresses: string[],
@@ -28,42 +29,46 @@ export default function useTokenApprovalActions(
   /**
    * METHODS
    */
-  async function getTokenApprovalActionsForSpender(spender: string) {
+  async function getTokenApprovalActionsForSpender(
+    spender: string,
+    amount: string = MaxUint256.toString()
+  ) {
     const requiredApprovalStateForSpender = await getApprovalForSpender(
       spender
     );
     const actions = getTokenApprovalActions(
       requiredApprovalStateForSpender,
-      spender
+      spender,
+      amount
     );
     return actions;
   }
 
   function getTokenApprovalActions(
     customApprovalState?: Record<string, ApprovalState>,
-    spender?: string
+    spender?: string,
+    amount: string = MaxUint256.toString()
   ): TransactionActionInfo[] {
-    return Object.keys(customApprovalState || requiredApprovalState.value).map(
-      address => {
-        const token = getToken(address);
-        return {
-          label: t(
-            spender === appNetworkConfig.addresses.veBAL
-              ? 'transactionSummary.approveForLocking'
-              : 'transactionSummary.approveForInvesting',
-            [token.symbol]
-          ),
-          loadingLabel: t('investment.preview.loadingLabel.approval'),
-          confirmingLabel: t('confirming'),
-          stepTooltip: t('investment.preview.tooltips.approval', [
-            token.symbol
-          ]),
-          action: () => {
-            return approveToken(token.address, spender, customApprovalState);
-          }
-        };
-      }
-    );
+    const approvalStates = customApprovalState || requiredApprovalState.value;
+
+    return Object.keys(approvalStates).map(address => {
+      const token = getToken(address);
+      const state = approvalStates[address];
+      return {
+        label: t(
+          spender === appNetworkConfig.addresses.veBAL
+            ? 'transactionSummary.approveForLocking'
+            : 'transactionSummary.approveForInvesting',
+          [token.symbol]
+        ),
+        loadingLabel: t('investment.preview.loadingLabel.approval'),
+        confirmingLabel: t('confirming'),
+        stepTooltip: t('investment.preview.tooltips.approval', [token.symbol]),
+        action: () => {
+          return approveToken(token.address, { spender, state, amount });
+        }
+      };
+    });
   }
 
   return {

--- a/src/composables/useTokenApprovalActions.ts
+++ b/src/composables/useTokenApprovalActions.ts
@@ -46,7 +46,7 @@ export default function useTokenApprovalActions(
 
   function getTokenApprovalActions(
     customApprovalState?: Record<string, ApprovalState>,
-    spender?: string,
+    spender: string = appNetworkConfig.addresses.vault,
     amount: string = MaxUint256.toString()
   ): TransactionActionInfo[] {
     const approvalStates = customApprovalState || requiredApprovalState.value;


### PR DESCRIPTION
# Description

Lock approvals should only approve the exact amount about to be locked. This PR refactors the token approval composables to allow this.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## How should this be tested?

- [ ] Test locking with a fresh account that hasn't locked before, only lock some of your BPT, then increase your lock. Check that for the increase lock it asks for a second approval.
- [ ] Test other approval flows, investments, pool creation still work as expected

## Visual context

n/a

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have requested at least 2 reviews (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] If package-lock.json has changes, it was intentional.
- [x] The base of this PR is `master` if hotfix, `develop` if not
