### PR TITLE
Hotfix: block number fetching

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.69.1",
+  "version": "1.69.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@balancer-labs/frontend-v2",
-      "version": "1.69.1",
+      "version": "1.69.2",
       "license": "MIT",
       "devDependencies": {
         "@aave/protocol-js": "^4.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.69.1",
+  "version": "1.69.2",
   "engines": {
     "node": "14.x",
     "npm": ">=7"

--- a/src/composables/useTime.ts
+++ b/src/composables/useTime.ts
@@ -6,6 +6,10 @@ export const oneHourInMs = 60 * oneMinInMs;
 export const oneDayInMs = 24 * oneHourInMs;
 export const oneWeekInMs = 7 * oneDayInMs;
 
+export const oneSecond = 1;
+export const oneMinInSecs = 60 * oneSecond;
+export const oneHourInSecs = 60 * oneMinInSecs;
+
 export const twentyFourHoursInMs = 24 * oneHourInMs;
 export const twentyFourHoursInSecs = twentyFourHoursInMs / oneSecondInMs;
 

--- a/src/services/block/block.service.ts
+++ b/src/services/block/block.service.ts
@@ -22,14 +22,14 @@ export default class BlockService {
         const startTimestamp = bnum(timestamp).minus(oneHourInSecs);
         query = {
           where: {
-            timestamp_gt: startTimestamp.toString(),
-            timestamp_lt: timestamp,
+            timestamp_gt: timestamp,
+            timestamp_lt: startTimestamp.toString(),
           },
         };
       } else {
         query = {
           where: {
-            timestamp: timestamp,
+            timestamp_gt: timestamp,
           },
         };
       }
@@ -37,7 +37,6 @@ export default class BlockService {
       const response: BlockNumberResponse =
         await this.subgraphService.blockNumber.get(query);
 
-      console.log(response.blocks);
       return parseInt(response.blocks[0].number);
     } catch (error) {
       if (useRange) return this.fetchBlockByTime(timestamp, false);

--- a/src/services/block/block.service.ts
+++ b/src/services/block/block.service.ts
@@ -19,11 +19,11 @@ export default class BlockService {
     try {
       let query = {};
       if (useRange) {
-        const startTimestamp = bnum(timestamp).minus(oneHourInSecs);
+        const oneHourLater = bnum(timestamp).plus(oneHourInSecs);
         query = {
           where: {
             timestamp_gt: timestamp,
-            timestamp_lt: startTimestamp.toString(),
+            timestamp_lt: oneHourLater.toString(),
           },
         };
       } else {

--- a/src/services/block/block.service.ts
+++ b/src/services/block/block.service.ts
@@ -2,6 +2,8 @@ import { BlockNumberResponse } from './types';
 import BlockSubgraphService, {
   blockSubgraphService,
 } from './subgraph/block-subgraph.service';
+import { oneHourInSecs } from '@/composables/useTime';
+import { bnum } from '@/lib/utils';
 
 export default class BlockService {
   subgraphService: BlockSubgraphService;
@@ -10,13 +12,37 @@ export default class BlockService {
     this.subgraphService = subgraphService;
   }
 
-  public async fetchBlockByTime(timestamp: string): Promise<number> {
-    const response: BlockNumberResponse =
-      await this.subgraphService.blockNumber.get({
-        where: { timestamp_gt: timestamp },
-      });
+  public async fetchBlockByTime(
+    timestamp: string,
+    useRange = true
+  ): Promise<number> {
+    try {
+      let query = {};
+      if (useRange) {
+        const startTimestamp = bnum(timestamp).minus(oneHourInSecs);
+        query = {
+          where: {
+            timestamp_gt: startTimestamp.toString(),
+            timestamp_lt: timestamp,
+          },
+        };
+      } else {
+        query = {
+          where: {
+            timestamp: timestamp,
+          },
+        };
+      }
 
-    return parseInt(response.blocks[0].number);
+      const response: BlockNumberResponse =
+        await this.subgraphService.blockNumber.get(query);
+
+      console.log(response.blocks);
+      return parseInt(response.blocks[0].number);
+    } catch (error) {
+      if (useRange) return this.fetchBlockByTime(timestamp, false);
+      throw error;
+    }
   }
 }
 


### PR DESCRIPTION
# Description

The subgraph query to fetch the block number at a particular timestamp was taking a long time. This was due to the structure of the query, using a range to search for the block number drastically reduces the query time.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## How should this be tested?

- [ ] Test APR data loads relatively quickly.

## Visual context

n/a

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have requested at least 2 reviews (If the PR is significant enough, use best judgement here)
- [ ] I have commented my code where relevant, particularly in hard-to-understand areas
- [ ] If package-lock.json has changes, it was intentional.
- [ ] The base of this PR is `master` if hotfix, `develop` if not
