### PR TITLE
Hotfix - staking data fetching

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.52.5",
+  "version": "1.52.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@balancer-labs/frontend-v2",
-      "version": "1.52.5",
+      "version": "1.52.6",
       "license": "MIT",
       "devDependencies": {
         "@aave/protocol-js": "^4.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.52.5",
+  "version": "1.52.6",
   "engines": {
     "node": "14.x",
     "npm": ">=7"

--- a/src/providers/local/staking/userUserStakingData.ts
+++ b/src/providers/local/staking/userUserStakingData.ts
@@ -159,7 +159,7 @@ export default function useUserStakingData(
     isRefetching: isRefetchingStakedShares,
     refetch: refetchStakedShares
   } = useQuery<string>(
-    ['staking', 'pool', 'shares'],
+    ['staking', 'pool', 'shares', { poolAddress }],
     () => getStakedShares(),
     reactive({
       enabled: isStakedSharesQueryEnabled,


### PR DESCRIPTION
# Description

The fetching of user-based staking data was not being re-fetched for new pool IDs. I tried logging out `stakedSharesForProvidedPool` on each pool page and it was always the value of the first staked pool I accessed. Weirdly, the staked shares value in the pool page staking card always updated appropriately.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## How should this be tested?

- [ ] Test that staking continues to work as expected

## Visual context

n/a

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have requested at least 2 reviews (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] If package-lock.json has changes, it was intentional.
- [x] The base of this PR is `master` if hotfix, `develop` if not
