### PR TITLE
Hotfix - fix no zero amounts bug

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.48.2",
+  "version": "1.48.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@balancer-labs/frontend-v2",
-      "version": "1.48.2",
+      "version": "1.48.3",
       "license": "MIT",
       "devDependencies": {
         "@aave/protocol-js": "^4.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.48.2",
+  "version": "1.48.3",
   "engines": {
     "node": "14.x",
     "npm": ">=7"

--- a/src/components/forms/pool_actions/InvestForm/components/InvestPreviewModal/components/TokenAmounts.vue
+++ b/src/components/forms/pool_actions/InvestForm/components/InvestPreviewModal/components/TokenAmounts.vue
@@ -52,7 +52,7 @@ const groupedAmounts = computed(() =>
 );
 
 const shouldShowCompactViewForZeroAmounts = computed(
-  () => groupedAmounts.value.zeroAmounts.length > 3
+  () => (groupedAmounts.value.zeroAmounts?.length || 0) > 3
 );
 
 const amountsToShow = computed(() =>


### PR DESCRIPTION
# Description

If the user tried to invest with all tokens the computed property `shouldShowCompactViewForZeroAmounts` would fail because there is no `zeroAmounts` property in the grouped amounts. This PR ensures that computed doesn't fail be defaulting to 0 in this case.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## How should this be tested?

- [ ] Test an investment where you are investing with every token in the pool

## Visual context

n/a

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have requested at least 2 reviews (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] If package-lock.json has changes, it was intentional.
- [x] The base of this PR is `master` if hotfix, `develop` if not
