### PR TITLE
Improve token search performance

### DIFF
--- a/src/components/inputs/TokenSearchInput.vue
+++ b/src/components/inputs/TokenSearchInput.vue
@@ -15,12 +15,10 @@ import TokenSearchInputSelectTokens from './TokenSearchInputSelectTokens.vue';
 
 type Props = {
   modelValue: string[];
-  loading?: boolean;
 };
 
 const props = withDefaults(defineProps<Props>(), {
-  modelValue: () => [],
-  loading: true
+  modelValue: () => []
 });
 
 const emit = defineEmits<{
@@ -103,7 +101,7 @@ function addToken(token: string) {
 }
 
 function onClick() {
-  if (!props.loading) selectTokenModal.value = true;
+  selectTokenModal.value = true;
 }
 </script>
 <template>

--- a/src/pages/index.vue
+++ b/src/pages/index.vue
@@ -54,7 +54,6 @@ function navigateToCreatePool() {
         >
           <TokenSearchInput
             v-model="selectedTokens"
-            :loading="false"
             @add="addSelectedToken"
             @remove="removeSelectedToken"
             class="w-full md:w-2/3"

--- a/src/providers/tokens.provider.ts
+++ b/src/providers/tokens.provider.ts
@@ -249,22 +249,20 @@ export default {
      * Create token map from a token list tokens array.
      */
     function mapTokenListTokens(tokenLists: TokenList[]): TokenInfoMap {
-      const tokensMap = {};
       const tokens = [...tokenLists].map(list => list.tokens).flat();
 
-      tokens.forEach(token => {
+      const tokensMap = tokens.reduce<TokenInfoMap>((acc, token) => {
         const address: string = getAddress(token.address);
-        const existingAddresses = Object.keys(tokensMap);
-        // Don't include if already included
-        if (includesAddress(existingAddresses, address)) return;
-        // Don't include if not on app network
-        if (token.chainId !== networkConfig.chainId) return;
 
-        tokensMap[address] = {
-          ...token,
-          address
-        };
-      });
+        // Don't include if already included
+        if (acc[address]) return acc;
+
+        // Don't include if not on app network
+        if (token.chainId !== networkConfig.chainId) return acc;
+
+        acc[address] = token;
+        return acc;
+      }, {});
 
       return tokensMap;
     }


### PR DESCRIPTION
# Description

- Removed extraneous loading prop
- First keypress on search input caused UI to freeze for ~3 seconds. Removed nested loops from `mapTokenListTokens`.

## Type of change

- [x] Code refactor / cleanup

## How should this be tested?

Please provide instructions so we can test. Please also list any relevant details for your test configuration.

1. Go to home page
2. Click "Filter by token" button
3. Start typing to token search
4. Token list should update immediately

## Visual Context

### First keypress event run time dropped from 3.38s to 43ms
| Before | Now |
| ------ | ---- |
| <img width="640" alt="Screen Shot 2022-07-01 at 12 39 44" src="https://user-images.githubusercontent.com/28311328/176871207-48c30ad9-14f9-4434-8187-4c62871fe40e.png">   | <img width="640" alt="Screen Shot 2022-07-01 at 12 37 41" src="https://user-images.githubusercontent.com/28311328/176871265-b7017e02-cf89-47d8-bf56-3472385b6616.png">  |


## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have requested at least 2 reviews (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] If package-lock.json has changes, it was intentional.
- [x] The base of this PR is `master` if hotfix, `develop` if not
