### PR TITLE
Unblock testnet pools

### DIFF
--- a/src/composables/useNetwork.ts
+++ b/src/composables/useNetwork.ts
@@ -21,6 +21,7 @@ export const isKovan = computed(() => networkId.value === Network.KOVAN);
 export const isGoerli = computed(() => networkId.value === Network.GOERLI);
 
 export const isL2 = computed(() => isPolygon.value || isArbitrum.value);
+export const isTestnet = computed(() => isKovan.value || isGoerli.value);
 
 /**
  * METHODS

--- a/src/composables/usePool.ts
+++ b/src/composables/usePool.ts
@@ -12,7 +12,7 @@ import { AnyPool, Pool, PoolAPRs, PoolToken } from '@/services/pool/types';
 import { PoolType } from '@/services/pool/types';
 import { hasBalEmissions } from '@/services/staking/utils';
 
-import { urlFor } from './useNetwork';
+import { isTestnet, urlFor } from './useNetwork';
 import useNumbers, { FNumFormats, numF } from './useNumbers';
 
 /**
@@ -207,7 +207,9 @@ export function isBlocked(pool: Pool, account: string): boolean {
     POOLS.Stable.AllowList.includes(pool.id) ||
     POOLS.Investment.AllowList.includes(pool.id);
 
-  return requiresAllowlisting && !isAllowlisted && !isOwnedByUser;
+  return (
+    !isTestnet.value && requiresAllowlisting && !isAllowlisted && !isOwnedByUser
+  );
 }
 
 /**


### PR DESCRIPTION
# Description

Currently, we block all stable pools unless they've been added to the Allowlist array for their network. I think we can remove that auto-blocking on testnets for quicker testing, as requested by @mikebmikeb.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## How should this be tested?

- [ ] Try to access a pool page of a stable pool not in the Goerli Allowlist, it should load.
- [ ] Try to access a pool page of a stable pool not in the mainnet Allowlist, it should not load.

## Visual context

n/a

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have requested at least 2 reviews (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] If package-lock.json has changes, it was intentional.
- [x] The base of this PR is `master` if hotfix, `develop` if not
