### PR TITLE
Enable prefetch for certain routes

### DIFF
--- a/src/plugins/router.ts
+++ b/src/plugins/router.ts
@@ -11,9 +11,13 @@ const CookiesPolicyPage = () =>
 const GetVeBalPage = () =>
   import(/* webpackChunkName: "GetVeBalPage" */ '@/pages/get-vebal.vue');
 const HomePage = () =>
-  import(/* webpackChunkName: "HomePage" */ '@/pages/index.vue');
+  import(
+    /* webpackChunkName: "HomePage" */ /* webpackPrefetch: true */ '@/pages/index.vue'
+  );
 const PoolPage = () =>
-  import(/* webpackChunkName: "PoolPage" */ '@/pages/pool/_id.vue');
+  import(
+    /* webpackChunkName: "PoolPage" */ /* webpackPrefetch: true */ '@/pages/pool/_id.vue'
+  );
 const CreatePoolPage = () =>
   import(/* webpackChunkName: "CreatePoolPage" */ '@/pages/pool/create.vue');
 const PoolInvestPage = () =>
@@ -40,7 +44,9 @@ const FaucetPage = () =>
   import(/* webpackChunkName: "FaucetPage" */ '@/pages/faucet.vue');
 
 const PortfolioPage = () =>
-  import(/* webpackChunkName: "PortfolioPage" */ '@/pages/portfolio.vue');
+  import(
+    /* webpackChunkName: "PortfolioPage" */ /* webpackPrefetch: true */ '@/pages/portfolio.vue'
+  );
 
 declare module 'vue-router' {
   interface RouteMeta {

--- a/src/plugins/router.ts
+++ b/src/plugins/router.ts
@@ -35,7 +35,9 @@ const PrivacyPolicyPage = () =>
 const TermsOfUsePage = () =>
   import(/* webpackChunkName: "TermsOfUsePage" */ '@/pages/terms-of-use.vue');
 const TradePage = () =>
-  import(/* webpackChunkName: "TradePage" */ '@/pages/trade.vue');
+  import(
+    /* webpackChunkName: "TradePage" */ /* webpackPrefetch: true */ '@/pages/trade.vue'
+  );
 const UnlockVeBalPage = () =>
   import(/* webpackChunkName: "UnlockVeBalPage" */ '@/pages/unlock-vebal.vue');
 const VeBalPage = () =>

--- a/vue.config.js
+++ b/vue.config.js
@@ -17,6 +17,7 @@ module.exports = {
       'bn.js',
       path.resolve(path.join(__dirname, 'node_modules', 'bn.js'))
     );
+    config.plugins.delete('prefetch');
   },
   devServer: {
     headers: {


### PR DESCRIPTION
# Description
Currently webpack automatically generates prefetch hints for all JavaScript files of our async routes.
Downloading all that chunks at start is not necessary + it leads to additional load on server, so this pr enables prefetching only for certain most common routes.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [x] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## How should this be tested?

Please provide instructions so we can test. Please also list any relevant details for your test configuration.

- [ ] Test A
- [ ] Test B

## Visual context

Please provide any relevant visual context for UI changes or additions. This could be static screenshots or a loom screencast.

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have requested at least 2 reviews (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] If package-lock.json has changes, it was intentional.
- [x] The base of this PR is `master` if hotfix, `develop` if not
