### PR TITLE
Disable lock preview from appearing if the lock end date is invalid

### DIFF
--- a/src/components/forms/lock_actions/LockForm/components/VeBalForm/VeBalForm.vue
+++ b/src/components/forms/lock_actions/LockForm/components/VeBalForm/VeBalForm.vue
@@ -115,6 +115,11 @@ const lockType = computed(() => {
 function handleClosePreviewModal() {
   showPreviewModal.value = false;
 }
+
+function handleShowPreviewModal() {
+  if (!isValidLockEndDate.value) return;
+  showPreviewModal.value = true;
+}
 </script>
 
 <template>
@@ -158,7 +163,7 @@ function handleClosePreviewModal() {
         color="gradient"
         block
         :disabled="submissionDisabled"
-        @click="showPreviewModal = true"
+        @click="handleShowPreviewModal"
       >
         {{ $t('preview') }}
       </BalBtn>

--- a/src/components/forms/lock_actions/LockForm/components/VeBalForm/VeBalForm.vue
+++ b/src/components/forms/lock_actions/LockForm/components/VeBalForm/VeBalForm.vue
@@ -117,7 +117,7 @@ function handleClosePreviewModal() {
 }
 
 function handleShowPreviewModal() {
-  if (!isValidLockEndDate.value) return;
+  if (submissionDisabled.value) return;
   showPreviewModal.value = true;
 }
 </script>


### PR DESCRIPTION
# Description

Title. This is because on mobile and some platforms it allows you to bypass the date picker change event. So check on submit too.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## How should this be tested?

Enter invalid lock end date on mobile, shouldn't allow you to get to the preview modal

## Visual context

n/a

## Checklist:

- [X] I have performed a self-review of my own code
- [X] I have requested at least 2 reviews (If the PR is significant enough, use best judgement here)
- [X] I have commented my code where relevant, particularly in hard-to-understand areas
- [X] If package-lock.json has changes, it was intentional.
- [X] The base of this PR is `master` if hotfix, `develop` if not
