### PR TITLE
Hotfix - respect staking allowlist

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.46.3",
+  "version": "1.46.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@balancer-labs/frontend-v2",
-      "version": "1.46.3",
+      "version": "1.46.4",
       "license": "MIT",
       "devDependencies": {
         "@aave/protocol-js": "^4.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.46.3",
+  "version": "1.46.4",
   "engines": {
     "node": "14.x",
     "npm": ">=7"

--- a/src/pages/pool/_id.vue
+++ b/src/pages/pool/_id.vue
@@ -141,7 +141,10 @@
               v-if="loadingPool"
               class="pool-actions-card h-40"
             />
-            <StakingIncentivesCard v-if="!loadingPool" :pool="pool" />
+            <StakingIncentivesCard
+              v-if="isStakeablePool && !loadingPool"
+              :pool="pool"
+            />
             <!-- <PoolActionsCard
           v-else-if="!noInitLiquidity"
           :pool="pool"
@@ -396,6 +399,10 @@ export default defineComponent({
       );
     });
 
+    const isStakeablePool = computed((): boolean =>
+      POOLS.Stakeable.AllowList.includes(route.params.id as string)
+    );
+
     /**
      * METHODS
      */
@@ -451,6 +458,7 @@ export default defineComponent({
       isStablePhantomPool,
       copperNetworkPrefix,
       hasCustomToken,
+      isStakeablePool,
       // methods
       fNum2,
       onNewTx,


### PR DESCRIPTION
# Description

It should not be possible to stake in a pool via our UI if the pool ID is not on the allowlist. This PR inforces that condition on the pool page.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## How should this be tested?

- [ ] Test that removing a pool ID from the allow list removes the staking incentives card from the pools page.

## Visual context

n/a

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have requested at least 2 reviews (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] If package-lock.json has changes, it was intentional.
- [x] The base of this PR is `master` if hotfix, `develop` if not
