### PR TITLE
Hotfix: Fix Table Sorting

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.52.8",
+  "version": "1.52.9",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@balancer-labs/frontend-v2",
-      "version": "1.52.8",
+      "version": "1.52.9",
       "license": "MIT",
       "devDependencies": {
         "@aave/protocol-js": "^4.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.52.8",
+  "version": "1.52.9",
   "engines": {
     "node": "14.x",
     "npm": ">=7"

--- a/src/components/_global/BalTable/BalTable.vue
+++ b/src/components/_global/BalTable/BalTable.vue
@@ -181,7 +181,7 @@ onMounted(() => {
  * COMPUTED
  */
 const unpinnedData = computed(() => {
-  if (!props.pin) return props.data;
+  if (!props.pin) return tableData.value;
   return (tableData.value || []).filter(
     data => !props.pin?.pinnedData.includes(data[props.pin.pinOn])
   );


### PR DESCRIPTION
# Description

Fixes table sorting breaking after the BalTable refactor. Just needed to return the sorted data for the `unpinnedData` computable when no data was pinned. 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## How should this be tested?

- Load Any Balancer Table
- Check that it sorts when clicking column headers
- Ensure pools are sorted by TVL when first loaded

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have requested at least 2 reviews (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] If package-lock.json has changes, it was intentional.
- [x] The base of this PR is `master` if hotfix, `develop` if not
