### PR TITLE
Hotfix: fix multiple gauges apr bug

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.70.2",
+  "version": "1.70.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@balancer-labs/frontend-v2",
-      "version": "1.70.2",
+      "version": "1.70.3",
       "license": "MIT",
       "devDependencies": {
         "@aave/protocol-js": "^4.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.70.2",
+  "version": "1.70.3",
   "engines": {
     "node": "14.x",
     "npm": ">=7"

--- a/src/services/staking/staking-rewards.service.ts
+++ b/src/services/staking/staking-rewards.service.ts
@@ -118,6 +118,13 @@ export class StakingRewardsService {
       const pool = pools.find(pool => pool.id === poolId);
       const nilApr = [poolId, { min: '0', max: '0' }];
 
+      // Temp fix to handle case of multiple gauges
+      const poolGauges = gauges.filter(gauge => gauge.poolId === poolId);
+      const bestGauge = poolGauges.reduce((prev, current) =>
+        bnum(prev.totalSupply).gt(current.totalSupply) ? prev : current
+      );
+      if (bestGauge.id !== gauge.id) return [null];
+
       if (!pool) return nilApr;
       if (isNil(inflationRate)) return nilApr;
 
@@ -142,7 +149,8 @@ export class StakingRewardsService {
       const range = getAprRange(gaugeBALApr || '0'.toString());
       return [poolId, { ...range }];
     });
-    return Object.fromEntries(aprs);
+
+    return Object.fromEntries(aprs.filter(apr => apr));
   }
 
   async getRewardTokenAprs({


### PR DESCRIPTION
# Description

The staking reward service is running through all gauges to generate a list of APRs here: https://github.com/balancer-labs/frontend-v2/blob/develop/src/services/staking/staking-rewards.service.ts#L116 and creating a map of poolIds > APR range. Now that we may have two gauges per pool, it was overriding the first apr result with the second. If the second result happened to be the new one it would set BAL rewards APRs to zero.

This PR introduces a temporary fix that checks for the gauge with the highest totalSupply and uses that one.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## How should this be tested?

- [ ] Check this pool on mainnet includes BAL rewards: `0x1b65fe4881800b91d4277ba738b567cbb200a60d0002000000000000000002cc`

## Visual context

n/a

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have requested at least 2 reviews (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] If package-lock.json has changes, it was intentional.
- [x] The base of this PR is `master` if hotfix, `develop` if not
