### PR TITLE
Refetch poolQuery when blocknumber changes

### DIFF
--- a/src/composables/contextual/pool-transfers/usePoolTransfers.ts
+++ b/src/composables/contextual/pool-transfers/usePoolTransfers.ts
@@ -1,4 +1,4 @@
-import { computed, ref } from 'vue';
+import { computed, ref, watch } from 'vue';
 import { useRoute } from 'vue-router';
 
 // Composables
@@ -7,6 +7,7 @@ import { isStablePhantom } from '@/composables/usePool';
 import useTokens from '@/composables/useTokens';
 import { includesAddress } from '@/lib/utils';
 import { Pool } from '@/services/pool/types';
+import useWeb3 from '@/services/web3/useWeb3';
 
 /**
  * STATE
@@ -22,6 +23,7 @@ export default function usePoolTransfers() {
    * COMPOSABLES
    */
   const { prices } = useTokens();
+  const { blockNumber } = useWeb3();
 
   /**
    * QUERIES
@@ -61,6 +63,13 @@ export default function usePoolTransfers() {
     return !tokenAddresses.value.every(token =>
       includesAddress(tokensWithPrice, token)
     );
+  });
+
+  /**
+   * WATCHERS
+   */
+  watch(blockNumber, async () => {
+    poolQuery.refetch.value();
   });
 
   return {


### PR DESCRIPTION
# Description

In invest/withdraw flow, keep the pool data up to date by refetching it on every block.

## Type of change

- [x] New feature (non-breaking change which adds functionality)


## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have requested at least 2 reviews (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] The base of this PR is `master` if hotfix, `develop` if not
