### PR TITLE
Hotfix: Add proportional exits for ComposableStable pools

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.73.8",
+  "version": "1.73.9",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@balancer-labs/frontend-v2",
-      "version": "1.73.8",
+      "version": "1.73.9",
       "license": "MIT",
       "devDependencies": {
         "@aave/protocol-js": "^4.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.73.8",
+  "version": "1.73.9",
   "engines": {
     "node": "14.x",
     "npm": ">=7"

--- a/src/components/forms/pool_actions/WithdrawForm/components/ProportionalWithdrawalInput.vue
+++ b/src/components/forms/pool_actions/WithdrawForm/components/ProportionalWithdrawalInput.vue
@@ -96,7 +96,7 @@ function handleSliderChange(newVal: number): void {
 
 async function handleSliderEnd(): Promise<void> {
   if (shouldFetchBatchSwap.value) {
-    await props.math.getSwap();
+    await props.math.fetchExitData();
   }
 }
 

--- a/src/components/forms/pool_actions/WithdrawForm/components/WithdrawPreviewModal/components/WithdrawActions.vue
+++ b/src/components/forms/pool_actions/WithdrawForm/components/WithdrawPreviewModal/components/WithdrawActions.vue
@@ -189,7 +189,7 @@ onBeforeMount(() => {
  */
 watch(blockNumber, async () => {
   if (shouldFetchBatchSwap.value && !txInProgress.value) {
-    await props.math.getSwap();
+    await props.math.fetchExitData();
     if (
       batchSwap.value &&
       (batchSwap.value.assets.length === 0 ||

--- a/src/components/forms/pool_actions/WithdrawForm/components/WithdrawalTokenSelect.vue
+++ b/src/components/forms/pool_actions/WithdrawForm/components/WithdrawalTokenSelect.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
-import { computed, onMounted, ref, toRef } from 'vue';
+import { computed, ref, toRef } from 'vue';
 
-import { isComposableStable, isDeep, usePool } from '@/composables/usePool';
+import { usePool } from '@/composables/usePool';
 import useTokens from '@/composables/useTokens';
 import { isSameAddress } from '@/lib/utils';
 import { Pool } from '@/services/pool/types';
@@ -46,17 +46,10 @@ const tokenAddresses = computed(() => {
 });
 
 const options = computed(() => {
-  if (!noProportionalWithdrawals.value) {
-    return ['all', ...tokenAddresses.value];
-  }
-  return tokenAddresses.value;
+  return ['all', ...tokenAddresses.value];
 });
 
 const selectedToken = computed((): TokenInfo => getToken(selectedOption.value));
-
-const noProportionalWithdrawals = computed(
-  () => isComposableStable(props.pool.poolType) && !isDeep(props.pool)
-);
 
 const assetSetWidth = computed(
   () => 40 + (tokenAddresses.value.length - 2) * 10
@@ -82,13 +75,6 @@ function handleSelected(newToken: string): void {
     tokenOut.value = newToken;
   }
 }
-
-onMounted(() => {
-  // if all option is not available, select the first token
-  if (noProportionalWithdrawals.value) {
-    handleSelected(options.value[0]);
-  }
-});
 </script>
 
 <template>

--- a/src/components/forms/pool_actions/WithdrawForm/composables/useWithdrawMath.ts
+++ b/src/components/forms/pool_actions/WithdrawForm/composables/useWithdrawMath.ts
@@ -269,7 +269,9 @@ export default function useWithdrawMath(
    */
   const fullBPTIn = computed((): string => {
     if (isProportional.value) {
-      const _bpt = bnum(propBptIn.value).minus(bptBuffer.value).toString();
+      const _bpt = bnum(propBptIn.value)
+        .minus(formatUnits(bptBuffer.value), 18)
+        .toString();
       return parseUnits(_bpt, poolDecimals.value).toString();
     }
     if (!exactOut.value)

--- a/src/components/forms/pool_actions/WithdrawForm/composables/useWithdrawMath.ts
+++ b/src/components/forms/pool_actions/WithdrawForm/composables/useWithdrawMath.ts
@@ -63,11 +63,12 @@ export default function useWithdrawMath(
   /**
    * STATE
    */
-  const propBptIn = ref<string>('');
+  const propBptIn = ref<string>('0');
   const tokenOutAmount = ref<string>('');
 
   const loadingData = ref(false);
   const queryBptIn = ref<string>('');
+  const evmGuideBptIn = ref<string>('0');
   const batchSwap = ref<BatchSwapOut | null>(null);
   const batchRelayerSwap = ref<any | null>(null);
 
@@ -176,22 +177,34 @@ export default function useWithdrawMath(
     bnum(tokenOutAmount.value).gt(tokenOutPoolBalance.value)
   );
 
+  // To account for exact maths required in BPTInForExactTokensOut cases.
+  const shouldUseBptBuffer = computed(
+    (): boolean => isProportional.value && isShallowComposableStablePool.value
+  );
+
+  const bptBuffer = computed((): number =>
+    shouldUseBptBuffer.value ? SHALLOW_COMPOSABLE_STABLE_BUFFER : 0
+  );
+
   /**
    * Proportional pool token amounts out given BPT in.
    * Only relevant for exit calls, not batchSwap or batch relayer exits.
    */
   const proportionalPoolTokenAmounts = computed((): string[] => {
-    const shouldUseBuffer =
-      isProportional.value &&
-      isShallowComposableStablePool.value &&
-      propBptIn.value === bptBalance.value;
-    const buffer = shouldUseBuffer ? SHALLOW_COMPOSABLE_STABLE_BUFFER : 0;
+    let fixedRatioOverride;
+    if (shouldUseBptBuffer.value && bnum(evmGuideBptIn.value).gt(0)) {
+      fixedRatioOverride = {
+        bps: 1000, // 10%
+        value: evmGuideBptIn.value,
+        buffer: bptBuffer.value,
+      };
+    }
 
     const { receive } = poolCalculator.propAmountsGiven(
       propBptIn.value,
       0,
       'send',
-      buffer
+      fixedRatioOverride
     );
     return receive;
   });
@@ -255,8 +268,10 @@ export default function useWithdrawMath(
    * The BPT value to be used for the withdrawal transaction without accounting for slippage.
    */
   const fullBPTIn = computed((): string => {
-    if (isProportional.value)
-      return parseUnits(propBptIn.value, poolDecimals.value).toString();
+    if (isProportional.value) {
+      const _bpt = bnum(propBptIn.value).minus(bptBuffer.value).toString();
+      return parseUnits(_bpt, poolDecimals.value).toString();
+    }
     if (!exactOut.value)
       return parseUnits(absMaxBpt.value, poolDecimals.value).toString(); // Single asset max withdrawal
 
@@ -462,10 +477,11 @@ export default function useWithdrawMath(
    * METHODS
    */
   async function initMath(): Promise<void> {
+    await getBptOutGuide();
     propBptIn.value = bptBalance.value;
 
     if (shouldFetchBatchSwap.value) {
-      swapPromises.value.push(getSwap);
+      swapPromises.value.push(fetchExitData);
       if (!processingSwaps.value) processSwaps();
     }
   }
@@ -646,43 +662,48 @@ export default function useWithdrawMath(
    * High level function that uses withdrawal state to
    * decide what swap should be fetched and sets it.
    */
-  async function getSwap(): Promise<void> {
-    if (!isDeepPool.value) return;
+  async function fetchExitData(): Promise<void> {
+    if (!isDeepPool.value || !isShallowComposableStablePool.value) return;
 
-    if (isProportional.value) {
-      batchSwap.value = await getBatchSwap();
-      if (shouldUseBatchRelayer.value) {
-        batchRelayerSwap.value = await getBatchRelayerSwap();
-      }
-    } else if (exactOut.value) {
-      const amountsOut = fullAmountsScaled.value.filter(amount =>
-        bnum(amount).gt(0)
-      );
-      batchSwap.value = await getBatchSwap(
-        amountsOut,
-        [tokenOut.value],
-        SwapType.SwapExactOut
-      );
-
-      if (shouldUseBatchRelayer.value) {
-        batchRelayerSwap.value = await getBatchRelayerSwap(
-          amountsOut.map(amount => amount.toString()),
-          [batchRelayerTokenOut.value],
-          true
-        );
-      }
+    if (isShallowComposableStablePool.value) {
+      await getQueryBptIn();
     } else {
-      // Single asset max out case
-      batchSwap.value = await getBatchSwap(
-        [bptBalanceScaled.value],
-        [tokenOut.value]
-      );
-
-      if (shouldUseBatchRelayer.value) {
-        batchRelayerSwap.value = await getBatchRelayerSwap(
-          [bptBalanceScaled.value.toString()],
-          [batchRelayerTokenOut.value]
+      // Is deep pool, use batch swap or relayer.
+      if (isProportional.value) {
+        batchSwap.value = await getBatchSwap();
+        if (shouldUseBatchRelayer.value) {
+          batchRelayerSwap.value = await getBatchRelayerSwap();
+        }
+      } else if (exactOut.value) {
+        const amountsOut = fullAmountsScaled.value.filter(amount =>
+          bnum(amount).gt(0)
         );
+        batchSwap.value = await getBatchSwap(
+          amountsOut,
+          [tokenOut.value],
+          SwapType.SwapExactOut
+        );
+
+        if (shouldUseBatchRelayer.value) {
+          batchRelayerSwap.value = await getBatchRelayerSwap(
+            amountsOut.map(amount => amount.toString()),
+            [batchRelayerTokenOut.value],
+            true
+          );
+        }
+      } else {
+        // Single asset max out case
+        batchSwap.value = await getBatchSwap(
+          [bptBalanceScaled.value],
+          [tokenOut.value]
+        );
+
+        if (shouldUseBatchRelayer.value) {
+          batchRelayerSwap.value = await getBatchRelayerSwap(
+            [bptBalanceScaled.value.toString()],
+            [batchRelayerTokenOut.value]
+          );
+        }
       }
     }
   }
@@ -707,6 +728,39 @@ export default function useWithdrawMath(
       loadingData.value = false;
     } catch (error) {
       console.error('Failed to fetch queryJoin', error);
+    }
+  }
+
+  /**
+   * Fetches BPT out given 10% of pool token balances in. This value can then be
+   * used as a guide for proportional exits in the shallow ComposableStable case.
+   */
+  async function getBptOutGuide() {
+    if (!isShallowComposableStablePool.value) return;
+
+    const bptIn = pool.value.onchain?.totalSupply || '0';
+    const amountsOut = Object.values(pool.value.onchain?.tokens || []).map(t =>
+      formatUnits(
+        parseUnits(t.balance, t.decimals).mul(1000).div(10000),
+        t.decimals
+      )
+    );
+
+    try {
+      loadingData.value = true;
+      const result = await poolExchange.queryExit(
+        getProvider(),
+        account.value,
+        amountsOut,
+        tokensOut.value,
+        bptIn,
+        null,
+        false
+      );
+      evmGuideBptIn.value = result.bptIn.toString();
+      loadingData.value = false;
+    } catch (error) {
+      console.error('Failed to fetch queryExit', error);
     }
   }
 
@@ -738,8 +792,7 @@ export default function useWithdrawMath(
        * need to refetch the swap to get the required BPT in.
        */
       if (!isProportional.value) {
-        await getQueryBptIn();
-        swapPromises.value.push(getSwap);
+        swapPromises.value.push(fetchExitData);
         if (!processingSwaps.value) processSwaps();
       }
     }
@@ -775,6 +828,6 @@ export default function useWithdrawMath(
     // methods
     initMath,
     resetMath,
-    getSwap,
+    fetchExitData,
   };
 }

--- a/src/constants/pools.ts
+++ b/src/constants/pools.ts
@@ -15,7 +15,7 @@ export const APR_THRESHOLD = 10_000;
  * order to 'fix' this we need to subtract a little bit from the bptIn value
  * when calculating the ExactTokensOut. The variable below is that "little bit".
  */
-export const SHALLOW_COMPOSABLE_STABLE_BUFFER = 1e6; // EVM scale, so this is 1 Mwei
+export const SHALLOW_COMPOSABLE_STABLE_BUFFER = 1e9; // EVM scale, so this is 1 Gwei
 
 export type FactoryType =
   | 'oracleWeightedPool'

--- a/src/services/balancer/subgraph/entities/poolShares/query.ts
+++ b/src/services/balancer/subgraph/entities/poolShares/query.ts
@@ -3,7 +3,7 @@ import { merge } from 'lodash';
 const defaultArgs = {
   first: 1000,
   where: {
-    balance_gt: 0,
+    balance_gt: 1e-6, // To exclude dust shares
   },
 };
 


### PR DESCRIPTION
# Description

Adds support for proportional exits from shallow ComposableStable pools using the `BPTInForExactTokensOut` exit type.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## How should this be tested?

Shallow ComposableStable pools for testing:

- Goerli - https://beta-goerli-git-hotix-proportional-composable-stable-balancer.vercel.app/#/pool/0x98087bf6a5ca828a6e09391ace674dbabb6a4c5600000000000000000000019b
- Polygon - https://beta-polygon-git-hotix-proportional-composable-stable-balancer.vercel.app/#/pool/0x8159462d255c1d24915cb51ec361f700174cd99400000000000000000000075d
- Polygon - https://beta-polygon-git-hotix-proportional-composable-stable-balancer.vercel.app/#/pool/0xb20fc01d21a50d2c734c4a1262b4404d41fa7bf000000000000000000000075c

- [ ] Test proportional exits from he above pools
- [ ] Test proportional exits from other pool types are not effected

## Visual context

Please provide any relevant visual context for UI changes or additions. This could be static screenshots or a loom screencast.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have requested at least 2 reviews (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] If package-lock.json has changes, it was intentional.
- [x] The base of this PR is `master` if hotfix, `develop` if not
