### PR TITLE
Hotfix: bb-a-usd v2 added to feeDistrubutor token list

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.73.0",
+  "version": "1.73.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@balancer-labs/frontend-v2",
-      "version": "1.73.0",
+      "version": "1.73.2",
       "license": "MIT",
       "devDependencies": {
         "@aave/protocol-js": "^4.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.73.0",
+  "version": "1.73.2",
   "engines": {
     "node": "14.x",
     "npm": ">=7"

--- a/src/constants/tokens.ts
+++ b/src/constants/tokens.ts
@@ -12,6 +12,7 @@ type CommonTokens = {
   WETH: string;
   BAL: string;
   bbaUSD?: string;
+  bbaUSDv2?: string;
 };
 
 type TokenConstants = {
@@ -38,6 +39,7 @@ export const TOKENS_MAINNET: TokenConstants = {
     WETH: '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2',
     BAL: '0xba100000625a3754423978a60c9317c58a424e3d',
     bbaUSD: '0x7B50775383d3D6f0215A8F290f2C9e2eEBBEceb2',
+    bbaUSDv2: '0xA13a9247ea42D743238089903570127DdA72fE44',
   },
 };
 

--- a/src/pages/claim.vue
+++ b/src/pages/claim.vue
@@ -26,6 +26,7 @@ import { Gauge } from '@/services/balancer/gauges/types';
 import { configService } from '@/services/config/config.service';
 import { BalanceMap } from '@/services/token/concerns/balances.concern';
 import useWeb3 from '@/services/web3/useWeb3';
+import { TOKENS } from '@/constants/tokens';
 
 /**
  * TYPES
@@ -197,11 +198,10 @@ function formatRewardsData(data?: BalanceMap): ProtocolRewardRow[] {
  */
 async function getBBaUSDPrice() {
   if (isMainnet.value) {
-    const appoxPrice = await bbAUSDToken.getRate();
+    const appoxPrice = bnum(await bbAUSDToken.getRate()).toNumber();
     injectPrices({
-      [FiatCurrency.usd]: {
-        [bbAUSDToken.address as string]: bnum(appoxPrice).toNumber(),
-      },
+      [TOKENS.Addresses.bbaUSD as string]: { [FiatCurrency.usd]: appoxPrice },
+      [TOKENS.Addresses.bbaUSDv2 as string]: { [FiatCurrency.usd]: appoxPrice },
     });
   }
 }

--- a/src/services/balancer/contracts/contracts/fee-distributor.ts
+++ b/src/services/balancer/contracts/contracts/fee-distributor.ts
@@ -13,8 +13,8 @@ import { web3Service } from '@/services/web3/web3.service';
 
 export class FeeDistributor {
   public claimableTokens: string[] = [
-    '0x7B50775383d3D6f0215A8F290f2C9e2eEBBEceb2', // bb-a-USD
-    '0xa13a9247ea42d743238089903570127dda72fe44', // bb-a-USD
+    '0x7B50775383d3D6f0215A8F290f2C9e2eEBBEceb2', // bb-a-USD v1
+    '0xa13a9247ea42d743238089903570127dda72fe44', // bb-a-USD v2
     '0xba100000625a3754423978a60c9317c58a424e3D', // BAL
   ];
 

--- a/src/services/balancer/contracts/contracts/fee-distributor.ts
+++ b/src/services/balancer/contracts/contracts/fee-distributor.ts
@@ -14,7 +14,7 @@ import { web3Service } from '@/services/web3/web3.service';
 export class FeeDistributor {
   public claimableTokens: string[] = [
     '0x7B50775383d3D6f0215A8F290f2C9e2eEBBEceb2', // bb-a-USD v1
-    '0xa13a9247ea42d743238089903570127dda72fe44', // bb-a-USD v2
+    '0xA13a9247ea42D743238089903570127DdA72fE44', // bb-a-USD v2
     '0xba100000625a3754423978a60c9317c58a424e3D', // BAL
   ];
 

--- a/src/services/balancer/contracts/contracts/fee-distributor.ts
+++ b/src/services/balancer/contracts/contracts/fee-distributor.ts
@@ -14,6 +14,7 @@ import { web3Service } from '@/services/web3/web3.service';
 export class FeeDistributor {
   public claimableTokens: string[] = [
     '0x7B50775383d3D6f0215A8F290f2C9e2eEBBEceb2', // bb-a-USD
+    '0xa13a9247ea42d743238089903570127dda72fe44', // bb-a-USD
     '0xba100000625a3754423978a60c9317c58a424e3D', // BAL
   ];
 


### PR DESCRIPTION
# Description

We support two versions of bb-a-USD token. On claims page, only v1 is showing up. After this merge request, both versions of the token are visible.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## How should this be tested?

Go to claims page and you should see both versions of bb-a-USD and be able to claim them.

## Visual context

N/A

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have requested at least 2 reviews (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [ ] If package-lock.json has changes, it was intentional.
- [x] The base of this PR is `master` if hotfix, `develop` if not
