### PR TITLE
Hotfix: Fix Missing APR's for pools with 2 gauges

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.72.3",
+  "version": "1.72.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@balancer-labs/frontend-v2",
-      "version": "1.72.3",
+      "version": "1.72.4",
       "license": "MIT",
       "devDependencies": {
         "@aave/protocol-js": "^4.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.72.3",
+  "version": "1.72.4",
   "engines": {
     "node": "14.x",
     "npm": ">=7"

--- a/src/services/staking/staking-rewards.service.ts
+++ b/src/services/staking/staking-rewards.service.ts
@@ -119,9 +119,9 @@ export class StakingRewardsService {
       const nilApr = [poolId, { min: '0', max: '0' }];
 
       if (!pool) return nilApr;
+      if (!gauge.isPreferentialGauge) return [null];
       if (isNil(inflationRate)) return nilApr;
       if (gauge.isKilled) return nilApr;
-      if (!gauge.isPreferentialGauge) return [null];
 
       const poolService = new PoolService(pool);
       if (!balAddress) return nilApr;


### PR DESCRIPTION

# Description

Bug: Some pools are missing staking APR's in prod when they should have them. 

Reason: Gauges that were not preferential had no inflationRate or had `isKilled` set to true and so were returning nilApr which meant those pools had 2 staking APR's returned and the nilApr over-wrote the real gauges APR in the Object.fromEntries at the end of this function. 

By moving the isPreferentialGauge check higher the extra gauges are removed from the array instead.

This fixes the APR not being shown for pools such as `0xa7ff759dbef9f3efdd1d59beee44b966acafe214000200000000000000000180` and `0x27c9f71cc31464b906e0006d4fcbc8900f48f15f00020000000000000000010f`

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

- Check that APR's are showing for all pools the same as in production. 
- Check that for the pools above they are now showing staking APR's (they are not showing them in production ATM). 

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have requested at least 2 reviews (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] If package-lock.json has changes, it was intentional.
- [x] The base of this PR is `master` if hotfix, `develop` if not
