### PR TITLE
Hotfix - Conditional LM page access

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.46.13",
+  "version": "1.46.14",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@balancer-labs/frontend-v2",
-      "version": "1.46.13",
+      "version": "1.46.14",
       "license": "MIT",
       "devDependencies": {
         "@aave/protocol-js": "^4.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.46.13",
+  "version": "1.46.14",
   "engines": {
     "node": "14.x",
     "npm": ">=7"

--- a/src/plugins/router.ts
+++ b/src/plugins/router.ts
@@ -3,6 +3,7 @@ import HomePage from '@/pages/index.vue';
 import PoolPage from '@/pages/pool/_id.vue';
 import PoolInvestPage from '@/pages/pool/invest.vue';
 import PoolWithdrawPage from '@/pages/pool/withdraw.vue';
+import LiquidityMiningPage from '@/pages/liquidity-mining.vue';
 import TradePage from '@/pages/trade.vue';
 import CreatePoolPage from '@/pages/pool/create.vue';
 import TermsOfUsePage from '@/pages/terms-of-use.vue';
@@ -12,6 +13,7 @@ import GetVeBalPage from '@/pages/get-vebal.vue';
 import UnlockVeBalPage from '@/pages/unlock-vebal.vue';
 import VeBalPage from '@/pages/vebal.vue';
 import ClaimPage from '@/pages/claim.vue';
+import { isL2 } from '@/composables/useNetwork';
 
 declare module 'vue-router' {
   interface RouteMeta {
@@ -109,6 +111,17 @@ const routes: RouteRecordRaw[] = [
     component: ClaimPage
   }
 ];
+
+/**
+ * NETWORK SPECIFIC ROUTES
+ */
+if (isL2.value) {
+  routes.push({
+    path: '/liquidity-mining',
+    name: 'liquidity-mining',
+    component: LiquidityMiningPage
+  });
+}
 
 /**
  * DEV/STAGING ONLY ROUTES


### PR DESCRIPTION
# Description

The liquidity mining page was removed from all network apps but it should still exist on L2s. This PR re-introduced the LM page on L2s with a conditional route injection.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## How should this be tested?

- [ ] Test that /liquidity-mining is accessible on Polygon and Arbitrum but not mainnet.

## Visual context

n/a

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have requested at least 2 reviews (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] If package-lock.json has changes, it was intentional.
- [x] The base of this PR is `master` if hotfix, `develop` if not
