### PR TITLE
Hotfix - percentage formatting

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.53.0",
+  "version": "1.53.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@balancer-labs/frontend-v2",
-      "version": "1.53.0",
+      "version": "1.53.1",
       "license": "MIT",
       "devDependencies": {
         "@aave/protocol-js": "^4.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.53.0",
+  "version": "1.53.1",
   "engines": {
     "node": "14.x",
     "npm": ">=7"

--- a/src/composables/useNumbers.spec.ts
+++ b/src/composables/useNumbers.spec.ts
@@ -283,7 +283,7 @@ describe('useNumbers', () => {
     });
 
     it('Should return < 0.01% if percent is between 0 and 0.01', () => {
-      const formattedNumber = fNum2('0.001', FNumFormats.percent);
+      const formattedNumber = fNum2('0.00009', FNumFormats.percent);
       expect(formattedNumber).toEqual('< 0.01%');
     });
   });

--- a/src/composables/useNumbers.ts
+++ b/src/composables/useNumbers.ts
@@ -146,7 +146,7 @@ export default function useNumbers() {
       }
       formatterOptions.useGrouping = false;
 
-      if (number > 0 && number < 0.01) {
+      if (number > 0 && number < 0.0001) {
         return '< 0.01%';
       }
     }


### PR DESCRIPTION
# Description

I accidentally set the percentage formatting for very small numbers to the unscaled target cutoff of 0.01 for 0.01% instead of 0.0001. This PR reverts that mistake.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## How should this be tested?

- [ ] Test small percentage gauges on the veBAL page present the vote percentage correctly down to 0.01%.

## Visual context

n/a

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have requested at least 2 reviews (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] If package-lock.json has changes, it was intentional.
- [x] The base of this PR is `master` if hotfix, `develop` if not
