### PR TITLE
Safe friendly pool creation recovery

### DIFF
--- a/src/composables/pools/usePoolCreation.spec.ts
+++ b/src/composables/pools/usePoolCreation.spec.ts
@@ -24,28 +24,28 @@ describe('usePoolCreation', () => {
       tokenAddress: '0x9f8F72aA9304c8B593d555F12eF6589cC3A579A2',
       weight: 70,
       isLocked: false,
-      id: 0,
+      id: '0',
       amount: '0',
     };
     tokens.WETH = {
       tokenAddress: '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2',
       weight: 20,
       isLocked: false,
-      id: 1,
+      id: '1',
       amount: '0',
     };
     tokens.USDT = {
       tokenAddress: '0xdac17f958d2ee523a2206206994597c13d831ec7',
       weight: 10,
       isLocked: false,
-      id: 2,
+      id: '2',
       amount: '0',
     };
     tokens.USDC = {
       tokenAddress: '0xc2569dd7d0fd715B054fBf16E75B001E5c0C1115',
       weight: 50,
       isLocked: false,
-      id: 3,
+      id: '3',
       amount: '7643.537999999996',
     };
   });

--- a/src/composables/pools/usePoolCreation.spec.ts
+++ b/src/composables/pools/usePoolCreation.spec.ts
@@ -24,28 +24,28 @@ describe('usePoolCreation', () => {
       tokenAddress: '0x9f8F72aA9304c8B593d555F12eF6589cC3A579A2',
       weight: 70,
       isLocked: false,
-      id: '0',
+      id: 0,
       amount: '0',
     };
     tokens.WETH = {
       tokenAddress: '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2',
       weight: 20,
       isLocked: false,
-      id: '1',
+      id: 1,
       amount: '0',
     };
     tokens.USDT = {
       tokenAddress: '0xdac17f958d2ee523a2206206994597c13d831ec7',
       weight: 10,
       isLocked: false,
-      id: '2',
+      id: 2,
       amount: '0',
     };
     tokens.USDC = {
       tokenAddress: '0xc2569dd7d0fd715B054fBf16E75B001E5c0C1115',
       weight: 50,
       isLocked: false,
-      id: '3',
+      id: 3,
       amount: '7643.537999999996',
     };
   });

--- a/src/composables/pools/usePoolCreation.ts
+++ b/src/composables/pools/usePoolCreation.ts
@@ -562,7 +562,7 @@ export default function usePoolCreation() {
         weight: Number(details.weights[i]) * 100,
         isLocked: true,
         amount: '0',
-        id: i,
+        id: i.toString(),
       };
     });
     poolCreationState.tokensList = details.tokens;

