### PR TITLE
Hotfix: total shares bug

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.66.3",
+  "version": "1.66.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@balancer-labs/frontend-v2",
-      "version": "1.66.3",
+      "version": "1.66.4",
       "license": "MIT",
       "devDependencies": {
         "@aave/protocol-js": "^4.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.66.3",
+  "version": "1.66.4",
   "engines": {
     "node": "14.x",
     "npm": ">=7"

--- a/src/composables/queries/usePoolQuery.ts
+++ b/src/composables/queries/usePoolQuery.ts
@@ -61,7 +61,7 @@ export default function usePoolQuery(
       [pool] = await balancerSubgraphService.pools.get({
         where: {
           id: id.toLowerCase(),
-          totalShares_gt: -20, // Avoid the filtering for low liquidity pools
+          totalShares_gt: -10000, // Avoid the filtering for low liquidity pools
           poolType_not_in: POOLS.ExcludedPoolTypes,
         },
       });

--- a/src/composables/queries/usePoolQuery.ts
+++ b/src/composables/queries/usePoolQuery.ts
@@ -61,7 +61,7 @@ export default function usePoolQuery(
       [pool] = await balancerSubgraphService.pools.get({
         where: {
           id: id.toLowerCase(),
-          totalShares_gt: -1, // Avoid the filtering for low liquidity pools
+          totalShares_gt: -20, // Avoid the filtering for low liquidity pools
           poolType_not_in: POOLS.ExcludedPoolTypes,
         },
       });

--- a/src/services/pool/pool.service.ts
+++ b/src/services/pool/pool.service.ts
@@ -101,7 +101,7 @@ export default class PoolService {
       {
         where: {
           address_in: this.pool.tokensList,
-          totalShares_gt: -1, // Avoid the filtering for low liquidity pools
+          totalShares_gt: -20, // Avoid the filtering for low liquidity pools
         },
       },
       { mainIndex: true, wrappedIndex: true }

--- a/src/services/pool/pool.service.ts
+++ b/src/services/pool/pool.service.ts
@@ -101,7 +101,7 @@ export default class PoolService {
       {
         where: {
           address_in: this.pool.tokensList,
-          totalShares_gt: -20, // Avoid the filtering for low liquidity pools
+          totalShares_gt: -10000, // Avoid the filtering for low liquidity pools
         },
       },
       { mainIndex: true, wrappedIndex: true }


### PR DESCRIPTION
# Description

For pool pages we override a default subgraph query attribute that ensures very low liquidity pools don't appear in our lists. This PR reduces the totalShares threshold to fix an Arbitrum subgraph bug where totalShares are -18 for some pools.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## How should this be tested?

- [x] Test this pool is accessible on arbitrum: `0xc720d790dc6062a7f19501dc8abbfb3041c52ea6000200000000000000000003`

## Visual context

n/a

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have requested at least 2 reviews (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] If package-lock.json has changes, it was intentional.
- [x] The base of this PR is `master` if hotfix, `develop` if not
