### PR TITLE
fix: turn lock preview modal to static

### DIFF
--- a/src/components/forms/lock_actions/LockForm/components/VeBalForm/VeBalForm.vue
+++ b/src/components/forms/lock_actions/LockForm/components/VeBalForm/VeBalForm.vue
@@ -2,7 +2,6 @@
 import { computed, ref, toRef } from 'vue';
 
 import { LockType } from '@/components/forms/lock_actions/LockForm/types';
-import useVeBalLockInfoQuery from '@/composables/queries/useVeBalLockInfoQuery';
 import useTokens from '@/composables/useTokens';
 import { expectedVeBal } from '@/composables/useVeBAL';
 import { bnum } from '@/lib/utils';
@@ -58,7 +57,6 @@ const {
   isValidLockEndDate,
   isExtendedLockEndDate
 } = useLockEndDate(props.veBalLockInfo);
-const { refetch: refetchLockInfo } = useVeBalLockInfoQuery();
 
 /**
  * COMPOSABLES
@@ -116,7 +114,6 @@ const lockType = computed(() => {
  */
 function handleClosePreviewModal() {
   showPreviewModal.value = false;
-  refetchLockInfo.value();
 }
 </script>
 


### PR DESCRIPTION
# Description

Turns the lock preview modal to static so that you can trigger a refresh of the values.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## How should this be tested?

Please provide instructions so we can test. Please also list any relevant details for your test configuration.

- [ ] Lock / increase amount / extend date and check that the lock info refreshed in the background

## Visual context

Please provide any relevant visual context for UI changes or additions. This could be static screenshots or a loom screencast.

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have requested at least 2 reviews (If the PR is significant enough, use best judgement here)
- [ ] I have commented my code where relevant, particularly in hard-to-understand areas
- [ ] If package-lock.json has changes, it was intentional.
- [ ] The base of this PR is `master` if hotfix, `develop` if not
