### PR TITLE
Invest flow tweaks for low liqudity protection

### DIFF
--- a/src/components/forms/pool_actions/InvestForm/InvestForm.vue
+++ b/src/components/forms/pool_actions/InvestForm/InvestForm.vue
@@ -21,6 +21,8 @@ import StakePreviewModal from '@/components/contextual/stake/StakePreviewModal.v
 
 import StakingProvider from '@/providers/local/staking.provider';
 
+import { LOW_LIQUIDITY_THRESHOLD } from '@/constants/poolLiquidity';
+
 /**
  * TYPES
  */
@@ -101,6 +103,10 @@ const hasAcceptedHighPriceImpact = computed((): boolean =>
 
 const forceProportionalInputs = computed(
   (): boolean => managedPoolWithTradingHalted.value
+);
+
+const poolHasLowLiquidity = computed((): boolean =>
+  bnum(props.pool.totalLiquidity).lt(LOW_LIQUIDITY_THRESHOLD)
 );
 
 const investmentTokens = computed((): string[] => {
@@ -210,10 +216,18 @@ watch(useNativeAsset, shouldUseNativeAsset => {
     <BalAlert
       v-if="forceProportionalInputs"
       type="warning"
-      :title="$t('investment.warning.managedPoolTradingHaulted.title')"
+      :title="$t('investment.warning.managedPoolTradingHalted.title')"
       :description="
-        $t('investment.warning.managedPoolTradingHaulted.description')
+        $t('investment.warning.managedPoolTradingHalted.description')
       "
+      class="mb-4"
+    />
+
+    <BalAlert
+      v-if="poolHasLowLiquidity"
+      type="warning"
+      :title="$t('investment.warning.lowLiquidity.title')"
+      :description="$t('investment.warning.lowLiquidity.description')"
       class="mb-4"
     />
 

--- a/src/components/forms/pool_actions/InvestForm/components/InvestPreviewModal/InvestPreviewModal.vue
+++ b/src/components/forms/pool_actions/InvestForm/components/InvestPreviewModal/InvestPreviewModal.vue
@@ -51,7 +51,9 @@ const investmentConfirmed = ref(false);
 const { t } = useI18n();
 const { getToken } = useTokens();
 const { toFiat } = useNumbers();
-const { fullAmounts, priceImpact, highPriceImpact } = toRefs(props.math);
+const { fullAmounts, priceImpact, highPriceImpact, rektPriceImpact } = toRefs(
+  props.math
+);
 const { resetAmounts } = useInvestState();
 
 /**
@@ -151,10 +153,19 @@ function handleShowStakeModal() {
       :highPriceImpact="highPriceImpact"
     />
 
+    <BalAlert
+      v-if="rektPriceImpact"
+      type="error"
+      :title="$t('investment.error.rektPriceImpact.title')"
+      :description="$t('investment.error.rektPriceImpact.description')"
+      class="mt-6 mb-2"
+    />
+
     <InvestActions
       :pool="pool"
       :math="math"
       :tokenAddresses="tokenAddresses"
+      :disabled="rektPriceImpact"
       class="mt-4"
       @success="investmentConfirmed = true"
       @showStakeModal="handleShowStakeModal"

--- a/src/components/forms/pool_actions/InvestForm/components/InvestPreviewModal/InvestPreviewModal.vue
+++ b/src/components/forms/pool_actions/InvestForm/components/InvestPreviewModal/InvestPreviewModal.vue
@@ -67,7 +67,7 @@ const amountMap = computed(
   (): AmountMap => {
     const amountMap = {};
     fullAmounts.value.forEach((amount, i) => {
-      if (hasAmount(i)) amountMap[props.tokenAddresses[i]] = amount;
+      amountMap[props.tokenAddresses[i]] = amount;
     });
     return amountMap;
   }
@@ -106,10 +106,6 @@ const fiatTotal = computed((): string =>
 /**
  * METHODS
  */
-function hasAmount(index: number): boolean {
-  return bnum(fullAmounts.value[index]).gt(0);
-}
-
 function handleClose(): void {
   if (investmentConfirmed.value) {
     resetAmounts();

--- a/src/components/forms/pool_actions/InvestForm/components/InvestPreviewModal/components/InvestActions.vue
+++ b/src/components/forms/pool_actions/InvestForm/components/InvestPreviewModal/components/InvestActions.vue
@@ -34,6 +34,7 @@ type Props = {
   pool: FullPool;
   math: InvestMathResponse;
   tokenAddresses: string[];
+  disabled: boolean;
 };
 
 type InvestmentState = {
@@ -200,7 +201,11 @@ watch(blockNumber, async () => {
 
 <template>
   <transition>
-    <BalActionSteps v-if="!investmentState.confirmed" :actions="actions" />
+    <BalActionSteps
+      v-if="!investmentState.confirmed"
+      :actions="actions"
+      :disabled="disabled"
+    />
     <div v-else>
       <ConfirmationIndicator :txReceipt="investmentState.receipt" />
       <BalBtn

--- a/src/components/forms/pool_actions/InvestForm/components/InvestPreviewModal/components/TokenAmounts.vue
+++ b/src/components/forms/pool_actions/InvestForm/components/InvestPreviewModal/components/TokenAmounts.vue
@@ -1,9 +1,12 @@
 <script setup lang="ts">
-import { orderBy } from 'lodash';
-import useNumbers, { FNumFormats } from '@/composables/useNumbers';
-import { bnum } from '@/lib/utils';
-import { TokenInfoMap } from '@/types/TokenList';
 import { computed } from 'vue';
+import { orderBy } from 'lodash';
+
+import useNumbers, { FNumFormats } from '@/composables/useNumbers';
+
+import { bnum } from '@/lib/utils';
+
+import { TokenInfoMap } from '@/types/TokenList';
 
 /**
  * TYPES

--- a/src/components/forms/pool_actions/InvestForm/components/InvestPreviewModal/components/TokenAmounts.vue
+++ b/src/components/forms/pool_actions/InvestForm/components/InvestPreviewModal/components/TokenAmounts.vue
@@ -1,7 +1,9 @@
 <script setup lang="ts">
+import { orderBy } from 'lodash';
 import useNumbers, { FNumFormats } from '@/composables/useNumbers';
 import { bnum } from '@/lib/utils';
 import { TokenInfoMap } from '@/types/TokenList';
+import { computed } from 'vue';
 
 /**
  * TYPES
@@ -28,6 +30,21 @@ const props = defineProps<Props>();
 const { fNum2 } = useNumbers();
 
 /**
+ * COMPUTED
+ */
+const sortedAmounts = computed(() =>
+  orderBy(
+    Object.entries(props.fiatAmountMap),
+    ([, fiatAmount]) => Number(fiatAmount),
+    'desc'
+  ).map(([address, fiatAmount]) => ({
+    amount: props.amountMap[address],
+    fiatAmount,
+    address
+  }))
+);
+
+/**
  * METHODS
  */
 // The investment amount's relative percentage of the total fiat investment value.
@@ -41,19 +58,25 @@ function amountShare(address: string): string {
 
 <template>
   <div class="token-amount-table">
-    <div v-for="(amount, address) in amountMap" :key="address" class="relative">
+    <div
+      v-for="sortedAmount in sortedAmounts"
+      :key="sortedAmount.address"
+      class="relative"
+    >
       <div class="token-amount-table-content">
-        <BalAsset :address="address" :size="36" />
+        <BalAsset :address="sortedAmount.address" :size="36" />
         <div class="flex flex-col ml-3">
           <div class="font-medium text-lg">
             <span class="font-numeric">
-              {{ fNum2(amount, FNumFormats.token) }}
+              {{ fNum2(sortedAmount.amount, FNumFormats.token) }}
             </span>
-            {{ tokenMap[address].symbol }}
+            {{ tokenMap[sortedAmount.address].symbol }}
           </div>
           <div class="text-sm text-gray-500 font-numeric">
-            {{ fNum2(fiatAmountMap[address], FNumFormats.fiat) }}
-            ({{ fNum2(amountShare(address), FNumFormats.percent) }})
+            {{ fNum2(sortedAmount.fiatAmount, FNumFormats.fiat) }}
+            ({{
+              fNum2(amountShare(sortedAmount.address), FNumFormats.percent)
+            }})
           </div>
         </div>
       </div>

--- a/src/components/forms/pool_actions/InvestForm/composables/useInvestMath.ts
+++ b/src/components/forms/pool_actions/InvestForm/composables/useInvestMath.ts
@@ -136,7 +136,6 @@ export default function useInvestMath(
 
   const rektPriceImpact = computed((): boolean => {
     if (batchSwapLoading.value) return false;
-    console.log(priceImpact.value);
     return bnum(priceImpact.value).isGreaterThanOrEqualTo(REKT_PRICE_IMPACT);
   });
 

--- a/src/components/forms/pool_actions/InvestForm/composables/useInvestMath.ts
+++ b/src/components/forms/pool_actions/InvestForm/composables/useInvestMath.ts
@@ -13,6 +13,10 @@ import { queryBatchSwapTokensIn, SOR } from '@balancer-labs/sdk';
 import { BatchSwap } from '@/types';
 import { balancerContractsService } from '@/services/balancer/contracts/balancer-contracts.service';
 import usePromiseSequence from '@/composables/usePromiseSequence';
+import {
+  HIGH_PRICE_IMPACT,
+  REKT_PRICE_IMPACT
+} from '@/constants/poolLiquidity';
 
 export type InvestMathResponse = ReturnType<typeof useInvestMath>;
 
@@ -127,7 +131,13 @@ export default function useInvestMath(
 
   const highPriceImpact = computed((): boolean => {
     if (batchSwapLoading.value) return false;
-    return bnum(priceImpact.value).isGreaterThanOrEqualTo(0.01);
+    return bnum(priceImpact.value).isGreaterThanOrEqualTo(HIGH_PRICE_IMPACT);
+  });
+
+  const rektPriceImpact = computed((): boolean => {
+    if (batchSwapLoading.value) return false;
+    console.log(priceImpact.value);
+    return bnum(priceImpact.value).isGreaterThanOrEqualTo(REKT_PRICE_IMPACT);
   });
 
   const maximized = computed(() =>
@@ -274,6 +284,7 @@ export default function useInvestMath(
     fiatTotalLabel,
     priceImpact,
     highPriceImpact,
+    rektPriceImpact,
     maximized,
     optimized,
     proportionalAmounts,

--- a/src/components/forms/pool_actions/MigrateForm/composables/useMigrateMath.ts
+++ b/src/components/forms/pool_actions/MigrateForm/composables/useMigrateMath.ts
@@ -18,6 +18,7 @@ import { queryBatchSwapTokensIn } from '@balancer-labs/sdk';
 import { balancerContractsService } from '@/services/balancer/contracts/balancer-contracts.service';
 
 import { BatchSwap } from '@/types';
+import { HIGH_PRICE_IMPACT } from '@/constants/poolLiquidity';
 
 export type MigrateMathResponse = ReturnType<typeof useMigrateMath>;
 
@@ -137,7 +138,7 @@ export default function useMigrateMath(
 
   const highPriceImpact = computed(() => {
     if (!batchSwapLoaded.value) return false;
-    return bnum(priceImpact.value).isGreaterThanOrEqualTo(0.01);
+    return bnum(priceImpact.value).isGreaterThanOrEqualTo(HIGH_PRICE_IMPACT);
   });
 
   const batchSwapAmountMap = computed(

--- a/src/components/forms/pool_actions/WithdrawForm/composables/useWithdrawMath.ts
+++ b/src/components/forms/pool_actions/WithdrawForm/composables/useWithdrawMath.ts
@@ -34,6 +34,7 @@ import {
 import { SwapKind } from '@balancer-labs/balancer-js';
 import usePromiseSequence from '@/composables/usePromiseSequence';
 import { setError, WithdrawalError } from './useWithdrawalState';
+import { HIGH_PRICE_IMPACT } from '@/constants/poolLiquidity';
 
 /**
  * TYPES
@@ -340,7 +341,7 @@ export default function useWithdrawMath(
   });
 
   const highPriceImpact = computed(() =>
-    bnum(priceImpact.value).isGreaterThanOrEqualTo(0.01)
+    bnum(priceImpact.value).isGreaterThanOrEqualTo(HIGH_PRICE_IMPACT)
   );
 
   const fiatAmounts = computed((): string[] =>

--- a/src/constants/poolAPR.ts
+++ b/src/constants/poolAPR.ts
@@ -1,3 +1,3 @@
 // Do not display APR values greater than this amount; they are likely to be nonsensical
 // These can arise from pools with extremely low balances (e.g., completed LBPs)
-export const APR_THRESHOLD = 10000;
+export const APR_THRESHOLD = 10_000;

--- a/src/constants/poolLiquidity.ts
+++ b/src/constants/poolLiquidity.ts
@@ -1,1 +1,3 @@
 export const LOW_LIQUIDITY_THRESHOLD = 50_000;
+export const HIGH_PRICE_IMPACT = 0.01;
+export const REKT_PRICE_IMPACT = 0.5;

--- a/src/constants/poolLiquidity.ts
+++ b/src/constants/poolLiquidity.ts
@@ -1,3 +1,3 @@
 export const LOW_LIQUIDITY_THRESHOLD = 50_000;
 export const HIGH_PRICE_IMPACT = 0.01;
-export const REKT_PRICE_IMPACT = 0.5;
+export const REKT_PRICE_IMPACT = 0.2;

--- a/src/constants/poolLiquidity.ts
+++ b/src/constants/poolLiquidity.ts
@@ -1,0 +1,1 @@
+export const LOW_LIQUIDITY_THRESHOLD = 50_000;

--- a/src/locales/default.json
+++ b/src/locales/default.json
@@ -322,9 +322,13 @@
             }
         },
         "warning": {
-            "managedPoolTradingHaulted": {
+            "managedPoolTradingHalted": {
                 "description": "A trading halt has been issued by the manager of this pool. For your safety, while the trading halt is in effect, you may only invest in proportional amounts.",
                 "title": "Trading halted - proportional investments only"
+            },
+            "lowLiquidity": {
+                "description": "Add assets proportionally to the pool weights or the price impact will be high and you will likely get REKT and lose money.",
+                "title": "Be careful: This pool has low liquidity"
             }
         }
     },

--- a/src/locales/default.json
+++ b/src/locales/default.json
@@ -330,6 +330,12 @@
                 "description": "Add assets proportionally to the pool weights or the price impact will be high and you will likely get REKT and lose money.",
                 "title": "Be careful: This pool has low liquidity"
             }
+        },
+        "error": {
+            "rektPriceImpact": {
+                "description": "The likelyhood of you losing money is too high. For your protection, you can’t perform this transaction on this interface.",
+                "title": "This price impact is too high. You cannot proceed"
+            }
         }
     },
     "investmentPool": "Investment pool",


### PR DESCRIPTION
# Description

Adds a couple of warnings/errors for low liquidity pools - according to "quick wins" design here: https://www.figma.com/file/S5p30cxomV6gIyRZJMrvb3/Add-liquidity?node-id=802%3A6347

1. Added a "low liquidity" warning if the total liquidity is less than 50K.
2. Added "zero amount" assets to be shown in the preview screen (along with sorting them by their fiat value).
3. Added a new "rekt" error that disallows the user to continue.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## How should this be tested?

Please provide instructions so we can test. Please also list any relevant details for your test configuration.

- [ ] Easiest to test is to tweak the values locally to see the different warnings/errors.

## Visual context

Please provide any relevant visual context for UI changes or additions. This could be static screenshots or a loom screencast.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have requested at least 2 reviews (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] If package-lock.json has changes, it was intentional.
- [x] The base of this PR is `master` if hotfix, `develop` if not
