### PR TITLE
fix: veBAL APR never loads

### DIFF
--- a/src/composables/queries/usePoolQuery.ts
+++ b/src/composables/queries/usePoolQuery.ts
@@ -72,7 +72,7 @@ export default function usePoolQuery(
     // Decorate subgraph data with additional data
     const poolDecorator = new PoolDecorator([pool]);
     const [decoratedPool] = await poolDecorator.decorate(
-      undefined,
+      subgraphGauges.value || [],
       prices.value,
       currency.value,
       tokens.value


### PR DESCRIPTION
# Description

Closes #2118 

- This bug doesn't occur when user visits portfolio page from homepage
- It only occurs when user visits page directly
- Fixed by reverting a change made in #2037, subgraph query with apr information was removed 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

- Go to portfolio page
- APR under **veBAL protocol liquidity** should correctly show

## Visual context

![screenshot-2022 08 09-15_53_32](https://user-images.githubusercontent.com/35571969/183685215-7fa4630b-feec-420f-9a9f-e5d5c8ff7e1d.png)

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have requested at least 2 reviews (If the PR is significant enough, use best judgement here)
- [n/a] I have commented my code where relevant, particularly in hard-to-understand areas
- [n/a] If package-lock.json has changes, it was intentional.
- [x] The base of this PR is `master` if hotfix, `develop` if not
