### PR TITLE
Divide snapshot and prices queries

### DIFF
--- a/src/components/contextual/pages/pool/PoolChart.vue
+++ b/src/components/contextual/pages/pool/PoolChart.vue
@@ -166,8 +166,14 @@ function getTVLData(periodSnapshots: PoolSnapshot[]) {
       const prices =
         props.historicalPrices && props.historicalPrices[snapshot.timestamp];
 
-      // timestamp is removed if there are no prices from coingecko
+      // if there are no prices from coingecko use snapshot.liquidity
       if (!prices || prices.length < (props.tokensList?.length || 0)) {
+        tvlValues.push(
+          Object.freeze<[string, number]>([
+            timestamp,
+            Number(snapshot.liquidity),
+          ])
+        );
         return;
       }
 

--- a/src/composables/queries/usePoolSnapshotsQuery.ts
+++ b/src/composables/queries/usePoolSnapshotsQuery.ts
@@ -1,4 +1,3 @@
-import differenceInDays from 'date-fns/differenceInDays';
 import { QueryObserverOptions } from 'react-query/core';
 import { computed, reactive } from 'vue';
 import { useQuery } from 'vue-query';
@@ -47,10 +46,12 @@ export default function usePoolSnapshotsQuery(
     if (!pool.value && !storedPool) throw new Error('No pool');
 
     const createTime = storedPool?.createTime || pool.value?.createTime || 0;
-    const shapshotDaysNum =
-      days || differenceInDays(new Date(), new Date(createTime * 1000));
-
-    return await balancerSubgraphService.poolSnapshots.get(id, shapshotDaysNum);
+    return await balancerSubgraphService.poolSnapshots.get({
+      where: {
+        pool: id.toLowerCase(),
+        timestamp_gt: createTime,
+      },
+    });
   };
 
   const queryOptions = reactive({

--- a/src/constants/queryKeys.ts
+++ b/src/constants/queryKeys.ts
@@ -64,6 +64,11 @@ const QUERY_KEYS = {
       'user',
       { networkId, account, id },
     ],
+    HistoricalPrices: (networkId: Ref<Network>, id: string) => [
+      POOLS_ROOT_KEY,
+      'historicalPrices',
+      { networkId, id },
+    ],
   },
   TokenLists: {
     All: (networkId: Ref<Network>) => ['tokenLists', 'all', { networkId }],

--- a/src/pages/pool/_id.vue
+++ b/src/pages/pool/_id.vue
@@ -24,6 +24,7 @@ import useTokens from '@/composables/useTokens';
 import { POOLS } from '@/constants/pools';
 import { getAddressFromPoolId, includesAddress } from '@/lib/utils';
 import StakingProvider from '@/providers/local/staking/staking.provider';
+import useHistoricalPricesQuery from '@/composables/queries/useHistoricalPricesQuery';
 
 /**
  * STATE
@@ -59,18 +60,24 @@ const {
 //#endregion
 
 //#region pool snapshot query
-const poolSnapshotsQuery = usePoolSnapshotsQuery(
+const poolSnapshotsQuery = usePoolSnapshotsQuery(poolId, undefined, {
+  refetchOnWindowFocus: false,
+});
+const isLoadingSnapshots = computed(
+  () => poolSnapshotsQuery.isLoading.value || poolSnapshotsQuery.isIdle.value
+);
+
+const snapshots = computed(() => poolSnapshotsQuery.data.value);
+//#endregion
+
+//#region historical prices query
+const historicalPricesQuery = useHistoricalPricesQuery(
   poolId,
   undefined,
   // in order to prevent multiple coingecko requests
   { refetchOnWindowFocus: false }
 );
-const isLoadingSnapshots = computed(
-  () => poolSnapshotsQuery.isLoading.value || poolSnapshotsQuery.isIdle.value
-);
-
-const snapshots = computed(() => poolSnapshotsQuery.data.value?.snapshots);
-const historicalPrices = computed(() => poolSnapshotsQuery.data.value?.prices);
+const historicalPrices = computed(() => historicalPricesQuery.data.value);
 //#endregion
 
 //#region APR query

--- a/src/services/balancer/subgraph/entities/poolSnapshots/index.ts
+++ b/src/services/balancer/subgraph/entities/poolSnapshots/index.ts
@@ -5,7 +5,7 @@ import { QueryBuilder } from '@/types/subgraph';
 import Service from '../../balancer-subgraph.service';
 import poolQueryBuilder from './query';
 
-export default class PoolShares {
+export default class PoolSnapshotsRequest {
   service: Service;
   query: QueryBuilder;
 


### PR DESCRIPTION
# Description
If coingecko is down there will be blank state instead of pool charts, this happens because of fetching prices in `usePoolSnapshotsQuery`. 
This pr adds new composable to fetch historical prices and use `snapshot.liquidity` from subgraph if there are no prices. 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [x] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## How should this be tested?

Please provide instructions so we can test. Please also list any relevant details for your test configuration.

- [ ] Test A
- [ ] Test B

## Visual context

Please provide any relevant visual context for UI changes or additions. This could be static screenshots or a loom screencast.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have requested at least 2 reviews (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] If package-lock.json has changes, it was intentional.
- [x] The base of this PR is `master` if hotfix, `develop` if not
