### PR TITLE
Pair price chart is not in USD

### DIFF
--- a/src/components/cards/PairPriceGraph/PairPriceGraph.vue
+++ b/src/components/cards/PairPriceGraph/PairPriceGraph.vue
@@ -321,7 +321,7 @@ const chartGrid = computed(() => {
               :color="chartColors"
               :customGrid="chartGrid"
               :axisLabelFormatter="{
-                yAxis: { maximumFractionDigits: 6, fixedFormat: true },
+                yAxis: { maximumSignificantDigits: 6, fixedFormat: true },
               }"
               :wrapperClass="[
                 'flex flex-row lg:flex-col',

--- a/src/components/cards/PairPriceGraph/PairPriceGraph.vue
+++ b/src/components/cards/PairPriceGraph/PairPriceGraph.vue
@@ -320,7 +320,9 @@ const chartGrid = computed(() => {
               :showLegend="false"
               :color="chartColors"
               :customGrid="chartGrid"
-              :axisLabelFormatter="{ yAxis: { style: 'currency' } }"
+              :axisLabelFormatter="{
+                yAxis: { maximumFractionDigits: 6, fixedFormat: true },
+              }"
               :wrapperClass="[
                 'flex flex-row lg:flex-col',
                 {


### PR DESCRIPTION
# Description

Fixes #2149 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## How should this be tested?

- [ ] Test pair price chart in trade interface, should not show values in USD.

## Visual context

See issue.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have requested at least 2 reviews (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] If package-lock.json has changes, it was intentional.
- [x] The base of this PR is `master` if hotfix, `develop` if not
