### PR TITLE
Fix kovan boosted pool

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36955,7 +36955,7 @@
     "@balancer-labs/sdk": {
       "version": "git+ssh://git@github.com/balancer-labs/balancer-sdk.git#5cf4748867d44dbb2723a8334e906b045d756cbc",
       "dev": true,
-      "from": "@balancer-labs/sdk@git+https://github.com/balancer-labs/balancer-sdk.git#build-0.1.18",
+      "from": "@balancer-labs/sdk@github:balancer-labs/balancer-sdk#build-0.1.18",
       "requires": {
         "@balancer-labs/sor": "^4.0.1-beta.1",
         "@balancer-labs/typechain": "^1.0.0",

--- a/src/services/pool/concerns/liquidity.concern.ts
+++ b/src/services/pool/concerns/liquidity.concern.ts
@@ -171,12 +171,12 @@ export default class LiquidityConcern {
 
         const mainTokenBalance = formatUnits(
           token.mainToken.balance,
-          tokenMeta[getAddress(token.mainToken.address)].decimals
+          tokenMeta[getAddress(token.mainToken.address)]?.decimals
         );
 
         const wrappedTokenBalance = formatUnits(
           token.wrappedToken.balance,
-          tokenMeta[getAddress(token.wrappedToken.address)].decimals
+          tokenMeta[getAddress(token.wrappedToken.address)]?.decimals
         );
 
         const mainTokenPrice =


### PR DESCRIPTION
# Description

Due to the restructuring of the pool queries we no longer rely on / assume that the pool's tokens will be injected into the registry before the pool is decorated. Therefore the liquidity calc was failing on Kovan when trying to fetch the decimals of the boosted pool's sub tokens since they're not in the registry when that calc happens. This is not a problem on mainnet since the boosted pool's sub tokens are included in the tokenlist.

This PR conditionally accesses the token decimal attribute. This will break the total liquidity calc for boosted pools on kovan but it's not a major issue since it will resort back to the subgraph value.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## How should this be tested?

- [ ] The boosted pool on kovan should now be accessible: 0x8fd162f338b770f7e879030830cde9173367f3010000000000000000000004d8

## Visual context

n/a

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have requested at least 2 reviews (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] If package-lock.json has changes, it was intentional.
- [x] The base of this PR is `master` if hotfix, `develop` if not
