### PR TITLE
Hotfix - image scaling

### DIFF
--- a/src/components/contextual/pages/vebal/Hero.vue
+++ b/src/components/contextual/pages/vebal/Hero.vue
@@ -80,8 +80,6 @@ function navigateToGetVeBAL() {
           <div class="coin group">
             <BalImage
               class="graphic"
-              width="724"
-              height="800"
               :src="require('@/assets/images/coins-1.png')"
               alt=""
             />

--- a/src/components/contextual/pages/vebal/Hero.vue
+++ b/src/components/contextual/pages/vebal/Hero.vue
@@ -80,6 +80,8 @@ function navigateToGetVeBAL() {
           <div class="coin group">
             <BalImage
               class="graphic"
+              width="724"
+              height="800"
               :src="require('@/assets/images/coins-1.png')"
               alt=""
             />
@@ -148,7 +150,7 @@ function navigateToGetVeBAL() {
 .graphic {
   @apply mb-4 lg:px-8;
   transition: 0.3s all ease-out;
-  max-height: 420px;
+  max-height: 290px;
 }
 .caption {
   @apply font-semibold text-sm md:text-base text-gray-400 transition-colors text-center group-hover:text-white;

--- a/src/components/contextual/pages/vebal/Hero.vue
+++ b/src/components/contextual/pages/vebal/Hero.vue
@@ -80,8 +80,6 @@ function navigateToGetVeBAL() {
           <div class="coin group">
             <BalImage
               class="graphic"
-              width="724"
-              height="800"
               :src="require('@/assets/images/coins-1.png')"
               alt=""
             />
@@ -95,8 +93,6 @@ function navigateToGetVeBAL() {
           <div class="coin group">
             <BalImage
               class="graphic"
-              width="696"
-              height="800"
               :src="require('@/assets/images/coins-2.png')"
               alt=""
             />
@@ -110,8 +106,6 @@ function navigateToGetVeBAL() {
           <div class="coin group">
             <BalImage
               class="graphic"
-              width="696"
-              height="800"
               :src="require('@/assets/images/coins-3.png')"
               alt=""
             />


### PR DESCRIPTION
# Description

On initial page load the verbal images are loading full size and then scaling down. This PR fixes that so that they load in without and jank.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## How should this be tested?

Please provide instructions so we can test. Please also list any relevant details for your test configuration.

- [ ] Test A
- [ ] Test B

## Visual context

Please provide any relevant visual context for UI changes or additions. This could be static screenshots or a loom screencast.

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have requested at least 2 reviews (If the PR is significant enough, use best judgement here)
- [ ] I have commented my code where relevant, particularly in hard-to-understand areas
- [ ] If package-lock.json has changes, it was intentional.
- [ ] The base of this PR is `master` if hotfix, `develop` if not
