### PR TITLE
Hotfix - fix steth trades

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.53.13",
+  "version": "1.53.14",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@balancer-labs/frontend-v2",
-      "version": "1.53.13",
+      "version": "1.53.14",
       "license": "MIT",
       "devDependencies": {
         "@aave/protocol-js": "^4.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.53.13",
+  "version": "1.53.14",
   "engines": {
     "node": "14.x",
     "npm": ">=7"

--- a/src/composables/trade/useSor.ts
+++ b/src/composables/trade/useSor.ts
@@ -222,6 +222,10 @@ export default function useSor({
             ? AddressZero
             : tokenOutAddressInput.value;
 
+        // If the token in/out is stETH then finding the token position
+        // below doesn't work because result.tokenAddresses only includes
+        // wstETH. This is a crude hack to replace token in/out address
+        // with wstETH so the index mapping works.
         if (isStEthAddress(tokenInAddressInput.value))
           tokenInAddress = configService.network.addresses.wstETH;
         if (isStEthAddress(tokenOutAddressInput.value))

--- a/src/composables/trade/useSor.ts
+++ b/src/composables/trade/useSor.ts
@@ -27,7 +27,7 @@ import {
   SorManager,
   SorReturn
 } from '@/lib/utils/balancer/helpers/sor/sorManager';
-import { getStETHByWstETH } from '@/lib/utils/balancer/lido';
+import { getStETHByWstETH, isStEthAddress } from '@/lib/utils/balancer/lido';
 import { swapIn, swapOut } from '@/lib/utils/balancer/swapper';
 import {
   getWrapOutput,
@@ -213,14 +213,19 @@ export default function useSor({
         const tokenInDecimals = getTokenDecimals(tokenInAddressInput.value);
         const tokenOutDecimals = getTokenDecimals(tokenOutAddressInput.value);
 
-        const tokenInAddress =
+        let tokenInAddress =
           tokenInAddressInput.value === NATIVE_ASSET_ADDRESS
             ? AddressZero
             : tokenInAddressInput.value;
-        const tokenOutAddress =
+        let tokenOutAddress =
           tokenOutAddressInput.value === NATIVE_ASSET_ADDRESS
             ? AddressZero
             : tokenOutAddressInput.value;
+
+        if (isStEthAddress(tokenInAddressInput.value))
+          tokenInAddress = configService.network.addresses.wstETH;
+        if (isStEthAddress(tokenOutAddressInput.value))
+          tokenOutAddress = configService.network.addresses.wstETH;
 
         const tokenInPosition = result.tokenAddresses.indexOf(
           tokenInAddress.toLowerCase()
@@ -248,17 +253,15 @@ export default function useSor({
         );
 
         if (swapType === SwapType.SwapExactOut) {
-          tokenInAmountInput.value =
-            tokenInAmountNormalised.toNumber() > 0
-              ? formatAmount(tokenInAmountNormalised.toString())
-              : '';
+          tokenInAmountInput.value = tokenInAmountNormalised.gt(0)
+            ? formatAmount(tokenInAmountNormalised.toString())
+            : '';
         }
 
         if (swapType === SwapType.SwapExactIn) {
-          tokenOutAmountInput.value =
-            tokenOutAmountNormalised.toNumber() > 0
-              ? formatAmount(tokenOutAmountNormalised.toString())
-              : '';
+          tokenOutAmountInput.value = tokenOutAmountNormalised.gt(0)
+            ? formatAmount(tokenOutAmountNormalised.toString())
+            : '';
         }
       }
     }

--- a/src/lib/utils/balancer/lido.ts
+++ b/src/lib/utils/balancer/lido.ts
@@ -18,6 +18,14 @@ export function isStETH(tokenInAddress: string, tokenOutAddress: string) {
     .includes(getAddress(stEthAddress));
 }
 
+export function isStEthAddress(address: string): boolean {
+  return address.toLowerCase() === stEthAddress.toLowerCase();
+}
+
+export function isWstEthAddress(address: string): boolean {
+  return address.toLowerCase() === wstEthAddress.toLowerCase();
+}
+
 /**
  * @notice Get amount of wstETH for a given amount of stETH
  */


### PR DESCRIPTION
# Description

Currently if you were trading from or too stETH, after inputting amounts when the next block was mined the stETH amount would reset to zero. This is because for the initial amounts we're using the SOR and then to update amounts on each block we're using the queryBatchSwap, since it's a more efficient call. However, the return from the query batch swap only includes a reference to wstETH in the path addresses and so it's impossible to map the tokenOut address which is stETH to the query batch swap amount out index.

This PR adds a crude hack that checks if the token in/out is stETH and in this specific function for updating amounts on each block, replaces it with wstETH for finding the mapped amount values from the query batch swap results.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## How should this be tested?

- [ ] Test swaps to or from stETH. Input amounts and then wait for about a minute for new blocks to come in. The amount for stETH should not reset to 0.

## Visual context

n/a

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have requested at least 2 reviews (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] If package-lock.json has changes, it was intentional.
- [x] The base of this PR is `master` if hotfix, `develop` if not
