### PR TITLE
Hotfix: Use an interval for new blocks instead of constantly listening to the websocket

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.67.0",
+  "version": "1.67.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@balancer-labs/frontend-v2",
-      "version": "1.67.0",
+      "version": "1.67.1",
       "license": "MIT",
       "devDependencies": {
         "@aave/protocol-js": "^4.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.67.0",
+  "version": "1.67.1",
   "engines": {
     "node": "14.x",
     "npm": ">=7"

--- a/src/lib/config/arbitrum.json
+++ b/src/lib/config/arbitrum.json
@@ -21,6 +21,7 @@
   },
   "supportsEIP1559": false,
   "supportsElementPools": false,
+  "blockTime": 2,
   "nativeAsset": {
     "name": "Ether",
     "address": "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",

--- a/src/lib/config/docker.json
+++ b/src/lib/config/docker.json
@@ -19,6 +19,7 @@
     "gauge": ""
   },
   "supportsEIP1559": false,
+  "blockTime": 12,
   "nativeAsset": {
     "name": "Ether",
     "address": "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",

--- a/src/lib/config/goerli.json
+++ b/src/lib/config/goerli.json
@@ -19,6 +19,7 @@
   },
   "supportsEIP1559": true,
   "supportsElementPools": true,
+  "blockTime": 12,
   "nativeAsset": {
     "name": "Ether",
     "address": "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",

--- a/src/lib/config/homestead.json
+++ b/src/lib/config/homestead.json
@@ -20,6 +20,7 @@
   },
   "supportsEIP1559": true,
   "supportsElementPools": true,
+  "blockTime": 12,
   "nativeAsset": {
     "name": "Ether",
     "address": "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",

--- a/src/lib/config/index.ts
+++ b/src/lib/config/index.ts
@@ -32,6 +32,7 @@ export interface Config {
   };
   supportsEIP1559: boolean;
   supportsElementPools: boolean;
+  blockTime: number;
   nativeAsset: {
     name: string;
     address: string;

--- a/src/lib/config/kovan.json
+++ b/src/lib/config/kovan.json
@@ -19,6 +19,7 @@
   },
   "supportsEIP1559": true,
   "supportsElementPools": true,
+  "blockTime": 12,
   "nativeAsset": {
     "name": "Ether",
     "address": "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",

--- a/src/lib/config/polygon.json
+++ b/src/lib/config/polygon.json
@@ -21,6 +21,7 @@
   },
   "supportsEIP1559": true,
   "supportsElementPools": false,
+  "blockTime": 4,
   "nativeAsset": {
     "name": "Matic",
     "address": "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",

--- a/src/lib/config/rinkeby.json
+++ b/src/lib/config/rinkeby.json
@@ -19,6 +19,7 @@
   },
   "supportsEIP1559": true,
   "supportsElementPools": false,
+  "blockTime": 12,
   "nativeAsset": {
     "name": "Ether",
     "address": "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",

--- a/src/lib/config/test.json
+++ b/src/lib/config/test.json
@@ -19,6 +19,7 @@
   },
   "supportsEIP1559": true,
   "supportsElementPools": true,
+  "blockTime": 12,
   "nativeAsset": {
     "name": "Ether",
     "address": "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",

--- a/src/services/rpc-provider/rpc-provider.service.spec.ts
+++ b/src/services/rpc-provider/rpc-provider.service.spec.ts
@@ -16,7 +16,7 @@ jest.mock('@ethersproject/providers', () => {
     }),
     WebSocketProvider: jest.fn().mockImplementation(() => {
       return {
-        on: jest.fn().mockImplementation(),
+        once: jest.fn().mockImplementation(),
       };
     }),
   };

--- a/src/services/rpc-provider/rpc-provider.service.ts
+++ b/src/services/rpc-provider/rpc-provider.service.ts
@@ -20,7 +20,13 @@ export default class RpcProviderService {
 
   public initBlockListener(newBlockHandler: NewBlockHandler): void {
     const wsProvider = new WebSocketProvider(this.config.ws);
-    wsProvider.on('block', newBlockNumber => newBlockHandler(newBlockNumber));
+    wsProvider.once('block', newBlockNumber => {
+      let currentBlockNumber = newBlockNumber;
+      setInterval(() => {
+        currentBlockNumber++;
+        newBlockHandler(currentBlockNumber);
+      }, configService.network.blockTime * 1000);
+    });
   }
 
   public async getBlockNumber(): Promise<number> {

--- a/src/services/rpc-provider/rpc-provider.service.ts
+++ b/src/services/rpc-provider/rpc-provider.service.ts
@@ -22,6 +22,7 @@ export default class RpcProviderService {
     const wsProvider = new WebSocketProvider(this.config.ws);
     wsProvider.once('block', newBlockNumber => {
       let currentBlockNumber = newBlockNumber;
+      newBlockHandler(currentBlockNumber);
       setInterval(() => {
         currentBlockNumber++;
         newBlockHandler(currentBlockNumber);


### PR DESCRIPTION
# Description

Currently most of our alchemy bill is from listening for new blocks through the websocket connection. The only thing we use from these new blocks is the block number. 

This PR switches this to only listen for one block, then set an interval of the chains cadence to update the current block number, which should lower our costs while providing essentially the same service to the rest of the app. 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## How should this be tested?

- Test the app on Polygon and Arbitrum and ensure all functionality is working as expected.
- Test trading and ensure SOR is pulling in new data and updating prices on an interval. 
- After merging, ensure our Alchemy usage has dropped. 

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have requested at least 2 reviews (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] If package-lock.json has changes, it was intentional.
- [x] The base of this PR is `master` if hotfix, `develop` if not
