### PR TITLE
Fix stETH apr for weighted pools

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.73.0",
+  "version": "1.73.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@balancer-labs/frontend-v2",
-      "version": "1.73.0",
+      "version": "1.73.1",
       "license": "MIT",
       "devDependencies": {
         "@aave/protocol-js": "^4.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.73.0",
+  "version": "1.73.1",
   "engines": {
     "node": "14.x",
     "npm": ">=7"

--- a/src/lib/config/arbitrum.json
+++ b/src/lib/config/arbitrum.json
@@ -45,7 +45,7 @@
     "stablePoolFactory": "0x2433477A10FC5d31B9513C638F19eE85CaED53Fd",
     "weth": "0x82aF49447D8a07e3bd95BD0d56f35241523fBab1",
     "stETH": "",
-    "wstETH": "",
+    "wstETH": "0x5979d7b546e38e414f7e9822514be443a4800529",
     "lidoRelayer": "",
     "balancerHelpers": "0x77d46184d22CA6a3726a2F500c776767b6A3d6Ab",
     "batchRelayer": "0x466262c2a275aB106E54D95B5B04603e12b58cA1",

--- a/src/services/lido/lido.service.ts
+++ b/src/services/lido/lido.service.ts
@@ -53,7 +53,7 @@ export default class LidoService {
         ?.weight || bnum(wstethBalance).div(totalBalance);
 
     return bnum(stethAPR)
-      .times(1 - protocolFeePercentage)
+      .times(1 - protocolFeePercentage) // TODO: check pool type and use protocol yield percentage cache when applicable
       .times(wstethRatio)
       .toString();
   }

--- a/src/services/lido/lido.service.ts
+++ b/src/services/lido/lido.service.ts
@@ -48,7 +48,9 @@ export default class LidoService {
       pool.tokens.find(t => isSameAddress(t.address, this.wstEthAddress))
         ?.balance || '0';
     const totalBalance = bnum(wethBalance).plus(wstethBalance);
-    const wstethRatio = bnum(wstethBalance).div(totalBalance);
+    const wstethRatio =
+      pool.tokens.find(t => isSameAddress(t.address, this.wstEthAddress))
+        ?.weight || bnum(wstethBalance).div(totalBalance);
 
     return bnum(stethAPR)
       .times(1 - protocolFeePercentage)


### PR DESCRIPTION
# Description

Current stETH APR calculation assumes all pools with wstETH were WETH/wstETH stable pools. This causes the stETH APR on weighted pools to be overestimated.

This PR implements a check for the weight of wstETH in the pool and uses this weight as the ratio if it exists.

It also adds the address of wstETH on Arbitrum so that stETH APR is displayed for pool in that network.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## How should this be tested?

- Check the stETH APR [here](https://stake.lido.fi/api/apr)
- On the app's Invest tab (mainnet and arbitrum), search for a weighted pool containing wstETH
- Check the APR breakdown tooltip:
  - it should be equal to `50% * wstETH_weight_in_the_pool * stETH_APR_from_Lido`

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have requested at least 2 reviews (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] If package-lock.json has changes, it was intentional.
- [x] The base of this PR is `master` if hotfix, `develop` if not
