### PR TITLE
fix: staking incentive card infinite loading bug

### DIFF
--- a/src/components/contextual/pages/pool/StakingIncentivesCard/StakingIncentivesCard.vue
+++ b/src/components/contextual/pages/pool/StakingIncentivesCard/StakingIncentivesCard.vue
@@ -225,10 +225,7 @@ async function handleActionSuccess() {
   </AnimatePresence>
   <AnimatePresence
     :isVisible="
-      isLoadingStakedShares ||
-        isStakedSharesIdle ||
-        isLoadingPoolEligibility ||
-        isLoadingBoosts
+      isLoadingStakedShares || isLoadingPoolEligibility || isLoadingBoosts
     "
     unmountInstantly
   >


### PR DESCRIPTION
# Description

Loading condition broken for staking incentives card when wallet not connected.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## How should this be tested?

When wallet not loaded, the card should not be visible

## Visual context

N/A

## Checklist:

- [X] I have performed a self-review of my own code
- [X] I have requested at least 2 reviews (If the PR is significant enough, use best judgement here)
- [X] I have commented my code where relevant, particularly in hard-to-understand areas
- [X] If package-lock.json has changes, it was intentional.
- [X] The base of this PR is `master` if hotfix, `develop` if not
