### PR TITLE
fix: refetch lock preview + turn props to static

### DIFF
--- a/src/components/forms/lock_actions/UnlockForm/components/UnlockPreviewModal/UnlockPreviewModal.vue
+++ b/src/components/forms/lock_actions/UnlockForm/components/UnlockPreviewModal/UnlockPreviewModal.vue
@@ -104,6 +104,7 @@ function handleSuccess() {
       :totalLpTokens="totalLpTokens"
       :veBalLockInfo="veBalLockInfo"
       @success="handleSuccess"
+      @close="handleClose"
       class="mt-4"
     />
   </BalModal>

--- a/src/components/forms/lock_actions/UnlockForm/components/UnlockPreviewModal/UnlockPreviewModal.vue
+++ b/src/components/forms/lock_actions/UnlockForm/components/UnlockPreviewModal/UnlockPreviewModal.vue
@@ -2,6 +2,7 @@
 import { computed, ref } from 'vue';
 import { useI18n } from 'vue-i18n';
 
+import useVeBalLockInfoQuery from '@/composables/queries/useVeBalLockInfoQuery';
 import { VeBalLockInfo } from '@/services/balancer/contracts/contracts/veBAL';
 import { FullPool } from '@/services/balancer/subgraph/types';
 import { TokenInfo } from '@/types/TokenList';
@@ -24,16 +25,26 @@ type Props = {
 /**
  * PROPS & EMITS
  */
-defineProps<Props>();
+const props = defineProps<Props>();
 
 const emit = defineEmits<{
   (e: 'close'): void;
 }>();
 
 /**
+ * COMPOSABLES
+ */
+const { refetch: refetchLockInfo } = useVeBalLockInfoQuery();
+
+/**
  * STATE
  */
 const unlockConfirmed = ref(false);
+const lockablePool = ref(props.lockablePool);
+const lockablePoolTokenInfo = ref(props.lockablePoolTokenInfo);
+const veBalLockInfo = ref(props.veBalLockInfo);
+const totalLpTokens = ref(props.totalLpTokens);
+const fiatTotalLpTokens = ref(props.fiatTotalLpTokens);
 
 /**
  * COMPOSABLES
@@ -54,6 +65,11 @@ const title = computed(() => {
  */
 function handleClose() {
   emit('close');
+}
+
+function handleSuccess() {
+  unlockConfirmed.value = true;
+  refetchLockInfo.value();
 }
 </script>
 
@@ -87,7 +103,7 @@ function handleClose() {
       :lockablePoolTokenInfo="lockablePoolTokenInfo"
       :totalLpTokens="totalLpTokens"
       :veBalLockInfo="veBalLockInfo"
-      @success="unlockConfirmed = true"
+      @success="handleSuccess"
       class="mt-4"
     />
   </BalModal>

--- a/src/components/forms/lock_actions/UnlockForm/components/UnlockPreviewModal/components/UnlockActions.vue
+++ b/src/components/forms/lock_actions/UnlockForm/components/UnlockPreviewModal/components/UnlockActions.vue
@@ -39,6 +39,7 @@ const props = defineProps<Props>();
 
 const emit = defineEmits<{
   (e: 'success', value: UnlockActionState): void;
+  (e: 'close'): void;
 }>();
 
 /**
@@ -159,14 +160,7 @@ async function submit() {
           />
         </BalLink>
       </div>
-      <BalBtn
-        tag="router-link"
-        :to="{ name: 'vebal' }"
-        color="gray"
-        outline
-        block
-        class="mt-2"
-      >
+      <BalBtn color="gray" outline block class="mt-2" @click="emit('close')">
         {{ $t('unlockVeBAL.previewModal.returnToVeBalPage') }}
       </BalBtn>
     </template>

--- a/src/locales/default.json
+++ b/src/locales/default.json
@@ -880,7 +880,7 @@
                     "loadingLabel": "Confirm unlock in wallet"
                 }
             },
-            "returnToVeBalPage": "Return to veBAL lock page"
+            "returnToVeBalPage": "Return to veBAL page"
         },
         "notSupported": {
             "title": "Unlocking is unavailable on this network",


### PR DESCRIPTION
# Description

When unlocking - it should be behave like the lock (refetch info + being static).

Fixes #1694

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## How should this be tested?

Please provide instructions so we can test. Please also list any relevant details for your test configuration.

- [ ] Unlock your position (if you got an account to test!) and see that the modal is static and the lock info is refetched.

## Visual context

Please provide any relevant visual context for UI changes or additions. This could be static screenshots or a loom screencast.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have requested at least 2 reviews (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] If package-lock.json has changes, it was intentional.
- [x] The base of this PR is `master` if hotfix, `develop` if not
