### PR TITLE
Remove /liquidity-mining route

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.48.5",
+  "version": "1.48.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@balancer-labs/frontend-v2",
-      "version": "1.48.5",
+      "version": "1.48.7",
       "license": "MIT",
       "devDependencies": {
         "@aave/protocol-js": "^4.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.48.5",
+  "version": "1.48.7",
   "engines": {
     "node": "14.x",
     "npm": ">=7"

--- a/src/plugins/router.ts
+++ b/src/plugins/router.ts
@@ -115,14 +115,14 @@ const routes: RouteRecordRaw[] = [
 
 /**
  * NETWORK SPECIFIC ROUTES
- */
-if (isL2.value) {
-  routes.push({
-    path: '/liquidity-mining',
-    name: 'liquidity-mining',
-    component: LiquidityMiningPage
-  });
-}
+//  */
+// if (isL2.value) {
+//   routes.push({
+//     path: '/liquidity-mining',
+//     name: 'liquidity-mining',
+//     component: LiquidityMiningPage
+//   });
+// }
 
 /**
  * DEV/STAGING ONLY ROUTES

--- a/src/plugins/router.ts
+++ b/src/plugins/router.ts
@@ -1,11 +1,9 @@
 import { createRouter, createWebHashHistory, RouteRecordRaw } from 'vue-router';
 
-import { isL2 } from '@/composables/useNetwork';
 import ClaimPage from '@/pages/claim.vue';
 import CookiesPolicyPage from '@/pages/cookies-policy.vue';
 import GetVeBalPage from '@/pages/get-vebal.vue';
 import HomePage from '@/pages/index.vue';
-import LiquidityMiningPage from '@/pages/liquidity-mining.vue';
 import PoolPage from '@/pages/pool/_id.vue';
 import CreatePoolPage from '@/pages/pool/create.vue';
 import PoolInvestPage from '@/pages/pool/invest.vue';
@@ -112,17 +110,6 @@ const routes: RouteRecordRaw[] = [
     component: ClaimPage
   }
 ];
-
-/**
- * NETWORK SPECIFIC ROUTES
-//  */
-// if (isL2.value) {
-//   routes.push({
-//     path: '/liquidity-mining',
-//     name: 'liquidity-mining',
-//     component: LiquidityMiningPage
-//   });
-// }
 
 /**
  * DEV/STAGING ONLY ROUTES


### PR DESCRIPTION
# Description

#1722 adds LM data for Polygon and Arbitrum for week 99. However, that's only valid for 3 days. The /liquidity-mining page would indicate it would be valid for the entire week. This removes the route so that the only information displayed to users is the pools APRs, which is consistent.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [x] Other

## How should this be tested?

/liquidity-mining route should redirect to main page of the app

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have requested at least 2 reviews (If the PR is significant enough, use best judgement here)
- [ ] I have commented my code where relevant, particularly in hard-to-understand areas
- [ ] If package-lock.json has changes, it was intentional.
- [ ] The base of this PR is `master` if hotfix, `develop` if not
