### PR TITLE
Remove Popperjs warnings from console

### DIFF
--- a/src/components/_global/BalTooltip/BalTooltip.vue
+++ b/src/components/_global/BalTooltip/BalTooltip.vue
@@ -120,7 +120,7 @@ onUnmounted(() => {
       <BalIcon :name="iconName" :size="iconSize" :class="iconClass" />
     </slot>
   </button>
-  <div ref="content" class="tooltip" :class="tooltipClasses" v-bind="$attrs">
+  <div ref="content" class="tooltip" :class="tooltipClasses">
     <div :class="tooltipPad" class="tooltip-content font-medium">
       <p class="tooltip-text" v-if="text" v-text="text" />
       <slot v-else />


### PR DESCRIPTION
# Description

All attributes passed to `BalToolTip.vue` was bound to activator button, and to tooltip content elements.
Popperjs gave warnings if said attributes contained margin styles for the tooltip content.

**Solution:** Bind the attributes only to activator button.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

Go to `/vebal` page and open browser console. You should not see these warnings anymore:
<img width="755" alt="Screen Shot 2022-07-11 at 15 16 27" src="https://user-images.githubusercontent.com/28311328/178262160-44bba125-b093-4428-a6eb-995fb32f1175.png">


## Visual context

Please provide any relevant visual context for UI changes or additions. This could be static screenshots or a loom screencast.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have requested at least 2 reviews (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] If package-lock.json has changes, it was intentional.
- [x] The base of this PR is `master` if hotfix, `develop` if not
