### PR TITLE
Fix bug with trade error state (Closes #1716)

### DIFF
--- a/src/components/cards/TradeCardGP/TradeCardGP.vue
+++ b/src/components/cards/TradeCardGP/TradeCardGP.vue
@@ -324,8 +324,7 @@ export default defineComponent({
     // METHODS
     function trade() {
       trading.trade(() => {
-        tokenInAmount.value = '';
-        tokenOutAmount.value = '';
+        trading.resetAmounts();
         modalTradePreviewIsOpen.value = false;
       });
     }

--- a/src/composables/trade/useSor.ts
+++ b/src/composables/trade/useSor.ts
@@ -239,6 +239,14 @@ export default function useSor({
     }
   }
 
+  function resetInputAmounts(amount: string): void {
+    tokenInAmountInput.value = amount;
+    tokenOutAmountInput.value = amount;
+    priceImpact.value = 0;
+    sorReturn.value.hasSwaps = false;
+    sorReturn.value.returnAmount = Zero;
+  }
+
   async function handleAmountChange(): Promise<void> {
     const amount = exactIn.value
       ? tokenInAmountInput.value
@@ -246,11 +254,7 @@ export default function useSor({
     // Avoid using SOR if querying a zero value or (un)wrapping trade
     const zeroValueTrade = amount === '' || amount === '0';
     if (zeroValueTrade) {
-      tokenInAmountInput.value = amount;
-      tokenOutAmountInput.value = amount;
-      priceImpact.value = 0;
-      sorReturn.value.hasSwaps = false;
-      sorReturn.value.returnAmount = Zero;
+      resetInputAmounts(amount);
       return;
     }
 
@@ -681,7 +685,7 @@ export default function useSor({
     resetState,
     confirming,
     updateTradeAmounts,
-
+    resetInputAmounts,
     // For Tests
     setSwapCost
   };

--- a/src/composables/trade/useTrading.ts
+++ b/src/composables/trade/useTrading.ts
@@ -229,6 +229,10 @@ export default function useTrading(
     }
   }
 
+  function resetAmounts() {
+    sor.resetInputAmounts('');
+  }
+
   function handleAmountChange() {
     if (exactIn.value) {
       tokenOutAmountInput.value = '';
@@ -313,7 +317,7 @@ export default function useTrading(
     toggleTradeGasless,
     isGaslessTradingDisabled,
     isGnosisSupportedOnNetwork,
-
+    resetAmounts,
     // methods
     getQuote,
     trade,


### PR DESCRIPTION
# Description
This pr closes [#1716 bug](https://github.com/balancer-labs/frontend-v2/issues/1716)
The problem was in side effect of `updateTradeAmounts` function in `useSor`. It updated input amounts but should not have.
Setting `sorReturn.value.hasSwaps` to `false` solves the problem. 
## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## How should this be tested?

Please provide instructions so we can test. Please also list any relevant details for your test configuration.

- [ ] Test A
- [ ] Test B

## Visual context

Please provide any relevant visual context for UI changes or additions. This could be static screenshots or a loom screencast.

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have requested at least 2 reviews (If the PR is significant enough, use best judgement here)
- [ ] I have commented my code where relevant, particularly in hard-to-understand areas
- [ ] If package-lock.json has changes, it was intentional.
- [ ] The base of this PR is `master` if hotfix, `develop` if not
