### PR TITLE
Enable LDO claims on Polygon

### DIFF
--- a/src/services/claim/MultiTokenClaim.json
+++ b/src/services/claim/MultiTokenClaim.json
@@ -115,6 +115,13 @@
             "token": "0x580a84c73811e1839f75d86d75d88cca0c241ff4",
             "manifest": "https://raw.githubusercontent.com/balancer-labs/bal-mining-scripts/master/reports/_current-qi-polygon.json",
             "weekStart": 1
+        },
+        {
+            "label": "LDO",
+            "distributor": "0x0000000000000000000000000000000000000000",
+            "token": "0xC3C7d422809852031b44ab29EEC9F1EfF2A58756",
+            "manifest": "https://raw.githubusercontent.com/balancer-labs/bal-mining-scripts/master/reports/_current-ldo-polygon.json",
+            "weekStart": 1
         }
       ],
     "42161": [


### PR DESCRIPTION
# Description

LDO is being distributed via the Merkle Orchard on Polygon to LPs. Waiting to find out their distributor address.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## How should this be tested?

- [ ] Impersonate `0x000000e28fAA823d5B53ff6C2922c28335840375` on Polygon. It should be possible to claim 10.62326488 LDO

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have requested at least 2 reviews (If the PR is significant enough, use best judgement here)
- [ ] I have commented my code where relevant, particularly in hard-to-understand areas
- [ ] If package-lock.json has changes, it was intentional.
- [ ] The base of this PR is `master` if hotfix, `develop` if not
