### PR TITLE
Hotfix - hide staking preview yield

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.54.3",
+  "version": "1.54.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@balancer-labs/frontend-v2",
-      "version": "1.54.3",
+      "version": "1.54.4",
       "license": "MIT",
       "devDependencies": {
         "@aave/protocol-js": "^4.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.54.3",
+  "version": "1.54.4",
   "engines": {
     "node": "14.x",
     "npm": ">=7"

--- a/src/components/contextual/stake/StakePreview.vue
+++ b/src/components/contextual/stake/StakePreview.vue
@@ -13,11 +13,11 @@ import useTokenApprovalActions from '@/composables/useTokenApprovalActions';
 import useTokens from '@/composables/useTokens';
 import { bnum } from '@/lib/utils';
 import {
-  getGaugeAddress,
-  isL2StakingAprLive
+  getGaugeAddress
+  // isL2StakingAprLive
 } from '@/providers/local/staking/staking.provider';
 import { DecoratedPoolWithShares } from '@/services/balancer/subgraph/types';
-import { getAprRangeWithRewardEmissions } from '@/services/staking/utils';
+// import { getAprRangeWithRewardEmissions } from '@/services/staking/utils';
 import useWeb3 from '@/services/web3/useWeb3';
 import { TransactionActionInfo } from '@/types/transactions';
 
@@ -43,8 +43,8 @@ const {
   userData: {
     stakedSharesForProvidedPool,
     refetchStakedShares,
-    refetchUserStakingData,
-    getBoostFor
+    refetchUserStakingData
+    // getBoostFor
   },
   stakeBPT,
   unstakeBPT
@@ -123,19 +123,25 @@ const totalUserPoolSharePct = ref(
     .toString()
 );
 
-const stakingApr = computed(() => {
-  return bnum(getAprRangeWithRewardEmissions(props.pool).min).times(
-    getBoostFor(props.pool.id)
-  );
-});
+/**
+ * TODO implement staking APR and potential weekly yield
+ * Doesn't currently work because getBoostFor only returns boosts
+ * For staked positions and not pools you're invested in but not staked.
+ */
+// const stakingApr = computed(() => {
+//   return bnum(getAprRangeWithRewardEmissions(props.pool).min).times(
+//     getBoostFor(props.pool.id)
+//   );
+// });
 
-const potentialyWeeklyYield = computed(() => {
-  return bnum(getAprRangeWithRewardEmissions(props.pool).min)
-    .times(getBoostFor(props.pool.id))
-    .times(fiatValueOfModifiedShares.value)
-    .div(52)
-    .toString();
-});
+// const potentialyWeeklyYield = computed(() => {
+//   console.log('boost', getBoostFor(props.pool.id))
+//   return bnum(getAprRangeWithRewardEmissions(props.pool).min)
+//     .times(getBoostFor(props.pool.id))
+//     .times(fiatValueOfModifiedShares.value)
+//     .div(52)
+//     .toString();
+// });
 
 /**
  * LIFECYCLE
@@ -237,7 +243,7 @@ function handleClose() {
             />
           </BalStack>
         </BalStack>
-        <BalStack horizontal justify="between" v-if="isL2StakingAprLive">
+        <!-- <BalStack horizontal justify="between" v-if="isL2StakingAprLive">
           <span class="text-sm">
             {{ action === 'stake' ? $t('your') : $t('lost') }}
             {{ $t('staking.stakingApr') }}:
@@ -268,7 +274,7 @@ function handleClose() {
               textAlign="center"
             />
           </BalStack>
-        </BalStack>
+        </BalStack> -->
       </BalStack>
     </BalCard>
     <BalActionSteps


### PR DESCRIPTION
# Description

Hides incorrect yield information until we can implement the correct calculations.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## How should this be tested?

- [ ] Test yield info doesn't appear in staking preview.

## Visual context

n/a

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have requested at least 2 reviews (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] If package-lock.json has changes, it was intentional.
- [x] The base of this PR is `master` if hotfix, `develop` if not
