### PR TITLE
Hotfix: Use infura for arbitrum RPC endpoint

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.61.4",
+  "version": "1.61.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@balancer-labs/frontend-v2",
-      "version": "1.61.4",
+      "version": "1.61.5",
       "license": "MIT",
       "devDependencies": {
         "@aave/protocol-js": "^4.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.61.4",
+  "version": "1.61.5",
   "engines": {
     "node": "14.x",
     "npm": ">=7"

--- a/src/lib/config/arbitrum.json
+++ b/src/lib/config/arbitrum.json
@@ -6,7 +6,7 @@
   "shortName": "Arbitrum",
   "network": "arbitrum-one",
   "unknown": false,
-  "rpc": "https://arb-mainnet.g.alchemy.com/v2/{{ALCHEMY_KEY}}",
+  "rpc": "https://arbitrum-mainnet.infura.io/v3/{{INFURA_KEY}}",
   "ws": "wss://arb-mainnet.g.alchemy.com/v2/{{ALCHEMY_KEY}}",
   "publicRpc": "https://arb1.arbitrum.io/rpc",
   "loggingRpc": "https://arb-mainnet.g.alchemy.com/v2/{{ALCHEMY_KEY}}",


### PR DESCRIPTION
# Description

Today Alchemy had issues with their Arbitrum RPC endpoint and even though they say it has recovered it still seems to be returning incorrect data as most of the time when trading it is reporting that there is no liquidity available even for common pairs like ETH/USDC. 

Until we figure out what the origin of this is temporarily switching the main RPC endpoint for Arbitrum to use Infura as it is working correctly. 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## How should this be tested?

Test viewing pools + making trades on Arbitrum. Ensure all are working correctly. 

## Visual context

From Discord support:
![image](https://user-images.githubusercontent.com/525534/176993167-59456815-7e23-4f4a-bb9d-7e1bbd8931df.png)

From my own testing:

![2022-07-02-173323_1746x683_scrot](https://user-images.githubusercontent.com/525534/176993217-035db35a-893c-499e-bd4e-b87c93778982.png)

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have requested at least 2 reviews (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] If package-lock.json has changes, it was intentional.
- [x] The base of this PR is `master` if hotfix, `develop` if not
