### PR TITLE
Hotfix: Calculate gauge weights manually

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.46.11",
+  "version": "1.46.12",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@balancer-labs/frontend-v2",
-      "version": "1.46.11",
+      "version": "1.46.12",
       "license": "MIT",
       "devDependencies": {
         "@aave/protocol-js": "^4.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.46.11",
+  "version": "1.46.12",
   "engines": {
     "node": "14.x",
     "npm": ">=7"

--- a/src/components/_global/BalTable/BalTable.vue
+++ b/src/components/_global/BalTable/BalTable.vue
@@ -428,6 +428,8 @@ export default defineComponent({
           }
         });
       }
+
+      handleSort(currentSortColumn.value, false);
     });
 
     const filteredColumns = computed(() =>

--- a/src/components/contextual/pages/vebal/LMVoting/GaugesTable.vue
+++ b/src/components/contextual/pages/vebal/LMVoting/GaugesTable.vue
@@ -159,7 +159,7 @@ function redirectToPool(gauge: VotingGaugeWithVotes) {
       :is-paginated="isPaginated"
       :on-row-click="redirectToPool"
       :initial-state="{
-        sortColumn: 'poolValue',
+        sortColumn: 'nextPeriodVotes',
         sortDirection: 'desc'
       }"
     >

--- a/src/composables/useTime.ts
+++ b/src/composables/useTime.ts
@@ -12,6 +12,7 @@ export const twentyFourHoursInSecs = twentyFourHoursInMs / oneSecondInMs;
 export const timeNowInMs = Math.floor(Date.now() / oneSecondInMs);
 
 export const oneYearInSecs = twentyFourHoursInSecs * 365;
+export const oneWeekInSecs = twentyFourHoursInSecs * 7;
 
 export function dateTimeLabelFor(date: Date): string {
   return date.toLocaleString(undefined, {

--- a/src/lib/config/arbitrum.json
+++ b/src/lib/config/arbitrum.json
@@ -66,5 +66,6 @@
       "name": "weightedPool"
     }
   },
-  "supportsElementPools": false
+  "supportsElementPools": false,
+  "gaugeTypeWeight": "0"
 }

--- a/src/lib/config/arbitrum.json
+++ b/src/lib/config/arbitrum.json
@@ -20,6 +20,7 @@
     "gauge": ""
   },
   "supportsEIP1559": false,
+  "supportsElementPools": false,
   "nativeAsset": {
     "name": "Ether",
     "address": "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
@@ -66,6 +67,8 @@
       "name": "weightedPool"
     }
   },
-  "supportsElementPools": false,
-  "gaugeTypeWeight": "0"
+  "gauges": {
+    "type": 3,
+    "weight": 0
+  }
 }

--- a/src/lib/config/homestead.json
+++ b/src/lib/config/homestead.json
@@ -70,5 +70,6 @@
       "name": "weightedPool"
     }
   },
-  "supportsElementPools": true
+  "supportsElementPools": true,
+  "gaugeTypeWeight": "100"
 }

--- a/src/lib/config/homestead.json
+++ b/src/lib/config/homestead.json
@@ -19,6 +19,7 @@
     "gauge": "https://api.thegraph.com/subgraphs/name/balancer-labs/balancer-gauges"
   },
   "supportsEIP1559": true,
+  "supportsElementPools": true,
   "nativeAsset": {
     "name": "Ether",
     "address": "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
@@ -70,6 +71,8 @@
       "name": "weightedPool"
     }
   },
-  "supportsElementPools": true,
-  "gaugeTypeWeight": "100"
+  "gauges": {
+    "type": 2,
+    "weight": 100
+  }
 }

