### PR TITLE
Add button to claims page on staking success

### DIFF
--- a/src/components/contextual/stake/StakePreview.vue
+++ b/src/components/contextual/stake/StakePreview.vue
@@ -253,6 +253,9 @@ function handleClose() {
     <BalStack v-if="isActionConfirmed && confirmationReceipt" vertical>
       <ConfirmationIndicator :txReceipt="confirmationReceipt" />
       <AnimatePresence :isVisible="isActionConfirmed">
+        <BalBtn color="gradient" block @click="$router.push({ name: 'claim' })">
+          {{ $t('viewClaims') }}
+        </BalBtn>
         <BalBtn color="gray" outline block @click="handleClose">
           {{ $t('close') }}
         </BalBtn>

--- a/src/components/contextual/stake/StakePreview.vue
+++ b/src/components/contextual/stake/StakePreview.vue
@@ -253,7 +253,13 @@ function handleClose() {
     <BalStack v-if="isActionConfirmed && confirmationReceipt" vertical>
       <ConfirmationIndicator :txReceipt="confirmationReceipt" />
       <AnimatePresence :isVisible="isActionConfirmed">
-        <BalBtn color="gradient" block @click="$router.push({ name: 'claim' })">
+        <BalBtn
+          v-if="action === 'stake'"
+          color="gradient"
+          block
+          class="mb-2"
+          @click="$router.push({ name: 'claim' })"
+        >
           {{ $t('viewClaims') }}
         </BalBtn>
         <BalBtn color="gray" outline block @click="handleClose">

--- a/src/locales/default.json
+++ b/src/locales/default.json
@@ -1237,6 +1237,7 @@
   "vestVote": "Vest+Vote",
   "viewAllAssets": "View all assets ({0})",
   "viewAndManangeOnElement": "View and manage all pools on Element.fi",
+  "viewClaims": "View claims",
   "viewFullWallet": "View full wallet",
   "viewLess": "View less",
   "viewOnElement": "View on Element.fi",

--- a/src/locales/default.json
+++ b/src/locales/default.json
@@ -1237,7 +1237,7 @@
   "vestVote": "Vest+Vote",
   "viewAllAssets": "View all assets ({0})",
   "viewAndManangeOnElement": "View and manage all pools on Element.fi",
-  "viewClaims": "View claims",
+  "viewClaims": "View & claim rewards",
   "viewFullWallet": "View full wallet",
   "viewLess": "View less",
   "viewOnElement": "View on Element.fi",


### PR DESCRIPTION
# Description

Fixes #1573 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## How should this be tested?

- [ ] Test staking and check that there is a button linking to the claims page on success.

## Visual context

<img width="604" alt="Screenshot 2022-09-14 at 09 51 40" src="https://user-images.githubusercontent.com/2406506/190108571-e7b4fd73-56da-43f2-89ae-02cee1432137.png">

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have requested at least 2 reviews (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] If package-lock.json has changes, it was intentional.
- [x] The base of this PR is `master` if hotfix, `develop` if not
