### PR TITLE
Hotfix - claims missing rewards

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.46.10",
+  "version": "1.46.11",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@balancer-labs/frontend-v2",
-      "version": "1.46.10",
+      "version": "1.46.11",
       "license": "MIT",
       "devDependencies": {
         "@aave/protocol-js": "^4.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.46.10",
+  "version": "1.46.11",
   "engines": {
     "node": "14.x",
     "npm": ">=7"

--- a/src/pages/claim.vue
+++ b/src/pages/claim.vue
@@ -99,10 +99,15 @@ const gaugesWithRewards = computed((): Gauge[] => {
 });
 
 const gaugeTables = computed((): GaugeTable[] => {
+  // Only return gauges if we have a corresponding pool and rewards > 0
   return gaugesWithRewards.value.reduce<GaugeTable[]>((arr, gauge) => {
     const pool = gaugePools.value.find(pool => pool.id === gauge.poolId);
+    const totalRewardValue = Object.values(gauge.claimableRewards).reduce(
+      (acc, reward) => acc.plus(reward),
+      bnum(0)
+    );
 
-    if (pool)
+    if (pool && totalRewardValue.gt(0))
       arr.push({
         gauge,
         pool

--- a/src/services/balancer/gauges/entities/gauges/query.ts
+++ b/src/services/balancer/gauges/entities/gauges/query.ts
@@ -1,7 +1,7 @@
 import { merge } from 'lodash';
 
 const defaultArgs = {
-  first: 20
+  first: 999
 };
 
 const defaultAttrs = {


### PR DESCRIPTION
# Description

We had limited the liquidity gauge subgraph query to 20 which was cutting off some new gauges. This PR increases that limit to 999 for now and additionally hides reward tables for gauges where the connected account does not have rewards.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## How should this be tested?

- [ ] Test the claims page works as expected

## Visual context

n/a

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have requested at least 2 reviews (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] If package-lock.json has changes, it was intentional.
- [x] The base of this PR is `master` if hotfix, `develop` if not
