### PR TITLE
Hotfix/sd apr

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.62.3",
+  "version": "1.62.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@balancer-labs/frontend-v2",
-      "version": "1.62.3",
+      "version": "1.62.4",
       "license": "MIT",
       "devDependencies": {
         "@aave/protocol-js": "^4.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.62.3",
+  "version": "1.62.4",
   "engines": {
     "node": "14.x",
     "npm": ">=7"

--- a/src/services/staking/utils.ts
+++ b/src/services/staking/utils.ts
@@ -73,7 +73,7 @@ export function calculateRewardTokenAprs({
       const yearlyReward = weeklyReward
         .times(boost)
         .times(52)
-        .times(prices[rewardTokenAddress].usd);
+        .times(prices[rewardTokenAddress] ? prices[rewardTokenAddress].usd : 0);
       const apr = yearlyReward.div(bptPrice);
       return [rewardTokenAddress, apr.toString()];
     })


### PR DESCRIPTION
# Description

Stader added SD rewards to the maticX polygon pool and it seems to have broken the polygon UI because SD has no polygon contract address on coingecko. Console log

```
TypeError: Cannot read properties of undefined (reading 'usd')
    at utils.ts:76:43
    at Array.map (<anonymous>)
    at l (utils.ts:53:35)
    at staking-rewards.service.ts:188:31
    at Proxy.map (<anonymous>)
    at P.getRewardTokenAprs (staking-rewards.service.ts:178:25)
    at async f.getData (pool.decorator.ts:112:9)
    at async f.decorate (pool.decorator.ts:43:7)
    at async Object.queryFn (useQueryStream.ts:171:17)
```

This PR attempts to fix the issue by falling back to 0 if no price exists.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## How should this be tested?

Polygon APRs should be displayed on the main app page

## Visual context
![image](https://user-images.githubusercontent.com/34865315/179362624-1b0ce08b-203a-4a86-b536-925e34f19029.png)
![image](https://user-images.githubusercontent.com/34865315/179362640-92df9323-4a40-4416-8c02-0ae025e0495d.png)


## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have requested at least 2 reviews (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] If package-lock.json has changes, it was intentional.
- [x] The base of this PR is `master` if hotfix, `develop` if not
