### PR TITLE
Hotfix - Jazzicon fix 2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.53.7",
+  "version": "1.53.8",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@balancer-labs/frontend-v2",
-      "version": "1.53.7",
+      "version": "1.53.8",
       "license": "MIT",
       "devDependencies": {
         "@aave/protocol-js": "^4.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.53.7",
+  "version": "1.53.8",
   "engines": {
     "node": "14.x",
     "npm": ">=7"

--- a/src/components/images/Avatar.vue
+++ b/src/components/images/Avatar.vue
@@ -1,3 +1,54 @@
+<script lang="ts" setup>
+import { computed, onMounted, ref, watch } from 'vue';
+
+import useUrls from '@/composables/useUrls';
+
+/**
+ * TYPES
+ */
+type Props = {
+  address: string;
+  iconURI?: string;
+  size?: number;
+};
+
+/**
+ * PROPS & EMITS
+ */
+const props = withDefaults(defineProps<Props>(), {
+  iconURI: '',
+  size: 24
+});
+
+/**
+ * COMPOSABLES
+ */
+const { resolve } = useUrls();
+
+/**
+ * STATE
+ */
+const error = ref(false);
+const isMounted = ref(false);
+
+/**
+ * COMPUTED
+ */
+const iconSRC = computed(() => resolve(props.iconURI));
+
+/**
+ * WATCHERS
+ */
+watch(iconSRC, newURL => {
+  if (newURL !== '') error.value = false;
+});
+
+/**
+ * LIFECYCLE
+ */
+onMounted(() => (isMounted.value = true));
+</script>
+
 <template>
   <img
     v-if="iconSRC && !error"
@@ -18,57 +69,6 @@
       height: `${size}px`
     }"
   >
-    <Jazzicon :address="address" :diameter="size" />
+    <Jazzicon v-if="isMounted" :address="address" :diameter="size" />
   </div>
 </template>
-
-<script>
-import { computed, defineComponent, ref, watch } from 'vue';
-
-import useUrls from '@/composables/useUrls';
-
-export default defineComponent({
-  name: 'Avatar',
-
-  props: {
-    address: {
-      type: String,
-      required: true
-    },
-    iconURI: { type: String },
-    size: {
-      type: Number,
-      default: 24
-    }
-  },
-
-  setup(props) {
-    /**
-     * COMPOSABLES
-     */
-    const { resolve } = useUrls();
-
-    /**
-     * STATE
-     */
-    const error = ref(false);
-
-    /**
-     * COMPUTED
-     */
-    const iconSRC = computed(() => resolve(props.iconURI));
-
-    /**
-     * WATCHERS
-     */
-    watch(iconSRC, newURL => {
-      if (newURL !== '') error.value = false;
-    });
-
-    return {
-      iconSRC,
-      error
-    };
-  }
-});
-</script>


### PR DESCRIPTION
# Description

The original Jazzicon hotfix (#1868) only partially fixed the problem. The Jazzicon also needs to be rendered after the parent component is mounted for some reason.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## How should this be tested?

- [ ] Test no Jazzicon related errors show up in console on veBAL page.

## Visual context

n/a

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have requested at least 2 reviews (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] If package-lock.json has changes, it was intentional.
- [x] The base of this PR is `master` if hotfix, `develop` if not
