### PR TITLE
hotfix: Removed watcher for isLoading

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.66.0",
+  "version": "1.66.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@balancer-labs/frontend-v2",
-      "version": "1.66.0",
+      "version": "1.66.1",
       "license": "MIT",
       "devDependencies": {
         "@aave/protocol-js": "^4.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.66.0",
+  "version": "1.66.1",
   "engines": {
     "node": "14.x",
     "npm": ">=7"

--- a/src/components/cards/TradeCard/TradeCard.vue
+++ b/src/components/cards/TradeCard/TradeCard.vue
@@ -158,7 +158,7 @@
 <script lang="ts">
 import { getAddress, isAddress } from '@ethersproject/address';
 import { formatUnits } from '@ethersproject/units';
-import { computed, defineComponent, onBeforeMount, ref, watch } from 'vue';
+import { computed, defineComponent, onBeforeMount, ref } from 'vue';
 import { useI18n } from 'vue-i18n';
 import { useRouter } from 'vue-router';
 import { useStore } from 'vuex';
@@ -347,13 +347,6 @@ export default defineComponent({
       }
 
       return undefined;
-    });
-
-    // WATCHERS
-    watch(trading.isLoading, newVal => {
-      if (!newVal) {
-        trading.handleAmountChange();
-      }
     });
 
     // METHODS


### PR DESCRIPTION
# Description

A watcher was added to trigger swap calculation in the case of user inputting the data before the page dependencies have been loaded. This is unnecessary and causes a loop after dependencies are loaded -> then swap calculation gets triggered -> isLoading is set to true again.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## How should this be tested?

Attempt to swap currency on "Trade" page.

## Visual context

N/A

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have requested at least 2 reviews (If the PR is significant enough, use best judgement here)
- [n/a] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] If package-lock.json has changes, it was intentional.
- [x] The base of this PR is `master` if hotfix, `develop` if not
