### PR TITLE
Hotfix: block number fetching

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.69.2",
+  "version": "1.69.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@balancer-labs/frontend-v2",
-      "version": "1.69.2",
+      "version": "1.69.3",
       "license": "MIT",
       "devDependencies": {
         "@aave/protocol-js": "^4.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.69.2",
+  "version": "1.69.3",
   "engines": {
     "node": "14.x",
     "npm": ">=7"

--- a/src/services/block/subgraph/entities/block-number/query.ts
+++ b/src/services/block/subgraph/entities/block-number/query.ts
@@ -2,7 +2,7 @@ import { merge } from 'lodash';
 
 const defaultArgs = {
   first: 1,
-  orderBy: 'number',
+  orderBy: 'timestamp',
   orderDirection: 'asc',
 };
 


### PR DESCRIPTION
# Description

Use timestamp to order block number queries, using number is much slower.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## How should this be tested?

- [ ] Test pools lists loads with same APRs as production.

## Visual context

n/a

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have requested at least 2 reviews (If the PR is significant enough, use best judgement here)
- [ ] I have commented my code where relevant, particularly in hard-to-understand areas
- [ ] If package-lock.json has changes, it was intentional.
- [ ] The base of this PR is `master` if hotfix, `develop` if not
