### PR TITLE
fix: allow for a year lock when its Thursday

### DIFF
--- a/src/components/forms/lock_actions/LockForm/composables/useLockEndDate.ts
+++ b/src/components/forms/lock_actions/LockForm/composables/useLockEndDate.ts
@@ -1,6 +1,6 @@
 import {
   addDays,
-  isWednesday,
+  isThursday,
   nextThursday,
   previousThursday,
   startOfDay
@@ -19,7 +19,7 @@ import useLockState from './useLockState';
 function getMaxLockEndDateTimestamp(date: number) {
   const maxLockTimestamp = addDays(date, MAX_LOCK_PERIOD_IN_DAYS);
 
-  const timestamp = isWednesday(date)
+  const timestamp = isThursday(date)
     ? maxLockTimestamp
     : previousThursday(maxLockTimestamp);
 

--- a/src/components/forms/lock_actions/LockForm/composables/useLockEndDate.ts
+++ b/src/components/forms/lock_actions/LockForm/composables/useLockEndDate.ts
@@ -1,19 +1,36 @@
-import { addDays, nextThursday, previousThursday, startOfDay } from 'date-fns';
+import {
+  addDays,
+  isThursday,
+  nextThursday,
+  previousThursday,
+  startOfDay
+} from 'date-fns';
 import { computed } from 'vue';
 
 import {
   MAX_LOCK_PERIOD_IN_DAYS,
   MIN_LOCK_PERIOD_IN_DAYS
 } from '@/components/forms/lock_actions/constants';
+import { toUtcTime } from '@/composables/useTime';
 import { VeBalLockInfo } from '@/services/balancer/contracts/contracts/veBAL';
 
 import useLockState from './useLockState';
+
+function getMaxLockEndDateTimestamp(date: number) {
+  const maxLockTimestamp = addDays(date, MAX_LOCK_PERIOD_IN_DAYS);
+
+  const timestamp = isThursday(date)
+    ? maxLockTimestamp
+    : previousThursday(maxLockTimestamp);
+
+  return startOfDay(timestamp).getTime();
+}
 
 export default function useLockEndDate(veBalLockInfo?: VeBalLockInfo) {
   /**
    * STATE
    */
-  const todaysDate = new Date();
+  const todaysDate = toUtcTime(new Date());
 
   const minLockEndDateTimestamp = startOfDay(
     nextThursday(
@@ -26,9 +43,7 @@ export default function useLockEndDate(veBalLockInfo?: VeBalLockInfo) {
     )
   ).getTime();
 
-  const maxLockEndDateTimestamp = startOfDay(
-    previousThursday(addDays(todaysDate, MAX_LOCK_PERIOD_IN_DAYS))
-  ).getTime();
+  const maxLockEndDateTimestamp = getMaxLockEndDateTimestamp(todaysDate);
 
   /**
    * COMPOSABLES

--- a/src/components/forms/lock_actions/LockForm/composables/useLockEndDate.ts
+++ b/src/components/forms/lock_actions/LockForm/composables/useLockEndDate.ts
@@ -1,6 +1,6 @@
 import {
   addDays,
-  isThursday,
+  isWednesday,
   nextThursday,
   previousThursday,
   startOfDay
@@ -19,7 +19,7 @@ import useLockState from './useLockState';
 function getMaxLockEndDateTimestamp(date: number) {
   const maxLockTimestamp = addDays(date, MAX_LOCK_PERIOD_IN_DAYS);
 
-  const timestamp = isThursday(date)
+  const timestamp = isWednesday(date)
     ? maxLockTimestamp
     : previousThursday(maxLockTimestamp);
 

--- a/src/components/forms/lock_actions/LockForm/composables/useLockEndDate.ts
+++ b/src/components/forms/lock_actions/LockForm/composables/useLockEndDate.ts
@@ -19,7 +19,7 @@ import useLockState from './useLockState';
 function getMaxLockEndDateTimestamp(date: number) {
   const maxLockTimestamp = addDays(date, MAX_LOCK_PERIOD_IN_DAYS);
 
-  const timestamp = isThursday(date)
+  const timestamp = isThursday(maxLockTimestamp)
     ? maxLockTimestamp
     : previousThursday(maxLockTimestamp);
 


### PR DESCRIPTION
# Description

It should be possible to lock for 365 when its a Thursday. This PR checks this condition and will allow to have a year lock.

Also - I've changed the date to UTC.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## How should this be tested?

Please provide instructions so we can test. Please also list any relevant details for your test configuration.

- [ ] Might be useful to wait for a Thursday to try this out (not really easily tested - I put on "hold" for now)

## Visual context

Please provide any relevant visual context for UI changes or additions. This could be static screenshots or a loom screencast.

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have requested at least 2 reviews (If the PR is significant enough, use best judgement here)
- [ ] I have commented my code where relevant, particularly in hard-to-understand areas
- [ ] If package-lock.json has changes, it was intentional.
- [ ] The base of this PR is `master` if hotfix, `develop` if not
