### PR TITLE
Feature: friendly pool names

### DIFF
--- a/src/components/pool/PoolPageHeader.vue
+++ b/src/components/pool/PoolPageHeader.vue
@@ -125,7 +125,15 @@ const poolTypeLabel = computed(() => {
     <BalLoadingBlock v-if="loadingPool" class="h-16" />
     <div v-else class="flex flex-col">
       <div class="flex flex-wrap items-center -mt-2">
-        <h3 class="pool-title">
+        <div v-if="POOLS.Metadata[pool?.id]">
+          <h3 class="pool-title">
+            {{ POOLS.Metadata[pool.id].name }}
+          </h3>
+          <h5 class="text-sm">
+            {{ poolTypeLabel }}
+          </h5>
+        </div>
+        <h3 v-else class="pool-title">
           {{ poolTypeLabel }}
         </h3>
         <div
@@ -237,7 +245,6 @@ const poolTypeLabel = computed(() => {
 <style scoped>
 .pool-title {
   @apply mr-4 capitalize mt-2;
-
   font-variation-settings: 'wght' 700;
 }
 </style>

--- a/src/components/tables/PoolsTable/PoolsTable.vue
+++ b/src/components/tables/PoolsTable/PoolsTable.vue
@@ -24,6 +24,7 @@ import {
 } from '@/composables/usePool';
 import { bnum } from '@/lib/utils';
 import { PoolWithShares } from '@/services/pool/types';
+import { POOLS } from '@/constants/pools';
 
 import PoolsTableActionsCell from './PoolsTableActionsCell.vue';
 import TokenPills from './TokenPills/TokenPills.vue';
@@ -229,6 +230,12 @@ function aprLabelFor(pool: PoolWithShares): string {
 function lockedUntil(lockEndDate?: number) {
   return lockEndDate ? format(lockEndDate, PRETTY_DATE_FORMAT) : '—';
 }
+
+function iconAddresses(pool: PoolWithShares) {
+  return POOLS.Metadata[pool.id]?.hasIcon
+    ? [pool.address]
+    : orderedTokenAddresses(pool);
+}
 </script>
 
 <template>
@@ -273,19 +280,24 @@ function lockedUntil(lockEndDate?: number) {
       </template>
       <template #iconColumnCell="pool">
         <div v-if="!isLoading" class="py-4 px-6">
-          <BalAssetSet :addresses="orderedTokenAddresses(pool)" :width="100" />
+          <BalAssetSet :addresses="iconAddresses(pool)" :width="100" />
         </div>
       </template>
       <template #poolNameCell="pool">
         <div v-if="!isLoading" class="flex items-center py-4 px-6">
-          <TokenPills
-            :tokens="
-              orderedPoolTokens(pool.poolType, pool.address, pool.tokens)
-            "
-            :isStablePool="isStableLike(pool.poolType)"
-            :selectedTokens="selectedTokens"
-          />
-          <BalChipNew v-if="pool?.isNew" class="ml-2" />
+          <div v-if="POOLS.Metadata[pool.id]" class="text-left">
+            {{ POOLS.Metadata[pool.id].name }}
+          </div>
+          <div v-else>
+            <TokenPills
+              :tokens="
+                orderedPoolTokens(pool.poolType, pool.address, pool.tokens)
+              "
+              :isStablePool="isStableLike(pool.poolType)"
+              :selectedTokens="selectedTokens"
+            />
+            <BalChipNew v-if="pool?.isNew" class="ml-2" />
+          </div>
         </div>
       </template>
       <template #volumeCell="pool">

--- a/src/constants/pools.ts
+++ b/src/constants/pools.ts
@@ -16,6 +16,11 @@ export type FactoryType =
   | 'liquidityBootstrappingPool'
   | 'boostedPool';
 
+type PoolMetadata = {
+  name: string;
+  hasIcon: boolean;
+};
+
 export type Pools = {
   IdsMap: Partial<Record<'staBAL' | 'bbAaveUSD' | 'B-80BAL-20WETH', string>>;
   Pagination: {
@@ -40,6 +45,7 @@ export type Pools = {
   Stakable: {
     AllowList: string[];
   };
+  Metadata: Record<string, PoolMetadata>;
 };
 
 const POOLS_KOVAN: Pools = {
@@ -109,6 +115,20 @@ const POOLS_KOVAN: Pools = {
       '0x8fd162f338b770f7e879030830cde9173367f3010000000000000000000004d8',
     ],
   },
+  Metadata: {
+    '0x8fd162f338b770f7e879030830cde9173367f3010000000000000000000004d8': {
+      name: 'Balancer Boosted Aave USD',
+      hasIcon: false,
+    },
+    '0xd387dfd3a786e7caa06e6cf0c675352c7ffff30400000000000000000000063e': {
+      name: 'Balancer Stable USD',
+      hasIcon: false,
+    },
+    '0xdc2ecfdf2688f92c85064be0b929693acc6dbca6000200000000000000000701': {
+      name: 'Balancer Protocol Liquidity',
+      hasIcon: false,
+    },
+  },
 };
 
 const POOLS_GOERLI: Pools = {
@@ -156,6 +176,16 @@ const POOLS_GOERLI: Pools = {
     AllowList: [
       '0x16faf9f73748013155b7bc116a3008b57332d1e600020000000000000000005b',
     ],
+  },
+  Metadata: {
+    '0x13acd41c585d7ebb4a9460f7c8f50be60dc080cd00000000000000000000005f': {
+      name: 'Balancer Boosted Aave USD',
+      hasIcon: false,
+    },
+    '0xf8a0623ab66f985effc1c69d05f1af4badb01b00000200000000000000000060': {
+      name: 'Balancer Protocol Liquidity',
+      hasIcon: false,
+    },
   },
 };
 
@@ -267,6 +297,24 @@ const POOLS_MAINNET: Pools = {
       '0x1b65fe4881800b91d4277ba738b567cbb200a60d0002000000000000000002cc',
     ],
   },
+  Metadata: {
+    '0x7b50775383d3d6f0215a8f290f2c9e2eebbeceb20000000000000000000000fe': {
+      name: 'Balancer Boosted Aave USD',
+      hasIcon: true,
+    },
+    '0x06df3b2bbb68adc8b0e302443692037ed9f91b42000000000000000000000063': {
+      name: 'Balancer Stable USD',
+      hasIcon: true,
+    },
+    '0x5c6ee304399dbdb9c8ef030ab642b10820db8f56000200000000000000000014': {
+      name: 'Balancer Protocol Liquidity',
+      hasIcon: true,
+    },
+    '0x3dd0843a028c86e0b760b1a76929d1c5ef93a2dd000200000000000000000249': {
+      name: 'AuraBAL Stable Pool',
+      hasIcon: false,
+    },
+  },
 };
 
 const POOLS_POLYGON: Pools = {
@@ -339,6 +387,7 @@ const POOLS_POLYGON: Pools = {
       '0x8f9dd2064eb38e8e40f2ab67bde27c0e16ea9b080002000000000000000004ca',
     ],
   },
+  Metadata: {},
 };
 
 const POOLS_ARBITRUM: Pools = {
@@ -398,6 +447,7 @@ const POOLS_ARBITRUM: Pools = {
       '0xb3028ca124b80cfe6e9ca57b70ef2f0ccc41ebd40002000000000000000000ba',
     ],
   },
+  Metadata: {},
 };
 
 const POOLS_GENERIC: Pools = {
@@ -475,6 +525,20 @@ const POOLS_GENERIC: Pools = {
   Stakable: {
     AllowList: [],
   },
+  Metadata: {
+    '0x7b50775383d3d6f0215a8f290f2c9e2eebbeceb20000000000000000000000fe': {
+      name: 'Balancer Boosted Aave USD',
+      hasIcon: true,
+    },
+    '0x8fd162f338b770f7e879030830cde9173367f3010000000000000000000004d8': {
+      name: 'Balancer Boosted Aave USD',
+      hasIcon: true,
+    },
+    '0xd387dfd3a786e7caa06e6cf0c675352c7ffff30400000000000000000000063e': {
+      name: 'Balancer Stable USD',
+      hasIcon: true,
+    },
+  },
 };
 
 const POOLS_MAP = {
@@ -484,6 +548,7 @@ const POOLS_MAP = {
   [Network.POLYGON]: POOLS_POLYGON,
   [Network.ARBITRUM]: POOLS_ARBITRUM,
 };
+
 export const POOLS: Pools = POOLS_MAP[networkId.value]
   ? POOLS_MAP[networkId.value]
   : POOLS_GENERIC;


### PR DESCRIPTION
# Description

Use "friendly names" for pools - that is a custom name that is different to pool composition or type.

Closes https://github.com/balancer-labs/frontend-v2/issues/2097

## Type of change

In pools table and pool page header, certain pools should now have a custom name instead of default pool composition/type. Also, in pool table, a custom icons are being used.

## How should this be tested?

Check pool id "0x7b50775383d3d6f0215a8f290f2c9e2eebbeceb20000000000000000000000fe" which now has a name "Balancer Boosted Aave USD".

## Visual context

Custom icons in pools table.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have requested at least 2 reviews (If the PR is significant enough, use best judgement here)
- [n/a] I have commented my code where relevant, particularly in hard-to-understand areas
- [n/a] If package-lock.json has changes, it was intentional.
- [x] The base of this PR is `master` if hotfix, `develop` if not
