### PR TITLE
COW pool incentives APR

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.46.6",
+  "version": "1.46.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@balancer-labs/frontend-v2",
-      "version": "1.46.6",
+      "version": "1.46.7",
       "license": "MIT",
       "devDependencies": {
         "@aave/protocol-js": "^4.3.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.46.7",
+  "version": "1.46.8",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@balancer-labs/frontend-v2",
-      "version": "1.46.7",
+      "version": "1.46.8",
       "license": "MIT",
       "devDependencies": {
         "@aave/protocol-js": "^4.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.46.6",
+  "version": "1.46.7",
   "engines": {
     "node": "14.x",
     "npm": ">=7"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.46.7",
+  "version": "1.46.8",
   "engines": {
     "node": "14.x",
     "npm": ">=7"

--- a/src/components/tooltips/LiquidityAPRTooltip.vue
+++ b/src/components/tooltips/LiquidityAPRTooltip.vue
@@ -127,7 +127,14 @@ const thirdPartyAPRLabel = computed(() => {
           <div class="flex items-center">
             {{ fNum2(pool.dynamic.apr.liquidityMining, FNumFormats.percent) }}
             <span class="ml-1 text-gray-500 text-xs flex items-center">
-              {{ $t('liquidityMiningAPR') }}
+              {{
+                [
+                  '0xde8c195aa41c11a0c4787372defbbddaa31306d2000200000000000000000181',
+                  '0x92762b42a06dcdddc5b7362cfb01e631c4d44b40000200000000000000000182'
+                ].includes(pool.id)
+                  ? $t('staking.stakingApr')
+                  : $t('liquidityMiningAPR')
+              }}
             </span>
           </div>
           <template v-if="lmMultiRewardPool" #item="{ item }">

--- a/src/lib/utils/liquidityMining/MultiTokenLiquidityMining.json
+++ b/src/lib/utils/liquidityMining/MultiTokenLiquidityMining.json
@@ -13878,6 +13878,26 @@
             "tokenAddress": "0xba100000625a3754423978a60c9317c58a424e3d",
             "amount": 240
           }
+        ],
+        "0xde8c195aa41c11a0c4787372defbbddaa31306d2000200000000000000000181": [
+          {
+            "tokenAddress": "0x6810e776880c02933d47db1b9fc05908e5386b96",
+            "amount": 30
+          },
+          {
+            "tokenAddress": "0xdef1ca1fb7fbcdc777520aa7f396b4e015f497ab",
+            "amount": 30000
+          }
+        ],
+        "0x92762b42a06dcdddc5b7362cfb01e631c4d44b40000200000000000000000182": [
+          {
+            "tokenAddress": "0x6810e776880c02933d47db1b9fc05908e5386b96",
+            "amount": 30
+          },
+          {
+            "tokenAddress": "0xdef1ca1fb7fbcdc777520aa7f396b4e015f497ab",
+            "amount": 30000
+          }
         ]
       }
     },


### PR DESCRIPTION
This is a hacky workaround to get an approximate APR of GNO/COW incentives to be displayed on the app for the COW/GNO and COW/WETH pools. The tokens will not be distributed via the merkle orchard. APRs computed with this hack assume all BPT have been staked.