### PR TITLE
Improve initial loading timing

### DIFF
--- a/src/services/balancer/subgraph/entities/pools/index.ts
+++ b/src/services/balancer/subgraph/entities/pools/index.ts
@@ -127,13 +127,16 @@ export default class Pools {
     gauges: SubgraphGauge[],
     tokens: TokenInfoMap
   ): Promise<DecoratedPool[]> {
-    const protocolFeePercentage = await this.balancerContracts.vault.protocolFeesCollector.getSwapFeePercentage();
-    const gaugeAprs = await stakingRewardsService.getGaugeAprForPools({
-      prices,
-      gauges,
-      pools,
-      tokens
-    });
+    const [protocolFeePercentage, gaugeAprs] = await Promise.all([
+      this.balancerContracts.vault.protocolFeesCollector.getSwapFeePercentage(),
+      await stakingRewardsService.getGaugeAprForPools({
+        prices,
+        gauges,
+        pools,
+        tokens
+      })
+    ]);
+
     const promises = pools.map(async pool => {
       const poolService = new this.poolServiceClass(pool);
 

--- a/src/services/rpc-provider/rpc-provider.service.ts
+++ b/src/services/rpc-provider/rpc-provider.service.ts
@@ -1,5 +1,5 @@
 import { Network } from '@balancer-labs/sdk';
-import { JsonRpcProvider, WebSocketProvider } from '@ethersproject/providers';
+import { JsonRpcBatchProvider, JsonRpcProvider, WebSocketProvider } from '@ethersproject/providers';
 
 import template from '@/lib/utils/template';
 import ConfigService, { configService } from '@/services/config/config.service';
@@ -14,9 +14,9 @@ export default class RpcProviderService {
 
   constructor(private readonly config: ConfigService = configService) {
     this.network = this.config.network.shortName;
-    this.jsonProvider = new JsonRpcProvider(this.config.rpc);
+    this.jsonProvider = new JsonRpcBatchProvider(this.config.rpc);
     this.wsProvider = new WebSocketProvider(this.config.ws);
-    this.loggingProvider = new JsonRpcProvider(this.config.loggingRpc);
+    this.loggingProvider = new JsonRpcBatchProvider(this.config.loggingRpc);
   }
 
   public initBlockListener(newBlockHandler: NewBlockHandler): void {
@@ -34,7 +34,7 @@ export default class RpcProviderService {
       INFURA_KEY: this.config.env.INFURA_PROJECT_ID,
       ALCHEMY_KEY: this.config.env.ALCHEMY_KEY
     });
-    return new JsonRpcProvider(rpcUrl);
+    return new JsonRpcBatchProvider(rpcUrl);
   }
 }
 

--- a/src/services/staking/staking-rewards.service.ts
+++ b/src/services/staking/staking-rewards.service.ts
@@ -93,26 +93,27 @@ export class StakingRewardsService {
     tokens: TokenInfoMap;
   }): Promise<PoolAPRs> {
     const gaugeAddresses = gauges.map(gauge => gauge.id);
-    const inflationRate = await new BalancerTokenAdmin(
-      configService.network.addresses.tokenAdmin
-    ).getInflationRate();
     const balAddress = getBalAddress();
-    const relativeWeights = await this.getRelativeWeightsForGauges(
-      gaugeAddresses
-    );
 
     const rewardTokensForGauges = await LiquidityGauge.getRewardTokensForGauges(
       gaugeAddresses
     );
-    const rewardTokenData = await LiquidityGauge.getRewardTokenDataForGauges(
-      rewardTokensForGauges
-    );
 
-    const workingSupplies = await this.getWorkingSupplyForGauges(
-      gaugeAddresses
-    );
-
-    const totalSupplies = await this.getTotalSupplyForGauges(gaugeAddresses);
+    const [
+      inflationRate,
+      relativeWeights,
+      rewardTokenData,
+      workingSupplies,
+      totalSupplies
+    ] = await Promise.all([
+      new BalancerTokenAdmin(
+        configService.network.addresses.tokenAdmin
+      ).getInflationRate(),
+      this.getRelativeWeightsForGauges(gaugeAddresses),
+      LiquidityGauge.getRewardTokenDataForGauges(rewardTokensForGauges),
+      this.getWorkingSupplyForGauges(gaugeAddresses),
+      this.getTotalSupplyForGauges(gaugeAddresses)
+    ]);
 
     const aprs = gauges.map(async gauge => {
       const poolId = gauge.poolId;


### PR DESCRIPTION
# Description

While working with the app I noticed that initial loading takes quite a lot of time and many calls are going sequentially.
After some research, I found that most parts of the time were consumed by ```balancerSubgraphService.pools.decorate()``` method.

As the result on local, it dropped from ~7s to ~2s

## Type of change

- [x] migration from JsonRpcProvider to BatchJsonRpcProvider (helped do drop number of RPC calls from ~46 to ~21)
- [x] parallel requests
