### PR TITLE
Add explorer link for pools

### DIFF
--- a/src/pages/pool/_id.vue
+++ b/src/pages/pool/_id.vue
@@ -48,7 +48,7 @@
               <BalIcon
                 name="arrow-up-right"
                 size="sm"
-                class="ml-1 mt-1 text-gray-500 hover:text-blue-500 transition-colors"
+                class="ml-2 mt-2 text-gray-500 hover:text-blue-500 transition-colors"
               />
             </BalLink>
           </div>

--- a/src/pages/pool/_id.vue
+++ b/src/pages/pool/_id.vue
@@ -39,6 +39,18 @@
               {{ $t('new') }}
             </BalChip>
             <LiquidityAPRTooltip :pool="pool" class="-ml-1 mt-1" />
+            <BalLink
+              :href="explorer.addressLink(pool.address)"
+              external
+              noStyle
+              class="flex items-center"
+            >
+              <BalIcon
+                name="arrow-up-right"
+                size="sm"
+                class="ml-1 mt-1 text-gray-500 hover:text-blue-500 transition-colors"
+              />
+            </BalLink>
           </div>
           <div class="flex items-center mt-2">
             <div v-html="poolFeeLabel" class="text-sm text-gray-600 mr-2" />
@@ -197,7 +209,7 @@ export default defineComponent({
     const { t } = useI18n();
     const route = useRoute();
     const { fNum2 } = useNumbers();
-    const { isWalletReady } = useWeb3();
+    const { explorerLinks, isWalletReady } = useWeb3();
     const { prices } = useTokens();
     const { blockNumber, isKovan, isMainnet, isPolygon } = useWeb3();
     const { addAlert, removeAlert } = useAlerts();
@@ -404,6 +416,7 @@ export default defineComponent({
       // computed
       appLoading,
       pool,
+      explorer: explorerLinks,
       noInitLiquidity,
       poolTypeLabel,
       poolFeeLabel,


### PR DESCRIPTION
# Description

We get a lot of requests for how to find the pool address on the website in the discord. Having to explain to nontechnical users that they need to take the first bit of the url and then paste that into a block explorer is not great, ideally we'd have a simple button like we do in the pool tokens table.

Please feel free to tweak CSS as it looks a teensy bit wonky.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## How should this be tested?

Go to a pool page on each network and click the arrow button next to the pool title.

## Visual context

![image](https://user-images.githubusercontent.com/15848336/165797531-0a99d2e7-836b-40e0-9859-a046891ca284.png)

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have requested at least 2 reviews (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] If package-lock.json has changes, it was intentional.
- [x] The base of this PR is `master` if hotfix, `develop` if not
