### PR TITLE
Always check if an address is actually a poolID

### DIFF
--- a/src/providers/tokens.provider.ts
+++ b/src/providers/tokens.provider.ts
@@ -20,7 +20,12 @@ import useTokenLists from '@/composables/useTokenLists';
 import useUserSettings from '@/composables/useUserSettings';
 import symbolKeys from '@/constants/symbol.keys';
 import { TOKENS } from '@/constants/tokens';
-import { bnum, includesAddress, isSameAddress } from '@/lib/utils';
+import {
+  bnum,
+  getAddressFromPoolId,
+  includesAddress,
+  isSameAddress,
+} from '@/lib/utils';
 import { TokenPrices } from '@/services/coingecko/api/price.service';
 import { configService } from '@/services/config/config.service';
 import { ContractAllowancesMap } from '@/services/token/concerns/allowances.concern';
@@ -268,7 +273,7 @@ export default {
      * tokens into state tokens map.
      */
     async function injectTokens(addresses: string[]): Promise<void> {
-      addresses = addresses.map(address => getAddress(address));
+      addresses = addresses.map(getAddressFromPoolId).map(getAddress);
 
       // Remove any duplicates
       addresses = [...new Set(addresses)];
@@ -300,8 +305,10 @@ export default {
     ): Promise<TokenInfoMap> {
       if (!query) return removeExcluded(tokens.value, excluded);
 
-      if (isAddress(query)) {
-        const address = getAddress(query);
+      const potentialAddress = getAddressFromPoolId(query);
+
+      if (isAddress(potentialAddress)) {
+        const address = getAddress(potentialAddress);
         const token = allTokenListTokens.value[address];
         if (token) {
           return { [address]: token };
@@ -416,6 +423,7 @@ export default {
      * Get single token from state
      */
     function getToken(address: string): TokenInfo {
+      address = getAddressFromPoolId(address); // In case pool ID has been passed
       if (address) address = getAddress(address);
       return tokens.value[address];
     }

--- a/src/services/coingecko/api/price.service.ts
+++ b/src/services/coingecko/api/price.service.ts
@@ -4,7 +4,7 @@ import { groupBy, invert, last } from 'lodash';
 import { twentyFourHoursInSecs } from '@/composables/useTime';
 import { TOKENS } from '@/constants/tokens';
 import { returnChecksum } from '@/lib/decorators/return-checksum.decorator';
-import { includesAddress } from '@/lib/utils';
+import { getAddressFromPoolId, includesAddress } from '@/lib/utils';
 import { retryPromiseWithDelay } from '@/lib/utils/promise';
 import { configService as _configService } from '@/services/config/config.service';
 
@@ -73,7 +73,9 @@ export class PriceService {
       if (addresses.length / addressesPerRequest > 10)
         throw new Error('To many requests for rate limit.');
 
-      addresses = addresses.map(address => this.addressMapIn(address));
+      addresses = addresses
+        .map(getAddressFromPoolId)
+        .map(address => this.addressMapIn(address));
       const pageCount = Math.ceil(addresses.length / addressesPerRequest);
       const pages = Array.from(Array(pageCount).keys());
       const requests: Promise<PriceResponse>[] = [];
@@ -122,7 +124,9 @@ export class PriceService {
         aggregateBy === 'hour' ? now : now - (now % twentyFourHoursInSecs);
       const start = end - days * twentyFourHoursInSecs;
 
-      addresses = addresses.map(address => this.addressMapIn(address));
+      addresses = addresses
+        .map(getAddressFromPoolId)
+        .map(address => this.addressMapIn(address));
       const requests: Promise<HistoricalPriceResponse>[] = [];
 
       addresses.forEach(address => {


### PR DESCRIPTION
# Description

Sometimes pool IDs end up being used by accident to find tokens in the search input or via the trade UI URL params. At the moment we don't handle that and it causes errors like this one: https://sentry.io/organizations/balancer-labs/issues/3348522771/?project=5725878

This PR checks all passed token addresses in case they are a pool ID and extracts the substring in the case that it is.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## How should this be tested?

Please provide instructions so we can test. Please also list any relevant details for your test configuration.

- [ ] Test pasting pool IDs into token search
- [ ] Test that all other token functionality remains the same

## Visual context

n/a

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have requested at least 2 reviews (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] If package-lock.json has changes, it was intentional.
- [x] The base of this PR is `master` if hotfix, `develop` if not
