### PR TITLE
Hotfix: Fix avatar icon being passed to 'address' in trade table

### DIFF
--- a/src/components/contextual/pages/pool/PoolTransactionsCard/TradeTransactions/Table.vue
+++ b/src/components/contextual/pages/pool/PoolTransactionsCard/TradeTransactions/Table.vue
@@ -167,7 +167,8 @@ const swapRows = computed<SwapRow[]>(() =>
           <div class="flex items-center">
             <BalAsset
               class="mr-2 flex-shrink-0"
-              :address="action.ensAvatar || action.userAddress"
+              :address="action.userAddress"
+              :iconURI="action.ensAvatar"
               :size="30"
             />
             <span :class="[action.ensName && 'truncate']">


### PR DESCRIPTION
# Description

In the trade table users ens avatars were being loaded but passed to the `address` field of BalAsset instead of iconSRC. This caused this error to be thrown since we started sanity checking addresses: https://sentry.io/organizations/balancer-labs/issues/3347571815/?project=5725878&referrer=slack

Fixes the issue by correctly passing the avatar to the iconURI. 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## How should this be tested?

Look at pool `/#/pool/0x805ca3ccc61cc231851dee2da6aabff0a7714aa7000200000000000000000361` on Polygon in the trades table you should see a trade from timjrobinson.eth with my Rocketeer avatar. There should be no error in console. On current mainnet you'll see a generic jazzicon avatar and an error in the console

## Visual context

![2022-06-14-154443_1050x71_scrot](https://user-images.githubusercontent.com/525534/173502155-f1f9254a-3a35-4ad9-b1a8-38f0eecaa842.png)


## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have requested at least 2 reviews (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] If package-lock.json has changes, it was intentional.
- [x] The base of this PR is `master` if hotfix, `develop` if not
