### PR TITLE
fix: useGnosis requests undefined values from useTrading

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.53.14",
+  "version": "1.53.15",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@balancer-labs/frontend-v2",
-      "version": "1.53.14",
+      "version": "1.53.15",
       "license": "MIT",
       "devDependencies": {
         "@aave/protocol-js": "^4.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.53.14",
+  "version": "1.53.15",
   "engines": {
     "node": "14.x",
     "npm": ">=7"

--- a/src/composables/trade/useGnosis.ts
+++ b/src/composables/trade/useGnosis.ts
@@ -283,6 +283,14 @@ export default function useGnosis({
   }
 
   async function handleAmountChange() {
+    // Prevent quering undefined input amounts
+    if (
+      (exactIn.value && !tokenInAmountInput.value) ||
+      (!exactIn.value && !tokenOutAmountInput.value)
+    ) {
+      return;
+    }
+
     const amountToExchange = exactIn.value
       ? tokenInAmountScaled.value
       : tokenOutAmountScaled.value;
@@ -371,6 +379,16 @@ export default function useGnosis({
 
         if (priceQuoteAmount != null) {
           feeQuote.value = feeQuoteResult;
+
+          // When user clears the input while fee is fetching we won't be able to get the quote
+          // TODO: ideally cancel all pending requests on amount getting changed / cleared
+          if (
+            (exactIn.value && !tokenInAmountInput.value) ||
+            (!exactIn.value && !tokenOutAmountInput.value)
+          ) {
+            updatingQuotes.value = false;
+            return;
+          }
 
           if (exactIn.value) {
             tokenOutAmountInput.value = bnum(


### PR DESCRIPTION
# Description

When user was choosing to trade via cow swap and trade amounts weren't set yet, useGnosis.handleAmountChange function was asking for undefined input amounts.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## How should this be tested?

Open trade UI choose "Trade gasless". Changing trade direction with empty input amounts shouldn't be causing errors.
