### PR TITLE
Fixed alignment of 'new' label in pools table.

### DIFF
--- a/src/components/tables/PoolsTable/PoolsTable.vue
+++ b/src/components/tables/PoolsTable/PoolsTable.vue
@@ -297,8 +297,8 @@ function iconAddresses(pool: PoolWithShares) {
               :isStablePool="isStableLike(pool.poolType)"
               :selectedTokens="selectedTokens"
             />
-            <BalChipNew v-if="pool?.isNew" class="ml-2" />
           </div>
+          <BalChipNew v-if="pool?.isNew" class="mt-1" />
         </div>
       </template>
       <template #volumeCell="pool">


### PR DESCRIPTION
# Description

This fixes the UI bug where the 'new' label lost its alignment to the pool token pills.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

View a 'new' pool and check that the alignment has been corrected. There's a 'new' pool on Goerli – search for `DRGIV3`

## Visual context

Current UI:

<img width="507" alt="Screen Shot 2022-08-22 at 2 17 29 PM" src="https://user-images.githubusercontent.com/1121139/185931381-acb5bdbf-ffed-43cb-bbe2-5a5a8808deaa.png">

Proposed UI:

<img width="467" alt="Screen Shot 2022-08-22 at 2 17 17 PM" src="https://user-images.githubusercontent.com/1121139/185931404-3467ae12-05bf-43cd-ba62-325644e150fc.png">

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have requested at least 2 reviews (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] The base of this PR is `master` if hotfix, `develop` if not
