### PR TITLE
Fix relayApproval and minter errors on Polygon

### DIFF
--- a/src/composables/queries/useRelayerApprovalQuery.ts
+++ b/src/composables/queries/useRelayerApprovalQuery.ts
@@ -48,6 +48,10 @@ export default function useRelayerApprovalQuery(
   );
 
   const queryFn = async (): Promise<boolean> => {
+    if (!relayer.value) {
+      return true;
+    }
+
     const approved = await vaultContract.value.hasApprovedRelayer(
       account.value,
       relayer.value

--- a/src/lib/utils/balancer/lido.ts
+++ b/src/lib/utils/balancer/lido.ts
@@ -10,6 +10,7 @@ const {
 
 export function isStETH(tokenInAddress: string, tokenOutAddress: string) {
   if (!tokenInAddress || !tokenOutAddress || !stEthAddress) return false;
+  console.log('stETH: ', stEthAddress, ' is null: ', stEthAddress == null);
 
   return [tokenInAddress, tokenOutAddress]
     .map(getAddress)

--- a/src/services/balancer/contracts/contracts/balancer-minter.ts
+++ b/src/services/balancer/contracts/contracts/balancer-minter.ts
@@ -8,9 +8,7 @@ export class BalancerMinter {
     private readonly config = configService,
     private readonly web3 = web3Service,
     public readonly address = config.network.addresses.balancerMinter
-  ) {
-    if (!this.address) console.error('BalancerMinter address not set');
-  }
+  ) {}
 
   /**
    * @summary Claim BAL rewards for gauge


### PR DESCRIPTION
# Description

## Heisenbug on Polygon

I've come across a heisenbug on Polygon - in lido.ts the `isStETH` function is returning true for all trades, even though the value of `stEthAddress` is an empty string, so it should return false from the first if statement. When running development using Polygon chain the bug doesn't happen, it returns false from `isStETH` as expected. It may be something to do with source code compilation and `stEthAddress` being brought in from a closure instead of passed into the function. 

This bug causes the lidoRelayerApproval to trigger which calls useRelayerApproval with a relayer of an empty string (because the lido relayer is not set on Polygon). Which is causing this error: https://sentry.io/organizations/balancer-labs/issues/2862170362/?project=5725878&referrer=weekly-email because `vaultContract.value.hasApprovedRelayer` is attempting to check if the vault contract has an approved relayer of empty string. 

I've added a check in the relayer to make sure it has a value, and a log in isStETH to diagnose further what's on in production. 

Here's a loom of the weirdness:
https://www.loom.com/share/fc65118fb2ba49fbac85a0cdb83d8d20

## Balancer Minter

I removed the console.error because there is no minter on Polygon/Arbitrum so it always triggers upon loading the page. 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## How should this be tested?

- Load Polygon
- Add a breakpoint in `isStEth` in `lido.ts`
- Start a new trade.
- The breakpoint should be hit, see if it progresses past the if statement at the beginning. 

## Visual context

Please provide any relevant visual context for UI changes or additions. This could be static screenshots or a loom screencast.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have requested at least 2 reviews (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] If package-lock.json has changes, it was intentional.
- [x] The base of this PR is `master` if hotfix, `develop` if not
