### PR TITLE
Make pools table show loading animation while waiting for graph data

### DIFF
--- a/src/pages/index.vue
+++ b/src/pages/index.vue
@@ -32,7 +32,7 @@ const { upToMediumBreakpoint } = useBreakpoints();
 const { priceQueryLoading } = useTokens();
 
 const isInvestmentPoolsTableLoading = computed(
-  () => dataStates['basic'] === 'loading' || priceQueryLoading.value
+  () => dataStates.value['basic'] === 'loading' || priceQueryLoading.value
 );
 
 /**


### PR DESCRIPTION
# Description

This variable was being read wrongly so it would never be set to `loading`. This makes the pools table show "No pools" while price is done loading but pools are still loading from the graph. Fixed so that the pools table now correctly shows the loading animation while reading from the graph. 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## How should this be tested?

- Load pools table on any network, you should never see "No pools" only a loading animation before the pools are shown. 

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have requested at least 2 reviews (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] If package-lock.json has changes, it was intentional.
- [x] The base of this PR is `master` if hotfix, `develop` if not
