### PR TITLE
Add Kovan feeDistributor

### DIFF
--- a/src/lib/config/kovan.json
+++ b/src/lib/config/kovan.json
@@ -53,7 +53,7 @@
     "veBAL": "0x0BA4d28a89b0aB0c48253f4f36B204DE24354651",
     "veDelegationProxy": "0x5C7c4bdfEf212F3154156A84e8e44abed73D104b",
     "veBALHelpers": "",
-    "feeDistributor": ""
+    "feeDistributor": "0xcC508a455F5b0073973107Db6a878DdBDab957bC"
   },
   "keys": {
     "infura": "daaa68ec242643719749dd1caba2fc66",


### PR DESCRIPTION
# Description

Address from monorepo, added in https://github.com/balancer-labs/balancer-v2-monorepo/commit/5bb5a56a8dd0988ce11a41d424e5c8822e3477aa 

Fixes error `Failed to fetch claimable protocol balances Error: resolver or addr is not configured for ENS name (argument="name", value="", code=INVALID_ARGUMENT, version=contracts/5.4.1)` seen on Kovan claim page. 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [x] Other

## How should this be tested?

- Visit Claim page
- Ensure there are no errors about fetching claimable protocol balances. 
- Ensure claiming works correctly (I don't think there is any protocol fee claiming on Kovan, but other staking rewards should still work correctly). 

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have requested at least 2 reviews (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] If package-lock.json has changes, it was intentional.
- [x] The base of this PR is `master` if hotfix, `develop` if not
