### PR TITLE
Bump SDK to version with SG pagination.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@babel/core": "^7.13.8",
         "@babel/plugin-proposal-numeric-separator": "^7.14.5",
         "@balancer-labs/assets": "github:balancer-labs/assets#master",
-        "@balancer-labs/sdk": "^0.1.6",
+        "@balancer-labs/sdk": "^0.1.7",
         "@balancer-labs/sor": "^1.1.0",
         "@balancer-labs/typechain": "^1.0.0",
         "@ensdomains/content-hash": "^2.5.3",
@@ -1987,9 +1987,9 @@
       }
     },
     "node_modules/@balancer-labs/sdk": {
-      "version": "0.1.6",
-      "resolved": "https://registry.npmjs.org/@balancer-labs/sdk/-/sdk-0.1.6.tgz",
-      "integrity": "sha512-r9s7Y2XJks+8V53kqwaqHDAETipgFSEQxI7TFHYigoOtWp/sUaZnlu0kDMv3NuDvya0+t9gp5a0VxbztLwcn+g==",
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/@balancer-labs/sdk/-/sdk-0.1.7.tgz",
+      "integrity": "sha512-UejukxPFnQsTXNgCDq1CItcEbR7fG7yQqeql052laGr+InL/syRD/z/Y+ClAWfMTXoNdL3JYKJMRTU12CAeBxQ==",
       "dev": true,
       "dependencies": {
         "@balancer-labs/sor": "^4.0.0-beta.2",
@@ -36887,9 +36887,9 @@
       }
     },
     "@balancer-labs/sdk": {
-      "version": "0.1.6",
-      "resolved": "https://registry.npmjs.org/@balancer-labs/sdk/-/sdk-0.1.6.tgz",
-      "integrity": "sha512-r9s7Y2XJks+8V53kqwaqHDAETipgFSEQxI7TFHYigoOtWp/sUaZnlu0kDMv3NuDvya0+t9gp5a0VxbztLwcn+g==",
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/@balancer-labs/sdk/-/sdk-0.1.7.tgz",
+      "integrity": "sha512-UejukxPFnQsTXNgCDq1CItcEbR7fG7yQqeql052laGr+InL/syRD/z/Y+ClAWfMTXoNdL3JYKJMRTU12CAeBxQ==",
       "dev": true,
       "requires": {
         "@balancer-labs/sor": "^4.0.0-beta.2",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "@babel/core": "^7.13.8",
     "@babel/plugin-proposal-numeric-separator": "^7.14.5",
     "@balancer-labs/assets": "github:balancer-labs/assets#master",
-    "@balancer-labs/sdk": "^0.1.6",
+    "@balancer-labs/sdk": "^0.1.7",
     "@balancer-labs/sor": "^1.1.0",
     "@balancer-labs/typechain": "^1.0.0",
     "@ensdomains/content-hash": "^2.5.3",


### PR DESCRIPTION
# Description

Bump to latest version of SDK which uses Subgraph pagination to fetch pools. (Polygon has > 1000 now).

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## How should this be tested?

Should allow trading of DHT<>dUSD (0x8C92e38eCA8210f4fcBf17F0951b198Dd7668292<>0xbAe28251B2a4E621aA7e20538c06DEe010Bc06DE)on Polygon which was previously reported as broken on Discord testing channel.
Trading on Mainnet, etc should function as before.

## Visual context

Please provide any relevant visual context for UI changes or additions. This could be static screenshots or a loom screencast.

## Checklist:

- [X] I have performed a self-review of my own code
- [X] I have requested at least 2 reviews (If the PR is significant enough, use best judgement here)
- [X] I have commented my code where relevant, particularly in hard-to-understand areas
- [X] If package-lock.json has changes, it was intentional.
- [X] The base of this PR is `master` if hotfix, `develop` if not
