### PR TITLE
Fix boost calculation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.47.8",
+  "version": "1.47.9",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@balancer-labs/frontend-v2",
-      "version": "1.47.8",
+      "version": "1.47.9",
       "license": "MIT",
       "devDependencies": {
         "@aave/protocol-js": "^4.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.47.8",
+  "version": "1.47.9",
   "engines": {
     "node": "14.x",
     "npm": ">=7"

--- a/src/components/contextual/pages/pools/types.ts
+++ b/src/components/contextual/pages/pools/types.ts
@@ -1,4 +1,4 @@
-export type UserGuageShare = {
+export type UserGaugeShare = {
   id: string;
   gauge: {
     poolId: string;
@@ -15,8 +15,8 @@ export type LiquidityGauge = {
   }[];
 };
 
-export type UserGuageSharesResponse = {
-  gaugeShares: UserGuageShare[];
+export type UserGaugeSharesResponse = {
+  gaugeShares: UserGaugeShare[];
   liquidityGauges: LiquidityGauge[];
 };
 

--- a/src/providers/local/staking/userUserStakingData.ts
+++ b/src/providers/local/staking/userUserStakingData.ts
@@ -19,7 +19,7 @@ import { stakingRewardsService } from '@/services/staking/staking-rewards.servic
 import useWeb3 from '@/services/web3/useWeb3';
 
 import { getGaugeAddress } from './staking.provider';
-export type UserGuageShare = {
+export type UserGaugeShare = {
   id: string;
   gauge: {
     id: string;
@@ -37,8 +37,8 @@ export type UserLiquidityGauge = {
   }[];
 };
 
-export type UserGuageSharesResponse = {
-  gaugeShares: UserGuageShare[];
+export type UserGaugeSharesResponse = {
+  gaugeShares: UserGaugeShare[];
   liquidityGauges: UserLiquidityGauge[];
 };
 
@@ -50,7 +50,7 @@ export type UserStakingDataResponse = {
   // a list of the gauge shares owned by that user
   // a gauge share represents the amount of staked
   // BPT a user has in a pool, given balance >= 0
-  userGaugeShares: ComputedRef<UserGuageShare[]>;
+  userGaugeShares: ComputedRef<UserGaugeShare[]>;
   // a list of eligible gauges the user can stake into
   // this list is pulled against the users invested
   // pool ids
@@ -120,7 +120,7 @@ export default function useUserStakingData(
     isLoading: isLoadingUserStakingData,
     isIdle: isUserStakeDataIdle,
     refetch: refetchUserStakingData
-  } = useGraphQuery<UserGuageSharesResponse>(
+  } = useGraphQuery<UserGaugeSharesResponse>(
     subgraphs.gauge,
     ['staking', 'data', { account, userPoolIds }],
     () => ({

--- a/src/providers/local/staking/userUserStakingData.ts
+++ b/src/providers/local/staking/userUserStakingData.ts
@@ -22,6 +22,7 @@ import { getGaugeAddress } from './staking.provider';
 export type UserGuageShare = {
   id: string;
   gauge: {
+    id: string;
     poolId: string;
     totalSupply: string;
   };
@@ -129,6 +130,7 @@ export default function useUserStakingData(
         },
         balance: true,
         gauge: {
+          id: true,
           poolId: true,
           totalSupply: true
         }

--- a/src/services/staking/staking-rewards.service.ts
+++ b/src/services/staking/staking-rewards.service.ts
@@ -190,7 +190,8 @@ export class StakingRewardsService {
     );
 
     const boosts = gaugeShares.map(gaugeShare => {
-      const gaugeWorkingSupply = bnum(workingSupplies[gaugeShare.gauge.id]);
+      const gaugeAddress = getAddress(gaugeShare.gauge.id);
+      const gaugeWorkingSupply = bnum(workingSupplies[gaugeAddress]);
       const gaugeBalance = bnum(gaugeShare.balance);
       const adjustedGaugeBalance = bnum(0.4)
         .times(gaugeBalance)

--- a/src/services/staking/staking-rewards.service.ts
+++ b/src/services/staking/staking-rewards.service.ts
@@ -190,6 +190,7 @@ export class StakingRewardsService {
     );
 
     const boosts = gaugeShares.map(gaugeShare => {
+      const gaugeWorkingSupply = bnum(workingSupplies[gaugeShare.gauge.id]);
       const gaugeBalance = bnum(gaugeShare.balance);
       const adjustedGaugeBalance = bnum(0.4)
         .times(gaugeBalance)
@@ -206,11 +207,18 @@ export class StakingRewardsService {
         ? gaugeBalance
         : adjustedGaugeBalance;
 
-      const boostedFraction = workingBalance.div(
-        workingSupplies[gaugeShare.gauge.id]
+      const zeroBoostWorkingBalance = bnum(0.4).times(gaugeBalance);
+      const zeroBoostWorkingSupply = gaugeWorkingSupply
+        .minus(workingBalance)
+        .plus(zeroBoostWorkingBalance);
+
+      const boostedFraction = workingBalance.div(gaugeWorkingSupply);
+      const unboostedFraction = zeroBoostWorkingBalance.div(
+        zeroBoostWorkingSupply
       );
-      const unboostedFraction = gaugeBalance.div(gaugeShare.gauge.totalSupply);
+
       const boost = boostedFraction.div(unboostedFraction);
+
       return [gaugeShare.gauge.poolId, boost.toString()];
     });
 

--- a/src/services/staking/staking-rewards.service.ts
+++ b/src/services/staking/staking-rewards.service.ts
@@ -4,7 +4,7 @@ import { isNil, mapValues } from 'lodash';
 
 import { FiatCurrency } from '@/constants/currency';
 import { bnum, getBalAddress } from '@/lib/utils';
-import { UserGuageShare } from '@/providers/local/staking/userUserStakingData';
+import { UserGaugeShare } from '@/providers/local/staking/userUserStakingData';
 import { configService } from '@/services/config/config.service';
 import { TokenInfoMap } from '@/types/TokenList';
 
@@ -171,7 +171,7 @@ export class StakingRewardsService {
     gaugeShares
   }: {
     userAddress: string;
-    gaugeShares: UserGuageShare[];
+    gaugeShares: UserGaugeShare[];
   }) {
     const veBalProxy = new VeBALProxy(
       configService.network.addresses.veDelegationProxy


### PR DESCRIPTION
# Description

In the current code, we're making the assumption that gaugeWorkingSupply ~= zeroBoostWorkingSupply which breaks down for larger LPs. This PR fixes the boost calculation.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## How should this be tested?

- [ ] Test boost values in UI are as expected

## Visual context

n/a

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have requested at least 2 reviews (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] If package-lock.json has changes, it was intentional.
- [x] The base of this PR is `master` if hotfix, `develop` if not
