### PR TITLE
Hotfix - Don't show boosted pool BPT token in token list

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.58.2",
+  "version": "1.58.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@balancer-labs/frontend-v2",
-      "version": "1.58.2",
+      "version": "1.58.3",
       "license": "MIT",
       "devDependencies": {
         "@aave/protocol-js": "^4.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.58.2",
+  "version": "1.58.3",
   "engines": {
     "node": "14.x",
     "npm": ">=7"

--- a/src/composables/usePool.ts
+++ b/src/composables/usePool.ts
@@ -120,7 +120,7 @@ export function orderedPoolTokens(
   tokens: Pick<PoolToken, 'address' | 'weight'>[]
 ): Partial<PoolToken>[] {
   if (isStablePhantom(poolType))
-    return tokens.filter(token => token.address !== poolAddress);
+    return tokens.filter(token => !isSameAddress(token.address, poolAddress));
   if (isStableLike(poolType)) return tokens;
 
   return tokens


### PR DESCRIPTION
# Description

In the token list for the Boosted Pool the BPT token was showing because it wasn't being filtered out correctly as the token address was checksum styled while the pool address was lowercase. Using the correct comparison function fixes the issue. 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## How should this be tested?

- Load Balancer Homepage
- Ensure Boosted pool only shows 3 tokens, not 4. 

## Visual context

Incorrect:
![2022-06-15-170638_664x55_scrot](https://user-images.githubusercontent.com/525534/173764965-f1c72d6a-32a2-4251-8a83-f1983dac2cd3.png)

Correct:
![2022-06-15-170947_532x60_scrot](https://user-images.githubusercontent.com/525534/173764981-7eb1ef55-f6ea-42cb-b5b3-7d9f989a2cb8.png)


## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have requested at least 2 reviews (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] If package-lock.json has changes, it was intentional.
- [x] The base of this PR is `master` if hotfix, `develop` if not
