### PR TITLE
Hotfix/exclude goerli voting gauges on mainnet

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.60.0",
+  "version": "1.60.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@balancer-labs/frontend-v2",
-      "version": "1.60.0",
+      "version": "1.60.1",
       "license": "MIT",
       "devDependencies": {
         "@aave/protocol-js": "^4.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.60.0",
+  "version": "1.60.1",
   "engines": {
     "node": "14.x",
     "npm": ">=7"

--- a/src/composables/queries/useExpiredGaugesQuery.ts
+++ b/src/composables/queries/useExpiredGaugesQuery.ts
@@ -65,7 +65,12 @@ export default function useExpiredGaugesQuery(
     if (gaugeAddresses.value?.length) {
       const gaugesExpiredStatus = await callGaugesIsKilledStatus(
         gaugeAddresses.value
-      );
+      ).catch(error => {
+        console.error('Error when fetching voting gauges is_killed status', {
+          error
+        });
+        return [];
+      });
 
       for (const [address, value] of Object.entries(gaugesExpiredStatus)) {
         if (value.isKilled) {

--- a/src/constants/voting-gauges.ts
+++ b/src/constants/voting-gauges.ts
@@ -27,7 +27,7 @@ export const GOERLI_VOTING_GAUGES: VotingGauge[] = (ALL_VOTING_GAUGES as VotingG
 );
 
 export const MAINNET_VOTING_GAUGES: VotingGauge[] = (ALL_VOTING_GAUGES as VotingGauge[]).filter(
-  gauge => gauge.network !== Network.KOVAN
+  gauge => gauge.network !== Network.KOVAN && gauge.network !== Network.GOERLI
 );
 
 export const VEBAL_VOTING_GAUGE:


### PR DESCRIPTION
# Description

Calling `is_killed` status of the Voting Gauges was failing on `/vebal` page. It was failing because Multicaller query tried to read Voting Gauge contracts that didn't exist on the Mainnet.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

Go to `/vebal` page. Expired Element pools should have a red "Expired" label next to them.


## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have requested at least 2 reviews (If the PR is significant enough, use best judgement here)
- [x] If package-lock.json has changes, it was intentional.
- [x] The base of this PR is `master` if hotfix, `develop` if not