--- a/src/composables/pools/usePoolCreation.ts
+++ b/src/composables/pools/usePoolCreation.ts
@@ -32,7 +32,7 @@ export type PoolSeedToken = {
   weight: number;
   isLocked: boolean;
   amount: string;
-  id: string;
+  id: number;
 };
 
 export type OptimisedLiquidity = {

--- a/src/composables/pools/usePoolCreation.ts
+++ b/src/composables/pools/usePoolCreation.ts
@@ -32,7 +32,7 @@ export type PoolSeedToken = {
   weight: number;
   isLocked: boolean;
   amount: string;
-  id: number;
+  id: string;
 };
 
 export type OptimisedLiquidity = {

--- a/src/composables/pools/usePoolCreation.ts
+++ b/src/composables/pools/usePoolCreation.ts
@@ -541,10 +541,12 @@ export default function usePoolCreation() {
         getProvider(),
         hash
       );
-    poolCreationState.poolId = response.id;
-    poolCreationState.poolAddress = response.address;
-    poolCreationState.needsSeeding = true;
-    saveState();
+    if (response !== null) {
+      poolCreationState.poolId = response.id;
+      poolCreationState.poolAddress = response.address;
+      poolCreationState.needsSeeding = true;
+      saveState();
+    }
   }
 
   // when restoring from a pool creation transaction (not from localstorage)

--- a/src/composables/pools/usePoolCreation.ts
+++ b/src/composables/pools/usePoolCreation.ts
@@ -551,11 +551,10 @@ export default function usePoolCreation() {
 
   // when restoring from a pool creation transaction (not from localstorage)
   async function retrievePoolDetails(hash: string) {
-    const details =
-      await balancerService.pools.weighted.retrievePoolDetailsFromCall(
-        getProvider(),
-        hash
-      );
+    const details = await balancerService.pools.weighted.retrievePoolDetails(
+      getProvider(),
+      hash
+    );
     if (!details) return;
     poolCreationState.seedTokens = details.tokens.map((token, i) => {
       return {

--- a/src/constants/topics.ts
+++ b/src/constants/topics.ts
@@ -1,6 +1,0 @@
-const TOPICS = {
-  PoolCreated:
-    '0xa9ba3ffe0b6c366b81232caab38605a0699ad5398d6cce76f91ee809e322dafc',
-};
-
-export default TOPICS;

--- a/src/services/balancer/pools/weighted-pool.service.spec.ts
+++ b/src/services/balancer/pools/weighted-pool.service.spec.ts
@@ -40,21 +40,21 @@ describe('PoolCreator', () => {
       tokenAddress: '0x9f8F72aA9304c8B593d555F12eF6589cC3A579A2',
       weight: 70,
       isLocked: false,
-      id: 0,
+      id: '0',
       amount: '0',
     };
     tokens.WETH = {
       tokenAddress: '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2',
       weight: 20,
       isLocked: false,
-      id: 1,
+      id: '1',
       amount: '0',
     };
     tokens.USDT = {
       tokenAddress: '0xdac17f958d2ee523a2206206994597c13d831ec7',
       weight: 10,
       isLocked: false,
-      id: 2,
+      id: '2',
       amount: '0',
     };
   });

--- a/src/services/balancer/pools/weighted-pool.service.spec.ts
+++ b/src/services/balancer/pools/weighted-pool.service.spec.ts
@@ -40,21 +40,21 @@ describe('PoolCreator', () => {
       tokenAddress: '0x9f8F72aA9304c8B593d555F12eF6589cC3A579A2',
       weight: 70,
       isLocked: false,
-      id: '0',
+      id: 0,
       amount: '0',
     };
     tokens.WETH = {
       tokenAddress: '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2',
       weight: 20,
       isLocked: false,
-      id: '1',
+      id: 1,
       amount: '0',
     };
     tokens.USDT = {
       tokenAddress: '0xdac17f958d2ee523a2206206994597c13d831ec7',
       weight: 10,
       isLocked: false,
-      id: '2',
+      id: 2,
       amount: '0',
     };
   });

--- a/src/services/balancer/pools/weighted-pool.service.spec.ts
+++ b/src/services/balancer/pools/weighted-pool.service.spec.ts
@@ -151,8 +151,8 @@ describe('PoolCreator', () => {
         mockProvider,
         'hash'
       );
-      expect(poolDetails.id).toEqual(mockPoolId);
-      expect(poolDetails.address).toEqual(mockPoolAddress);
+      expect(poolDetails?.id).toEqual(mockPoolId);
+      expect(poolDetails?.address).toEqual(mockPoolAddress);
     });
 
     it('should work with a polygon create pool transaction receipt', async () => {
@@ -163,7 +163,7 @@ describe('PoolCreator', () => {
         mockProvider,
         'hash'
       );
-      expect(poolDetails.address.toLowerCase()).toEqual(
+      expect(poolDetails?.address.toLowerCase()).toEqual(
         '0x3bb9d50a0743103f896d823b332ee15e231848d1'
       );
     });
@@ -176,7 +176,7 @@ describe('PoolCreator', () => {
         mockProvider,
         'hash'
       );
-      expect(poolDetails.address.toLowerCase()).toEqual(
+      expect(poolDetails?.address.toLowerCase()).toEqual(
         '0x92e244b931bd6c71c1db2e50326480a0ba530fc7'
       );
     });


### PR DESCRIPTION
# Description

The pool creation form recovery mechanism relies on decoding the transaction data to recover the arguments sent to the pool factory (and so the config of the pool). This works from EOAs but if the pool is deployed using a contract wallet (such as a Safe) then this will fail as the call to the factory is wrapped in a call to the Safe. Instead we should read the pool's address through the emitted event and query the pool for it's config.

I've improved the `retrievePoolIdAndAddress` function to a method which uses the factory's interface to decode the event logs so we don't have to look for a hardcoded topic hash anymore. There was also a type issue in `PoolSeedToken` which I fixed.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## How should this be tested?

Connect to the polygon app and attempt to recover the pool creation form using tx hash [0xd206199ac88b0bcaf46efc7465cec6a3e6e9b3886c9fcf139061f87b0b4e5ee7](https://polygonscan.com/tx/0xd206199ac88b0bcaf46efc7465cec6a3e6e9b3886c9fcf139061f87b0b4e5ee7). This is a deployment of a pool through a gnosis safe.

Expect that the pool creation form cannot recover on the production site but can on this branch.

## Visual context

N/A

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have requested at least 2 reviews (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] If package-lock.json has changes, it was intentional.
- [x] The base of this PR is `master` if hotfix, `develop` if not