--- a/src/lib/config/index.ts
+++ b/src/lib/config/index.ts
@@ -22,6 +22,7 @@ export interface Config {
   loggingRpc: string;
   explorer: string;
   explorerName: string;
+  gaugeTypeWeight: string;
   subgraph: string;
   poolsUrlV2: string;
   subgraphs: {

--- a/src/lib/config/index.ts
+++ b/src/lib/config/index.ts
@@ -22,7 +22,6 @@ export interface Config {
   loggingRpc: string;
   explorer: string;
   explorerName: string;
-  gaugeTypeWeight: string;
   subgraph: string;
   poolsUrlV2: string;
   subgraphs: {
@@ -69,6 +68,10 @@ export interface Config {
       name: string;
     }
   >;
+  gauges: {
+    type: number;
+    weight: number;
+  };
 }
 
 const config: Record<Network | number, Config> = {

--- a/src/lib/config/kovan.json
+++ b/src/lib/config/kovan.json
@@ -18,6 +18,7 @@
     "gauge": "https://api.thegraph.com/subgraphs/name/balancer-labs/balancer-gauges-kovan"
   },
   "supportsEIP1559": true,
+  "supportsElementPools": true,
   "nativeAsset": {
     "name": "Ether",
     "address": "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
@@ -68,6 +69,8 @@
       "name": "weightedPool"
     }
   },
-  "supportsElementPools": true,
-  "gaugeTypeWeight": "100"
+  "gauges": {
+    "type": 1,
+    "weight": 100
+  }
 }

--- a/src/lib/config/kovan.json
+++ b/src/lib/config/kovan.json
@@ -68,5 +68,6 @@
       "name": "weightedPool"
     }
   },
-  "supportsElementPools": true
+  "supportsElementPools": true,
+  "gaugeTypeWeight": "100"
 }

--- a/src/lib/config/polygon.json
+++ b/src/lib/config/polygon.json
@@ -20,6 +20,7 @@
     "gauge": ""
   },
   "supportsEIP1559": true,
+  "supportsElementPools": false,
   "nativeAsset": {
     "name": "Matic",
     "address": "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
@@ -66,6 +67,8 @@
       "name": "weightedPool"
     }
   },
-  "supportsElementPools": false,
-  "gaugeTypeWeight": "0"
+  "gauges": {
+    "type": 4,
+    "weight": 0
+  }
 }

--- a/src/lib/config/polygon.json
+++ b/src/lib/config/polygon.json
@@ -66,5 +66,6 @@
       "name": "weightedPool"
     }
   },
-  "supportsElementPools": false
+  "supportsElementPools": false,
+  "gaugeTypeWeight": "0"
 }

--- a/src/lib/config/rinkeby.json
+++ b/src/lib/config/rinkeby.json
@@ -68,5 +68,6 @@
       "name": "weightedPool"
     }
   },
-  "supportsElementPools": false
+  "supportsElementPools": false,
+  "gaugeTypeWeight": "0"
 }

--- a/src/lib/config/rinkeby.json
+++ b/src/lib/config/rinkeby.json
@@ -18,6 +18,7 @@
     "gauge": ""
   },
   "supportsEIP1559": true,
+  "supportsElementPools": false,
   "nativeAsset": {
     "name": "Ether",
     "address": "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
@@ -68,6 +69,8 @@
       "name": "weightedPool"
     }
   },
-  "supportsElementPools": false,
-  "gaugeTypeWeight": "0"
+  "gauges": {
+    "type": 1,
+    "weight": 100
+  }
 }

--- a/src/lib/config/test.json
+++ b/src/lib/config/test.json
@@ -18,6 +18,7 @@
     "gauge": ""
   },
   "supportsEIP1559": true,
+  "supportsElementPools": true,
   "nativeAsset": {
     "name": "Ether",
     "address": "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
@@ -69,6 +70,8 @@
       "name": "weightedPool"
     }
   },
-  "supportsElementPools": true,
-  "gaugeTypeWeight": "0"
+  "gauges": {
+    "type": 1,
+    "weight": 100
+  }
 }

--- a/src/lib/config/test.json
+++ b/src/lib/config/test.json
@@ -69,5 +69,6 @@
       "name": "weightedPool"
     }
   },
