### PR TITLE
Fix underflow/overflow rounding errors when transacting

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.51.2",
+  "version": "1.51.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@balancer-labs/frontend-v2",
-      "version": "1.51.2",
+      "version": "1.51.3",
       "license": "MIT",
       "devDependencies": {
         "@aave/protocol-js": "^4.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.51.2",
+  "version": "1.51.3",
   "engines": {
     "node": "14.x",
     "npm": ">=7"

--- a/src/services/gas-price/providers/blocknative.provider.spec.node.ts
+++ b/src/services/gas-price/providers/blocknative.provider.spec.node.ts
@@ -1,0 +1,45 @@
+import nock from 'nock';
+
+import BlocknativeProvider from './blocknative.provider';
+
+const defaultResponse = {
+  blockPrices: [
+    {
+      estimatedPrices: [
+        {
+          confidence: 70,
+          price: 32.12,
+          maxFeePerGas: 32.12,
+          maxPriorityFeePerGas: 1.5
+        },
+        {
+          confidence: 90,
+          price: 66.15,
+          maxFeePerGas: 66.15,
+          maxPriorityFeePerGas: 1.5
+        }
+      ]
+    }
+  ]
+};
+
+describe('Blocknative Provider', () => {
+  const blocknativeProvider = new BlocknativeProvider();
+
+  beforeEach(() => {
+    nock('https://api.blocknative.com')
+      .options('/gasprices/blockprices')
+      .reply(200);
+
+    nock('https://api.blocknative.com')
+      .get('/gasprices/blockprices')
+      .reply(200, defaultResponse);
+  });
+
+  it('Should not return gas values with rounding errors', async () => {
+    const response = await blocknativeProvider.getLatest();
+    expect(response?.price).toEqual(32120000000);
+    expect(response?.maxFeePerGas).toEqual(32120000000);
+    expect(response?.maxPriorityFeePerGas).toEqual(1500000000);
+  });
+});

--- a/src/services/gas-price/providers/blocknative.provider.ts
+++ b/src/services/gas-price/providers/blocknative.provider.ts
@@ -70,9 +70,11 @@ export default class BlocknativeProvider {
       // gas price is in gwei
       if (gasPrice != null) {
         return {
-          price: gasPrice.price * GWEI_UNIT,
-          maxFeePerGas: gasPrice.maxFeePerGas * GWEI_UNIT,
-          maxPriorityFeePerGas: gasPrice.maxPriorityFeePerGas * GWEI_UNIT
+          price: Math.round(gasPrice.price * GWEI_UNIT),
+          maxFeePerGas: Math.round(gasPrice.maxFeePerGas * GWEI_UNIT),
+          maxPriorityFeePerGas: Math.round(
+            gasPrice.maxPriorityFeePerGas * GWEI_UNIT
+          )
         };
       }
     } catch (e) {


### PR DESCRIPTION
# Description

The underflow errors we're seeing when transacting are because of Javascript floating point rounding issues when multiplying numbers together. Specifically when we're converting the gwei gas estimations to wei values. 

Added a test to reproduce the issue with certain gas values and a fix for it. 

Fixes #1687

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## Visual context

Please provide any relevant visual context for UI changes or additions. This could be static screenshots or a loom screencast.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have requested at least 2 reviews (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] If package-lock.json has changes, it was intentional.
- [x] The base of this PR is `master` if hotfix, `develop` if not
