### PR TITLE
Hotfix - claims loading states

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.46.2",
+  "version": "1.46.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@balancer-labs/frontend-v2",
-      "version": "1.46.2",
+      "version": "1.46.3",
       "license": "MIT",
       "devDependencies": {
         "@aave/protocol-js": "^4.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.46.2",
+  "version": "1.46.3",
   "engines": {
     "node": "14.x",
     "npm": ">=7"

--- a/src/pages/claim.vue
+++ b/src/pages/claim.vue
@@ -76,7 +76,7 @@ const supportsContractBasedClaiming = computed(
 );
 
 const balRewardsData = computed((): RewardRow[] => {
-  if (!isWalletReady.value) return [];
+  if (!isWalletReady.value || appLoading.value) return [];
   // Using reduce to filter out gauges we don't have corresponding pools for
   return gauges.value.reduce<RewardRow[]>((arr, gauge) => {
     const amount = formatUnits(gauge.claimableTokens, balToken.value.decimals);
@@ -199,10 +199,12 @@ watch(gaugePools, async newPools => {
         </div>
         <BalClaimsTable
           :rewardsData="balRewardsData"
-          :isLoading="queriesLoading"
+          :isLoading="queriesLoading || appLoading"
         />
 
-        <template v-if="!queriesLoading && gaugesWithRewards.length > 0">
+        <template
+          v-if="!queriesLoading && !appLoading && gaugesWithRewards.length > 0"
+        >
           <h3 class="text-xl mt-8">{{ $t('otherTokenEarnings') }}</h3>
           <div v-for="{ gauge, pool } in gaugeTables" :key="gauge.id">
             <div class="flex mt-4">
@@ -210,7 +212,10 @@ watch(gaugePools, async newPools => {
                 {{ gaugeTitle(pool) }}
               </h4>
             </div>
-            <GaugeRewardsTable :gauge="gauge" :isLoading="queriesLoading" />
+            <GaugeRewardsTable
+              :gauge="gauge"
+              :isLoading="queriesLoading || appLoading"
+            />
           </div>
         </template>
 


### PR DESCRIPTION
# Description

Some data relied on tokenlists being loaded and was throwing console errors but not breaking the page. This PR waits for the global appLoading flag to be true before displaying some claim tables.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## How should this be tested?

- [ ] Test that claims page works as expected.

## Visual context

n/a

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have requested at least 2 reviews (If the PR is significant enough, use best judgement here)
- [ ] I have commented my code where relevant, particularly in hard-to-understand areas
- [ ] If package-lock.json has changes, it was intentional.
- [ ] The base of this PR is `master` if hotfix, `develop` if not
