### PR TITLE
hotfix/1.47.13

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.47.14",
+  "version": "1.47.15",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@balancer-labs/frontend-v2",
-      "version": "1.47.14",
+      "version": "1.47.15",
       "license": "MIT",
       "devDependencies": {
         "@aave/protocol-js": "^4.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.47.14",
+  "version": "1.47.15",
   "engines": {
     "node": "14.x",
     "npm": ">=7"

--- a/src/components/_global/BalPopover/BalPopover.vue
+++ b/src/components/_global/BalPopover/BalPopover.vue
@@ -40,9 +40,11 @@ const popoverActivatorWrapperClasses = computed(() => ({
   relative: !props.detached
 }));
 
-const activatorWidthPx = computed(
-  (): string => `${activatorWrapper.value?.clientWidth || 0}px`
-);
+const activatorWidth = computed(() => activatorWrapper.value?.clientWidth || 0);
+
+const activatorWidthPx = computed(() => `${activatorWidth.value}px`);
+
+const activatorHalfWidthPx = computed(() => `${activatorWidth.value / 2}px`);
 
 /**
  * METHODS
@@ -114,8 +116,10 @@ watch(popoverOpened, () => {
 }
 
 .align-center-transform {
-  -webkit-transform: translateX(-50%);
-  transform: translateX(-50%);
+  -webkit-transform: translateX(
+    -webkit-calc(-50% + v-bind(activatorHalfWidthPx))
+  );
+  transform: translateX(calc(-50% + v-bind(activatorHalfWidthPx)));
 }
 
 .align-right-transform {

--- a/src/components/navs/AppNav/AppNavAccountBtn.vue
+++ b/src/components/navs/AppNav/AppNavAccountBtn.vue
@@ -1,7 +1,7 @@
 <template>
   <BalPopover
     no-pad
-    :align="isMobile ? 'right' : undefined"
+    :align="isMobile ? 'center' : undefined"
     :detached="isMobile ? true : undefined"
   >
     <template v-slot:activator>

--- a/src/components/navs/AppNav/AppNavAccountBtn.vue
+++ b/src/components/navs/AppNav/AppNavAccountBtn.vue
@@ -1,5 +1,9 @@
 <template>
-  <BalPopover no-pad>
+  <BalPopover
+    no-pad
+    :align="isMobile ? 'right' : undefined"
+    :detached="isMobile ? true : undefined"
+  >
     <template v-slot:activator>
       <BalBtn
         class="text-base"
@@ -49,7 +53,7 @@ export default defineComponent({
   },
 
   setup() {
-    const { bp, upToLargeBreakpoint } = useBreakpoints();
+    const { bp, upToLargeBreakpoint, isMobile } = useBreakpoints();
     const { isLoadingProfile, profile, account } = useWeb3();
 
     const avatarSize = computed(() => {
@@ -69,7 +73,8 @@ export default defineComponent({
       profile,
       avatarSize,
       upToLargeBreakpoint,
-      isLoadingProfile
+      isLoadingProfile,
+      isMobile
     };
   }
 });

--- a/src/components/navs/AppNav/AppNavActivityBtn/AppNavActivityBtn.vue
+++ b/src/components/navs/AppNav/AppNavActivityBtn/AppNavActivityBtn.vue
@@ -1,5 +1,5 @@
 <template>
-  <BalPopover no-pad>
+  <BalPopover no-pad :align="isMobile ? 'left' : undefined">
     <template v-slot:activator>
       <BalBtn
         color="white"
@@ -81,7 +81,7 @@ export default defineComponent({
     /**
      * COMPOSABLES
      */
-    const { upToLargeBreakpoint } = useBreakpoints();
+    const { upToLargeBreakpoint, isMobile } = useBreakpoints();
     const { isLoadingProfile, profile, account, getSigner } = useWeb3();
     const { t } = useI18n();
 
@@ -145,7 +145,8 @@ export default defineComponent({
       isLoadingProfile,
       transactions,
       pendingTransactions,
-      finalizedTransactions
+      finalizedTransactions,
+      isMobile
     };
   }
 });


### PR DESCRIPTION
# Description

This PR fixes the issue described in #1653 where the popover is basically unreachable on mobile for the account/recent activity.

Fixes #1653 

Here's how it looks now:
<img width="380" alt="Screen Shot 2022-04-08 at 1 13 11 pm" src="https://user-images.githubusercontent.com/254095/162355771-6c9a50ff-4f7a-4f64-a979-53c80eda8393.png">

<img width="384" alt="Screen Shot 2022-04-08 at 1 15 15 pm" src="https://user-images.githubusercontent.com/254095/162355927-27f61a40-af5c-46c5-b06c-b1162783f8ad.png">


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## How should this be tested?

Please provide instructions so we can test. Please also list any relevant details for your test configuration.

- [ ] Try to open the recent activity / account on mobile.

## Visual context

Please provide any relevant visual context for UI changes or additions. This could be static screenshots or a loom screencast.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have requested at least 2 reviews (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] If package-lock.json has changes, it was intentional.
- [x] The base of this PR is `master` if hotfix, `develop` if not
