### PR TITLE
Fallback to totalLiquidity from the subgraph if missing Coingecko prices

### DIFF
--- a/src/services/pool/pool.service.ts
+++ b/src/services/pool/pool.service.ts
@@ -59,7 +59,12 @@ export default class PoolService {
       currency,
       tokenMeta
     );
-    return (this.pool.totalLiquidity = totalLiquidity);
+    // if totalLiquidity can be computed from coingecko prices, use that
+    // else, use the value retrieved from the subgraph
+    if (bnum(totalLiquidity).gt(0)) {
+      this.pool.totalLiquidity = totalLiquidity;
+    }
+    return this.pool.totalLiquidity;
   }
 
   /**


### PR DESCRIPTION
# Description

We should always prefer to compute the value of a pool with information derived from Coingecko's price feeds.
When that's not possible, we can fall back to the subgraph's `totalLiquidity` estimate.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## How should this be tested?

Please provide instructions so we can test. Please also list any relevant details for your test configuration.

- [ ] The app should display pool value and APR for the auraBAL/B-80BAL-20ETH pool 

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have requested at least 2 reviews (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] If package-lock.json has changes, it was intentional.
- [x] The base of this PR is `master` if hotfix, `develop` if not
