### PR TITLE
Hotfix: Fetch gauge weights in a more accurate way

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.49.11",
+  "version": "1.49.12",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@balancer-labs/frontend-v2",
-      "version": "1.49.11",
+      "version": "1.49.12",
       "license": "MIT",
       "devDependencies": {
         "@aave/protocol-js": "^4.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.49.11",
+  "version": "1.49.12",
   "engines": {
     "node": "14.x",
     "npm": ">=7"

--- a/src/lib/abi/GaugeController.json
+++ b/src/lib/abi/GaugeController.json
@@ -298,23 +298,6 @@
       {
         "name": "addr",
         "type": "address"
-      }
-    ],
-    "outputs": [
-      {
-        "name": "",
-        "type": "uint256"
-      }
-    ]
-  },
-  {
-    "stateMutability": "nonpayable",
-    "type": "function",
-    "name": "gauge_relative_weight_write",
-    "inputs": [
-      {
-        "name": "addr",
-        "type": "address"
       },
       {
         "name": "time",


### PR DESCRIPTION
# Description

Change fetching of gauge weights to use the function `gauge_relative_weight_write` which does a checkpoint on the gauge first to ensure it's weight is accurate for the week. Without the checkpoint weights aren't updated until a user votes on that specific gauge. 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## How should this be tested?

View the veBAL gauges page, it should be similar to production but with many more of the gauge weights filled in instead of being 0. 

## Visual context

Production on left, local testing against mainnet on right

![2022-04-21-230727_2363x1858_scrot](https://user-images.githubusercontent.com/525534/164464595-1400c61f-b61a-4e80-9842-5a004b148878.png)


## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have requested at least 2 reviews (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] If package-lock.json has changes, it was intentional.
- [x] The base of this PR is `master` if hotfix, `develop` if not
