### PR TITLE
Hotfix - Single asset max withdrawals

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.59.0",
+  "version": "1.59.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@balancer-labs/frontend-v2",
-      "version": "1.59.0",
+      "version": "1.59.1",
       "license": "MIT",
       "devDependencies": {
         "@aave/protocol-js": "^4.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.59.0",
+  "version": "1.59.1",
   "engines": {
     "node": "14.x",
     "npm": ">=7"

--- a/src/constants/tokens.ts
+++ b/src/constants/tokens.ts
@@ -109,7 +109,10 @@ export const TOKENS_KOVAN: TokenConstants = {
       '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48', // USDC
     // AAVE USDT
     '0x13512979ade267ab5100878e2e0f485b568328a4':
-      '0xdac17f958d2ee523a2206206994597c13d831ec7' // USDT
+      '0xdac17f958d2ee523a2206206994597c13d831ec7', // USDT
+    // wstETH
+    '0xa387b91e393cfb9356a460370842bc8dbb2f29af':
+      '0x7f39c581f595b53c5cb19bd0b3f8da6c935e2ca0'
   }
 };
 

--- a/src/providers/local/staking/userUserStakingData.ts
+++ b/src/providers/local/staking/userUserStakingData.ts
@@ -271,7 +271,7 @@ export default function useUserStakingData(
     );
 
     if (gaugeAddress === AddressZero) return '0';
-    console.log('gaugeAddress', gaugeAddress);
+
     const gauge = new LiquidityGauge(gaugeAddress);
     const balance = await gauge.balance(account.value);
     return formatUnits(balance.toString(), 18);

--- a/src/providers/local/staking/userUserStakingData.ts
+++ b/src/providers/local/staking/userUserStakingData.ts
@@ -1,4 +1,5 @@
 import { getAddress } from '@ethersproject/address';
+import { AddressZero } from '@ethersproject/constants';
 import { formatUnits } from 'ethers/lib/utils';
 import { intersection } from 'lodash';
 import { QueryObserverResult, RefetchOptions } from 'react-query';
@@ -19,6 +20,7 @@ import { stakingRewardsService } from '@/services/staking/staking-rewards.servic
 import useWeb3 from '@/services/web3/useWeb3';
 
 import { getGaugeAddress } from './staking.provider';
+
 export type UserGaugeShare = {
   id: string;
   gauge: {
@@ -267,6 +269,9 @@ export default function useUserStakingData(
       getAddress(poolAddress.value),
       getProvider()
     );
+
+    if (gaugeAddress === AddressZero) return '0';
+    console.log('gaugeAddress', gaugeAddress);
     const gauge = new LiquidityGauge(gaugeAddress);
     const balance = await gauge.balance(account.value);
     return formatUnits(balance.toString(), 18);

--- a/src/services/pool/calculator/calculator.sevice.ts
+++ b/src/services/pool/calculator/calculator.sevice.ts
@@ -104,11 +104,11 @@ export default class CalculatorService {
       let hasBalance = true;
       let balance;
       if (token === this.config.network.nativeAsset.address) {
-        balance = bnum(this.balances.value[token])
+        balance = bnum(this.balances.value[getAddress(token)])
           .minus(this.config.network.nativeAsset.minTransactionBuffer)
           .toString();
       } else {
-        balance = this.balances.value[token] || '0';
+        balance = this.balances.value[getAddress(token)] || '0';
       }
       const amounts = this.propAmountsGiven(balance, tokenIndex, type);
 
@@ -233,7 +233,7 @@ export default class CalculatorService {
   }
 
   public get bptBalance(): string {
-    return this.balances.value[this.pool.value.address];
+    return this.balances.value[getAddress(this.pool.value.address)];
   }
 
   public get isStablePool(): boolean {


### PR DESCRIPTION
# Description

Due to refactoring of checksum address usage a case where we were using an address map but not transforming the address was not caught. This caused an exception in the single asset max withdrawal case which crashed the form. This PR fixes a couple of references to that address map.

Reference bug: https://discord.com/channels/638460494168064021/829044997202378852/989072431467614229

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## How should this be tested?

- [ ] Test single asset max withdrawals doesn't crash form.

## Visual context

n/a

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have requested at least 2 reviews (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] If package-lock.json has changes, it was intentional.
- [x] The base of this PR is `master` if hotfix, `develop` if not
