### PR TITLE
Hotfix - Stable pool price impact

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.56.3",
+  "version": "1.56.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@balancer-labs/frontend-v2",
-      "version": "1.56.3",
+      "version": "1.56.4",
       "license": "MIT",
       "devDependencies": {
         "@aave/protocol-js": "^4.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.56.3",
+  "version": "1.56.4",
   "engines": {
     "node": "14.x",
     "npm": ">=7"

--- a/src/services/pool/calculator/stable.ts
+++ b/src/services/pool/calculator/stable.ts
@@ -187,9 +187,14 @@ export default class Stable {
     const ampAdjusted = BigNumber.from(this.adjustAmp(amp).toString());
     // These amounts need to take priceRate into consideration
     const denormAmounts = this.calc.pool.value.tokens.map(({ priceRate }, i) =>
-      this.scaleInput(tokenAmounts[i], priceRate).toString()
+      BigNumber.from(
+        this.scaleInput(
+          tokenAmounts[i],
+          priceRate,
+          this.calc.poolTokenDecimals[i]
+        ).toString()
+      )
     );
-
     // _bptForTokensZeroPriceImpact is the only stable pool function
     // that requires balances be scaled by the token decimals and not 18
     // scaledBalances already use priceRate
@@ -238,11 +243,12 @@ export default class Stable {
 
   private scaleInput(
     normalizedAmount: string,
-    priceRate: string | null = null
+    priceRate: string | null = null,
+    decimals = 18
   ): OldBigNumber {
     if (priceRate === null) priceRate = '1';
 
-    const denormAmount = bnum(parseUnits(normalizedAmount, 18).toString())
+    const denormAmount = bnum(parseUnits(normalizedAmount, decimals).toString())
       .times(priceRate)
       .toFixed(0, OldBigNumber.ROUND_UP);
 


### PR DESCRIPTION
# Description

The original fix in #1924 used `scaleInput` which assumed token decimals of 18 since until now it was only dealing with BPT. This PR refactors to allow the `scaleInput` function to handle different token decimals.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## How should this be tested?

- [ ] Test price impact on the old staBAL3 pool, check multiple input amounts don't result in 100% price impact as reported here: https://discord.com/channels/638460494168064021/638529669330894868/982241531832451073

## Visual context

n/a

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have requested at least 2 reviews (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] If package-lock.json has changes, it was intentional.
- [x] The base of this PR is `master` if hotfix, `develop` if not
