### PR TITLE
Use getToken insead of tokens array in a few locations

### DIFF
--- a/src/components/cards/CreatePool/PreviewPool.vue
+++ b/src/components/cards/CreatePool/PreviewPool.vue
@@ -49,7 +49,7 @@ const {
 } = usePoolCreation();
 
 const {
-  tokens,
+  getToken,
   priceFor,
   nativeAsset,
   wrappedNativeAsset,
@@ -221,7 +221,7 @@ function getInitialWeightHighlightClass(tokenAddress: string) {
                   <BalStack vertical spacing="none">
                     <span class="font-semibold">
                       {{ fNum2(token.weight / 100, FNumFormats.percent) }}
-                      {{ tokens[token.tokenAddress]?.symbol }}
+                      {{ getToken(token.tokenAddress)?.symbol }}
                     </span>
                     <span
                       :class="[

--- a/src/components/cards/CreatePool/TokenPrices.vue
+++ b/src/components/cards/CreatePool/TokenPrices.vue
@@ -17,7 +17,7 @@ defineProps<Props>();
  */
 const { upToLargeBreakpoint } = useBreakpoints();
 const { tokensList } = usePoolCreation();
-const { tokens, priceFor, injectedPrices } = useTokens();
+const { getToken, priceFor, injectedPrices } = useTokens();
 const { fNum2 } = useNumbers();
 
 /**
@@ -57,7 +57,7 @@ const hasUnknownPrice = computed(() =>
           justify="between"
           align="center"
         >
-          <span>{{ tokens[token]?.symbol }}</span>
+          <span>{{ getToken(token)?.symbol }}</span>
           <BalStack horizontal justify="center">
             <div>
               <div class="-mr-1">
@@ -95,7 +95,7 @@ const hasUnknownPrice = computed(() =>
                 'w-1/2 text-left',
                 { 'font-medium': injectedPrices[token]?.usd === undefined }
               ]"
-              >{{ tokens[token]?.symbol }}</span
+              >{{ getToken(token)?.symbol }}</span
             >
             <BalStack
               v-if="injectedPrices[token]?.usd !== undefined"

--- a/src/components/forms/pool_actions/MigrateForm/components/PoolsInfo/components/PoolInfoBreakdown.vue
+++ b/src/components/forms/pool_actions/MigrateForm/components/PoolsInfo/components/PoolInfoBreakdown.vue
@@ -23,7 +23,7 @@ const isExpanded = ref(false);
 /**
  * COMPOSABLES
  */
-const { tokens } = useTokens();
+const { getToken } = useTokens();
 </script>
 
 <template>
@@ -51,7 +51,7 @@ const { tokens } = useTokens();
           class="ml-2 rounded-lg border dark:border-gray-800 bg-gray-50 dark:bg-gray-700 px-2 py-1 inline-flex items-center"
         >
           <BalAsset :address="address" class="mr-2" />
-          {{ tokens[address].symbol }}
+          {{ getToken(address).symbol }}
         </div>
       </template>
     </BalBreakdown>

--- a/src/components/forms/pool_actions/WithdrawForm/components/WithdrawalTokenSelect.vue
+++ b/src/components/forms/pool_actions/WithdrawForm/components/WithdrawalTokenSelect.vue
@@ -113,7 +113,7 @@ function handleSelected(newToken: string): void {
       <div v-else class="flex items-center justify-between">
         <div class="flex items-center">
           <BalAsset :address="option" class="mr-2" />
-          {{ tokens[option]?.symbol }}
+          {{ getToken(option)?.symbol }}
         </div>
         <BalIcon
           v-if="selectedOption === option"

--- a/src/components/forms/pool_actions/WithdrawForm/components/WithdrawalTokenSelect.vue
+++ b/src/components/forms/pool_actions/WithdrawForm/components/WithdrawalTokenSelect.vue
@@ -33,7 +33,7 @@ const selectedOption = ref(props.initToken);
 /**
  * COMPOSABLES
  */
-const { getTokens, getToken, nativeAsset } = useTokens();
+const { getToken, getTokens, nativeAsset } = useTokens();
 const { isProportional, tokenOut } = useWithdrawalState(toRef(props, 'pool'));
 const { isWethPool, isStablePhantomPool } = usePool(toRef(props, 'pool'));
 
@@ -113,7 +113,7 @@ function handleSelected(newToken: string): void {
       <div v-else class="flex items-center justify-between">
         <div class="flex items-center">
           <BalAsset :address="option" class="mr-2" />
-          {{ getToken(option)?.symbol }}
+          {{ tokens[option]?.symbol }}
         </div>
         <BalIcon
           v-if="selectedOption === option"

--- a/src/components/inputs/TokenSearchInput.vue
+++ b/src/components/inputs/TokenSearchInput.vue
@@ -33,7 +33,7 @@ const selectTokenModal = ref(false);
 /**
  * COMPOSABLES
  */
-const { tokens, balances, dynamicDataLoading } = useTokens();
+const { getToken, tokens, balances, dynamicDataLoading } = useTokens();
 const { account, appNetworkConfig } = useWeb3();
 const { veBalTokenInfo } = useVeBal();
 
@@ -99,7 +99,7 @@ function onClick() {
           @closed="emit('remove', token)"
         >
           <BalAsset :address="token" :size="20" class="flex-auto" />
-          <span class="ml-2">{{ tokens[token]?.symbol }}</span>
+          <span class="ml-2">{{ getToken(token)?.symbol }}</span>
         </BalChip>
       </div>
       <div


### PR DESCRIPTION
# Description

We consolidated token fetching in #1941 so that we didn't have to worry about if addresses were lower case or checksummed. There were a few locations where the old tokens array was used causing missing symbols/details. This PR fixes them. 

The main one noticed was when withdrawing from the 80/20 pool the BAL and WETH tokens were missing their symbols. See Image. 

Also fixes a bug where the invest form disappears if you switch from WETH to ETH. 


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## How should this be tested?

- Try withdrawing from the 80/20 BAL/ETH pool or other pools and ensure all token symbols/images load. 
- Try investing in a pool with WETH and switch to ETH and make sure the form doesn't disappear. 

## Visual context

![2022-06-14-005101_162x267_scrot](https://user-images.githubusercontent.com/525534/173381512-d690f6be-24fb-4506-bd22-74d09729a583.png)

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have requested at least 2 reviews (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] If package-lock.json has changes, it was intentional.
- [x] The base of this PR is `master` if hotfix, `develop` if not
