### PR TITLE
Fix problem with downloading aprs (Closes #2118)

### DIFF
--- a/src/composables/queries/usePoolQuery.ts
+++ b/src/composables/queries/usePoolQuery.ts
@@ -19,7 +19,8 @@ import useGaugesQuery from './useGaugesQuery';
 export default function usePoolQuery(
   id: string,
   isEnabled: Ref<boolean> = ref(true),
-  options: QueryObserverOptions<Pool> = {}
+  options: QueryObserverOptions<Pool> = {},
+  includeAprs = true
 ) {
   /**
    * @description
@@ -72,10 +73,11 @@ export default function usePoolQuery(
     // Decorate subgraph data with additional data
     const poolDecorator = new PoolDecorator([pool]);
     const [decoratedPool] = await poolDecorator.decorate(
-      undefined,
+      subgraphGauges.value || [],
       prices.value,
       currency.value,
-      tokens.value
+      tokens.value,
+      includeAprs
     );
 
     // Inject pool tokens into token registry

--- a/src/pages/pool/_id.vue
+++ b/src/pages/pool/_id.vue
@@ -152,7 +152,12 @@ export default defineComponent({
     });
 
     //#region pool query
-    const poolQuery = usePoolQuery(route.params.id as string);
+    const poolQuery = usePoolQuery(
+      route.params.id as string,
+      undefined,
+      undefined,
+      false
+    );
     const pool = computed(() => poolQuery.data.value);
     const poolQueryLoading = computed(
       () =>

--- a/src/services/pool/decorators/pool.decorator.ts
+++ b/src/services/pool/decorators/pool.decorator.ts
@@ -30,7 +30,7 @@ export class PoolDecorator {
   ) {}
 
   public async decorate(
-    gauges: SubgraphGauge[] | undefined,
+    gauges: SubgraphGauge[],
     prices: TokenPrices,
     currency: FiatCurrency,
     tokens: TokenInfoMap,
@@ -114,14 +114,14 @@ export class PoolDecorator {
    */
   public async getData(
     prices: TokenPrices,
-    gauges: SubgraphGauge[] | undefined,
+    gauges: SubgraphGauge[],
     tokens: TokenInfoMap,
     pools: Pool[],
     includeAprs = true
   ): Promise<
     [number, GaugeBalAprs, GaugeRewardTokenAprs] | [null, null, null]
   > {
-    if (!includeAprs || !gauges) {
+    if (!includeAprs) {
       return [null, null, null];
     }
     return await Promise.all([


### PR DESCRIPTION
# Description

On pool page we fetch aprs separately from other pool information for optimisation reasons, and this pr https://github.com/balancer-labs/frontend-v2/pull/2037 affected other places where we use usePoolQuery composable (aprs were not fetched). 
This pr fixes this issue. 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## How should this be tested?
- Go to any page where aprs should be shown
- aprs are correctly shown
Please provide instructions so we can test. Please also list any relevant details for your test configuration.

- [ ] Test A
- [ ] Test B

## Visual context

Please provide any relevant visual context for UI changes or additions. This could be static screenshots or a loom screencast.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have requested at least 2 reviews (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] If package-lock.json has changes, it was intentional.
- [x] The base of this PR is `master` if hotfix, `develop` if not
