### PR TITLE
fix: Make sure SOR is used as soon as pools have been loaded

### DIFF
--- a/src/composables/trade/useTrading.ts
+++ b/src/composables/trade/useTrading.ts
@@ -134,7 +134,7 @@ export default function useTrading(
     tokenInAmountScaled,
     tokenOutAmountScaled,
     sorConfig: {
-      handleAmountsOnFetchPools: false,
+      handleAmountsOnFetchPools: true,
     },
     tokenIn,
     tokenOut,


### PR DESCRIPTION
# Description

On page load, if I enter a value before the SOR loads I get a not enough liquidity error. It should refetch the swap. This is because SOR needs to be loaded to calculate trade amounts and if both are not present, not enough liquidity is assumed.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

Load Trade page and enter amount before SOR has been loaded. If there is liquidity, it should allow you to preview/trade.

## Visual context

N/A

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have requested at least 2 reviews (If the PR is significant enough, use best judgement here)
- [n/a] I have commented my code where relevant, particularly in hard-to-understand areas
- [n/a] If package-lock.json has changes, it was intentional.
- [x] The base of this PR is `master` if hotfix, `develop` if not
