### PR TITLE
fix: unwrap trade summary token info

### DIFF
--- a/src/components/modals/TradePreviewModalGP.vue
+++ b/src/components/modals/TradePreviewModalGP.vue
@@ -514,10 +514,10 @@ export default defineComponent({
       const tokenOutAmountInput = props.trading.tokenOutAmountInput.value;
 
       if (props.trading.isWrapUnwrapTrade.value) {
-        summaryItems.amountBeforeFees = tokenInAmountInput;
+        summaryItems.amountBeforeFees = tokenOutAmountInput;
         summaryItems.tradeFees = '0';
-        summaryItems.totalWithoutSlippage = tokenInAmountInput;
-        summaryItems.totalWithSlippage = tokenInAmountInput;
+        summaryItems.totalWithoutSlippage = tokenOutAmountInput;
+        summaryItems.totalWithSlippage = tokenOutAmountInput;
       } else {
         const quote = props.trading.getQuote();
 


### PR DESCRIPTION
# Description

Closes #1913 

- Trade modal now shows correct token information when the trade is `wrap-unwrap`

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

- Open Trade UI
- Trade from wstETH to stETH
- Modal correctly shows "Amount before fees" and "Total to receive"

## Visual context

![screenshot-08 08-08_33_57](https://user-images.githubusercontent.com/35571969/183367753-2f028250-6fa3-4cf3-8aa5-70774fcd57c1.png)

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have requested at least 2 reviews (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [n/a ] If package-lock.json has changes, it was intentional.
- [x] The base of this PR is `master` if hotfix, `develop` if not
