### PR TITLE
Hotfix: gauge vote remaining time

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.71.1",
+  "version": "1.71.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@balancer-labs/frontend-v2",
-      "version": "1.71.1",
+      "version": "1.71.2",
       "license": "MIT",
       "devDependencies": {
         "@aave/protocol-js": "^4.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.71.1",
+  "version": "1.71.2",
   "engines": {
     "node": "14.x",
     "npm": ">=7"

--- a/src/composables/useVeBAL.ts
+++ b/src/composables/useVeBAL.ts
@@ -73,7 +73,7 @@ export function isVotingTimeLocked(lastVoteTime: number): boolean {
 
 export function remainingVoteLockTime(lastVoteTime: number): string {
   const lastUserVoteTime = toJsTimestamp(lastVoteTime);
-  return formatDistanceToNow(lastUserVoteTime - WEIGHT_VOTE_DELAY);
+  return formatDistanceToNow(lastUserVoteTime + WEIGHT_VOTE_DELAY);
 }
 
 export default function useVeBal() {


### PR DESCRIPTION
# Description

When refactoring the remaining time calculation into its own function for some reason the operation was reversed from plus to minus. This PR reverts that change. Fixes issue with incorrect remaining lock time being displayed in UI.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## How should this be tested?

- [ ] Test that remaining lock time labels in UI make sense, i.e. are less than 10 days.

## Visual context

n/a

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have requested at least 2 reviews (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] If package-lock.json has changes, it was intentional.
- [x] The base of this PR is `master` if hotfix, `develop` if not
