### PR TITLE
Hotfix - aave aprs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.53.1",
+  "version": "1.53.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@balancer-labs/frontend-v2",
-      "version": "1.53.1",
+      "version": "1.53.2",
       "license": "MIT",
       "devDependencies": {
         "@aave/protocol-js": "^4.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.53.1",
+  "version": "1.53.2",
   "engines": {
     "node": "14.x",
     "npm": ">=7"

--- a/src/services/aave/aave.service.ts
+++ b/src/services/aave/aave.service.ts
@@ -82,6 +82,10 @@ export default class AaveService {
         // Grabs the matching wrapped which generates the yield
         const wrappedToken = wrappedTokens[tokenIndex];
         const mainToken = mainTokens[tokenIndex];
+        const linearPoolAddress = pool.tokenAddresses[tokenIndex];
+        const linearPoolToken = pool.tokens.find(
+          token => token.address === linearPoolAddress
+        );
         const linearPoolTotalSupply = formatUnits(
           linearPoolTotalSupplies[tokenIndex],
           18
@@ -90,8 +94,7 @@ export default class AaveService {
         if (prices[mainToken] != null && linearPoolTotalSupply) {
           const price = prices[mainToken][currency] || 0;
           const balance = wrappedTokenBalances[tokenIndex];
-          const linearPoolBalance =
-            pool?.linearPoolTokensMap?.[wrappedToken].balance || '0';
+          const linearPoolBalance = linearPoolToken?.balance || '0';
           const linearPoolShare = bnum(linearPoolBalance).div(
             linearPoolTotalSupply
           );

--- a/src/services/aave/aave.service.ts
+++ b/src/services/aave/aave.service.ts
@@ -1,10 +1,12 @@
 import { getAddress } from '@ethersproject/address';
+import { formatUnits } from '@ethersproject/units';
 
 import { FiatCurrency } from '@/constants/currency';
 import { bnum } from '@/lib/utils';
 import { TokenPrices } from '@/services/coingecko/api/price.service';
 
 import { Pool } from '../balancer/subgraph/types';
+import { ERC20Multicaller } from '../multicalls/erc20.multicaller';
 import AaveSubgraphService, {
   aaveSubgraphService
 } from './subgraph/aave-subgraph.service';
@@ -21,7 +23,7 @@ export default class AaveService {
     prices: TokenPrices,
     currency: FiatCurrency
   ) {
-    const { mainTokens, wrappedTokens, onchain, linearPoolTokensMap } = pool;
+    const { mainTokens, wrappedTokens, linearPoolTokensMap } = pool;
 
     const wrappedTokenBalances = wrappedTokens?.map(
       token => linearPoolTokensMap?.[token].balance || ''
@@ -29,17 +31,35 @@ export default class AaveService {
     const hasAllWrappedTokenBalances =
       wrappedTokenBalances && wrappedTokenBalances.every(balance => !!balance);
 
+    const multicaller = new ERC20Multicaller();
+
+    wrappedTokens?.forEach((address, i) => {
+      multicaller.call(`unwrappedAave[${i}]`, address, 'ATOKEN');
+      multicaller.call(`unwrappedERC4626[${i}]`, address, 'asset');
+      multicaller.call(
+        `linearPoolTotalSupplies[${i}]`,
+        pool.tokensList[i],
+        'getVirtualSupply'
+      );
+    });
+
+    const {
+      unwrappedAave,
+      unwrappedERC4626,
+      linearPoolTotalSupplies
+    } = await multicaller.execute();
+
+    const unwrappedTokens = wrappedTokens?.map((_, i) => {
+      return (unwrappedAave[i] || unwrappedERC4626[i]).toLowerCase();
+    });
+
     if (
       !mainTokens ||
       !wrappedTokens ||
-      !onchain?.linearPools ||
+      !unwrappedTokens ||
       !hasAllWrappedTokenBalances
     )
       return { total: '0', breakdown: {} };
-
-    const unwrappedTokens = Object.values(
-      onchain?.linearPools
-    ).map(linearPool => linearPool.unwrappedTokenAddress.toLocaleLowerCase());
 
     let total = bnum(0);
     const breakdown: Record<string, string> = {};
@@ -62,16 +82,18 @@ export default class AaveService {
         // Grabs the matching wrapped which generates the yield
         const wrappedToken = wrappedTokens[tokenIndex];
         const mainToken = mainTokens[tokenIndex];
-        const linearPoolAddress = pool.tokenAddresses[tokenIndex];
-        const linearPool = pool.onchain?.linearPools?.[linearPoolAddress];
+        const linearPoolTotalSupply = formatUnits(
+          linearPoolTotalSupplies[tokenIndex],
+          18
+        );
 
-        if (prices[mainToken] != null && linearPool) {
+        if (prices[mainToken] != null && linearPoolTotalSupply) {
           const price = prices[mainToken][currency] || 0;
           const balance = wrappedTokenBalances[tokenIndex];
           const linearPoolBalance =
-            pool.onchain?.tokens[linearPoolAddress].balance || '0';
+            pool?.linearPoolTokensMap?.[wrappedToken].balance || '0';
           const linearPoolShare = bnum(linearPoolBalance).div(
-            linearPool.totalSupply
+            linearPoolTotalSupply
           );
           const actualBalance = bnum(balance).times(linearPoolShare);
           const value = bnum(actualBalance).times(price);

--- a/src/services/multicalls/erc20.multicaller.ts
+++ b/src/services/multicalls/erc20.multicaller.ts
@@ -1,0 +1,39 @@
+import {
+  InvestmentPool__factory,
+  StablePool__factory,
+  WeightedPool__factory
+} from '@balancer-labs/typechain';
+
+import ERC20_ABI from '@/lib/abi/ERC20.json';
+import IERC4626 from '@/lib/abi/IERC4626.json';
+import LinearPoolAbi from '@/lib/abi/LinearPool.json';
+import StablePhantomPool from '@/lib/abi/StablePhantomPool.json';
+import StaticATokenLMAbi from '@/lib/abi/StaticATokenLM.json';
+import { Multicaller } from '@/lib/utils/balancer/contract';
+
+import { configService } from '../config/config.service';
+import { rpcProviderService } from '../rpc-provider/rpc-provider.service';
+
+const ERC20ABIs = Object.values(
+  Object.fromEntries(
+    [
+      ...WeightedPool__factory.abi,
+      ...StablePool__factory.abi,
+      ...InvestmentPool__factory.abi,
+      ...StablePhantomPool,
+      ...LinearPoolAbi,
+      ...StaticATokenLMAbi,
+      ...ERC20_ABI,
+      ...IERC4626
+    ].map(row => [row.name, row])
+  )
+);
+
+export class ERC20Multicaller extends Multicaller {
+  constructor(
+    private readonly config = configService,
+    private readonly jsonProvider = rpcProviderService.jsonProvider
+  ) {
+    super(config.network.key, jsonProvider, ERC20ABIs);
+  }
+}


### PR DESCRIPTION
# Description

Currently, the Aave boosted APRs are only being displayed onm the pool page and not in the pool list. This is because the existing calculation for the boosted APR was dependent on onchain pool data which we only fetch for individual pools and not for every pool in the pools list.

This PR refactors the Aave boosted APR calculation so it's not reliant on that external onchain data being fetched. Unfortunately, this means we need to do onchain calls just to fetch this additional info in the APR calculation. However, each linear pool APR calculation should be as isolated as possible anyway so that we can migrate to a more generic solution soon so it would need to be refactored in a similar way anyway.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## How should this be tested?

- [ ] Test that aave boosted APRs show in the pools list and on the boosted pool page
- [ ] Test that the aave APRs make sense compared to existing APRs displayed in production.

## Visual context

n/a

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have requested at least 2 reviews (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] If package-lock.json has changes, it was intentional.
- [x] The base of this PR is `master` if hotfix, `develop` if not
