### PR TITLE
feat: Show warning that the user might be wasting their gauge vote

### DIFF
--- a/src/locales/default.json
+++ b/src/locales/default.json
@@ -926,6 +926,10 @@
           "veBalVoteOverLimitWarning": {
             "title": "You may be wasting your vote: veBAL cap hit",
             "description": "Distributions to veBAL holders of weekly emissions are capped at 10%. Any votes exceeding this amount at Thursday 0:00 UTC will not be counted."
+          },
+          "lpVoteOverLimitWarning": {
+            "title": "You may be wasting your vote",
+            "description": "Distributions to LPs of this pool gauge are capped at {0}%. Any votes exceeding this amount at Thursday 0:00 UTC will not be counted."
           }
         },
         "errors": {


### PR DESCRIPTION
# Description

When voting on gauges which have voting limits, warn users in the modal that their vote might be wasted. They might still proceed with the vote.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## How should this be tested?

Find a gauge which has a limit and votes above the cap. Click Vote button. In the modal, you should see a warning.

## Visual context

Check Figma for context.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have requested at least 2 reviews (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [n/a] If package-lock.json has changes, it was intentional.
- [x] The base of this PR is `master` if hotfix, `develop` if not
