### PR TITLE
allow swap fee to equal _MIN_SWAP_FEE_PERCENTAGE

### DIFF
--- a/src/components/cards/CreatePool/PoolFees.vue
+++ b/src/components/cards/CreatePool/PoolFees.vue
@@ -91,7 +91,7 @@ function onCustomInput(val: string): void {
   initialFee.value = (Number(val) / 100).toString();
   isCustomFee.value = true;
 
-  if (Number(val) <= 0.0001 || Number(val) > 10) {
+  if (Number(val) < 0.0001 || Number(val) > 10) {
     isInvalidFee.value = true;
   } else {
     isInvalidFee.value = false;


### PR DESCRIPTION
# Description

Pool creation page was rejecting swap fees equal to the MIN_SWAP_FEE_PERCENTAGE. Removing the `=` as a criteria for this being invalid solves this issue.

View [relevant pool code](https://github.com/balancer-labs/balancer-v2-monorepo/blob/master/pkg/pool-utils/contracts/BasePool.sol#L174) to see how fee can equal min fee.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## How should this be tested?

Please provide instructions so we can test. Please also list any relevant details for your test configuration.

- [ ] Test A
- [ ] Test B

## Visual context

Please provide any relevant visual context for UI changes or additions. This could be static screenshots or a loom screencast.

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have requested at least 2 reviews (If the PR is significant enough, use best judgement here)
- [ ] I have commented my code where relevant, particularly in hard-to-understand areas
- [ ] If package-lock.json has changes, it was intentional.
- [ ] The base of this PR is `master` if hotfix, `develop` if not
