### PR TITLE
feat: remove loading for unconnected wallets

### DIFF
--- a/src/components/contextual/pages/vebal/MyVeBAL/MyVeBAL.vue
+++ b/src/components/contextual/pages/vebal/MyVeBAL/MyVeBAL.vue
@@ -25,7 +25,7 @@ const { isWalletReady } = useWeb3();
 const isLoading = computed(() =>
   isWalletReady.value
     ? isLoadingLockPool.value || isLoadingLockInfo.value
-    : isLoadingLockPool.value
+    : false
 );
 </script>
 

--- a/src/components/contextual/pages/vebal/MyVeBAL/components/MyVeBalCards.vue
+++ b/src/components/contextual/pages/vebal/MyVeBAL/components/MyVeBalCards.vue
@@ -86,9 +86,7 @@ const cards = computed(() => {
   return [
     {
       id: 'myLpToken',
-      label: t('veBAL.myVeBAL.cards.myLpToken.label', [
-        props.lockablePoolTokenInfo?.symbol
-      ]),
+      label: t('veBAL.myVeBAL.cards.myLpToken.label'),
       value: isWalletReady.value
         ? fNum2(fiatTotal.value, FNumFormats.fiat)
         : '—',
@@ -104,9 +102,7 @@ const cards = computed(() => {
     },
     {
       id: 'myLockedLpToken',
-      label: t('veBAL.myVeBAL.cards.myLockedLpToken.label', [
-        props.lockablePoolTokenInfo?.symbol
-      ]),
+      label: t('veBAL.myVeBAL.cards.myLockedLpToken.label'),
       value: isWalletReady.value
         ? fNum2(lockedFiatTotal.value, FNumFormats.fiat)
         : '—',

--- a/src/locales/default.json
+++ b/src/locales/default.json
@@ -649,10 +649,10 @@
             "title": "My veBAL",
             "cards": {
                 "myLpToken": {
-                    "label": "My 80BAL-20WETH"
+                    "label": "My B-80BAL-20WETH"
                 },
                 "myLockedLpToken": {
-                    "label": "My locked 80BAL-20WETH"
+                    "label": "My locked B-80BAL-20WETH"
                 },
                 "lockedEndDate": {
                     "label": "Locked until",

--- a/src/locales/default.json
+++ b/src/locales/default.json
@@ -649,10 +649,10 @@
             "title": "My veBAL",
             "cards": {
                 "myLpToken": {
-                    "label": "My {0}"
+                    "label": "My 80BAL-20WETH"
                 },
                 "myLockedLpToken": {
-                    "label": "My locked {0}"
+                    "label": "My locked 80BAL-20WETH"
                 },
                 "lockedEndDate": {
                     "label": "Locked until",


### PR DESCRIPTION
# Description

Speeds up loading of the "My veBAL" cards for unconnected wallets by hardcoding the pool name in the translation file.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## How should this be tested?

Please provide instructions so we can test. Please also list any relevant details for your test configuration.

- [ ] Open the veBAL page with an unconnected wallet - should show the cards instantly.

## Visual context

Please provide any relevant visual context for UI changes or additions. This could be static screenshots or a loom screencast.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have requested at least 2 reviews (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] If package-lock.json has changes, it was intentional.
- [x] The base of this PR is `master` if hotfix, `develop` if not
