### PR TITLE
Show warning when veBAL gauge is over 10% vote

### DIFF
--- a/src/components/contextual/pages/vebal/LMVoting/GaugeVoteModal.vue
+++ b/src/components/contextual/pages/vebal/LMVoting/GaugeVoteModal.vue
@@ -18,6 +18,7 @@ import {
 import useTransactions from '@/composables/useTransactions';
 import useVeBal from '@/composables/useVeBAL';
 import { WEIGHT_VOTE_DELAY } from '@/constants/gauge-controller';
+import { VEBAL_VOTING_GAUGE } from '@/constants/voting-gauges';
 import { bnum, scale } from '@/lib/utils';
 import { isPositive } from '@/lib/utils/validations';
 import { VeBalLockInfo } from '@/services/balancer/contracts/contracts/veBAL';
@@ -144,6 +145,24 @@ const veBalLockTooShortWarning = computed(() => {
   return null;
 });
 
+const veBalVoteOverLimitWarning = computed(() => {
+  if (props.gauge.address === VEBAL_VOTING_GAUGE?.address) {
+    const gaugeVoteWeightNormalized = scale(props.gauge.votesNextPeriod, -18);
+    if (gaugeVoteWeightNormalized.gte(bnum('0.1'))) {
+      return {
+        title: t(
+          'veBAL.liquidityMining.popover.warnings.veBalVoteOverLimitWarning.title'
+        ),
+        description: t(
+          'veBAL.liquidityMining.popover.warnings.veBalVoteOverLimitWarning.description'
+        )
+      };
+    }
+  }
+
+  return null;
+});
+
 const voteWarning = computed((): {
   title: string;
   description: string;
@@ -151,6 +170,7 @@ const voteWarning = computed((): {
   if (votedToRecentlyWarning.value) return votedToRecentlyWarning.value;
   if (noVeBalWarning.value) return noVeBalWarning.value;
   if (veBalLockTooShortWarning.value) return veBalLockTooShortWarning.value;
+  if (veBalVoteOverLimitWarning.value) return veBalVoteOverLimitWarning.value;
   return null;
 });
 

--- a/src/constants/voting-gauges.ts
+++ b/src/constants/voting-gauges.ts
@@ -24,3 +24,7 @@ export const KOVAN_VOTING_GAUGES: VotingGauge[] = (ALL_VOTING_GAUGES as VotingGa
 export const MAINNET_VOTING_GAUGES: VotingGauge[] = (ALL_VOTING_GAUGES as VotingGauge[]).filter(
   gauge => gauge.network !== Network.KOVAN
 );
+
+export const VEBAL_VOTING_GAUGE: VotingGauge | undefined = (ALL_VOTING_GAUGES as VotingGauge[]).find(
+  gauge => gauge.pool.symbol === "veBAL"
+);

--- a/src/locales/default.json
+++ b/src/locales/default.json
@@ -733,6 +733,10 @@
                     "veBalLockTooShort": {
                         "title": "veBAL not locked for 7 days.",
                         "description": "You must have veBAL locked for more than 7 days to vote on gagues."
+                    },
+                    "veBalVoteOverLimitWarning": {
+                        "title": "You may be wasting your vote: veBAL cap hit",
+                        "description": "Distributions to veBAL holders of weekly emissions are capped at 10%. Any votes exceeding this amount at Thursday 0:00 UTC will not be counted."
                     }
                 },
                 "errors": {


### PR DESCRIPTION
# Description

Show a warning discouraging people from voting when the veBAL gauge is over 10% next week. 

Fix #1807

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## How should this be tested?

- Visit the vebal page
- Attempt to vote for the veBAL gauge, notice the warning that appears (only one warning appears at a time, so you need to view from an account that has veBAL locked)

## Visual context

![2022-04-29-171249_487x453_scrot](https://user-images.githubusercontent.com/525534/165899883-a7c2195c-80bd-45b3-9e11-66f7c04954d2.png)

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have requested at least 2 reviews (If the PR is significant enough, use best judgement here)
- [ ] I have commented my code where relevant, particularly in hard-to-understand areas
- [ ] If package-lock.json has changes, it was intentional.
- [ ] The base of this PR is `master` if hotfix, `develop` if not
