### PR TITLE
Refactor pool queries

### DIFF
--- a/src/components/tooltips/APRTooltip/components/YieldBreakdown.vue
+++ b/src/components/tooltips/APRTooltip/components/YieldBreakdown.vue
@@ -8,6 +8,7 @@ import { isStablePhantom } from '@/composables/usePool';
 import useTokens from '@/composables/useTokens';
 import { includesWstEth } from '@/lib/utils/balancer/lido';
 import { PoolAPRs } from '@/services/pool/types';
+import { getAddress } from '@ethersproject/address';
 
 /**
  * TYPES
@@ -33,7 +34,7 @@ const { t } = useI18n();
 /**
  * COMPUTED
  */
-const yieldAPRTokens = computed(() =>
+const yieldAPRTokens = computed(() => 
   getTokens(Object.keys(props.yieldAPR.breakdown))
 );
 
@@ -64,7 +65,7 @@ const yieldBreakdownItems = computed((): [string, string][] =>
     <template v-if="hasMultiRewardTokens" #item="{ item: [address, amount] }">
       {{ fNum2(amount, FNumFormats.percent) }}
       <span class="text-gray-500 text-xs ml-1">
-        {{ yieldAPRTokens[address].symbol }} {{ $t('apr') }}
+        {{ yieldAPRTokens[getAddress(address)].symbol }} {{ $t('apr') }}
       </span>
     </template>
   </BalBreakdown>

--- a/src/components/tooltips/APRTooltip/components/YieldBreakdown.vue
+++ b/src/components/tooltips/APRTooltip/components/YieldBreakdown.vue
@@ -1,5 +1,6 @@
 <script lang="ts" setup>
 import { PoolType } from '@balancer-labs/sdk';
+import { getAddress } from '@ethersproject/address';
 import { computed } from 'vue';
 import { useI18n } from 'vue-i18n';
 
@@ -8,7 +9,6 @@ import { isStablePhantom } from '@/composables/usePool';
 import useTokens from '@/composables/useTokens';
 import { includesWstEth } from '@/lib/utils/balancer/lido';
 import { PoolAPRs } from '@/services/pool/types';
-import { getAddress } from '@ethersproject/address';
 
 /**
  * TYPES
@@ -34,7 +34,7 @@ const { t } = useI18n();
 /**
  * COMPUTED
  */
-const yieldAPRTokens = computed(() => 
+const yieldAPRTokens = computed(() =>
   getTokens(Object.keys(props.yieldAPR.breakdown))
 );
 

--- a/src/composables/pools/usePools.ts
+++ b/src/composables/pools/usePools.ts
@@ -1,26 +1,10 @@
-import { flatten } from 'lodash';
-import { computed, Ref, ref } from 'vue';
+import { computed } from 'vue';
 
-import usePoolsQuery from '@/composables/queries/usePoolsQuery';
 import useUserPoolsQuery from '@/composables/queries/useUserPoolsQuery';
 
-export default function usePools(poolsTokenList: Ref<string[]> = ref([])) {
+export default function usePools() {
   // COMPOSABLES
-  const poolsQuery = usePoolsQuery(poolsTokenList);
   const userPoolsQuery = useUserPoolsQuery();
-
-  // COMPUTED
-  const pools = computed(() =>
-    poolsQuery.data.value
-      ? flatten(poolsQuery.data.value.pages.map(page => page.pools))
-      : []
-  );
-
-  const tokens = computed(() =>
-    poolsQuery.data.value
-      ? flatten(poolsQuery.data.value.pages.map(page => page.tokens))
-      : []
-  );
 
   const userPools = computed(() => userPoolsQuery.data.value?.pools || []);
 
@@ -28,37 +12,13 @@ export default function usePools(poolsTokenList: Ref<string[]> = ref([])) {
     () => userPoolsQuery.data.value?.totalInvestedAmount
   );
 
-  const isLoadingPools = computed(
-    () => poolsQuery.isLoading.value || poolsQuery.isIdle.value
-  );
-
   const isLoadingUserPools = computed(
     () => userPoolsQuery.isLoading.value || userPoolsQuery.isIdle.value
   );
 
-  const poolsHasNextPage = computed(() => poolsQuery.hasNextPage?.value);
-  const poolsIsFetchingNextPage = computed(
-    () => poolsQuery.isFetchingNextPage?.value
-  );
-
-  // METHODS
-  function loadMorePools() {
-    poolsQuery.fetchNextPage.value();
-  }
-
   return {
-    // computed
-    pools,
-    tokens,
     userPools,
     totalInvestedAmount,
-    isLoadingPools,
-    isLoadingUserPools,
-    poolsHasNextPage,
-    poolsIsFetchingNextPage,
-    poolsQuery,
-
-    // methods
-    loadMorePools
+    isLoadingUserPools
   };
 }

--- a/src/composables/queries/usePoolQuery.ts
+++ b/src/composables/queries/usePoolQuery.ts
@@ -1,5 +1,3 @@
-import { getAddress, isAddress } from '@ethersproject/address';
-import { formatUnits } from 'ethers/lib/utils';
 import { QueryObserverOptions } from 'react-query/core';
 import { computed, reactive, Ref, ref } from 'vue';
 import { useQuery } from 'vue-query';
@@ -7,21 +5,13 @@ import { useQuery } from 'vue-query';
 import useTokens from '@/composables/useTokens';
 import { POOLS } from '@/constants/pools';
 import QUERY_KEYS from '@/constants/queryKeys';
-import { bnum, forChange } from '@/lib/utils';
-import { balancerContractsService } from '@/services/balancer/contracts/balancer-contracts.service';
 import { balancerSubgraphService } from '@/services/balancer/subgraph/balancer-subgraph.service';
 import { PoolDecorator } from '@/services/pool/decorators/pool.decorator';
-import PoolService from '@/services/pool/pool.service';
 import { Pool } from '@/services/pool/types';
 import useWeb3 from '@/services/web3/useWeb3';
 
 import useApp from '../useApp';
-import {
-  isManaged,
-  isStableLike,
-  isStablePhantom,
-  lpTokensFor
-} from '../usePool';
+import { isBlocked, lpTokensFor } from '../usePool';
 import useUserSettings from '../useUserSettings';
 import useGaugesQuery from './useGaugesQuery';
 
@@ -33,7 +23,7 @@ export default function usePoolQuery(
   /**
    * COMPOSABLES
    */
-  const { getTokens, injectTokens, prices, dynamicDataLoading } = useTokens();
+  const { injectTokens, prices, dynamicDataLoading } = useTokens();
   const { appLoading } = useApp();
   const { account } = useWeb3();
   const { currency } = useUserSettings();
@@ -52,28 +42,13 @@ export default function usePoolQuery(
   );
 
   /**
-   * METHODS
-   */
-  function isBlocked(pool: Pool): boolean {
-    const requiresAllowlisting =
-      isStableLike(pool.poolType) || isManaged(pool.poolType);
-    const isOwnedByUser =
-      isAddress(account.value) &&
-      getAddress(pool.owner) === getAddress(account.value);
-    const isAllowlisted =
-      POOLS.Stable.AllowList.includes(id) ||
-      POOLS.Investment.AllowList.includes(id);
-
-    return requiresAllowlisting && !isAllowlisted && !isOwnedByUser;
-  }
-
-  /**
    * QUERY INPUTS
    */
   const queryKey = QUERY_KEYS.Pools.Current(id, gaugeAddresses);
 
   const queryFn = async () => {
-    let [pool] = await balancerSubgraphService.pools.get({
+    // Fetch basic data from subgraph
+    const [pool] = await balancerSubgraphService.pools.get({
       where: {
         id: id.toLowerCase(),
         totalShares_gt: -1, // Avoid the filtering for low liquidity pools
@@ -81,34 +56,9 @@ export default function usePoolQuery(
       }
     });
 
-    if (isBlocked(pool)) throw new Error('Pool not allowed');
+    if (isBlocked(pool, account.value)) throw new Error('Pool not allowed');
 
-    const isStablePhantomPool = isStablePhantom(pool.poolType);
-
-    if (isStablePhantomPool) {
-      const poolService = new PoolService(pool);
-      poolService.removePreMintedBPT();
-      await poolService.setLinearPools();
-      pool = poolService.pool;
-    }
-
-    // Inject relevant pool tokens to fetch metadata
-    await injectTokens([
-      ...pool.tokensList,
-      ...lpTokensFor(pool),
-      pool.address
-    ]);
-    await forChange(dynamicDataLoading, false);
-
-    // Need to fetch onchain pool data first so that calculations can be
-    // performed in the decoration step.
-    const poolTokenMeta = getTokens(pool.tokensList);
-    pool.onchain = await balancerContractsService.vault.getPoolData(
-      id,
-      pool.poolType,
-      poolTokenMeta
-    );
-
+    // Decorate subgraph data with additional data
     const poolDecorator = new PoolDecorator([pool]);
     const [decoratedPool] = await poolDecorator.decorate(
       subgraphGauges.value || [],
@@ -117,60 +67,14 @@ export default function usePoolQuery(
       tokens.value
     );
 
-    let unwrappedTokens: Pool['unwrappedTokens'];
+    // Inject pool tokens into token registry
+    await injectTokens([
+      ...decoratedPool.tokensList,
+      ...lpTokensFor(decoratedPool),
+      decoratedPool.address
+    ]);
 
-    if (isStablePhantomPool && pool.onchain.linearPools != null) {
-      unwrappedTokens = Object.entries(pool.onchain.linearPools).map(
-        ([, linearPool]) => linearPool.unwrappedTokenAddress
-      );
-
-      if (decoratedPool.linearPoolTokensMap != null) {
-        let totalLiquidity = bnum(0);
-        const tokensMap = getTokens(
-          Object.keys(decoratedPool.linearPoolTokensMap)
-        );
-
-        Object.entries(pool.onchain.linearPools).forEach(([address, token]) => {
-          const tokenShare = bnum(
-            pool?.onchain?.tokens?.[address]?.balance || '0'
-          ).div(token.totalSupply);
-
-          const mainTokenBalance = formatUnits(
-            token.mainToken.balance,
-            tokensMap[token.mainToken.address].decimals
-          );
-
-          const wrappedTokenBalance = formatUnits(
-            token.wrappedToken.balance,
-            tokensMap[token.wrappedToken.address].decimals
-          );
-
-          const mainTokenPrice =
-            prices.value[token.mainToken.address] != null
-              ? prices.value[token.mainToken.address].usd
-              : null;
-
-          if (mainTokenPrice != null) {
-            const mainTokenValue = bnum(mainTokenBalance)
-              .times(tokenShare)
-              .times(mainTokenPrice);
-
-            const wrappedTokenValue = bnum(wrappedTokenBalance)
-              .times(tokenShare)
-              .times(mainTokenPrice)
-              .times(token.wrappedToken.priceRate);
-
-            totalLiquidity = bnum(totalLiquidity)
-              .plus(mainTokenValue)
-              .plus(wrappedTokenValue);
-          }
-        });
-
-        decoratedPool.totalLiquidity = totalLiquidity.toString();
-      }
-    }
-
-    return { unwrappedTokens, ...decoratedPool };
+    return decoratedPool;
   };
 
   const queryOptions = reactive({

--- a/src/composables/queries/usePoolQuery.ts
+++ b/src/composables/queries/usePoolQuery.ts
@@ -95,7 +95,7 @@ export default function usePoolQuery(
     await injectTokens([
       ...pool.tokensList,
       ...lpTokensFor(pool),
-      balancerSubgraphService.pools.addressFor(pool.id)
+      pool.address
     ]);
     await forChange(dynamicDataLoading, false);
 

--- a/src/composables/queries/usePoolQuery.ts
+++ b/src/composables/queries/usePoolQuery.ts
@@ -110,7 +110,6 @@ export default function usePoolQuery(
 
     const [decoratedPool] = await balancerSubgraphService.pools.decorate(
       [{ ...pool, onchain: onchainData }],
-      '24h',
       prices.value,
       currency.value,
       subgraphGauges.value || [],

--- a/src/composables/queries/usePoolsQuery.ts
+++ b/src/composables/queries/usePoolsQuery.ts
@@ -1,4 +1,3 @@
-import { formatUnits } from '@ethersproject/units';
 import { flatten } from 'lodash';
 import { UseInfiniteQueryOptions } from 'react-query/types';
 import { computed, reactive, Ref, ref } from 'vue';
@@ -6,16 +5,13 @@ import { useInfiniteQuery } from 'vue-query';
 
 import { POOLS } from '@/constants/pools';
 import QUERY_KEYS from '@/constants/queryKeys';
-import { bnum, forChange } from '@/lib/utils';
-import { balancerContractsService } from '@/services/balancer/contracts/balancer-contracts.service';
 import { balancerSubgraphService } from '@/services/balancer/subgraph/balancer-subgraph.service';
 import { PoolDecorator } from '@/services/pool/decorators/pool.decorator';
-import PoolService from '@/services/pool/pool.service';
 import { Pool } from '@/services/pool/types';
 
 import useApp from '../useApp';
 import useNetwork from '../useNetwork';
-import { isStablePhantom, lpTokensFor } from '../usePool';
+import { lpTokensFor } from '../usePool';
 import useTokens from '../useTokens';
 import useUserSettings from '../useUserSettings';
 import useGaugesQuery from './useGaugesQuery';
@@ -42,13 +38,7 @@ export default function usePoolsQuery(
   /**
    * COMPOSABLES
    */
-  const {
-    injectTokens,
-    dynamicDataLoading,
-    prices,
-    getTokens,
-    tokens: tokenMeta
-  } = useTokens();
+  const { injectTokens, prices, tokens: tokenMeta } = useTokens();
   const { currency } = useUserSettings();
   const { appLoading } = useApp();
   const { networkId } = useNetwork();
@@ -61,6 +51,31 @@ export default function usePoolsQuery(
    * COMPUTED
    */
   const enabled = computed(() => !appLoading.value && options.enabled);
+
+  /**
+   * METHODS
+   */
+  function getQueryArgs(pageParam = 0) {
+    const tokensListFilterKey = filterOptions?.isExactTokensList
+      ? 'tokensList'
+      : 'tokensList_contains';
+
+    const queryArgs: any = {
+      first: filterOptions?.pageSize || POOLS.Pagination.PerPage,
+      skip: pageParam,
+      where: {
+        [tokensListFilterKey]: tokenList.value,
+        poolType_not_in: POOLS.ExcludedPoolTypes
+      }
+    };
+    if (filterOptions?.poolIds?.value.length) {
+      queryArgs.value.where.id_in = filterOptions.poolIds.value;
+    }
+    if (filterOptions?.poolAddresses?.value.length) {
+      queryArgs.value.where.address_in = filterOptions.poolAddresses.value;
+    }
+    return queryArgs;
+  }
 
   /**
    * QUERY KEY
@@ -77,45 +92,8 @@ export default function usePoolsQuery(
    * QUERY FUNCTION
    */
   const queryFn = async ({ pageParam = 0 }) => {
-    const tokensListFilterKey = filterOptions?.isExactTokensList
-      ? 'tokensList'
-      : 'tokensList_contains';
-    const queryArgs: any = {
-      first: filterOptions?.pageSize || POOLS.Pagination.PerPage,
-      skip: pageParam,
-      where: {
-        [tokensListFilterKey]: tokenList.value,
-        poolType_not_in: POOLS.ExcludedPoolTypes
-      }
-    };
-    if (filterOptions?.poolIds?.value.length) {
-      queryArgs.where.id_in = filterOptions.poolIds.value;
-    }
-    if (filterOptions?.poolAddresses?.value.length) {
-      queryArgs.where.address_in = filterOptions.poolAddresses.value;
-    }
+    const queryArgs = getQueryArgs(pageParam);
     const pools = await balancerSubgraphService.pools.get(queryArgs);
-
-    for (let i = 0; i < pools.length; i++) {
-      const isStablePhantomPool = isStablePhantom(pools[i].poolType);
-
-      if (isStablePhantomPool) {
-        const poolService = new PoolService(pools[i]);
-        poolService.removePreMintedBPT();
-        await poolService.setLinearPools();
-        pools[i] = poolService.pool;
-      }
-    }
-
-    const tokens = flatten(
-      pools.map(pool => [
-        ...pool.tokensList,
-        ...lpTokensFor(pool),
-        pool.address
-      ])
-    );
-    await injectTokens(tokens);
-    await forChange(dynamicDataLoading, false);
 
     const poolDecorator = new PoolDecorator(pools);
     const decoratedPools = await poolDecorator.decorate(
@@ -125,74 +103,14 @@ export default function usePoolsQuery(
       tokenMeta.value
     );
 
-    // TODO - cleanup and extract elsewhere in refactor
-    for (let i = 0; i < decoratedPools.length; i++) {
-      const isStablePhantomPool = isStablePhantom(decoratedPools[i].poolType);
-
-      if (isStablePhantomPool) {
-        const decoratedPool = decoratedPools[i];
-
-        const poolTokenMeta = getTokens(decoratedPool.tokensList);
-
-        const onchainData = await balancerContractsService.vault.getPoolData(
-          decoratedPool.id,
-          decoratedPool.poolType,
-          poolTokenMeta
-        );
-
-        if (
-          onchainData != null &&
-          onchainData.linearPools != null &&
-          decoratedPool.linearPoolTokensMap != null
-        ) {
-          let totalLiquidity = bnum(0);
-          const tokensMap = getTokens(
-            Object.keys(decoratedPool.linearPoolTokensMap)
-          );
-
-          Object.entries(onchainData.linearPools).forEach(
-            ([address, token]) => {
-              const tokenShare = bnum(onchainData.tokens[address].balance).div(
-                token.totalSupply
-              );
-
-              const mainTokenBalance = formatUnits(
-                token.mainToken.balance,
-                tokensMap[token.mainToken.address].decimals
-              );
-
-              const wrappedTokenBalance = formatUnits(
-                token.wrappedToken.balance,
-                tokensMap[token.wrappedToken.address].decimals
-              );
-
-              const mainTokenPrice =
-                prices.value[token.mainToken.address] != null
-                  ? prices.value[token.mainToken.address].usd
-                  : null;
-
-              if (mainTokenPrice != null) {
-                const mainTokenValue = bnum(mainTokenBalance)
-                  .times(tokenShare)
-                  .times(mainTokenPrice);
-
-                const wrappedTokenValue = bnum(wrappedTokenBalance)
-                  .times(tokenShare)
-                  .times(mainTokenPrice)
-                  .times(token.wrappedToken.priceRate);
-
-                totalLiquidity = bnum(totalLiquidity)
-                  .plus(mainTokenValue)
-                  .plus(wrappedTokenValue);
-              }
-            }
-          );
-
-          decoratedPools[i].onchain = onchainData;
-          decoratedPools[i].totalLiquidity = totalLiquidity.toString();
-        }
-      }
-    }
+    const tokens = flatten(
+      pools.map(pool => [
+        ...pool.tokensList,
+        ...lpTokensFor(pool),
+        pool.address
+      ])
+    );
+    await injectTokens(tokens);
 
     return {
       pools: decoratedPools,

--- a/src/composables/queries/usePoolsQuery.ts
+++ b/src/composables/queries/usePoolsQuery.ts
@@ -110,7 +110,7 @@ export default function usePoolsQuery(
       pools.map(pool => [
         ...pool.tokensList,
         ...lpTokensFor(pool),
-        balancerSubgraphService.pools.addressFor(pool.id)
+        pool.address
       ])
     );
     await injectTokens(tokens);

--- a/src/composables/queries/usePoolsQuery.ts
+++ b/src/composables/queries/usePoolsQuery.ts
@@ -9,6 +9,7 @@ import QUERY_KEYS from '@/constants/queryKeys';
 import { bnum, forChange } from '@/lib/utils';
 import { balancerContractsService } from '@/services/balancer/contracts/balancer-contracts.service';
 import { balancerSubgraphService } from '@/services/balancer/subgraph/balancer-subgraph.service';
+import { PoolDecorator } from '@/services/pool/decorators/pool.decorator';
 import PoolService from '@/services/pool/pool.service';
 import { Pool } from '@/services/pool/types';
 
@@ -116,13 +117,14 @@ export default function usePoolsQuery(
     await injectTokens(tokens);
     await forChange(dynamicDataLoading, false);
 
-    const decoratedPools = await balancerSubgraphService.pools.decorate(
-      pools,
+    const poolDecorator = new PoolDecorator(pools);
+    const decoratedPools = await poolDecorator.decorate(
+      subgraphGauges.value || [],
       prices.value,
       currency.value,
-      subgraphGauges.value || [],
       tokenMeta.value
     );
+
     // TODO - cleanup and extract elsewhere in refactor
     for (let i = 0; i < decoratedPools.length; i++) {
       const isStablePhantomPool = isStablePhantom(decoratedPools[i].poolType);

--- a/src/composables/queries/usePoolsQuery.ts
+++ b/src/composables/queries/usePoolsQuery.ts
@@ -38,7 +38,9 @@ export default function usePoolsQuery(
   options: UseInfiniteQueryOptions<PoolsQueryResponse> = {},
   filterOptions?: FilterOptions
 ) {
-  // COMPOSABLES
+  /**
+   * COMPOSABLES
+   */
   const {
     injectTokens,
     dynamicDataLoading,
@@ -54,7 +56,14 @@ export default function usePoolsQuery(
     (subgraphGauges.value || []).map(gauge => gauge.id)
   );
 
-  // DATA
+  /**
+   * COMPUTED
+   */
+  const enabled = computed(() => !appLoading.value && options.enabled);
+
+  /**
+   * QUERY KEY
+   */
   const queryKey = QUERY_KEYS.Pools.All(
     networkId,
     tokenList,
@@ -63,9 +72,9 @@ export default function usePoolsQuery(
     gaugeAddresses
   );
 
-  // COMPUTED
-  const enabled = computed(() => !appLoading.value && options.enabled);
-
+  /**
+   * QUERY FUNCTION
+   */
   const queryFn = async ({ pageParam = 0 }) => {
     const tokensListFilterKey = filterOptions?.isExactTokensList
       ? 'tokensList'
@@ -109,7 +118,6 @@ export default function usePoolsQuery(
 
     const decoratedPools = await balancerSubgraphService.pools.decorate(
       pools,
-      '24h',
       prices.value,
       currency.value,
       subgraphGauges.value || [],

--- a/src/composables/queries/usePoolsQuery.ts
+++ b/src/composables/queries/usePoolsQuery.ts
@@ -69,10 +69,10 @@ export default function usePoolsQuery(
       }
     };
     if (filterOptions?.poolIds?.value.length) {
-      queryArgs.value.where.id_in = filterOptions.poolIds.value;
+      queryArgs.where.id_in = filterOptions.poolIds.value;
     }
     if (filterOptions?.poolAddresses?.value.length) {
-      queryArgs.value.where.address_in = filterOptions.poolAddresses.value;
+      queryArgs.where.address_in = filterOptions.poolAddresses.value;
     }
     return queryArgs;
   }

--- a/src/composables/queries/useStreamedPoolsQuery.ts
+++ b/src/composables/queries/useStreamedPoolsQuery.ts
@@ -3,11 +3,10 @@ import { computed, Ref, ref } from 'vue';
 
 import { FiatCurrency } from '@/constants/currency';
 import { POOLS } from '@/constants/pools';
-import { getPoolAddress } from '@/lib/utils/balancer/pool';
-import { balancerContractsService } from '@/services/balancer/contracts/balancer-contracts.service';
 import { SubgraphGauge } from '@/services/balancer/gauges/types';
 import { balancerSubgraphService } from '@/services/balancer/subgraph/balancer-subgraph.service';
 import { TokenPrices } from '@/services/coingecko/api/price.service';
+import { PoolDecorator } from '@/services/pool/decorators/pool.decorator';
 import PoolService from '@/services/pool/pool.service';
 import { Pool } from '@/services/pool/types';
 import { stakingRewardsService } from '@/services/staking/staking-rewards.service';
@@ -20,7 +19,6 @@ import useTokens from '../useTokens';
 import useUserSettings from '../useUserSettings';
 import useGaugesQuery from './useGaugesQuery';
 import useQueryStreams from './useQueryStream';
-import { PoolDecorator } from '@/services/pool/decorators/pool.decorator';
 
 type FilterOptions = {
   poolIds?: Ref<string[]>;
@@ -192,7 +190,7 @@ export default function useStreamedPoolsQuery(
     injectTokens: {
       type: 'independent',
       queryFn: async (pools: Ref<Pool[]>) => {
-        getTimeTravelBlock(await web3Service.getCurrentBlock())
+        getTimeTravelBlock(await web3Service.getCurrentBlock());
       }
     },
     // liquidity: {

--- a/src/composables/queries/useStreamedPoolsQuery.ts
+++ b/src/composables/queries/useStreamedPoolsQuery.ts
@@ -100,7 +100,6 @@ export default function useStreamedPoolsQuery(
       enabled: decorationEnabled,
       queryFn: async (pools: Ref<Pool[]>) => {
         const poolDecorator = new PoolDecorator(pools.value);
-        console.log('RUN DECORATION');
         return poolDecorator.decorate(
           gaugesQuery.data.value || [],
           prices.value,

--- a/src/composables/queries/useTokenPricesQuery.ts
+++ b/src/composables/queries/useTokenPricesQuery.ts
@@ -61,7 +61,6 @@ export default function useTokenPricesQuery(
       };
     }
 
-    console.log('Injecting price data', pricesToInject.value);
     prices = injectCustomTokens(prices, pricesToInject.value);
     return prices;
   };

--- a/src/composables/queries/useUserPoolsQuery.ts
+++ b/src/composables/queries/useUserPoolsQuery.ts
@@ -88,11 +88,7 @@ export default function useUserPoolsQuery(
 
     const tokens = flatten(
       pools.map(pool => {
-        return [
-          ...pool.tokensList,
-          ...lpTokensFor(pool),
-          balancerSubgraphService.pools.addressFor(pool.id)
-        ];
+        return [...pool.tokensList, ...lpTokensFor(pool), pool.address];
       })
     );
     await injectTokens(tokens);

--- a/src/composables/queries/useUserPoolsQuery.ts
+++ b/src/composables/queries/useUserPoolsQuery.ts
@@ -9,6 +9,7 @@ import QUERY_KEYS from '@/constants/queryKeys';
 import { bnum, forChange } from '@/lib/utils';
 import { balancerContractsService } from '@/services/balancer/contracts/balancer-contracts.service';
 import { balancerSubgraphService } from '@/services/balancer/subgraph/balancer-subgraph.service';
+import { PoolDecorator } from '@/services/pool/decorators/pool.decorator';
 import PoolService from '@/services/pool/pool.service';
 import { PoolWithShares } from '@/services/pool/types';
 import useWeb3 from '@/services/web3/useWeb3';
@@ -94,11 +95,11 @@ export default function useUserPoolsQuery(
     await injectTokens(tokens);
     await forChange(dynamicDataLoading, false);
 
-    const decoratedPools = await balancerSubgraphService.pools.decorate(
-      pools,
+    const poolDecorator = new PoolDecorator(pools);
+    const decoratedPools = await poolDecorator.decorate(
+      subgraphGauges.value || [],
       prices.value,
       currency.value,
-      subgraphGauges.value || [],
       tokenMeta.value
     );
 

--- a/src/composables/queries/useUserPoolsQuery.ts
+++ b/src/composables/queries/useUserPoolsQuery.ts
@@ -100,7 +100,6 @@ export default function useUserPoolsQuery(
 
     const decoratedPools = await balancerSubgraphService.pools.decorate(
       pools,
-      '24h',
       prices.value,
       currency.value,
       subgraphGauges.value || [],

--- a/src/composables/usePool.ts
+++ b/src/composables/usePool.ts
@@ -1,4 +1,5 @@
 import { Network } from '@balancer-labs/sdk';
+import { isAddress } from '@ethersproject/address';
 import { getAddress } from 'ethers/lib/utils';
 import { computed, Ref } from 'vue';
 
@@ -192,6 +193,21 @@ export function removePreMintedBPT(pool: Pool): Pool {
     address => !isSameAddress(address, pool.address)
   );
   return pool;
+}
+
+/**
+ * @summary Check if pool should be accessible in UI
+ */
+export function isBlocked(pool: Pool, account: string): boolean {
+  const requiresAllowlisting =
+    isStableLike(pool.poolType) || isManaged(pool.poolType);
+  const isOwnedByUser =
+    isAddress(account) && isSameAddress(pool.owner, account);
+  const isAllowlisted =
+    POOLS.Stable.AllowList.includes(pool.id) ||
+    POOLS.Investment.AllowList.includes(pool.id);
+
+  return requiresAllowlisting && !isAllowlisted && !isOwnedByUser;
 }
 
 /**

--- a/src/pages/index.vue
+++ b/src/pages/index.vue
@@ -33,8 +33,7 @@ const {
   dataStates,
   result: investmentPools,
   loadMore,
-  isLoadingMore,
-  isComplete
+  isLoadingMore
 } = useStreamedPoolsQuery(selectedTokens);
 const { upToMediumBreakpoint } = useBreakpoints();
 const { priceQueryLoading } = useTokens();

--- a/src/pages/index.vue
+++ b/src/pages/index.vue
@@ -1,24 +1,26 @@
 <script setup lang="ts">
 import { computed, watch } from 'vue';
-import { useI18n } from 'vue-i18n';
 import { useRouter } from 'vue-router';
 
-import HomePageHero from '@/components/heros/HomePageHero.vue';
+import StakedPoolsTable from '@/components/contextual/pages/pools/StakedPoolsTable.vue';
+import UnstakedPoolsTable from '@/components/contextual/pages/pools/UnstakedPoolsTable.vue';
 import TokenSearchInput from '@/components/inputs/TokenSearchInput.vue';
 import FeaturedProtocols from '@/components/sections/FeaturedProtocols.vue';
 import PoolsTable from '@/components/tables/PoolsTable/PoolsTable.vue';
 import usePoolFilters from '@/composables/pools/usePoolFilters';
 import usePools from '@/composables/pools/usePools';
 import useStreamedPoolsQuery from '@/composables/queries/useStreamedPoolsQuery';
-import useAlerts, { AlertPriority, AlertType } from '@/composables/useAlerts';
 import useBreakpoints from '@/composables/useBreakpoints';
+import { isMigratablePool } from '@/composables/usePool';
 import useTokens from '@/composables/useTokens';
+import { MIN_FIAT_VALUE_POOL_MIGRATION } from '@/constants/pools';
+import { bnum } from '@/lib/utils';
+import StakingProvider from '@/providers/local/staking/staking.provider';
 import useWeb3 from '@/services/web3/useWeb3';
 
 // COMPOSABLES
 const router = useRouter();
-const { t } = useI18n();
-const { appNetworkConfig } = useWeb3();
+const { isWalletReady, appNetworkConfig, isWalletConnecting } = useWeb3();
 const isElementSupported = appNetworkConfig.supportsElementPools;
 const {
   selectedTokens,
@@ -26,38 +28,37 @@ const {
   removeSelectedToken
 } = usePoolFilters();
 
-const { isLoadingPools, poolsQuery } = usePools(selectedTokens);
+const { userPools, isLoadingUserPools } = usePools();
 const {
   dataStates,
   result: investmentPools,
   loadMore,
-  isLoadingMore
+  isLoadingMore,
+  isComplete
 } = useStreamedPoolsQuery(selectedTokens);
-const { addAlert, removeAlert } = useAlerts();
 const { upToMediumBreakpoint } = useBreakpoints();
 const { priceQueryLoading } = useTokens();
 
-// userPools.value[0].shares
-watch(poolsQuery.error, () => {
-  if (poolsQuery.error.value) {
-    addAlert({
-      id: 'pools-fetch-error',
-      label: t('alerts.pools-fetch-error'),
-      type: AlertType.ERROR,
-      persistent: true,
-      action: poolsQuery.refetch.value,
-      actionLabel: t('alerts.retry-label'),
-      priority: AlertPriority.MEDIUM
-    });
-  } else {
-    removeAlert('pools-fetch-error');
-  }
+// COMPUTED
+const showMigrationColumn = computed(() =>
+  userPools.value?.some(pool => {
+    return (
+      isMigratablePool(pool) &&
+      // TODO: this is a temporary solution to allow only big holders to migrate due to gas costs.
+      bnum(pool.shares).gt(MIN_FIAT_VALUE_POOL_MIGRATION)
+    );
+  })
+);
+
+const migratableUserPools = computed(() => {
+  return userPools.value.filter(pool => isMigratablePool(pool));
 });
 
 const isInvestmentPoolsTableLoading = computed(
   () => dataStates['basic'] === 'loading' || priceQueryLoading.value
 );
 
+watch(showMigrationColumn, () => console.log(showMigrationColumn.value));
 /**
  * METHODS
  */
@@ -67,8 +68,36 @@ function navigateToCreatePool() {
 </script>
 
 <template>
-  <HomePageHero />
   <div class="lg:container lg:mx-auto pt-10 md:pt-12">
+    <template v-if="isWalletReady || isWalletConnecting">
+      <BalStack vertical>
+        <div class="px-4 lg:px-0">
+          <BalStack horizontal justify="between" align="center">
+            <h3>{{ $t('myInvestments') }}</h3>
+          </BalStack>
+        </div>
+        <BalStack vertical spacing="xl">
+          <StakingProvider>
+            <UnstakedPoolsTable :userPools="userPools" />
+            <StakedPoolsTable :userPools="userPools" />
+          </StakingProvider>
+          <BalStack vertical spacing="sm" v-if="migratableUserPools.length > 0">
+            <h5 class="px-4 lg:px-0">{{ $t('poolsToMigrate') }}</h5>
+            <PoolsTable
+              :key="migratableUserPools"
+              :isLoading="isLoadingUserPools"
+              :data="migratableUserPools"
+              :noPoolsLabel="$t('noInvestments')"
+              showPoolShares
+              :selectedTokens="selectedTokens"
+              :hiddenColumns="['poolVolume', 'poolValue', 'stake']"
+            />
+          </BalStack>
+        </BalStack>
+      </BalStack>
+      <div class="mb-16" />
+    </template>
+
     <BalStack vertical>
       <div class="px-4 lg:px-0">
         <h3 class="mb-3">{{ $t('investmentPools') }}</h3>
@@ -77,7 +106,7 @@ function navigateToCreatePool() {
         >
           <TokenSearchInput
             v-model="selectedTokens"
-            :loading="isLoadingPools"
+            :loading="false"
             @add="addSelectedToken"
             @remove="removeSelectedToken"
             class="w-full md:w-2/3"

--- a/src/pages/index.vue
+++ b/src/pages/index.vue
@@ -1,25 +1,24 @@
 <script setup lang="ts">
-import { computed } from 'vue';
+import { computed, watch } from 'vue';
+import { useI18n } from 'vue-i18n';
 import { useRouter } from 'vue-router';
 
-import StakedPoolsTable from '@/components/contextual/pages/pools/StakedPoolsTable.vue';
-import UnstakedPoolsTable from '@/components/contextual/pages/pools/UnstakedPoolsTable.vue';
+import HomePageHero from '@/components/heros/HomePageHero.vue';
 import TokenSearchInput from '@/components/inputs/TokenSearchInput.vue';
 import FeaturedProtocols from '@/components/sections/FeaturedProtocols.vue';
 import PoolsTable from '@/components/tables/PoolsTable/PoolsTable.vue';
 import usePoolFilters from '@/composables/pools/usePoolFilters';
+import usePools from '@/composables/pools/usePools';
 import useStreamedPoolsQuery from '@/composables/queries/useStreamedPoolsQuery';
+import useAlerts, { AlertPriority, AlertType } from '@/composables/useAlerts';
 import useBreakpoints from '@/composables/useBreakpoints';
-import { isMigratablePool } from '@/composables/usePool';
 import useTokens from '@/composables/useTokens';
-import { MIN_FIAT_VALUE_POOL_MIGRATION } from '@/constants/pools';
-import { bnum } from '@/lib/utils';
-import StakingProvider from '@/providers/local/staking/staking.provider';
 import useWeb3 from '@/services/web3/useWeb3';
 
 // COMPOSABLES
 const router = useRouter();
-const { isWalletReady, appNetworkConfig, isWalletConnecting } = useWeb3();
+const { t } = useI18n();
+const { appNetworkConfig } = useWeb3();
 const isElementSupported = appNetworkConfig.supportsElementPools;
 const {
   selectedTokens,
@@ -27,36 +26,38 @@ const {
   removeSelectedToken
 } = usePoolFilters();
 
-const { userPools, isLoadingUserPools } = usePools();
+const { isLoadingPools, poolsQuery } = usePools(selectedTokens);
 const {
   dataStates,
   result: investmentPools,
   loadMore,
   isLoadingMore
 } = useStreamedPoolsQuery(selectedTokens);
+const { addAlert, removeAlert } = useAlerts();
 const { upToMediumBreakpoint } = useBreakpoints();
 const { priceQueryLoading } = useTokens();
 
-// COMPUTED
-const showMigrationColumn = computed(() =>
-  userPools.value?.some(pool => {
-    return (
-      isMigratablePool(pool) &&
-      // TODO: this is a temporary solution to allow only big holders to migrate due to gas costs.
-      bnum(pool.shares).gt(MIN_FIAT_VALUE_POOL_MIGRATION)
-    );
-  })
-);
-
-const migratableUserPools = computed(() => {
-  return userPools.value.filter(pool => isMigratablePool(pool));
+// userPools.value[0].shares
+watch(poolsQuery.error, () => {
+  if (poolsQuery.error.value) {
+    addAlert({
+      id: 'pools-fetch-error',
+      label: t('alerts.pools-fetch-error'),
+      type: AlertType.ERROR,
+      persistent: true,
+      action: poolsQuery.refetch.value,
+      actionLabel: t('alerts.retry-label'),
+      priority: AlertPriority.MEDIUM
+    });
+  } else {
+    removeAlert('pools-fetch-error');
+  }
 });
 
 const isInvestmentPoolsTableLoading = computed(
   () => dataStates['basic'] === 'loading' || priceQueryLoading.value
 );
 
-watch(showMigrationColumn, () => console.log(showMigrationColumn.value));
 /**
  * METHODS
  */
@@ -66,36 +67,8 @@ function navigateToCreatePool() {
 </script>
 
 <template>
+  <HomePageHero />
   <div class="lg:container lg:mx-auto pt-10 md:pt-12">
-    <template v-if="isWalletReady || isWalletConnecting">
-      <BalStack vertical>
-        <div class="px-4 lg:px-0">
-          <BalStack horizontal justify="between" align="center">
-            <h3>{{ $t('myInvestments') }}</h3>
-          </BalStack>
-        </div>
-        <BalStack vertical spacing="xl">
-          <StakingProvider>
-            <UnstakedPoolsTable :userPools="userPools" />
-            <StakedPoolsTable :userPools="userPools" />
-          </StakingProvider>
-          <BalStack vertical spacing="sm" v-if="migratableUserPools.length > 0">
-            <h5 class="px-4 lg:px-0">{{ $t('poolsToMigrate') }}</h5>
-            <PoolsTable
-              :key="migratableUserPools"
-              :isLoading="isLoadingUserPools"
-              :data="migratableUserPools"
-              :noPoolsLabel="$t('noInvestments')"
-              showPoolShares
-              :selectedTokens="selectedTokens"
-              :hiddenColumns="['poolVolume', 'poolValue', 'stake']"
-            />
-          </BalStack>
-        </BalStack>
-      </BalStack>
-      <div class="mb-16" />
-    </template>
-
     <BalStack vertical>
       <div class="px-4 lg:px-0">
         <h3 class="mb-3">{{ $t('investmentPools') }}</h3>
@@ -104,7 +77,7 @@ function navigateToCreatePool() {
         >
           <TokenSearchInput
             v-model="selectedTokens"
-            :loading="false"
+            :loading="isLoadingPools"
             @add="addSelectedToken"
             @remove="removeSelectedToken"
             class="w-full md:w-2/3"

--- a/src/pages/index.vue
+++ b/src/pages/index.vue
@@ -1,6 +1,5 @@
 <script setup lang="ts">
-import { computed, watch } from 'vue';
-import { useI18n } from 'vue-i18n';
+import { computed } from 'vue';
 import { useRouter } from 'vue-router';
 
 import HomePageHero from '@/components/heros/HomePageHero.vue';
@@ -8,16 +7,13 @@ import TokenSearchInput from '@/components/inputs/TokenSearchInput.vue';
 import FeaturedProtocols from '@/components/sections/FeaturedProtocols.vue';
 import PoolsTable from '@/components/tables/PoolsTable/PoolsTable.vue';
 import usePoolFilters from '@/composables/pools/usePoolFilters';
-import usePools from '@/composables/pools/usePools';
 import useStreamedPoolsQuery from '@/composables/queries/useStreamedPoolsQuery';
-import useAlerts, { AlertPriority, AlertType } from '@/composables/useAlerts';
 import useBreakpoints from '@/composables/useBreakpoints';
 import useTokens from '@/composables/useTokens';
 import useWeb3 from '@/services/web3/useWeb3';
 
 // COMPOSABLES
 const router = useRouter();
-const { t } = useI18n();
 const { appNetworkConfig } = useWeb3();
 const isElementSupported = appNetworkConfig.supportsElementPools;
 const {
@@ -26,33 +22,14 @@ const {
   removeSelectedToken
 } = usePoolFilters();
 
-const { isLoadingPools, poolsQuery } = usePools(selectedTokens);
 const {
   dataStates,
   result: investmentPools,
   loadMore,
   isLoadingMore
 } = useStreamedPoolsQuery(selectedTokens);
-const { addAlert, removeAlert } = useAlerts();
 const { upToMediumBreakpoint } = useBreakpoints();
 const { priceQueryLoading } = useTokens();
-
-// userPools.value[0].shares
-watch(poolsQuery.error, () => {
-  if (poolsQuery.error.value) {
-    addAlert({
-      id: 'pools-fetch-error',
-      label: t('alerts.pools-fetch-error'),
-      type: AlertType.ERROR,
-      persistent: true,
-      action: poolsQuery.refetch.value,
-      actionLabel: t('alerts.retry-label'),
-      priority: AlertPriority.MEDIUM
-    });
-  } else {
-    removeAlert('pools-fetch-error');
-  }
-});
 
 const isInvestmentPoolsTableLoading = computed(
   () => dataStates['basic'] === 'loading' || priceQueryLoading.value
@@ -77,7 +54,7 @@ function navigateToCreatePool() {
         >
           <TokenSearchInput
             v-model="selectedTokens"
-            :loading="isLoadingPools"
+            :loading="false"
             @add="addSelectedToken"
             @remove="removeSelectedToken"
             class="w-full md:w-2/3"

--- a/src/pages/index.vue
+++ b/src/pages/index.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, watch } from 'vue';
+import { computed } from 'vue';
 import { useRouter } from 'vue-router';
 
 import StakedPoolsTable from '@/components/contextual/pages/pools/StakedPoolsTable.vue';
@@ -8,7 +8,6 @@ import TokenSearchInput from '@/components/inputs/TokenSearchInput.vue';
 import FeaturedProtocols from '@/components/sections/FeaturedProtocols.vue';
 import PoolsTable from '@/components/tables/PoolsTable/PoolsTable.vue';
 import usePoolFilters from '@/composables/pools/usePoolFilters';
-import usePools from '@/composables/pools/usePools';
 import useStreamedPoolsQuery from '@/composables/queries/useStreamedPoolsQuery';
 import useBreakpoints from '@/composables/useBreakpoints';
 import { isMigratablePool } from '@/composables/usePool';

--- a/src/pages/portfolio.vue
+++ b/src/pages/portfolio.vue
@@ -1,6 +1,5 @@
 <script setup lang="ts">
 import { computed } from 'vue';
-import { useI18n } from 'vue-i18n';
 
 import StakedPoolsTable from '@/components/contextual/pages/pools/StakedPoolsTable.vue';
 import UnstakedPoolsTable from '@/components/contextual/pages/pools/UnstakedPoolsTable.vue';

--- a/src/pages/portfolio.vue
+++ b/src/pages/portfolio.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, watch } from 'vue';
+import { computed } from 'vue';
 import { useI18n } from 'vue-i18n';
 
 import StakedPoolsTable from '@/components/contextual/pages/pools/StakedPoolsTable.vue';
@@ -8,36 +8,14 @@ import PortfolioPageHero from '@/components/heros/PortfolioPageHero.vue';
 import PoolsTable from '@/components/tables/PoolsTable/PoolsTable.vue';
 import usePoolFilters from '@/composables/pools/usePoolFilters';
 import usePools from '@/composables/pools/usePools';
-import useAlerts, { AlertPriority, AlertType } from '@/composables/useAlerts';
 import { isMigratablePool } from '@/composables/usePool';
 import StakingProvider from '@/providers/local/staking/staking.provider';
 
 // COMPOSABLES
 
-const { t } = useI18n();
-
 const { selectedTokens } = usePoolFilters();
 
-const { userPools, isLoadingUserPools, poolsQuery } = usePools(selectedTokens);
-
-const { addAlert, removeAlert } = useAlerts();
-
-// userPools.value[0].shares
-watch(poolsQuery.error, () => {
-  if (poolsQuery.error.value) {
-    addAlert({
-      id: 'pools-fetch-error',
-      label: t('alerts.pools-fetch-error'),
-      type: AlertType.ERROR,
-      persistent: true,
-      action: poolsQuery.refetch.value,
-      actionLabel: t('alerts.retry-label'),
-      priority: AlertPriority.MEDIUM
-    });
-  } else {
-    removeAlert('pools-fetch-error');
-  }
-});
+const { userPools, isLoadingUserPools } = usePools();
 
 const migratableUserPools = computed(() => {
   return userPools.value.filter(pool => isMigratablePool(pool));

--- a/src/services/aave/aave.service.ts
+++ b/src/services/aave/aave.service.ts
@@ -1,3 +1,4 @@
+import { getAddress } from '@ethersproject/address';
 import { formatUnits } from '@ethersproject/units';
 
 import { FiatCurrency } from '@/constants/currency';
@@ -107,15 +108,16 @@ export default class AaveService {
           18
         );
 
-        if (prices[mainToken] != null && linearPoolTotalSupply) {
-          const price = prices[mainToken][currency] || 0;
+        const mainTokenPrice = prices[getAddress(mainToken)]?.[currency];
+
+        if (mainTokenPrice && linearPoolTotalSupply) {
           const balance = wrappedTokenBalances[tokenIndex];
           const linearPoolBalance = linearPoolToken?.balance || '0';
           const linearPoolShare = bnum(linearPoolBalance).div(
             linearPoolTotalSupply
           );
           const actualBalance = bnum(balance).times(linearPoolShare);
-          const value = bnum(actualBalance).times(price);
+          const value = bnum(actualBalance).times(mainTokenPrice);
           const weightedAPR = value.times(supplyAPR).div(pool.totalLiquidity);
 
           breakdown[wrappedToken] = weightedAPR.toString();

--- a/src/services/balancer/subgraph/entities/pools/index.ts
+++ b/src/services/balancer/subgraph/entities/pools/index.ts
@@ -1,16 +1,5 @@
-import { Network } from '@balancer-labs/sdk';
-
-import { getTimeTravelBlock } from '@/composables/useSnapshots';
-import { FiatCurrency } from '@/constants/currency';
-import { balancerContractsService } from '@/services/balancer/contracts/balancer-contracts.service';
-import { SubgraphGauge } from '@/services/balancer/gauges/types';
-import { TokenPrices } from '@/services/coingecko/api/price.service';
-import { configService as _configService } from '@/services/config/config.service';
-import { PoolDecorator } from '@/services/pool/decorators/pool.decorator';
-import PoolService from '@/services/pool/pool.service';
 import { Pool } from '@/services/pool/types';
 import { QueryBuilder } from '@/types/subgraph';
-import { TokenInfoMap } from '@/types/TokenList';
 
 import Service from '../../balancer-subgraph.service';
 import queryBuilder from './query';
@@ -18,61 +7,15 @@ import queryBuilder from './query';
 export default class Pools {
   service: Service;
   query: QueryBuilder;
-  networkId: Network;
 
-  constructor(
-    service: Service,
-    query: QueryBuilder = queryBuilder,
-    private readonly configService = _configService,
-    private readonly poolServiceClass = PoolService,
-    private readonly balancerContracts = balancerContractsService,
-    private readonly poolDecoratorClass = PoolDecorator
-  ) {
+  constructor(service: Service, query: QueryBuilder = queryBuilder) {
     this.service = service;
     this.query = query;
-    this.networkId = configService.env.NETWORK;
   }
 
   public async get(args = {}, attrs = {}): Promise<Pool[]> {
     const query = this.query(args, attrs);
     const data = await this.service.client.get(query);
     return data.pools;
-  }
-
-  /**
-   *
-   */
-  public async decorate(
-    pools: Pool[],
-    prices: TokenPrices,
-    currency: FiatCurrency,
-    gauges: SubgraphGauge[],
-    tokens: TokenInfoMap
-  ): Promise<Pool[]> {
-    // Get past state of pools
-    const currentBlock = await this.service.rpcProviderService.getBlockNumber();
-    const blockNumber = await getTimeTravelBlock(currentBlock);
-    const block = { number: blockNumber };
-    const isInPoolIds = { id_in: pools.map(pool => pool.id) };
-    const poolSnapshotQuery = this.query({ where: isInPoolIds, block });
-    let poolSnapshots: Pool[] = [];
-    try {
-      const data: { pools: Pool[] } = await this.service.client.get(
-        poolSnapshotQuery
-      );
-      poolSnapshots = data.pools;
-    } catch {
-      // eslint-disable-previous-line no-empty
-    }
-
-    const poolDecorator = new this.poolDecoratorClass(pools);
-
-    return await poolDecorator.decorate(
-      gauges,
-      prices,
-      currency,
-      poolSnapshots,
-      tokens
-    );
   }
 }

--- a/src/services/balancer/subgraph/entities/pools/index.ts
+++ b/src/services/balancer/subgraph/entities/pools/index.ts
@@ -1,10 +1,6 @@
 import { Network } from '@balancer-labs/sdk';
-import { getAddress } from '@ethersproject/address';
 
-import {
-  getTimeTravelBlock,
-  TimeTravelPeriod
-} from '@/composables/useSnapshots';
+import { getTimeTravelBlock } from '@/composables/useSnapshots';
 import { FiatCurrency } from '@/constants/currency';
 import { balancerContractsService } from '@/services/balancer/contracts/balancer-contracts.service';
 import { SubgraphGauge } from '@/services/balancer/gauges/types';
@@ -43,6 +39,9 @@ export default class Pools {
     return data.pools;
   }
 
+  /**
+   *
+   */
   public async decorate(
     pools: Pool[],
     prices: TokenPrices,
@@ -75,9 +74,5 @@ export default class Pools {
       poolSnapshots,
       tokens
     );
-  }
-
-  public addressFor(poolId: string): string {
-    return getAddress(poolId.slice(0, 42));
   }
 }

--- a/src/services/balancer/subgraph/entities/pools/index.ts
+++ b/src/services/balancer/subgraph/entities/pools/index.ts
@@ -45,7 +45,6 @@ export default class Pools {
 
   public async decorate(
     pools: Pool[],
-    period: TimeTravelPeriod,
     prices: TokenPrices,
     currency: FiatCurrency,
     gauges: SubgraphGauge[],
@@ -53,7 +52,7 @@ export default class Pools {
   ): Promise<Pool[]> {
     // Get past state of pools
     const currentBlock = await this.service.rpcProviderService.getBlockNumber();
-    const blockNumber = await getTimeTravelBlock(currentBlock, period);
+    const blockNumber = await getTimeTravelBlock(currentBlock);
     const block = { number: blockNumber };
     const isInPoolIds = { id_in: pools.map(pool => pool.id) };
     const poolSnapshotQuery = this.query({ where: isInPoolIds, block });

--- a/src/services/pool/concerns/liquidity.concern.ts
+++ b/src/services/pool/concerns/liquidity.concern.ts
@@ -171,12 +171,12 @@ export default class LiquidityConcern {
 
         const mainTokenBalance = formatUnits(
           token.mainToken.balance,
-          tokenMeta[token.mainToken.address].decimals
+          tokenMeta[getAddress(token.mainToken.address)].decimals
         );
 
         const wrappedTokenBalance = formatUnits(
           token.wrappedToken.balance,
-          tokenMeta[token.wrappedToken.address].decimals
+          tokenMeta[getAddress(token.wrappedToken.address)].decimals
         );
 
         const mainTokenPrice =

--- a/src/services/pool/decorators/onchain-data.formater.ts
+++ b/src/services/pool/decorators/onchain-data.formater.ts
@@ -1,0 +1,140 @@
+import { toNormalizedWeights } from '@balancer-labs/sdk';
+import { getAddress } from '@ethersproject/address';
+import { formatUnits } from '@ethersproject/units';
+
+import { isStableLike, isWeightedLike } from '@/composables/usePool';
+import { TokenInfoMap } from '@/types/TokenList';
+
+import {
+  LinearPoolDataMap,
+  OnchainPoolData,
+  OnchainTokenDataMap,
+  Pool,
+  RawOnchainPoolData
+} from '../types';
+
+/**
+ * @summary Takes map of pool ids to onchain data and formats.
+ */
+export class OnchainDataFormater {
+  constructor(
+    private readonly pool: Pool,
+    private readonly rawData: RawOnchainPoolData,
+    private readonly tokenMeta: TokenInfoMap
+  ) {}
+
+  public format(): OnchainPoolData {
+    const poolData = <OnchainPoolData>{};
+
+    poolData.tokens = this.formatPoolTokens();
+
+    poolData.amp = '0';
+    if (this.rawData?.amp) {
+      poolData.amp = this.rawData.amp.value
+        .div(this.rawData.amp.precision)
+        .toString();
+    }
+
+    poolData.swapEnabled = true;
+    if (this.rawData.swapEnabled !== undefined) {
+      poolData.swapEnabled = this.rawData.swapEnabled;
+    }
+
+    if (this.rawData?.linearPools) {
+      poolData.linearPools = this.formatLinearPools();
+    }
+
+    if (this.rawData.tokenRates) {
+      poolData.tokenRates = this.rawData.tokenRates.map(rate =>
+        formatUnits(rate.toString(), 18)
+      );
+    }
+
+    poolData.totalSupply = formatUnits(
+      this.rawData.totalSupply,
+      this.rawData.decimals
+    );
+    poolData.decimals = this.rawData.decimals;
+    poolData.swapFee = formatUnits(this.rawData.swapFee, 18);
+
+    return poolData;
+  }
+
+  private formatPoolTokens(): OnchainTokenDataMap {
+    const tokens = <OnchainTokenDataMap>{};
+    const weights = this.normalizeWeights();
+
+    this.rawData.poolTokens.tokens.forEach((token, i) => {
+      const tokenBalance = this.rawData.poolTokens.balances[i];
+      const decimals = this.tokenMeta[token]?.decimals;
+      tokens[token.toLowerCase()] = {
+        decimals,
+        balance: formatUnits(tokenBalance, decimals),
+        weight: weights[i],
+        symbol: this.tokenMeta[token]?.symbol,
+        name: this.tokenMeta[token]?.name,
+        logoURI: this.tokenMeta[token]?.logoURI
+      };
+    });
+
+    // Remove pre-minted BPT
+    delete tokens[this.pool.address.toLowerCase()];
+
+    return tokens;
+  }
+
+  private formatLinearPools(): LinearPoolDataMap {
+    const _linearPools = <LinearPoolDataMap>{};
+
+    for (const address in this.rawData.linearPools) {
+      const {
+        id,
+        mainToken,
+        wrappedToken,
+        priceRate,
+        unwrappedTokenAddress,
+        unwrappedERC4626Address,
+        tokenData,
+        totalSupply
+      } = this.rawData.linearPools[address];
+
+      const unwrappedAddress = unwrappedTokenAddress || unwrappedERC4626Address;
+
+      _linearPools[address.toLowerCase()] = {
+        id,
+        priceRate: formatUnits(priceRate.toString(), 18),
+        mainToken: {
+          address: getAddress(mainToken.address),
+          index: mainToken.index.toNumber(),
+          balance: tokenData.balances[mainToken.index.toNumber()].toString()
+        },
+        wrappedToken: {
+          address: getAddress(wrappedToken.address),
+          index: wrappedToken.index.toNumber(),
+          balance: tokenData.balances[wrappedToken.index.toNumber()].toString(),
+          priceRate: formatUnits(wrappedToken.rate, 18)
+        },
+        unwrappedTokenAddress: unwrappedAddress,
+        totalSupply: formatUnits(totalSupply, 18)
+      };
+    }
+
+    return _linearPools;
+  }
+
+  private normalizeWeights(): number[] {
+    if (isWeightedLike(this.pool.poolType)) {
+      // toNormalizedWeights returns weights as 18 decimal fixed point
+      return toNormalizedWeights(this.rawData.weights || []).map(w =>
+        Number(formatUnits(w, 18))
+      );
+    } else if (isStableLike(this.pool.poolType)) {
+      const value = this.pool.tokensList.map(
+        () => 1 / this.pool.tokensList.length
+      );
+      return this.rawData.poolTokens.tokens.map(() => value[0]);
+    } else {
+      return [];
+    }
+  }
+}

--- a/src/services/pool/decorators/pool.decorator.ts
+++ b/src/services/pool/decorators/pool.decorator.ts
@@ -55,8 +55,6 @@ export class PoolDecorator {
       poolService.setVolumeSnapshot(poolSnapshot);
       poolService.setUnwrappedTokens();
 
-      console.log(pool);
-
       await poolService.setAPR(
         poolSnapshot,
         prices,

--- a/src/services/pool/decorators/pool.decorator.ts
+++ b/src/services/pool/decorators/pool.decorator.ts
@@ -97,7 +97,7 @@ export class PoolDecorator {
   /**
    * @summary Fetch supporting data required to calculate APRs.
    */
-  private async getData(
+  public async getData(
     prices: TokenPrices,
     gauges: SubgraphGauge[],
     tokens: TokenInfoMap

--- a/src/services/pool/decorators/pool.multicaller.ts
+++ b/src/services/pool/decorators/pool.multicaller.ts
@@ -1,0 +1,218 @@
+import {
+  InvestmentPool__factory,
+  StablePool__factory,
+  Vault__factory,
+  WeightedPool__factory
+} from '@balancer-labs/typechain';
+
+import {
+  isStableLike,
+  isStablePhantom,
+  isTradingHaltable,
+  isWeightedLike,
+  removePreMintedBPT
+} from '@/composables/usePool';
+import ERC20_ABI from '@/lib/abi/ERC20.json';
+import IERC4626 from '@/lib/abi/IERC4626.json';
+import LinearPoolABI from '@/lib/abi/LinearPool.json';
+import StablePhantomPoolABI from '@/lib/abi/StablePhantomPool.json';
+import StaticATokenLMABI from '@/lib/abi/StaticATokenLM.json';
+import { configService } from '@/services/config/config.service';
+import { Multicaller } from '@/services/multicalls/multicaller';
+
+import { Pool, RawLinearPoolData, RawOnchainPoolDataMap } from '../types';
+
+const PoolTypeABIs = Object.values(
+  Object.fromEntries(
+    [
+      ...WeightedPool__factory.abi,
+      ...StablePool__factory.abi,
+      ...InvestmentPool__factory.abi,
+      ...StablePhantomPoolABI,
+      ...LinearPoolABI,
+      ...StaticATokenLMABI,
+      ...ERC20_ABI,
+      ...IERC4626
+    ].map(row => [row.name, row])
+  )
+);
+
+export class PoolMulticaller {
+  constructor(
+    public readonly pools: Pool[],
+    private readonly MulticallerClass = Multicaller,
+    private readonly vaultAddress = configService.network.addresses.vault
+  ) {}
+
+  public async fetch(): Promise<RawOnchainPoolDataMap> {
+    let result = <RawOnchainPoolDataMap>{};
+    const multicaller = new this.MulticallerClass();
+
+    this.pools.forEach(pool => {
+      pool = removePreMintedBPT(pool);
+
+      multicaller
+        .call({
+          key: `${pool.id}.totalSupply`,
+          address: pool.address,
+          function: 'totalSupply',
+          abi: PoolTypeABIs
+        })
+        .call({
+          key: `${pool.id}.decimals`,
+          address: pool.address,
+          function: 'decimals',
+          abi: PoolTypeABIs
+        })
+        .call({
+          key: `${pool.id}.swapFee`,
+          address: pool.address,
+          function: 'getSwapFeePercentage',
+          abi: PoolTypeABIs
+        });
+
+      if (isWeightedLike(pool.poolType)) {
+        multicaller.call({
+          key: `${pool.id}.weights`,
+          address: pool.address,
+          function: 'getNormalizedWeights',
+          abi: PoolTypeABIs
+        });
+
+        if (isTradingHaltable(pool.poolType)) {
+          multicaller.call({
+            key: `${pool.id}.swapEnabled`,
+            address: pool.address,
+            function: 'getSwapEnabled',
+            abi: PoolTypeABIs
+          });
+        }
+      } else if (isStableLike(pool.poolType)) {
+        multicaller.call({
+          key: `${pool.id}.amp`,
+          address: pool.address,
+          function: 'getAmplificationParameter',
+          abi: PoolTypeABIs
+        });
+
+        if (isStablePhantom(pool.poolType)) {
+          // Overwrite totalSupply with virtualSupply for StablePhantom pools
+          multicaller.call({
+            key: `${pool.id}.totalSupply`,
+            address: pool.address,
+            function: 'getVirtualSupply',
+            abi: PoolTypeABIs
+          });
+
+          pool.tokensList.forEach((poolToken, i) => {
+            multicaller
+              .call({
+                key: `${pool.id}.linearPools.${poolToken}.id`,
+                address: poolToken,
+                function: 'getPoolId',
+                abi: PoolTypeABIs
+              })
+              .call({
+                key: `${pool.id}.linearPools.${poolToken}.priceRate`,
+                address: poolToken,
+                function: 'getRate',
+                abi: PoolTypeABIs
+              })
+              .call({
+                key: `${pool.id}.tokenRates[${i}]`,
+                address: pool.address,
+                function: 'getTokenRate',
+                abi: PoolTypeABIs,
+                params: [poolToken]
+              })
+              .call({
+                key: `${pool.id}.linearPools.${poolToken}.mainToken.address`,
+                address: poolToken,
+                function: 'getMainToken',
+                abi: PoolTypeABIs
+              })
+              .call({
+                key: `${pool.id}.linearPools.${poolToken}.mainToken.index`,
+                address: poolToken,
+                function: 'getMainIndex',
+                abi: PoolTypeABIs
+              })
+              .call({
+                key: `${pool.id}.linearPools.${poolToken}.wrappedToken.address`,
+                address: poolToken,
+                function: 'getWrappedToken',
+                abi: PoolTypeABIs
+              })
+              .call({
+                key: `${pool.id}.linearPools.${poolToken}.wrappedToken.index`,
+                address: poolToken,
+                function: 'getWrappedIndex',
+                abi: PoolTypeABIs
+              })
+              .call({
+                key: `${pool.id}.linearPools.${poolToken}.wrappedToken.rate`,
+                address: poolToken,
+                function: 'getWrappedTokenRate',
+                abi: PoolTypeABIs
+              });
+          });
+        }
+      }
+    });
+
+    result = await multicaller.execute();
+
+    this.pools.forEach(pool => {
+      if (isStablePhantom(pool.poolType) && result[pool.id].linearPools) {
+        const wrappedTokensMap: Record<string, string> = {};
+        const linearPools = result[pool.id].linearPools || {};
+
+        for (const address in linearPools) {
+          const linearPool: RawLinearPoolData = linearPools[address];
+
+          multicaller.call({
+            key: `${pool.id}.linearPools.${address}.tokenData`,
+            address: this.vaultAddress,
+            function: 'getPoolTokens',
+            abi: Vault__factory.abi,
+            params: [linearPool.id]
+          });
+
+          wrappedTokensMap[address] = linearPool.wrappedToken.address;
+        }
+
+        Object.entries(wrappedTokensMap).forEach(([address, wrappedToken]) => {
+          multicaller
+            .call({
+              key: `${pool.id}.linearPools.${address}.unwrappedTokenAddress`,
+              address: wrappedToken,
+              function: 'ATOKEN',
+              abi: PoolTypeABIs
+            })
+            .call({
+              key: `${pool.id}.linearPools.${address}.unwrappedERC4626Address`,
+              address: wrappedToken,
+              function: 'asset',
+              abi: PoolTypeABIs
+            })
+            .call({
+              key: `${pool.id}.linearPools.${address}.totalSupply`,
+              address: address,
+              function: 'getVirtualSupply',
+              abi: PoolTypeABIs
+            });
+        });
+      }
+
+      multicaller.call({
+        key: `${pool.id}.poolTokens`,
+        address: this.vaultAddress,
+        function: 'getPoolTokens',
+        abi: Vault__factory.abi,
+        params: [pool.id]
+      });
+    });
+
+    return await multicaller.execute(result);
+  }
+}

--- a/src/services/pool/pool.service.ts
+++ b/src/services/pool/pool.service.ts
@@ -53,7 +53,6 @@ export default class PoolService {
     currency: FiatCurrency,
     tokenMeta: TokenInfoMap = {}
   ): string {
-    if (isStablePhantom(this.pool.poolType)) console.log('setTotalLiquidity')
     const liquidityConcern = new this.liquidity(this.pool);
     const totalLiquidity = liquidityConcern.calcTotal(
       prices,

--- a/src/services/pool/pool.service.ts
+++ b/src/services/pool/pool.service.ts
@@ -53,6 +53,7 @@ export default class PoolService {
     currency: FiatCurrency,
     tokenMeta: TokenInfoMap = {}
   ): string {
+    if (isStablePhantom(this.pool.poolType)) console.log('setTotalLiquidity')
     const liquidityConcern = new this.liquidity(this.pool);
     const totalLiquidity = liquidityConcern.calcTotal(
       prices,

--- a/src/services/pool/types.ts
+++ b/src/services/pool/types.ts
@@ -108,6 +108,8 @@ export interface RawOnchainPoolData {
   tokenRates?: BigNumber[];
 }
 
+export type RawOnchainPoolDataMap = Record<string, RawOnchainPoolData>;
+
 export interface OnchainPoolData {
   tokens: Record<Address, OnchainTokenData>;
   totalSupply: string;
@@ -118,6 +120,8 @@ export interface OnchainPoolData {
   linearPools?: Record<Address, LinearPoolData>;
   tokenRates?: string[];
 }
+
+export type OnchainPoolDataMap = Record<string, OnchainPoolData>;
 
 export interface RawLinearPoolToken {
   address: string;

--- a/src/services/staking/staking-rewards.service.ts
+++ b/src/services/staking/staking-rewards.service.ts
@@ -125,7 +125,6 @@ export class StakingRewardsService {
       if (isNil(inflationRate)) return nilApr;
 
       const poolService = new PoolService(pool);
-      poolService.setTotalLiquidity(prices, FiatCurrency.usd);
       if (!balAddress) return nilApr;
 
       const totalSupply = bnum(totalSupplies[getAddress(gauge.id)]);
@@ -142,6 +141,7 @@ export class StakingRewardsService {
         relativeWeights,
         totalSupply
       });
+
       const range = getAprRange(gaugeBALApr || '0'.toString());
       return [poolId, { ...range }];
     });


### PR DESCRIPTION
# Description

Various refactorings of coupled and messy code in pool queries,  i.e. usePoolQuery, usePoolsQuery & useUserPoolsQuery.

TODO before merge:
- Test changes to stream query doesn't break any functionality on home page.

Next steps for refactoring pool decoration/schema (in a new PR)
- Deep dive into all the additional fetching we're doing around linear pools and generalise. i.e. fetch additional sub-pool data for any pool token that happens to be a pool, not just linear pools of StablePhantom pools.
- Fix weird cyclic dependency in [staking-rewards.service.ts](https://github.com/balancer-labs/frontend-v2/pull/1963/files#diff-ec494d6f45c6897a66b89ac170e96d4aac13d3cc8f71e52133e4ef226475478dR183-R184) where we need accurate total liquidities to calc those APRs, but also we call this function in the [decorator](https://github.com/balancer-labs/frontend-v2/blob/develop/src/services/pool/decorators/pool.decorator.ts#L77) as part of the calls to get supporting data for decoration. So fetching onchain data and calculating total liquidities ends up being done twice. Needs to be re-thought and refactored.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [x] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## How should this be tested?

- [ ] Test pools lists load as expected
- [ ] Test pool pages load as expected

## Visual context

n/a

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have requested at least 2 reviews (If the PR is significant enough, use best judgement here)
- [ ] I have commented my code where relevant, particularly in hard-to-understand areas
- [ ] If package-lock.json has changes, it was intentional.
- [ ] The base of this PR is `master` if hotfix, `develop` if not
