### PR TITLE
Hotfix - table vote btn

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.51.1",
+  "version": "1.51.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@balancer-labs/frontend-v2",
-      "version": "1.51.1",
+      "version": "1.51.2",
       "license": "MIT",
       "devDependencies": {
         "@aave/protocol-js": "^4.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.51.1",
+  "version": "1.51.2",
   "engines": {
     "node": "14.x",
     "npm": ">=7"

--- a/src/components/contextual/pages/vebal/LMVoting/GaugesTable.vue
+++ b/src/components/contextual/pages/vebal/LMVoting/GaugesTable.vue
@@ -158,10 +158,6 @@ function redirectToPool(gauge: VotingGaugeWithVotes) {
       :columns="columns"
       :data="data"
       :is-loading="isLoading"
-      :link="{
-        to: 'pool',
-        getParams: gauge => ({ id: gauge?.pool?.id })
-      }"
       skeleton-class="h-64"
       sticky="both"
       :square="upToLargeBreakpoint"
@@ -218,7 +214,7 @@ function redirectToPool(gauge: VotingGaugeWithVotes) {
         </div>
       </template>
       <template v-slot:voteColumnCell="gauge">
-        <div v-if="isWalletReady" class="px-4">
+        <div v-if="isWalletReady" class="px-4" @click.stop>
           <BalBtn
             color="blue"
             :outline="true"

--- a/src/components/contextual/pages/vebal/LMVoting/GaugesTable.vue
+++ b/src/components/contextual/pages/vebal/LMVoting/GaugesTable.vue
@@ -214,7 +214,7 @@ function redirectToPool(gauge: VotingGaugeWithVotes) {
         </div>
       </template>
       <template v-slot:voteColumnCell="gauge">
-        <div v-if="isWalletReady" class="px-4" @click.stop>
+        <div v-if="isWalletReady" class="px-4">
           <BalBtn
             color="blue"
             :outline="true"


### PR DESCRIPTION
# Description

Following the BalTable refactor it looks like something broke the click.stop event handler when you use the :link prop BalTable. This PR removes that link prop from the GaugesTable so that the vote button opens the modal rather than redirecting to the pool page.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## How should this be tested?

- [ ] Test that on clicking the vote button the modal opens.

## Visual context

n/a

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have requested at least 2 reviews (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] If package-lock.json has changes, it was intentional.
- [x] The base of this PR is `master` if hotfix, `develop` if not
