### PR TITLE
Fix div by zero

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.47.6",
+  "version": "1.47.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@balancer-labs/frontend-v2",
-      "version": "1.47.6",
+      "version": "1.47.7",
       "license": "MIT",
       "devDependencies": {
         "@aave/protocol-js": "^4.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.47.6",
+  "version": "1.47.7",
   "engines": {
     "node": "14.x",
     "npm": ">=7"

--- a/src/services/balancer/gauges/gauge-controller.decorator.ts
+++ b/src/services/balancer/gauges/gauge-controller.decorator.ts
@@ -103,15 +103,26 @@ export class GaugeControllerDecorator {
     const multiplier = VOTE_MULTIPLIER.mul(
       this.config.network.gauges.weight
     ).div(100);
-    return {
-      votes: votesData.gaugeWeightThisPeriod.bias
+
+    let votes = '0';
+    if (totalWeightThisPeriod.gt(0)) {
+      votes = votesData.gaugeWeightThisPeriod.bias
         .mul(multiplier)
         .div(totalWeightThisPeriod)
-        .toString(),
-      votesNextPeriod: votesData.gaugeWeightNextPeriod.bias
+        .toString();
+    }
+
+    let votesNextPeriod = '0';
+    if (totalWeightNextPeriod.gt(0)) {
+      votesNextPeriod = votesData.gaugeWeightNextPeriod.bias
         .mul(multiplier)
         .div(totalWeightNextPeriod)
-        .toString(),
+        .toString();
+    }
+
+    return {
+      votes,
+      votesNextPeriod,
       userVotes: votesData?.userVotes?.power.toString() || '0',
       lastUserVoteTime: votesData?.lastUserVoteTime?.toNumber() || 0
     };


### PR DESCRIPTION
# Description

Fixes a divide by zero error when the total weight for this week or next is still 0. Only happens at the very start of a new veBAL period, noticed today when refreshing just after UTC midnight. 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## How should this be tested?

Please provide instructions so we can test. Please also list any relevant details for your test configuration.

- [ ] Test A
- [ ] Test B

## Visual context

Please provide any relevant visual context for UI changes or additions. This could be static screenshots or a loom screencast.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have requested at least 2 reviews (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] If package-lock.json has changes, it was intentional.
- [x] The base of this PR is `master` if hotfix, `develop` if not
