### PR TITLE
Hotfix - fix gauge relative weights

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.48.3",
+  "version": "1.48.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@balancer-labs/frontend-v2",
-      "version": "1.48.3",
+      "version": "1.48.4",
       "license": "MIT",
       "devDependencies": {
         "@aave/protocol-js": "^4.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.48.3",
+  "version": "1.48.4",
   "engines": {
     "node": "14.x",
     "npm": ">=7"

--- a/src/components/contextual/stake/StakePreview.vue
+++ b/src/components/contextual/stake/StakePreview.vue
@@ -246,7 +246,11 @@ function handleClose() {
             <span class="text-sm capitalize">
               ~{{ fNum2(stakingApr, FNumFormats.percent) }}</span
             >
-            <BalTooltip text="s" width="20" textAlign="center" />
+            <BalTooltip
+              :text="$t('staking.stakingAprTooltip')"
+              width="20"
+              textAlign="center"
+            />
           </BalStack>
         </BalStack>
         <BalStack horizontal justify="between" v-if="showStakingRewards">
@@ -258,7 +262,11 @@ function handleClose() {
             <span class="text-sm capitalize"
               >~{{ fNum2(potentialyWeeklyYield, FNumFormats.fiat) }}</span
             >
-            <BalTooltip text="s" width="20" textAlign="center" />
+            <BalTooltip
+              :text="$t('potentialWeeklyEarningTooltip')"
+              width="20"
+              textAlign="center"
+            />
           </BalStack>
         </BalStack>
       </BalStack>

--- a/src/components/contextual/stake/StakePreview.vue
+++ b/src/components/contextual/stake/StakePreview.vue
@@ -263,7 +263,7 @@ function handleClose() {
               >~{{ fNum2(potentialyWeeklyYield, FNumFormats.fiat) }}</span
             >
             <BalTooltip
-              :text="$t('potentialWeeklyEarningTooltip')"
+              :text="$t('staking.potentialWeeklyEarningTooltip')"
               width="20"
               textAlign="center"
             />

--- a/src/locales/default.json
+++ b/src/locales/default.json
@@ -596,6 +596,7 @@
         "staking": "Staking",
         "stakeTooltip": "Confirm staking of LP tokens to earn liquidity mining incentives on this pool",
         "stakingApr": "Staking APR",
+        "stakingAprTooltip": "Your potential staking APR",
         "stakingIncentives": "Staking incentives",
         "totalShareTooltip": "Your current total share of LP tokens in the pool",
         "unclaimedIncentives": "Unclaimed incentives",

--- a/src/services/balancer/contracts/contracts/gauge-controller.ts
+++ b/src/services/balancer/contracts/contracts/gauge-controller.ts
@@ -1,3 +1,4 @@
+import { getUnixTime } from 'date-fns';
 import { formatUnits, getAddress } from 'ethers/lib/utils';
 import { mapValues } from 'lodash';
 
@@ -23,7 +24,7 @@ export class GaugeController {
         getAddress(gaugeAddress),
         this.address,
         'gauge_relative_weight(address, uint256)',
-        [getAddress(gaugeAddress), 1649427628 || timestamp]
+        [getAddress(gaugeAddress), timestamp || getUnixTime(new Date())]
       );
     }
     const result = await multicaller.execute();


### PR DESCRIPTION
# Description

- Forgot to change back the hardcoded timestamp for the gauge relative weights. 
- Fixes (again) the tooltips for stake preview.
- 
## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## How should this be tested?

Proper APRs. 
Stake preview proper tooltips

## Checklist:

- [X] I have performed a self-review of my own code
- [X] I have requested at least 2 reviews (If the PR is significant enough, use best judgement here)
- [X] I have commented my code where relevant, particularly in hard-to-understand areas
- [X] If package-lock.json has changes, it was intentional.
- [X] The base of this PR is `master` if hotfix, `develop` if not
