### PR TITLE
Fetch a more accurate time travel block for fees/volume

### DIFF
--- a/src/composables/queries/usePoolAprQuery.ts
+++ b/src/composables/queries/usePoolAprQuery.ts
@@ -9,7 +9,6 @@ import { balancerSubgraphService } from '@/services/balancer/subgraph/balancer-s
 import { AprConcern } from '@/services/pool/concerns/apr/apr.concern';
 import { poolsStoreService } from '@/services/pool/pools-store.service';
 import { Pool, PoolAPRs } from '@/services/pool/types';
-import { rpcProviderService } from '@/services/rpc-provider/rpc-provider.service';
 import { stakingRewardsService } from '@/services/staking/staking-rewards.service';
 
 import useNetwork from '../useNetwork';
@@ -55,8 +54,7 @@ export default function usePoolAprQuery(
   const queryKey = QUERY_KEYS.Pools.APR(networkId, id);
 
   async function getSnapshot(id: string): Promise<Pool[]> {
-    const currentBlock = await rpcProviderService.getBlockNumber();
-    const blockNumber = getTimeTravelBlock(currentBlock);
+    const blockNumber = await getTimeTravelBlock();
     const block = { number: blockNumber };
     const isInPoolIds = { id_in: [id] };
     try {

--- a/src/composables/useSnapshots.ts
+++ b/src/composables/useSnapshots.ts
@@ -1,6 +1,5 @@
-import { configService } from '@/services/config/config.service';
 import { twentyFourHoursInSecs } from './useTime';
-import { BlockNumberResponse } from '@/types';
+import { blockService } from '@/services/block/block.service';
 
 export type TimeTravelPeriod = '24h';
 
@@ -11,35 +10,8 @@ export async function getTimeTravelBlock(
 
   switch (period) {
     case '24h':
-      return fetchBlockByTime(dayAgo);
+      return blockService.fetchBlockByTime(dayAgo);
     default:
-      return fetchBlockByTime(dayAgo);
+      return blockService.fetchBlockByTime(dayAgo);
   }
 }
-
-const query = (timestamp: string) => `{
-  blocks(first: 1, orderBy: number, orderDirection: asc, where: { timestamp_gt: ${timestamp} }) {
-    number
-  }
-}`;
-
-const fetchBlockByTime = async (timestamp: string): Promise<number> => {
-  const endpoint = configService.network.subgraphs.blocks;
-  const payload = {
-    query: query(timestamp),
-  };
-
-  const response = await fetch(endpoint, {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-    },
-    body: JSON.stringify(payload),
-  });
-
-  const {
-    data: { blocks },
-  } = (await response.json()) as BlockNumberResponse;
-
-  return parseInt(blocks[0].number);
-};

--- a/src/lib/config/arbitrum.json
+++ b/src/lib/config/arbitrum.json
@@ -17,7 +17,8 @@
   "poolsUrlV2": "",
   "subgraphs": {
     "aave": "",
-    "gauge": "https://api.thegraph.com/subgraphs/name/balancer-labs/balancer-gauges-arbitrum"
+    "gauge": "https://api.thegraph.com/subgraphs/name/balancer-labs/balancer-gauges-arbitrum",
+    "blocks": "https://api.thegraph.com/subgraphs/name/ianlapham/arbitrum-one-blocks"
   },
   "supportsEIP1559": false,
   "supportsElementPools": false,

--- a/src/lib/config/docker.json
+++ b/src/lib/config/docker.json
@@ -16,7 +16,8 @@
   "poolsUrlV2": "",
   "subgraphs": {
     "aave": "",
-    "gauge": ""
+    "gauge": "",
+    "blocks": ""
   },
   "supportsEIP1559": false,
   "blockTime": 12,

--- a/src/lib/config/goerli.json
+++ b/src/lib/config/goerli.json
@@ -15,7 +15,8 @@
   "poolsUrlV2": "",
   "subgraphs": {
     "aave": "https://api.thegraph.com/subgraphs/name/aave/protocol-v2",
-    "gauge": "https://api.thegraph.com/subgraphs/name/balancer-labs/balancer-gauges-goerli"
+    "gauge": "https://api.thegraph.com/subgraphs/name/balancer-labs/balancer-gauges-goerli",
+    "blocks": "https://api.thegraph.com/subgraphs/name/blocklytics/goerli-blocks"
   },
   "supportsEIP1559": true,
   "supportsElementPools": true,

--- a/src/lib/config/homestead.json
+++ b/src/lib/config/homestead.json
@@ -16,7 +16,8 @@
   "poolsUrlV2": "https://storageapi.fleek.co/johngrantuk-team-bucket/poolsV2.json",
   "subgraphs": {
     "aave": "https://api.thegraph.com/subgraphs/name/aave/protocol-v2",
-    "gauge": "https://api.thegraph.com/subgraphs/name/balancer-labs/balancer-gauges"
+    "gauge": "https://api.thegraph.com/subgraphs/name/balancer-labs/balancer-gauges",
+    "blocks": "https://api.thegraph.com/subgraphs/name/blocklytics/ethereum-blocks"
   },
   "supportsEIP1559": true,
   "supportsElementPools": true,

--- a/src/lib/config/index.ts
+++ b/src/lib/config/index.ts
@@ -30,6 +30,7 @@ export interface Config {
   subgraphs: {
     aave: string;
     gauge: string;
+    blocks: string;
   };
   supportsEIP1559: boolean;
   supportsElementPools: boolean;

--- a/src/lib/config/kovan.json
+++ b/src/lib/config/kovan.json
@@ -15,7 +15,8 @@
   "poolsUrlV2": "https://storageapi.fleek.co/johngrantuk-team-bucket/poolsRc02.json",
   "subgraphs": {
     "aave": "https://api.thegraph.com/subgraphs/name/aave/protocol-v2-kovan",
-    "gauge": "https://api.thegraph.com/subgraphs/name/balancer-labs/balancer-gauges-kovan"
+    "gauge": "https://api.thegraph.com/subgraphs/name/balancer-labs/balancer-gauges-kovan",
+    "blocks": "https://api.thegraph.com/subgraphs/name/blocklytics/kovan-blocks"
   },
   "supportsEIP1559": true,
   "supportsElementPools": true,

--- a/src/lib/config/optimism.json
+++ b/src/lib/config/optimism.json
@@ -16,7 +16,8 @@
   "poolsUrlV2": "",
   "subgraphs": {
     "aave": "",
-    "gauge": "https://api.thegraph.com/subgraphs/name/mendesfabio/balancer-gauges"
+    "gauge": "https://api.thegraph.com/subgraphs/name/mendesfabio/balancer-gauges",
+    "blocks": ""
   },
   "supportsEIP1559": false,
   "supportsElementPools": false,

--- a/src/lib/config/polygon.json
+++ b/src/lib/config/polygon.json
@@ -17,7 +17,8 @@
   "poolsUrlV2": "",
   "subgraphs": {
     "aave": "https://api.thegraph.com/subgraphs/name/aave/aave-v2-matic",
-    "gauge": "https://api.thegraph.com/subgraphs/name/balancer-labs/balancer-gauges-polygon"
+    "gauge": "https://api.thegraph.com/subgraphs/name/balancer-labs/balancer-gauges-polygon",
+    "blocks": "https://api.thegraph.com/subgraphs/name/ianlapham/polygon-blocks"
   },
   "supportsEIP1559": true,
   "supportsElementPools": false,

--- a/src/lib/config/rinkeby.json
+++ b/src/lib/config/rinkeby.json
@@ -15,7 +15,8 @@
   "poolsUrlV2": "https://storageapi.fleek.co/johngrantuk-team-bucket/poolsRc02.json",
   "subgraphs": {
     "aave": "",
-    "gauge": ""
+    "gauge": "",
+    "blocks": ""
   },
   "supportsEIP1559": true,
   "supportsElementPools": false,

--- a/src/lib/config/test.json
+++ b/src/lib/config/test.json
@@ -15,7 +15,8 @@
   "poolsUrlV2": "https://storageapi.fleek.co/johngrantuk-team-bucket/poolsV2.json",
   "subgraphs": {
     "aave": "",
-    "gauge": ""
+    "gauge": "",
+    "blocks": ""
   },
   "supportsEIP1559": true,
   "supportsElementPools": true,

--- a/src/services/block/block.service.ts
+++ b/src/services/block/block.service.ts
@@ -1,0 +1,23 @@
+import { BlockNumberResponse } from './types';
+import BlockSubgraphService, {
+  blockSubgraphService,
+} from './subgraph/block-subgraph.service';
+
+export default class BlockService {
+  subgraphService: BlockSubgraphService;
+
+  constructor(subgraphService = blockSubgraphService) {
+    this.subgraphService = subgraphService;
+  }
+
+  public async fetchBlockByTime(timestamp: string): Promise<number> {
+    const response: BlockNumberResponse =
+      await this.subgraphService.blockNumber.get({
+        where: { timestamp_gt: timestamp },
+      });
+
+    return parseInt(response.blocks[0].number);
+  }
+}
+
+export const blockService = new BlockService();

--- a/src/services/block/subgraph/block-subgraph.client.ts
+++ b/src/services/block/subgraph/block-subgraph.client.ts
@@ -1,0 +1,30 @@
+import axios from 'axios';
+import { jsonToGraphQLQuery } from 'json-to-graphql-query';
+
+import { configService as _configService } from '@/services/config/config.service';
+
+export default class BlockSubgraphClient {
+  url: string;
+
+  constructor(private readonly configService = _configService) {
+    this.url = configService.network.subgraphs.blocks;
+  }
+
+  public async get(query) {
+    try {
+      const payload = this.toPayload(query);
+      const {
+        data: { data },
+      } = await axios.post(this.url, payload);
+      return data;
+    } catch (error) {
+      console.error(error);
+    }
+  }
+
+  public toPayload(query) {
+    return JSON.stringify({ query: jsonToGraphQLQuery({ query }) });
+  }
+}
+
+export const blockSubgraphClient = new BlockSubgraphClient();

--- a/src/services/block/subgraph/block-subgraph.service.ts
+++ b/src/services/block/subgraph/block-subgraph.service.ts
@@ -1,0 +1,17 @@
+import { rpcProviderService as _rpcProviderService } from '@/services/rpc-provider/rpc-provider.service';
+
+import { blockSubgraphClient } from './block-subgraph.client';
+import BlockNumber from './entities/block-number';
+
+export default class BlockSubgraphService {
+  blockNumber: BlockNumber;
+
+  constructor(
+    readonly client = blockSubgraphClient,
+    readonly rpcProviderService = _rpcProviderService
+  ) {
+    this.blockNumber = new BlockNumber(this);
+  }
+}
+
+export const blockSubgraphService = new BlockSubgraphService();

--- a/src/services/block/subgraph/entities/block-number/index.ts
+++ b/src/services/block/subgraph/entities/block-number/index.ts
@@ -1,0 +1,23 @@
+import { BlockNumberResponse } from '../../../types';
+
+import { QueryBuilder } from '@/types/subgraph';
+
+import Service from '../../block-subgraph.service';
+import queryBuilder from './query';
+
+export default class BlockNumber {
+  service: Service;
+  query: QueryBuilder;
+
+  constructor(service: Service, query: QueryBuilder = queryBuilder) {
+    this.service = service;
+    this.query = query;
+  }
+
+  public async get(args = {}, attrs = {}): Promise<BlockNumberResponse> {
+    const query = this.query(args, attrs);
+    const response = await this.service.client.get(query);
+
+    return response;
+  }
+}

--- a/src/services/block/subgraph/entities/block-number/query.ts
+++ b/src/services/block/subgraph/entities/block-number/query.ts
@@ -1,0 +1,18 @@
+import { merge } from 'lodash';
+
+const defaultArgs = {
+  first: 1,
+  orderBy: 'number',
+  orderDirection: 'asc',
+};
+
+const defaultAttrs = {
+  number: true,
+};
+
+export default (args = {}, attrs = {}) => ({
+  blocks: {
+    __args: merge({}, defaultArgs, args),
+    ...merge({}, defaultAttrs, attrs),
+  },
+});

--- a/src/services/block/types.ts
+++ b/src/services/block/types.ts
@@ -1,0 +1,7 @@
+export interface BlockNumberResponse {
+  blocks: [
+    {
+      number: string;
+    }
+  ];
+}

--- a/src/services/pool/decorators/pool.decorator.ts
+++ b/src/services/pool/decorators/pool.decorator.ts
@@ -94,8 +94,7 @@ export class PoolDecorator {
    * (see getTimeTravelBlock).
    */
   private async getSnapshots(): Promise<Pool[]> {
-    const currentBlock = await this.providerService.getBlockNumber();
-    const blockNumber = getTimeTravelBlock(currentBlock);
+    const blockNumber = await getTimeTravelBlock();
     const block = { number: blockNumber };
     const isInPoolIds = { id_in: this.pools.map(pool => pool.id) };
     try {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -67,13 +67,3 @@ export type BaseContent = {
   title: string;
   description: string;
 };
-
-export interface BlockNumberResponse {
-  data: {
-    blocks: [
-      {
-        number: string;
-      }
-    ];
-  };
-}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -67,3 +67,13 @@ export type BaseContent = {
   title: string;
   description: string;
 };
+
+export interface BlockNumberResponse {
+  data: {
+    blocks: [
+      {
+        number: string;
+      }
+    ];
+  };
+}


### PR DESCRIPTION
# Description

Currently to calculate fees/volume we find a block 24 hours in the past by doing (secondsInDay / 13). This isn't very accurate and is currently off by about 300 blocks from the actual block 24 hours ago. 

This PR uses a subgraph request to find the exactly block number from 24 hours ago instead of doing this rough calculation. This is what the SDK is also using in the [APRs Update](https://github.com/balancer-labs/balancer-sdk/pull/98) so it will be easier to compare Prod APR/fees/volume numbers to that PR. 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## How should this be tested?

- View pools page and individual pools, they should show volume / fees correctly. 

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have requested at least 2 reviews (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] If package-lock.json has changes, it was intentional.
- [x] The base of this PR is `master` if hotfix, `develop` if not
