### PR TITLE
feat: add compact view for there are multiple tokens with zero amounts

### DIFF
--- a/src/components/forms/pool_actions/InvestForm/components/InvestPreviewModal/components/TokenAmounts.vue
+++ b/src/components/forms/pool_actions/InvestForm/components/InvestPreviewModal/components/TokenAmounts.vue
@@ -1,7 +1,8 @@
 <script setup lang="ts">
-import { orderBy } from 'lodash';
+import { groupBy, orderBy } from 'lodash';
 import { computed } from 'vue';
 
+import BalAsset from '@/components/_global/BalAsset/BalAsset.vue';
 import useNumbers, { FNumFormats } from '@/composables/useNumbers';
 import { bnum } from '@/lib/utils';
 import { TokenInfoMap } from '@/types/TokenList';
@@ -45,6 +46,21 @@ const sortedAmounts = computed(() =>
   }))
 );
 
+const groupedAmounts = computed(() =>
+  groupBy(sortedAmounts.value, amounts =>
+    bnum(amounts.amount).isZero() ? 'zeroAmounts' : 'nonZeroAmounts'
+  )
+);
+
+const shouldShowCompactViewForZeroAmounts = computed(
+  () => groupedAmounts.value.zeroAmounts.length > 3
+);
+
+const amountsToShow = computed(() =>
+  shouldShowCompactViewForZeroAmounts.value
+    ? groupedAmounts.value.nonZeroAmounts
+    : sortedAmounts.value
+);
 /**
  * METHODS
  */
@@ -59,27 +75,42 @@ function amountShare(address: string): string {
 
 <template>
   <div class="token-amount-table">
-    <div
-      v-for="sortedAmount in sortedAmounts"
-      :key="sortedAmount.address"
-      class="relative"
-    >
-      <div class="token-amount-table-content">
-        <BalAsset :address="sortedAmount.address" :size="36" />
-        <div class="flex flex-col ml-3">
-          <div class="font-medium text-lg">
-            <span class="font-numeric">
-              {{ fNum2(sortedAmount.amount, FNumFormats.token) }}
-            </span>
-            {{ tokenMap[sortedAmount.address].symbol }}
-          </div>
-          <div class="text-sm text-gray-500 font-numeric">
-            {{ fNum2(sortedAmount.fiatAmount, FNumFormats.fiat) }}
-            ({{
-              fNum2(amountShare(sortedAmount.address), FNumFormats.percent)
-            }})
+    <div v-for="token in amountsToShow" :key="token.address" class="relative">
+      <div class="token-amount-table-content items-center">
+        <div class="flex items-center">
+          <BalAsset :address="token.address" :size="36" />
+          <div class="flex flex-col ml-3">
+            <div class="font-medium text-lg">
+              <span class="font-numeric">
+                {{ fNum2(token.amount, FNumFormats.token) }}
+              </span>
+              {{ tokenMap[token.address].symbol }}
+            </div>
           </div>
         </div>
+        <div class="text-sm text-gray-500 font-numeric">
+          {{ fNum2(token.fiatAmount, FNumFormats.fiat) }}
+          ({{ fNum2(amountShare(token.address), FNumFormats.percent) }})
+        </div>
+      </div>
+    </div>
+    <div
+      v-if="shouldShowCompactViewForZeroAmounts"
+      class="token-amount-table-content -mb-2 items-start"
+    >
+      <div class="flex flex-wrap mr-6">
+        <div
+          class="token"
+          v-for="token in groupedAmounts.zeroAmounts"
+          :key="token.address"
+        >
+          <BalAsset :address="token.address" class="mr-2" />
+          <span>{{ tokenMap[token.address].symbol }}</span>
+        </div>
+      </div>
+      <div class="text-sm text-gray-500 font-numeric whitespace-nowrap">
+        {{ fNum2(0, FNumFormats.fiat) }}
+        ({{ fNum2(0, FNumFormats.percent) }})
       </div>
     </div>
   </div>
@@ -91,6 +122,10 @@ function amountShare(address: string): string {
 }
 
 .token-amount-table-content {
-  @apply p-3 flex items-center;
+  @apply p-3 flex justify-between;
+}
+
+.token {
+  @apply flex items-center px-2 py-1 mr-2 mb-2 rounded-lg bg-gray-100 dark:bg-gray-700;
 }
 </style>

--- a/src/components/forms/pool_actions/InvestForm/components/InvestPreviewModal/components/TokenAmounts.vue
+++ b/src/components/forms/pool_actions/InvestForm/components/InvestPreviewModal/components/TokenAmounts.vue
@@ -2,7 +2,6 @@
 import { groupBy, orderBy } from 'lodash';
 import { computed } from 'vue';
 
-import BalAsset from '@/components/_global/BalAsset/BalAsset.vue';
 import useNumbers, { FNumFormats } from '@/composables/useNumbers';
 import { bnum } from '@/lib/utils';
 import { TokenInfoMap } from '@/types/TokenList';


### PR DESCRIPTION
# Description

When investing the preview modal shows all the amounts - even when they are `0`. On pools with a large number of tokens this could lead to taking up too much space.

This PR introduces a compact mode and triggers it only when there is more 3 tokens that have `0` amount. Otherwise it will default to its original behaviour.

Here's how it looks with > 3 tokens that have `0` amounts.

There was also a small visual change (moved amounts and % to the right)

<img width="575" alt="Screen Shot 2022-04-07 at 12 19 04 pm" src="https://user-images.githubusercontent.com/254095/162111172-a88f92be-faaa-428f-ba3a-0fbe872f282a.png">

Here's the preserved behaviour (only 1 token with `0` amount)
<img width="535" alt="Screen Shot 2022-04-07 at 12 19 50 pm" src="https://user-images.githubusercontent.com/254095/162111198-a594dfd9-b3f8-44c9-9735-b4e051971ef0.png">



## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## How should this be tested?

Please provide instructions so we can test. Please also list any relevant details for your test configuration.

- [ ] Try pool `0xe7b1d394f3b40abeaa0b64a545dbcf89da1ecb3f00010000000000000000009a` on mainnet for a pool that will show with a compact mode.
- [ ] Try pool other pools with 2/3 tokens - compact mode shouldn't be triggered.

## Visual context

Please provide any relevant visual context for UI changes or additions. This could be static screenshots or a loom screencast.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have requested at least 2 reviews (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] If package-lock.json has changes, it was intentional.
- [x] The base of this PR is `master` if hotfix, `develop` if not
