### PR TITLE
Remove totalLiquidity calc that's done in the decoration step

### DIFF
--- a/src/composables/queries/useUserPoolsQuery.ts
+++ b/src/composables/queries/useUserPoolsQuery.ts
@@ -1,4 +1,3 @@
-import { formatUnits } from 'ethers/lib/utils';
 import { flatten, keyBy } from 'lodash';
 import { UseQueryOptions } from 'react-query/types';
 import { computed, reactive } from 'vue';
@@ -7,7 +6,6 @@ import { useQuery } from 'vue-query';
 import { POOLS } from '@/constants/pools';
 import QUERY_KEYS from '@/constants/queryKeys';
 import { bnum, forChange } from '@/lib/utils';
-import { balancerContractsService } from '@/services/balancer/contracts/balancer-contracts.service';
 import { balancerSubgraphService } from '@/services/balancer/subgraph/balancer-subgraph.service';
 import { PoolDecorator } from '@/services/pool/decorators/pool.decorator';
 import PoolService from '@/services/pool/pool.service';
@@ -36,7 +34,6 @@ export default function useUserPoolsQuery(
     injectTokens,
     prices,
     dynamicDataLoading,
-    getTokens,
     tokens: tokenMeta,
   } = useTokens();
   const { account, isWalletReady } = useWeb3();
@@ -100,74 +97,6 @@ export default function useUserPoolsQuery(
       currency.value,
       tokenMeta.value
     );
-
-    // TODO - cleanup and extract elsewhere in refactor
-    for (let i = 0; i < decoratedPools.length; i++) {
-      if (isComposableStableLike(decoratedPools[i].poolType)) {
-        const decoratedPool = decoratedPools[i];
-
-        const poolTokenMeta = getTokens(decoratedPool.tokensList);
-
-        const onchainData = await balancerContractsService.vault.getPoolData(
-          decoratedPool,
-          decoratedPool.id,
-          decoratedPool.poolType,
-          poolTokenMeta
-        );
-
-        if (
-          onchainData != null &&
-          onchainData.linearPools != null &&
-          decoratedPool.linearPoolTokensMap != null
-        ) {
-          let totalLiquidity = bnum(0);
-          const tokensMap = getTokens(
-            Object.keys(decoratedPool.linearPoolTokensMap)
-          );
-
-          Object.entries(onchainData.linearPools).forEach(
-            ([address, token]) => {
-              const tokenShare = bnum(onchainData.tokens[address].balance).div(
-                token.totalSupply
-              );
-
-              const mainTokenBalance = formatUnits(
-                token.mainToken.balance,
-                tokensMap[token.mainToken.address].decimals
-              );
-
-              const wrappedTokenBalance = formatUnits(
-                token.wrappedToken.balance,
-                tokensMap[token.wrappedToken.address].decimals
-              );
-
-              const mainTokenPrice =
-                prices.value[token.mainToken.address] != null
-                  ? prices.value[token.mainToken.address].usd
-                  : null;
-
-              if (mainTokenPrice != null) {
-                const mainTokenValue = bnum(mainTokenBalance)
-                  .times(tokenShare)
-                  .times(mainTokenPrice);
-
-                const wrappedTokenValue = bnum(wrappedTokenBalance)
-                  .times(tokenShare)
-                  .times(mainTokenPrice)
-                  .times(token.wrappedToken.priceRate);
-
-                totalLiquidity = bnum(totalLiquidity)
-                  .plus(mainTokenValue)
-                  .plus(wrappedTokenValue);
-              }
-            }
-          );
-
-          decoratedPools[i].onchain = onchainData;
-          decoratedPools[i].totalLiquidity = totalLiquidity.toString();
-        }
-      }
-    }
 
     const poolsWithShares = decoratedPools.map(pool => ({
       ...pool,


### PR DESCRIPTION
# Description

There was a duplicate calculation of total liquidity for boosted pools happening in the useUserPoolsQuery that was also being done in the decorate call just before it. This PR simply removes that duplicate calculation.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [x] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## How should this be tested?

- [ ] Test that boosted pool investments are accurate on the portfolio page.

## Visual context

n/a

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have requested at least 2 reviews (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] If package-lock.json has changes, it was intentional.
- [x] The base of this PR is `master` if hotfix, `develop` if not
