### PR TITLE
Hotfix - kovan bal address

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.56.4",
+  "version": "1.56.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@balancer-labs/frontend-v2",
-      "version": "1.56.4",
+      "version": "1.56.5",
       "license": "MIT",
       "devDependencies": {
         "@aave/protocol-js": "^4.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.56.4",
+  "version": "1.56.5",
   "engines": {
     "node": "14.x",
     "npm": ">=7"

--- a/src/constants/tokens.ts
+++ b/src/constants/tokens.ts
@@ -71,9 +71,9 @@ export const TOKENS_KOVAN: TokenConstants = {
   },
   Addresses: {
     nativeAsset: '0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE',
-    wNativeAsset: '0x82aF49447D8a07e3bd95BD0d56f35241523fBab1',
+    wNativeAsset: '0xdFCeA9088c8A88A76FF74892C1457C17dfeef9C1',
     WETH: '0xdFCeA9088c8A88A76FF74892C1457C17dfeef9C1',
-    BAL: '0x41286Bb1D3E870f3F750eB7E1C25d7E48c8A1Ac7',
+    BAL: '0xcb355677E36f390Ccc4a5d4bEADFbF1Eb2071c81',
     bbaUSD: '0x8fd162f338B770F7E879030830cDe9173367f301'
   },
   PriceChainMap: {
@@ -85,12 +85,15 @@ export const TOKENS_KOVAN: TokenConstants = {
       '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2',
     '0x1c8e3bcb3378a443cc591f154c5ce0ebb4da9648':
       '0x2260fac5e5542a773aa44fbcfedf7c193bc2c599',
-    '0x41286bb1d3e870f3f750eb7e1c25d7e48c8a1ac7':
-      '0xba100000625a3754423978a60c9317c58a424e3d',
+    // '0x41286bb1d3e870f3f750eb7e1c25d7e48c8a1ac7':
+    //   '0xba100000625a3754423978a60c9317c58a424e3d',
     '0x8f4bebf498cc624a0797fe64114a6ff169eee078':
       '0xbc396689893d065f41bc2c6ecbee5e0085233447',
     '0xaf9ac3235be96ed496db7969f60d354fe5e426b0':
       '0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2',
+    // BAL
+    '0xcb355677e36f390ccc4a5d4beadfbf1eb2071c81':
+      '0xba100000625a3754423978a60c9317c58a424e3d',
     // USDC
     '0xc2569dd7d0fd715b054fbf16e75b001e5c0c1115':
       '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',


### PR DESCRIPTION
# Description

Was not possible to invest in the kovan veBAL pool because the BAL address was different from the config. This PR changes the kovan config to use the BAL address associated with the veBAL pool.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## How should this be tested?

- [ ] Test investments in the veBAL pool (0xdc2ecfdf2688f92c85064be0b929693acc6dbca6000200000000000000000701)

## Visual context

n/a

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have requested at least 2 reviews (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] If package-lock.json has changes, it was intentional.
- [x] The base of this PR is `master` if hotfix, `develop` if not
