### PR TITLE
Fix pool charts current date bug

### DIFF
--- a/src/components/contextual/pages/pool/PoolChart.vue
+++ b/src/components/contextual/pages/pool/PoolChart.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { format } from 'date-fns';
+import { format, addMinutes } from 'date-fns';
 import * as echarts from 'echarts/core';
 import { computed, ref } from 'vue';
 import { useI18n } from 'vue-i18n';
@@ -118,7 +118,15 @@ const periodOptions = computed(() => [
 const currentPeriod = ref<PoolChartPeriod>(periodOptions.value[0]);
 
 const timestamps = computed(() =>
-  snapshotValues.value.map(snapshot => format(snapshot.timestamp, 'yyyy/MM/dd'))
+  snapshotValues.value.map(snapshot =>
+    format(
+      addMinutes(
+        snapshot.timestamp,
+        new Date(snapshot.timestamp).getTimezoneOffset()
+      ),
+      'yyyy/MM/dd'
+    )
+  )
 );
 
 function getTVLData(periodSnapshots: PoolSnapshot[]) {


### PR DESCRIPTION
# Description
Pool snaphot timestamps are created on the base of utc day timestamps:
```
    const currentTimestamp = Math.ceil(Date.now() / 1000);
    const dayTimestamp = currentTimestamp - (currentTimestamp % DAY);
```
That is why in certain timezones (western ones), there is a problem of date delation, this pr fixes this. 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## How should this be tested?

Please provide instructions so we can test. Please also list any relevant details for your test configuration.

- [ ] Test A
- [ ] Test B

## Visual context

Please provide any relevant visual context for UI changes or additions. This could be static screenshots or a loom screencast.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have requested at least 2 reviews (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] If package-lock.json has changes, it was intentional.
- [x] The base of this PR is `master` if hotfix, `develop` if not
