### PR TITLE
Fix: hide 'Network mismatch' alert after disconnecting from the wallet

### DIFF
--- a/src/composables/watchers/useWeb3Watchers.ts
+++ b/src/composables/watchers/useWeb3Watchers.ts
@@ -46,7 +46,10 @@ export default function useWeb3Watchers() {
   }
 
   function checkIsUnsupportedNetwork() {
-    if (isUnsupportedNetwork.value || isMismatchedNetwork.value) {
+    if (
+      chainId.value &&
+      (isUnsupportedNetwork.value || isMismatchedNetwork.value)
+    ) {
       addAlert({
         id: 'network-mismatch',
         label: t('networkMismatch', [appNetworkConfig.name]),


### PR DESCRIPTION
# Description

https://github.com/balancer-labs/frontend-v2/issues/1464

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## How should this be tested?

Connect the wallet which is on a wrong network then disconnect - the alert should disappear.

## Visual context

N/A

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have requested at least 2 reviews (If the PR is significant enough, use best judgement here)
- [n/a] I have commented my code where relevant, particularly in hard-to-understand areas
- [n/a] If package-lock.json has changes, it was intentional.
- [x] The base of this PR is `master` if hotfix, `develop` if not
