### PR TITLE
Hotfix: Fix load more not appearing for trade / investment tables

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.68.1",
+  "version": "1.68.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@balancer-labs/frontend-v2",
-      "version": "1.68.1",
+      "version": "1.68.2",
       "license": "MIT",
       "devDependencies": {
         "@aave/protocol-js": "^4.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.68.1",
+  "version": "1.68.2",
   "engines": {
     "node": "14.x",
     "npm": ">=7"

--- a/src/components/_global/BalTable/BalTable.vue
+++ b/src/components/_global/BalTable/BalTable.vue
@@ -351,12 +351,7 @@ watch(
     </div>
   </div>
   <div
-    v-if="
-      isPaginated &&
-      !isLoading &&
-      tableData.length !== 0 &&
-      !(tableData.length < 10)
-    "
+    v-if="isPaginated && !isLoading"
     class="bal-table-pagination-btn text-secondary"
     @click="!isLoadingMore && $emit('loadMore')"
   >

--- a/src/pages/index.vue
+++ b/src/pages/index.vue
@@ -32,6 +32,8 @@ const isInvestmentPoolsTableLoading = computed(
   () => dataStates.value['basic'] === 'loading' || priceQueryLoading.value
 );
 
+const isPaginated = computed(() => investmentPools.value.length >= 10);
+
 /**
  * METHODS
  */
@@ -76,7 +78,7 @@ function navigateToCreatePool() {
         class="mb-8"
         :hiddenColumns="['migrate', 'actions', 'lockEndDate']"
         :columnStates="dataStates"
-        :isPaginated="true"
+        :isPaginated="isPaginated"
         :isLoading="isInvestmentPoolsTableLoading"
         @load-more="loadMore"
       />


### PR DESCRIPTION
# Description

@zekraken-bot reported that since the last weekly release the investments / trades list on a single pool page is no longer showing the "load more" button. This is because of the change in #2156 that made all BalTable's not show load more with <10 results. 

I've moved the logic to the main pools page only for now, to solve the original issue (#1989) while not changing the logic of BalTable. 

This does have an edge case if there are exactly 10 pools that match a token, the load more button will show but not do anything. I'll be fixing this in #2093 when we rework pool fetching. I'll make this variable be based on if the vue-query reports there is more to load. 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## How should this be tested?

- On the homepage, ensure load more works
- When filtering by a token on the homepage, load more should only show if there are >= 10 pools with that token 
- On an individual pool page the investments and swaps tables should have load more buttons. 

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have requested at least 2 reviews (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] If package-lock.json has changes, it was intentional.
- [x] The base of this PR is `master` if hotfix, `develop` if not
