### PR TITLE
Hotfix: Fix trade value snapping

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.51.6",
+  "version": "1.51.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@balancer-labs/frontend-v2",
-      "version": "1.51.6",
+      "version": "1.51.7",
       "license": "MIT",
       "devDependencies": {
         "@aave/protocol-js": "^4.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.51.6",
+  "version": "1.51.7",
   "engines": {
     "node": "14.x",
     "npm": ">=7"

--- a/src/composables/trade/useSor.ts
+++ b/src/composables/trade/useSor.ts
@@ -1,7 +1,11 @@
 import { SubgraphPoolBase, SwapType, SwapTypes } from '@balancer-labs/sdk';
 import { Pool } from '@balancer-labs/sor/dist/types';
 import { BigNumber, formatFixed, parseFixed } from '@ethersproject/bignumber';
-import { WeiPerEther as ONE, Zero } from '@ethersproject/constants';
+import {
+  AddressZero,
+  WeiPerEther as ONE,
+  Zero
+} from '@ethersproject/constants';
 import { TransactionResponse } from '@ethersproject/providers';
 import { BigNumber as OldBigNumber } from 'bignumber.js';
 import { formatUnits, parseUnits } from 'ethers/lib/utils';
@@ -16,6 +20,7 @@ import {
 } from 'vue';
 import { useI18n } from 'vue-i18n';
 
+import { NATIVE_ASSET_ADDRESS } from '@/constants/tokens';
 import { balancer } from '@/lib/balancer.sdk';
 import { bnum, scale } from '@/lib/utils';
 import {
@@ -209,9 +214,25 @@ export default function useSor({
         const tokenInDecimals = getTokenDecimals(tokenInAddressInput.value);
         const tokenOutDecimals = getTokenDecimals(tokenOutAddressInput.value);
 
+        const tokenInAddress =
+          tokenInAddressInput.value === NATIVE_ASSET_ADDRESS
+            ? AddressZero
+            : tokenInAddressInput.value;
+        const tokenOutAddress =
+          tokenOutAddressInput.value === NATIVE_ASSET_ADDRESS
+            ? AddressZero
+            : tokenOutAddressInput.value;
+
+        const tokenInPosition = result.tokenAddresses.indexOf(
+          tokenInAddress.toLowerCase()
+        );
+        const tokenOutPosition = result.tokenAddresses.indexOf(
+          tokenOutAddress.toLowerCase()
+        );
+
         const tokenInAmountNormalised = bnum(
           formatFixed(
-            bnum(deltas[0])
+            bnum(deltas[tokenInPosition])
               .abs()
               .toString(),
             tokenInDecimals
@@ -220,7 +241,7 @@ export default function useSor({
 
         const tokenOutAmountNormalised = bnum(
           formatFixed(
-            bnum(deltas[deltas.length - 1])
+            bnum(deltas[tokenOutPosition])
               .abs()
               .toString(),
             tokenOutDecimals

--- a/src/composables/trade/useSor.ts
+++ b/src/composables/trade/useSor.ts
@@ -200,6 +200,11 @@ export default function useSor({
         assets: result.tokenAddresses
       });
 
+      if (result !== sorReturn.value.result) {
+        // sorReturn was updated while we were querying, abort to not show stale data.
+        return;
+      }
+
       if (deltas.length >= 2) {
         const tokenInDecimals = getTokenDecimals(tokenInAddressInput.value);
         const tokenOutDecimals = getTokenDecimals(tokenOutAddressInput.value);


### PR DESCRIPTION
# Description

On the trading screen when changing the input value sometimes the output was snapping to either 0 or the return value for the previous inputted amount. See: https://www.loom.com/share/639dc0d752d44fc7b65304704e41a2f2 /cc @zekraken-bot 

This is a race condition between:
- A new block comes in, which calls https://github.com/balancer-labs/frontend-v2/blob/develop/src/composables/trade/useSor.ts#L196
- While that async call is processing the user changes the value. This causes... 
- SOR recalculates the swap amount here: https://github.com/balancer-labs/frontend-v2/blob/develop/src/composables/trade/useSor.ts#L335 
- This sets the output value to the new amount. 
- Then the async call finishes and sets the value to the old sor return here: https://github.com/balancer-labs/frontend-v2/blob/develop/src/composables/trade/useSor.ts#L215

So I added a check for this race condition and it aborts if it happens. 

The value becoming 0 is happening because SOR is returning the address list (of all tokens involved in the swap) sorted, and when that list is passed into `batchQuerySwap` the first and last items are no longer the input/output tokens. So they correct indexes of those tokens must be found instead. This is also fixed. 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## How should this be tested?

- Open trade UI on Polygon
- Set two tokens
- Continually change the input value and watch the output value change, ensure it isn't snapping between any values or snapping back to a previously calculated output value. 

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have requested at least 2 reviews (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] If package-lock.json has changes, it was intentional.
- [x] The base of this PR is `master` if hotfix, `develop` if not
