### PR TITLE
Fix BAL APR for killed gauges

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.70.4",
+  "version": "1.70.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@balancer-labs/frontend-v2",
-      "version": "1.70.4",
+      "version": "1.70.5",
       "license": "MIT",
       "devDependencies": {
         "@aave/protocol-js": "^4.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.70.4",
+  "version": "1.70.5",
   "engines": {
     "node": "14.x",
     "npm": ">=7"

--- a/src/services/balancer/gauges/entities/gauges/query.ts
+++ b/src/services/balancer/gauges/entities/gauges/query.ts
@@ -9,6 +9,7 @@ const defaultAttrs = {
   symbol: true,
   poolId: true,
   totalSupply: true,
+  isKilled: true,
   factory: {
     id: true,
   },

--- a/src/services/balancer/gauges/types.ts
+++ b/src/services/balancer/gauges/types.ts
@@ -11,6 +11,7 @@ export interface SubgraphGauge {
   symbol: string;
   poolId: string;
   totalSupply: string;
+  isKilled: boolean;
   factory: {
     id: string;
   };

--- a/src/services/staking/staking-rewards.service.ts
+++ b/src/services/staking/staking-rewards.service.ts
@@ -127,6 +127,7 @@ export class StakingRewardsService {
 
       if (!pool) return nilApr;
       if (isNil(inflationRate)) return nilApr;
+      if (gauge.isKilled) return nilApr;
 
       const poolService = new PoolService(pool);
       if (!balAddress) return nilApr;


### PR DESCRIPTION
# Description

Maxis noticed the frontend shows a non-zero APR for pools that have had their gauges killed.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## How should this be tested?

CREAM and FEI pools should not display any liquidity mining APR

## Visual context

Please provide any relevant visual context for UI changes or additions. This could be static screenshots or a loom screencast.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have requested at least 2 reviews (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] If package-lock.json has changes, it was intentional.
- [x] The base of this PR is `master` if hotfix, `develop` if not
