### PR TITLE
Fix - Account for reward token periods

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.56.1",
+  "version": "1.56.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@balancer-labs/frontend-v2",
-      "version": "1.56.1",
+      "version": "1.56.2",
       "license": "MIT",
       "devDependencies": {
         "@aave/protocol-js": "^4.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.56.1",
+  "version": "1.56.2",
   "engines": {
     "node": "14.x",
     "npm": ">=7"

--- a/src/services/staking/utils.ts
+++ b/src/services/staking/utils.ts
@@ -56,6 +56,12 @@ export function calculateRewardTokenAprs({
         data.rate,
         tokens[getAddress(rewardTokenAddress)]?.decimals || 18
       );
+      // if the period is finished for a reward token,
+      // it should be 0 as emissions are no longer seeded
+      if (Date.now() / 1000 > data.period_finish.toNumber()) {
+        return [rewardTokenAddress, '0'];
+      }
+
       // for reward tokens, there is no relative weight
       // all tokens go to the gauge depositors
       const tokenPayable = calculateTokenPayableToGauge(


### PR DESCRIPTION
# Description

Reward tokens which were no longer being seeded were still being included in the APR calcs. This PR removes that.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## How should this be tested?

Test using COW/WETH pools, the APR should be lower.

## Visual context

N/A
## Checklist:

- [X] I have performed a self-review of my own code
- [X] I have requested at least 2 reviews (If the PR is significant enough, use best judgement here)
- [X] I have commented my code where relevant, particularly in hard-to-understand areas
- [X] If package-lock.json has changes, it was intentional.
- [X] The base of this PR is `master` if hotfix, `develop` if not
