### PR TITLE
Fix chore: Enable eslint as formatter in settings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,6 +5,7 @@
     "source.fixAll.stylelint": true
   },
   "eslint.validate": ["javascript", "javascriptreact", "vue"],
+  "eslint.format.enable": true,
   "stylelint.validate": ["css", "less", "postcss", "vue"],
   "[markdown]": {
     "editor.defaultFormatter": "esbenp.prettier-vscode",


### PR DESCRIPTION
# Description

Eslint is disabled as formatter by default, this enables it so you can run `Format document` command with eslint in VSCode.

## Type of change
- [x] Other

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have requested at least 2 reviews (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] If package-lock.json has changes, it was intentional.
- [x] The base of this PR is `master` if hotfix, `develop` if not
