### PR TITLE
feat: add secondary text to vebal cards

### DIFF
--- a/src/components/contextual/pages/vebal/MyVeBAL/components/MyVeBalCards.vue
+++ b/src/components/contextual/pages/vebal/MyVeBAL/components/MyVeBalCards.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { format } from 'date-fns';
+import { differenceInDays, format } from 'date-fns';
 import { computed, ref } from 'vue';
 import { useI18n } from 'vue-i18n';
 
@@ -86,11 +86,14 @@ const cards = computed(() => {
   return [
     {
       id: 'myLpToken',
-      label: t('veBAL.myVeBAL.cards.myLpToken', [
+      label: t('veBAL.myVeBAL.cards.myLpToken.title', [
         props.lockablePoolTokenInfo?.symbol
       ]),
       value: isWalletReady.value
         ? fNum2(fiatTotal.value, FNumFormats.fiat)
+        : '—',
+      secondaryText: isWalletReady.value
+        ? fNum2(bptBalance.value, FNumFormats.token)
         : '—',
       showPlusIcon: isWalletReady.value ? true : false,
       plusIconTo: {
@@ -101,11 +104,14 @@ const cards = computed(() => {
     },
     {
       id: 'myLockedLpToken',
-      label: t('veBAL.myVeBAL.cards.myLockedLpToken', [
+      label: t('veBAL.myVeBAL.cards.myLockedLpToken.title', [
         props.lockablePoolTokenInfo?.symbol
       ]),
-      value: hasExistingLock
+      value: isWalletReady.value
         ? fNum2(lockedFiatTotal.value, FNumFormats.fiat)
+        : '—',
+      secondaryText: isWalletReady.value
+        ? fNum2(props.veBalLockInfo?.lockedAmount ?? '0', FNumFormats.token)
         : '—',
       showPlusIcon: isWalletReady.value ? true : false,
       plusIconTo: { name: 'get-vebal', query: { returnRoute: 'vebal' } },
@@ -113,14 +119,34 @@ const cards = computed(() => {
     },
     {
       id: 'lockedEndDate',
-      label: t('veBAL.myVeBAL.cards.lockedEndDate'),
+      label: t('veBAL.myVeBAL.cards.lockedEndDate.title'),
       value: lockedUntil.value,
+      secondaryText:
+        hasExistingLock && !isExpired
+          ? t('veBAL.myVeBAL.cards.lockedEndDate.secondaryText', [
+              differenceInDays(new Date(lockedUntil.value), new Date())
+            ])
+          : '-',
       showPlusIcon: hasExistingLock ? true : false,
       plusIconTo: { name: 'get-vebal', query: { returnRoute: 'vebal' } }
     },
     {
       id: 'myVeBAL',
-      label: t('veBAL.myVeBAL.cards.myVeBAL'),
+      label: t('veBAL.myVeBAL.cards.myVeBAL.title'),
+      secondaryText:
+        hasExistingLock && !isExpired
+          ? t('veBAL.myVeBAL.cards.myVeBAL.secondaryText', [
+              fNum2(
+                bnum(veBalBalance.value)
+                  .div(props.veBalLockInfo.totalSupply)
+                  .toString(),
+                {
+                  style: 'percent',
+                  maximumFractionDigits: 4
+                }
+              )
+            ])
+          : '-',
       showPlusIcon: false,
       value: hasExistingLock
         ? fNum2(veBalBalance.value, FNumFormats.token)
@@ -153,6 +179,7 @@ const cards = computed(() => {
         </router-link>
       </span>
     </div>
+    <div class="secondary-value">{{ card.secondaryText }}</div>
   </BalCard>
   <teleport to="#modal">
     <UnlockPreviewModal
@@ -172,6 +199,10 @@ const cards = computed(() => {
   @apply text-sm text-gray-500 font-medium mb-2;
 }
 .value {
-  @apply text-xl font-medium truncate flex items-center justify-between;
+  @apply text-xl font-medium truncate flex items-center justify-between mb-1;
+}
+
+.secondary-value {
+  @apply text-gray-400 dark:text-gray-500;
 }
 </style>

--- a/src/components/contextual/pages/vebal/MyVeBAL/components/MyVeBalCards.vue
+++ b/src/components/contextual/pages/vebal/MyVeBAL/components/MyVeBalCards.vue
@@ -86,7 +86,7 @@ const cards = computed(() => {
   return [
     {
       id: 'myLpToken',
-      label: t('veBAL.myVeBAL.cards.myLpToken.title', [
+      label: t('veBAL.myVeBAL.cards.myLpToken.label', [
         props.lockablePoolTokenInfo?.symbol
       ]),
       value: isWalletReady.value
@@ -104,7 +104,7 @@ const cards = computed(() => {
     },
     {
       id: 'myLockedLpToken',
-      label: t('veBAL.myVeBAL.cards.myLockedLpToken.title', [
+      label: t('veBAL.myVeBAL.cards.myLockedLpToken.label', [
         props.lockablePoolTokenInfo?.symbol
       ]),
       value: isWalletReady.value
@@ -119,7 +119,7 @@ const cards = computed(() => {
     },
     {
       id: 'lockedEndDate',
-      label: t('veBAL.myVeBAL.cards.lockedEndDate.title'),
+      label: t('veBAL.myVeBAL.cards.lockedEndDate.label'),
       value: lockedUntil.value,
       secondaryText:
         hasExistingLock && !isExpired
@@ -132,7 +132,7 @@ const cards = computed(() => {
     },
     {
       id: 'myVeBAL',
-      label: t('veBAL.myVeBAL.cards.myVeBAL.title'),
+      label: t('veBAL.myVeBAL.cards.myVeBAL.label'),
       secondaryText:
         hasExistingLock && !isExpired
           ? t('veBAL.myVeBAL.cards.myVeBAL.secondaryText', [

--- a/src/locales/default.json
+++ b/src/locales/default.json
@@ -645,10 +645,20 @@
         "myVeBAL": {
             "title": "My veBAL",
             "cards": {
-                "myLpToken": "My {0}",
-                "myLockedLpToken": "My locked {0}",
-                "lockedEndDate": "Locked until",
-                "myVeBAL": "My veBAL"
+                "myLpToken": {
+                    "title": "My {0}"
+                },
+                "myLockedLpToken": {
+                    "title": "My locked {0}"
+                },
+                "lockedEndDate": {
+                    "title": "Locked until",
+                    "secondaryText": "{0} days"
+                },
+                "myVeBAL": {
+                    "title": "My veBAL",
+                    "secondaryText": "{0} of all veBAL"
+                }
             }
         },
         "communityVeBAL": {

--- a/src/locales/default.json
+++ b/src/locales/default.json
@@ -646,17 +646,17 @@
             "title": "My veBAL",
             "cards": {
                 "myLpToken": {
-                    "title": "My {0}"
+                    "label": "My {0}"
                 },
                 "myLockedLpToken": {
-                    "title": "My locked {0}"
+                    "label": "My locked {0}"
                 },
                 "lockedEndDate": {
-                    "title": "Locked until",
+                    "label": "Locked until",
                     "secondaryText": "{0} days"
                 },
                 "myVeBAL": {
-                    "title": "My veBAL",
+                    "label": "My veBAL",
                     "secondaryText": "{0} of all veBAL"
                 }
             }


### PR DESCRIPTION
# Description

Adds secondary text / aligns behaviour with https://github.com/balancer-labs/frontend-v2/issues/1699

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## How should this be tested?

Please provide instructions so we can test. Please also list any relevant details for your test configuration.

- [ ] VeBAL Cards should align with the design

## Visual context

Please provide any relevant visual context for UI changes or additions. This could be static screenshots or a loom screencast.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have requested at least 2 reviews (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] If package-lock.json has changes, it was intentional.
- [x] The base of this PR is `master` if hotfix, `develop` if not
