### PR TITLE
Show staking and unstaking notifications

### DIFF
--- a/src/composables/useTransactions.ts
+++ b/src/composables/useTransactions.ts
@@ -46,6 +46,7 @@ export type TransactionAction =
   | 'increaseLock'
   | 'unlock'
   | 'voteForGauge'
+  | 'unstake'
   | 'stake';
 
 export type TransactionType = 'order' | 'tx';

--- a/src/locales/default.json
+++ b/src/locales/default.json
@@ -1126,6 +1126,8 @@
     "tradeWithGas": "Trade with a gas fee"
   },
   "transactionAction": {
+    "stake": "Stake",
+    "unstake": "Unstake",
     "approve": "Approve",
     "claim": "Claim",
     "createPool": "Create pool",
@@ -1172,6 +1174,8 @@
     "pending": "Pending"
   },
   "transactionSummary": {
+    "stake": "{amount} in {pool}",
+    "unstake": "{amount} from {pool}",
     "approveForInvesting": "Approve {0} for investing",
     "approveForTrading": "Approve {0} for trading",
     "approveForLocking": "Approve {0} for locking",


### PR DESCRIPTION
# Description

#2117 
- Show staking and unstaking toast
- Add staking and unstaking transactions to Recent activity menu

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How should this be tested?

Please provide instructions so we can test. Please also list any relevant details for your test configuration.

1. Launch app in Goerli
2. Go to stakable pool: http://localhost:8080/#/pool/0x16faf9f73748013155b7bc116a3008b57332d1e600020000000000000000005b 
3. Try staking and unstaking

## Visual context

| Toast | Recent activity |
| ----   | --------------- |
|     ![Screen Shot 2022-08-12 at 14 53 52](https://user-images.githubusercontent.com/28311328/184350353-c929d4db-6b59-4f83-88df-ae52446484f5.png)     |               ![Screen Shot 2022-08-12 at 14 53 37](https://user-images.githubusercontent.com/28311328/184350397-1537b7ae-97e3-4faa-9d9e-6dff1066c84e.png)             |

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have requested at least 2 reviews (If the PR is significant enough, use best judgement here)
- [x] The base of this PR is `master` if hotfix, `develop` if not