-  "supportsElementPools": true
+  "supportsElementPools": true,
+  "gaugeTypeWeight": "0"
 }

--- a/src/services/balancer/gauges/gauge-controller.decorator.ts
+++ b/src/services/balancer/gauges/gauge-controller.decorator.ts
@@ -95,7 +95,7 @@ export class GaugeControllerDecorator {
     votesData: RawVotesData
   ): VotesData {
     const multiplier = VOTE_MULTIPLIER.mul(
-      this.config.network.gaugeTypeWeight
+      this.config.network.gauges.weight
     ).div(100);
     return {
       votes: votesData.gaugeWeightThisPeriod.bias
@@ -112,7 +112,7 @@ export class GaugeControllerDecorator {
   }
 
   /**
-   * @summary Fetch relative vote weight of each gauge
+   * @summary Fetch total points allocated towards each gauge for this period
    */
   private callGaugeWeightThisPeriod(votingGauges: VotingGauge[]) {
     const thisWeekTimestamp = toUnixTimestamp(
@@ -129,7 +129,7 @@ export class GaugeControllerDecorator {
   }
 
   /**
-   * @summary Fetch relative vote weight of each gauge for next period (1 week)
+   * @summary Fetch total points allocated towards each gauge for next period (+1 week)
    */
   private callGaugeWeightNextPeriod(votingGauges: VotingGauge[]) {
     const nextWeekTimestamp = toUnixTimestamp(
@@ -145,6 +145,9 @@ export class GaugeControllerDecorator {
     });
   }
 
+  /**
+   * @summary Fetch total points allocated towards all gauges on this network for this period
+   */
   private callTotalWeightThisPeriod() {
     const thisWeekTimestamp = toUnixTimestamp(
       Math.floor(Date.now() / oneWeekInMs) * oneWeekInMs
@@ -153,10 +156,13 @@ export class GaugeControllerDecorator {
       `totalWeightThisPeriod`,
       this.config.network.addresses.gaugeController,
       'points_sum',
-      [2, thisWeekTimestamp]
+      [this.config.network.gauges.type, thisWeekTimestamp]
     );
   }
 
+  /**
+   * @summary Fetch total points allocated towards all gauges on this network for next period (+1 week)
+   */
   private callTotalWeightNextPeriod() {
     const nextWeekTimestamp = toUnixTimestamp(
       Math.floor((Date.now() + oneWeekInMs) / oneWeekInMs) * oneWeekInMs
@@ -165,7 +171,7 @@ export class GaugeControllerDecorator {
       `totalWeightNextPeriod`,
       this.config.network.addresses.gaugeController,
       'points_sum',
-      [2, nextWeekTimestamp]
+      [this.config.network.gauges.type, nextWeekTimestamp]
     );
   }
 


### PR DESCRIPTION
# Description

Because the total_weight value is not yet set gauge voting weights cannot be calculated using it. @markusbkoch realized we can use points_sum to calculate relative gauge weights in #1620. This PR improves upon that using points_sum and points_weight to calculate the relative weights of each gauge for this week and next, which should be correct for both this first week and future weeks. 

In Markus's PR he used a type_weight of 0.56 however when adding up the percentages this way they don't add up to a full 100%, so I'm not sure if that is correct or maybe all percents on mainnet should only add up to 56% total? The weight for each chain is expected to change so they all add up to 100% so I've added this value to the config file for each. 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## How should this be tested?

- Visit the gauges page on mainnet Ethereum
- Ensure gauge weights look correct and add up to 100%

## Visual context

![2022-04-01-133031_1590x1082_scrot](https://user-images.githubusercontent.com/525534/161189872-1af69831-412d-452d-b1f7-ffa92e746c79.png)

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have requested at least 2 reviews (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] If package-lock.json has changes, it was intentional.
- [x] The base of this PR is `master` if hotfix, `develop` if not
