### PR TITLE
Fix: make sure restaking modal request token approval if needed

### DIFF
--- a/public/data/tokenlists/tokens-1.json
+++ b/public/data/tokenlists/tokens-1.json
@@ -1,0 +1,13639 @@
+{
+  "https://raw.githubusercontent.com/balancer-labs/assets/master/generated/listed.tokenlist.json": {
+    "name": "Balancer",
+    "timestamp": "2022-10-22T00:00:00.000Z",
+    "logoURI": "https://raw.githubusercontent.com/balancer-labs/pebbles/master/images/pebbles-pad.256w.png",
+    "keywords": ["balancer", "listed"],
+    "version": { "major": 1, "minor": 0, "patch": 0 },
+    "tokens": [
+      {
+        "address": "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
+        "chainId": 1,
+        "name": "Wrapped Ether",
+        "symbol": "WETH",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2/logo.png"
+      },
+      {
+        "address": "0xba100000625a3754423978a60c9317c58a424e3D",
+        "chainId": 1,
+        "name": "Balancer",
+        "symbol": "BAL",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xba100000625a3754423978a60c9317c58a424e3D/logo.png"
+      },
+      {
+        "address": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+        "chainId": 1,
+        "name": "USD Coin",
+        "symbol": "USDC",
+        "decimals": 6,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/logo.png"
+      },
+      {
+        "address": "0x6B175474E89094C44Da98b954EedeAC495271d0F",
+        "chainId": 1,
+        "name": "Dai Stablecoin",
+        "symbol": "DAI",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x6B175474E89094C44Da98b954EedeAC495271d0F/logo.png"
+      },
+      {
+        "address": "0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599",
+        "chainId": 1,
+        "name": "Wrapped BTC",
+        "symbol": "WBTC",
+        "decimals": 8,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599/logo.png"
+      },
+      {
+        "address": "0xdAC17F958D2ee523a2206206994597C13D831ec7",
+        "chainId": 1,
+        "name": "Tether USD",
+        "symbol": "USDT",
+        "decimals": 6,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xdAC17F958D2ee523a2206206994597C13D831ec7/logo.png"
+      },
+      {
+        "address": "0xe2f2a5C287993345a840Db3B0845fbC70f5935a5",
+        "chainId": 1,
+        "name": "mStable USD",
+        "symbol": "mUSD",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xe2f2a5C287993345a840Db3B0845fbC70f5935a5/logo.png"
+      },
+      {
+        "address": "0x9f8F72aA9304c8B593d555F12eF6589cC3A579A2",
+        "chainId": 1,
+        "name": "Maker",
+        "symbol": "MKR",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x9f8F72aA9304c8B593d555F12eF6589cC3A579A2/logo.png"
+      },
+      {
+        "address": "0xbC396689893D065F41bc2C6EcbeE5e0085233447",
+        "chainId": 1,
+        "name": "Perpetual",
+        "symbol": "PERP",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xbC396689893D065F41bc2C6EcbeE5e0085233447/logo.png"
+      },
+      {
+        "address": "0x0bc529c00C6401aEF6D220BE8C6Ea1667F6Ad93e",
+        "chainId": 1,
+        "name": "yearn.finance",
+        "symbol": "YFI",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x0bc529c00C6401aEF6D220BE8C6Ea1667F6Ad93e/logo.png"
+      },
+      {
+        "address": "0x0d438F3b5175Bebc262bF23753C1E53d03432bDE",
+        "chainId": 1,
+        "name": "Wrapped NXM",
+        "symbol": "wNXM",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x0d438F3b5175Bebc262bF23753C1E53d03432bDE/logo.png"
+      },
+      {
+        "address": "0x04Fa0d235C4abf4BcF4787aF4CF447DE572eF828",
+        "chainId": 1,
+        "name": "UMA Voting Token v1",
+        "symbol": "UMA",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x04Fa0d235C4abf4BcF4787aF4CF447DE572eF828/logo.png"
+      },
+      {
+        "address": "0x514910771AF9Ca656af840dff83E8264EcF986CA",
+        "chainId": 1,
+        "name": "ChainLink Token",
+        "symbol": "LINK",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x514910771AF9Ca656af840dff83E8264EcF986CA/logo.png"
+      },
+      {
+        "address": "0xEB4C2781e4ebA804CE9a9803C67d0893436bB27D",
+        "chainId": 1,
+        "name": "renBTC",
+        "symbol": "renBTC",
+        "decimals": 8,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xEB4C2781e4ebA804CE9a9803C67d0893436bB27D/logo.png"
+      },
+      {
+        "address": "0x56d811088235F11C8920698a204A5010a788f4b3",
+        "chainId": 1,
+        "name": "bZx Protocol Token",
+        "symbol": "BZRX",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x56d811088235F11C8920698a204A5010a788f4b3/logo.png"
+      },
+      {
+        "address": "0x476c5E26a75bd202a9683ffD34359C0CC15be0fF",
+        "chainId": 1,
+        "name": "Serum",
+        "symbol": "SRM",
+        "decimals": 6,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x476c5E26a75bd202a9683ffD34359C0CC15be0fF/logo.png"
+      },
+      {
+        "address": "0x7Fc66500c84A76Ad7e9c93437bFc5Ac33E2DDaE9",
+        "chainId": 1,
+        "name": "Aave Token",
+        "symbol": "AAVE",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x7Fc66500c84A76Ad7e9c93437bFc5Ac33E2DDaE9/logo.png"
+      },
+      {
+        "address": "0x1f9840a85d5aF5bf1D1762F925BDADdC4201F984",
+        "chainId": 1,
+        "name": "Uniswap",
+        "symbol": "UNI",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x1f9840a85d5aF5bf1D1762F925BDADdC4201F984/logo.png"
+      },
+      {
+        "address": "0xad32A8e6220741182940c5aBF610bDE99E737b2D",
+        "chainId": 1,
+        "name": "PieDAO DOUGH v2",
+        "symbol": "DOUGH",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/balancer-labs/assets/master/assets/0xad32a8e6220741182940c5abf610bde99e737b2d.png"
+      },
+      {
+        "address": "0xc00e94Cb662C3520282E6f5717214004A7f26888",
+        "chainId": 1,
+        "name": "Compound",
+        "symbol": "COMP",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xc00e94Cb662C3520282E6f5717214004A7f26888/logo.png"
+      },
+      {
+        "address": "0xB4EFd85c19999D84251304bDA99E90B92300Bd93",
+        "chainId": 1,
+        "name": "Rocket Pool",
+        "symbol": "RPL",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xB4EFd85c19999D84251304bDA99E90B92300Bd93/logo.png"
+      },
+      {
+        "address": "0x93ED3FBe21207Ec2E8f2d3c3de6e058Cb73Bc04d",
+        "chainId": 1,
+        "name": "Pinakion",
+        "symbol": "PNK",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x93ED3FBe21207Ec2E8f2d3c3de6e058Cb73Bc04d/logo.png"
+      },
+      {
+        "address": "0x0327112423F3A68efdF1fcF402F6c5CB9f7C33fd",
+        "chainId": 1,
+        "name": "PieDAO BTC++",
+        "symbol": "BTC++",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/balancer-labs/assets/master/assets/0x0327112423f3a68efdf1fcf402f6c5cb9f7c33fd.png"
+      },
+      {
+        "address": "0x9A48BD0EC040ea4f1D3147C025cd4076A2e71e3e",
+        "chainId": 1,
+        "name": "PieDAO USD++ Pool",
+        "symbol": "USD++",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/balancer-labs/assets/master/assets/0x9a48bd0ec040ea4f1d3147c025cd4076a2e71e3e.png"
+      },
+      {
+        "address": "0xaD6A626aE2B43DCb1B39430Ce496d2FA0365BA9C",
+        "chainId": 1,
+        "name": "PieDAO DEFI Small Cap",
+        "symbol": "DEFI+S",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/balancer-labs/assets/master/assets/0xad6a626ae2b43dcb1b39430ce496d2fa0365ba9c.png"
+      },
+      {
+        "address": "0x78F225869c08d478c34e5f645d07A87d3fe8eb78",
+        "chainId": 1,
+        "name": "PieDAO DEFI Large Cap",
+        "symbol": "DEFI+L",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/balancer-labs/assets/master/assets/0x78f225869c08d478c34e5f645d07a87d3fe8eb78.png"
+      },
+      {
+        "address": "0xC011a73ee8576Fb46F5E1c5751cA3B9Fe0af2a6F",
+        "chainId": 1,
+        "name": "Synthetix Network Token",
+        "symbol": "SNX",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xC011a73ee8576Fb46F5E1c5751cA3B9Fe0af2a6F/logo.png"
+      },
+      {
+        "address": "0x57Ab1ec28D129707052df4dF418D58a2D46d5f51",
+        "chainId": 1,
+        "name": "Synth sUSD",
+        "symbol": "sUSD",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/balancer-labs/assets/master/assets/0x57ab1ec28d129707052df4df418d58a2d46d5f51.png"
+      },
+      {
+        "address": "0xfE18be6b3Bd88A2D2A7f928d00292E7a9963CfC6",
+        "chainId": 1,
+        "name": "Synth sBTC",
+        "symbol": "sBTC",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/balancer-labs/assets/master/assets/0xfe18be6b3bd88a2d2a7f928d00292e7a9963cfc6.png"
+      },
+      {
+        "address": "0x408e41876cCCDC0F92210600ef50372656052a38",
+        "chainId": 1,
+        "name": "Republic Token",
+        "symbol": "REN",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x408e41876cCCDC0F92210600ef50372656052a38/logo.png"
+      },
+      {
+        "address": "0x0D8775F648430679A709E98d2b0Cb6250d2887EF",
+        "chainId": 1,
+        "name": "Basic Attention Token",
+        "symbol": "BAT",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x0D8775F648430679A709E98d2b0Cb6250d2887EF/logo.png"
+      },
+      {
+        "address": "0xE41d2489571d322189246DaFA5ebDe1F4699F498",
+        "chainId": 1,
+        "name": "0x Protocol Token",
+        "symbol": "ZRX",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xE41d2489571d322189246DaFA5ebDe1F4699F498/logo.png"
+      },
+      {
+        "address": "0x3212b29E33587A00FB1C83346f5dBFA69A458923",
+        "chainId": 1,
+        "name": "The Tokenized Bitcoin",
+        "symbol": "imBTC",
+        "decimals": 8,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x3212b29E33587A00FB1C83346f5dBFA69A458923/logo.png"
+      },
+      {
+        "address": "0x5228a22e72ccC52d415EcFd199F99D0665E7733b",
+        "chainId": 1,
+        "name": "pTokens BTC",
+        "symbol": "pBTC",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x5228a22e72ccC52d415EcFd199F99D0665E7733b/logo.png"
+      },
+      {
+        "address": "0x27054b13b1B798B345b591a4d22e6562d47eA75a",
+        "chainId": 1,
+        "name": "AirSwap Token",
+        "symbol": "AST",
+        "decimals": 4,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x27054b13b1B798B345b591a4d22e6562d47eA75a/logo.png"
+      },
+      {
+        "address": "0xBBbbCA6A901c926F240b89EacB641d8Aec7AEafD",
+        "chainId": 1,
+        "name": "LoopringCoin V2",
+        "symbol": "LRC",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xBBbbCA6A901c926F240b89EacB641d8Aec7AEafD/logo.png"
+      },
+      {
+        "address": "0xdd974D5C2e2928deA5F71b9825b8b646686BD200",
+        "chainId": 1,
+        "name": "Kyber Network Crystal",
+        "symbol": "KNC",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xdd974D5C2e2928deA5F71b9825b8b646686BD200/logo.png"
+      },
+      {
+        "address": "0x967da4048cD07aB37855c090aAF366e4ce1b9F48",
+        "chainId": 1,
+        "name": "Ocean Token",
+        "symbol": "OCEAN",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x967da4048cD07aB37855c090aAF366e4ce1b9F48/logo.png"
+      },
+      {
+        "address": "0xa3BeD4E1c75D00fa6f4E5E6922DB7261B5E9AcD2",
+        "chainId": 1,
+        "name": "Meta",
+        "symbol": "MTA",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xa3BeD4E1c75D00fa6f4E5E6922DB7261B5E9AcD2/logo.png"
+      },
+      {
+        "address": "0xD533a949740bb3306d119CC777fa900bA034cd52",
+        "chainId": 1,
+        "name": "Curve DAO Token",
+        "symbol": "CRV",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xD533a949740bb3306d119CC777fa900bA034cd52/logo.png"
+      },
+      {
+        "address": "0x58b6A8A3302369DAEc383334672404Ee733aB239",
+        "chainId": 1,
+        "name": "Livepeer Token",
+        "symbol": "LPT",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x58b6A8A3302369DAEc383334672404Ee733aB239/logo.png"
+      },
+      {
+        "address": "0x221657776846890989a759BA2973e427DfF5C9bB",
+        "chainId": 1,
+        "name": "Reputation",
+        "symbol": "REPv2",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x221657776846890989a759BA2973e427DfF5C9bB/logo.png"
+      },
+      {
+        "address": "0x8dAEBADE922dF735c38C80C7eBD708Af50815fAa",
+        "chainId": 1,
+        "name": "tBTC",
+        "symbol": "TBTC",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x8dAEBADE922dF735c38C80C7eBD708Af50815fAa/logo.png"
+      },
+      {
+        "address": "0x056Fd409E1d7A124BD7017459dFEa2F387b6d5Cd",
+        "chainId": 1,
+        "name": "Gemini dollar",
+        "symbol": "GUSD",
+        "decimals": 2,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x056Fd409E1d7A124BD7017459dFEa2F387b6d5Cd/logo.png"
+      },
+      {
+        "address": "0xD46bA6D942050d489DBd938a2C909A5d5039A161",
+        "chainId": 1,
+        "name": "Ampleforth",
+        "symbol": "AMPL",
+        "decimals": 9,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xD46bA6D942050d489DBd938a2C909A5d5039A161/logo.png"
+      },
+      {
+        "address": "0xf1f955016EcbCd7321c7266BccFB96c68ea5E49b",
+        "chainId": 1,
+        "name": "Rally",
+        "symbol": "RLY",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/balancer-labs/assets/master/assets/0xf1f955016ecbcd7321c7266bccfb96c68ea5e49b.png"
+      },
+      {
+        "address": "0xa117000000f279D81A1D3cc75430fAA017FA5A2e",
+        "chainId": 1,
+        "name": "Aragon Network Token",
+        "symbol": "ANT",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xa117000000f279D81A1D3cc75430fAA017FA5A2e/logo.png"
+      },
+      {
+        "address": "0x20945cA1df56D237fD40036d47E866C7DcCD2114",
+        "chainId": 1,
+        "name": "Nsure Network Token",
+        "symbol": "Nsure",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/balancer-labs/assets/master/assets/0x20945ca1df56d237fd40036d47e866c7dccd2114.png"
+      },
+      {
+        "address": "0x6810e776880C02933D47DB1b9fc05908e5386b96",
+        "chainId": 1,
+        "name": "Gnosis Token",
+        "symbol": "GNO",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x6810e776880C02933D47DB1b9fc05908e5386b96/logo.png"
+      },
+      {
+        "address": "0xCc80C051057B774cD75067Dc48f8987C4Eb97A5e",
+        "chainId": 1,
+        "name": "Ethfinex Nectar Token",
+        "symbol": "NEC",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xCc80C051057B774cD75067Dc48f8987C4Eb97A5e/logo.png"
+      },
+      {
+        "address": "0x8D1ce361eb68e9E05573443C407D4A3Bed23B033",
+        "chainId": 1,
+        "name": "PieDAO DEFI++",
+        "symbol": "DEFI++",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/balancer-labs/assets/master/assets/0x8d1ce361eb68e9e05573443c407d4a3bed23b033.png"
+      },
+      {
+        "address": "0xfFffFffF2ba8F66D4e51811C5190992176930278",
+        "chainId": 1,
+        "name": "Furucombo",
+        "symbol": "COMBO",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/balancer-labs/assets/master/assets/0xffffffff2ba8f66d4e51811c5190992176930278.png"
+      },
+      {
+        "address": "0x875773784Af8135eA0ef43b5a374AaD105c5D39e",
+        "chainId": 1,
+        "name": "Idle",
+        "symbol": "IDLE",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/balancer-labs/assets/master/assets/0x875773784af8135ea0ef43b5a374aad105c5d39e.png"
+      },
+      {
+        "address": "0x31c8EAcBFFdD875c74b94b077895Bd78CF1E64A3",
+        "chainId": 1,
+        "name": "Radicle",
+        "symbol": "RAD",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/balancer-labs/assets/master/assets/0x31c8eacbffdd875c74b94b077895bd78cf1e64a3.png"
+      },
+      {
+        "address": "0x33349B282065b0284d756F0577FB39c158F935e6",
+        "chainId": 1,
+        "name": "Maple Token",
+        "symbol": "MPL",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/balancer-labs/assets/master/assets/0x33349b282065b0284d756f0577fb39c158f935e6.png"
+      },
+      {
+        "address": "0x06Df3b2bbB68adc8B0e302443692037ED9f91b42",
+        "chainId": 1,
+        "name": "Balancer USD Stable Pool",
+        "symbol": "staBAL3",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/balancer-labs/assets/master/assets/0x06df3b2bbb68adc8b0e302443692037ed9f91b42.png"
+      },
+      {
+        "address": "0x5A98FcBEA516Cf06857215779Fd812CA3beF1B32",
+        "chainId": 1,
+        "name": "Lido DAO Token",
+        "symbol": "LDO",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/balancer-labs/assets/master/assets/0x5a98fcbea516cf06857215779fd812ca3bef1b32.png"
+      },
+      {
+        "address": "0xae7ab96520DE3A18E5e111B5EaAb095312D7fE84",
+        "chainId": 1,
+        "name": "Liquid staked Ether 2.0",
+        "symbol": "stETH",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/balancer-labs/assets/master/assets/0xae7ab96520de3a18e5e111b5eaab095312d7fe84.png"
+      },
+      {
+        "address": "0x7f39C581F595B53c5cb19bD0b3f8dA6c935E2Ca0",
+        "chainId": 1,
+        "name": "Wrapped liquid staked Ether 2.0",
+        "symbol": "wstETH",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/balancer-labs/assets/master/assets/0x7f39c581f595b53c5cb19bd0b3f8da6c935e2ca0.png"
+      },
+      {
+        "address": "0x123151402076fc819B7564510989e475c9cD93CA",
+        "chainId": 1,
+        "name": "wrapped-DGLD",
+        "symbol": "wDGLD",
+        "decimals": 8,
+        "logoURI": "https://raw.githubusercontent.com/balancer-labs/assets/master/assets/0x123151402076fc819b7564510989e475c9cd93ca.png"
+      },
+      {
+        "address": "0xdB25f211AB05b1c97D595516F45794528a807ad8",
+        "chainId": 1,
+        "name": "STASIS EURS Token",
+        "symbol": "EURS",
+        "decimals": 2,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xdB25f211AB05b1c97D595516F45794528a807ad8/logo.png"
+      },
+      {
+        "address": "0x3Ec8798B81485A254928B70CDA1cf0A2BB0B74D7",
+        "chainId": 1,
+        "name": "Gro DAO Token",
+        "symbol": "GRO",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/balancer-labs/assets/master/assets/0x3ec8798b81485a254928b70cda1cf0a2bb0b74d7.png"
+      },
+      {
+        "address": "0xfb5453340C03db5aDe474b27E68B6a9c6b2823Eb",
+        "chainId": 1,
+        "name": "MetaFactory",
+        "symbol": "ROBOT",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/balancer-labs/assets/master/assets/0xfb5453340c03db5ade474b27e68b6a9c6b2823eb.png"
+      },
+      {
+        "address": "0x956F47F50A910163D8BF957Cf5846D573E7f87CA",
+        "chainId": 1,
+        "name": "Fei USD",
+        "symbol": "FEI",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x956F47F50A910163D8BF957Cf5846D573E7f87CA/logo.png"
+      },
+      {
+        "address": "0xc7283b66Eb1EB5FB86327f08e1B5816b0720212B",
+        "chainId": 1,
+        "name": "Tribe",
+        "symbol": "TRIBE",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xc7283b66Eb1EB5FB86327f08e1B5816b0720212B/logo.png"
+      },
+      {
+        "address": "0xCFEAead4947f0705A14ec42aC3D44129E1Ef3eD5",
+        "chainId": 1,
+        "name": "Notional",
+        "symbol": "NOTE",
+        "decimals": 8,
+        "logoURI": "https://raw.githubusercontent.com/balancer-labs/assets/master/assets/0xcfeaead4947f0705a14ec42ac3d44129e1ef3ed5.png"
+      },
+      {
+        "address": "0xB62132e35a6c13ee1EE0f84dC5d40bad8d815206",
+        "chainId": 1,
+        "name": "Nexo",
+        "symbol": "NEXO",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xB62132e35a6c13ee1EE0f84dC5d40bad8d815206/logo.png"
+      },
+      {
+        "address": "0xA13a9247ea42D743238089903570127DdA72fE44",
+        "chainId": 1,
+        "name": "Balancer Aave Boosted StablePool",
+        "symbol": "bb-a-USD",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/balancer-labs/assets/master/assets/0xa13a9247ea42d743238089903570127dda72fe44.png"
+      },
+      {
+        "address": "0x2F4eb100552ef93840d5aDC30560E5513DFfFACb",
+        "chainId": 1,
+        "name": "Balancer Aave Boosted Pool (USDT)",
+        "symbol": "bb-a-USDT",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/balancer-labs/assets/master/assets/0x2f4eb100552ef93840d5adc30560e5513dfffacb.png"
+      },
+      {
+        "address": "0x82698aeCc9E28e9Bb27608Bd52cF57f704BD1B83",
+        "chainId": 1,
+        "name": "Balancer Aave Boosted Pool (USDC)",
+        "symbol": "bb-a-USDC",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/balancer-labs/assets/master/assets/0x82698aecc9e28e9bb27608bd52cf57f704bd1b83.png"
+      },
+      {
+        "address": "0xae37D54Ae477268B9997d4161B96b8200755935c",
+        "chainId": 1,
+        "name": "Balancer Aave Boosted Pool (DAI)",
+        "symbol": "bb-a-DAI",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/balancer-labs/assets/master/assets/0xae37d54ae477268b9997d4161b96b8200755935c.png"
+      },
+      {
+        "address": "0x7B50775383d3D6f0215A8F290f2C9e2eEBBEceb2",
+        "chainId": 1,
+        "name": "Balancer Aave Boosted StablePool (USD)",
+        "symbol": "bb-a-USD (old)",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/balancer-labs/assets/master/assets/0x7b50775383d3d6f0215a8f290f2c9e2eebbeceb2.png"
+      },
+      {
+        "address": "0x804CdB9116a10bB78768D3252355a1b18067bF8f",
+        "chainId": 1,
+        "name": "Balancer Aave Boosted Pool (DAI)",
+        "symbol": "bb-a-DAI (old)",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/balancer-labs/assets/master/assets/0x804cdb9116a10bb78768d3252355a1b18067bf8f.png"
+      },
+      {
+        "address": "0x9210F1204b5a24742Eba12f710636D76240dF3d0",
+        "chainId": 1,
+        "name": "Balancer Aave Boosted Pool (USDC)",
+        "symbol": "bb-a-USDC (old)",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/balancer-labs/assets/master/assets/0x9210f1204b5a24742eba12f710636d76240df3d0.png"
+      },
+      {
+        "address": "0x2BBf681cC4eb09218BEe85EA2a5d3D13Fa40fC0C",
+        "chainId": 1,
+        "name": "Balancer Aave Boosted Pool (USDT)",
+        "symbol": "bb-a-USDT (old)",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/balancer-labs/assets/master/assets/0x2bbf681cc4eb09218bee85ea2a5d3d13fa40fc0c.png"
+      },
+      {
+        "address": "0x43D4A3cd90ddD2F8f4f693170C9c8098163502ad",
+        "chainId": 1,
+        "name": "Prime",
+        "symbol": "D2D",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/balancer-labs/assets/master/assets/0x43d4a3cd90ddd2f8f4f693170c9c8098163502ad.png"
+      },
+      {
+        "address": "0x2d94AA3e47d9D5024503Ca8491fcE9A2fB4DA198",
+        "chainId": 1,
+        "name": "Bankless Token",
+        "symbol": "BANK",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x2d94AA3e47d9D5024503Ca8491fcE9A2fB4DA198/logo.png"
+      },
+      {
+        "address": "0x02d60b84491589974263d922D9cC7a3152618Ef6",
+        "chainId": 1,
+        "name": "Wrapped aDAI",
+        "symbol": "aDAI",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/balancer-labs/assets/master/assets/0x02d60b84491589974263d922d9cc7a3152618ef6.png"
+      },
+      {
+        "address": "0xd093fA4Fb80D09bB30817FDcd442d4d02eD3E5de",
+        "chainId": 1,
+        "name": "Wrapped aUSDC",
+        "symbol": "aUSDC",
+        "decimals": 6,
+        "logoURI": "https://raw.githubusercontent.com/balancer-labs/assets/master/assets/0xd093fa4fb80d09bb30817fdcd442d4d02ed3e5de.png"
+      },
+      {
+        "address": "0xf8Fd466F12e236f4c96F7Cce6c79EAdB819abF58",
+        "chainId": 1,
+        "name": "Wrapped aUSDT",
+        "symbol": "aUSDT",
+        "decimals": 6,
+        "logoURI": "https://raw.githubusercontent.com/balancer-labs/assets/master/assets/0xf8fd466f12e236f4c96f7cce6c79eadb819abf58.png"
+      },
+      {
+        "address": "0xD33526068D116cE69F19A9ee46F0bd304F21A51f",
+        "chainId": 1,
+        "name": "Rocket Pool Protocol",
+        "symbol": "RPL",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/balancer-labs/assets/master/assets/0xd33526068d116ce69f19a9ee46f0bd304f21a51f.png"
+      },
+      {
+        "address": "0xae78736Cd615f374D3085123A210448E74Fc6393",
+        "chainId": 1,
+        "name": "Rocket Pool ETH",
+        "symbol": "rETH",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/balancer-labs/assets/master/assets/0xae78736cd615f374d3085123a210448e74fc6393.png"
+      },
+      {
+        "address": "0xcAfE001067cDEF266AfB7Eb5A286dCFD277f3dE5",
+        "chainId": 1,
+        "name": "ParaSwap",
+        "symbol": "PSP",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/balancer-labs/assets/master/assets/0xcafe001067cdef266afb7eb5a286dcfd277f3de5.png"
+      },
+      {
+        "address": "0xEDB171C18cE90B633DB442f2A6F72874093b49Ef",
+        "chainId": 1,
+        "name": "Wrapped Ampleforth",
+        "symbol": "WAMPL",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/balancer-labs/assets/master/assets/0xedb171c18ce90b633db442f2a6f72874093b49ef.png"
+      },
+      {
+        "address": "0x64aa3364F17a4D01c6f1751Fd97C2BD3D7e7f1D5",
+        "chainId": 1,
+        "name": "Olympus",
+        "symbol": "OHM",
+        "decimals": 9,
+        "logoURI": "https://raw.githubusercontent.com/balancer-labs/assets/master/assets/0x64aa3364f17a4d01c6f1751fd97c2bd3d7e7f1d5.png"
+      },
+      {
+        "address": "0x10010078a54396F62c96dF8532dc2B4847d47ED3",
+        "chainId": 1,
+        "name": "Hundred Finance",
+        "symbol": "HND",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/balancer-labs/assets/master/assets/0x10010078a54396f62c96df8532dc2b4847d47ed3.png"
+      },
+      {
+        "address": "0x88ACDd2a6425c3FaAE4Bc9650Fd7E27e0Bebb7aB",
+        "chainId": 1,
+        "name": "Alchemist",
+        "symbol": "⚗️",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x88ACDd2a6425c3FaAE4Bc9650Fd7E27e0Bebb7aB/logo.png"
+      },
+      {
+        "address": "0x6f80310CA7F2C654691D1383149Fa1A57d8AB1f8",
+        "chainId": 1,
+        "name": "Silo Governance Token",
+        "symbol": "Silo",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/balancer-labs/assets/master/assets/0x6f80310ca7f2c654691d1383149fa1a57d8ab1f8.png"
+      },
+      {
+        "address": "0xf2051511B9b121394FA75B8F7d4E7424337af687",
+        "chainId": 1,
+        "name": "DAOhaus Token",
+        "symbol": "HAUS",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/balancer-labs/assets/master/assets/0xf2051511b9b121394fa75b8f7d4e7424337af687.png"
+      },
+      {
+        "address": "0xc976BE9DdBB3e2B2eFFd9af4845C38b6195dAB71",
+        "chainId": 1,
+        "name": "Wrapped SYS",
+        "symbol": "WSYS",
+        "decimals": 18
+      },
+      {
+        "address": "0x9C4A4204B79dd291D6b6571C5BE8BbcD0622F050",
+        "chainId": 1,
+        "name": "Tracer",
+        "symbol": "TCR",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/balancer-labs/assets/master/assets/0x9c4a4204b79dd291d6b6571c5be8bbcd0622f050.png"
+      },
+      {
+        "address": "0xAB846Fb6C81370327e784Ae7CbB6d6a6af6Ff4BF",
+        "chainId": 1,
+        "name": "Paladin Token",
+        "symbol": "PAL",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/balancer-labs/assets/master/assets/0xab846fb6c81370327e784ae7cbb6d6a6af6ff4bf.png"
+      },
+      {
+        "address": "0x12E457a5FC7707d0FDDA849068DF6e664d7a8569",
+        "chainId": 1,
+        "name": "Launch Paladin Token",
+        "symbol": "lPAL",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/balancer-labs/assets/master/assets/0x12e457a5fc7707d0fdda849068df6e664d7a8569.png"
+      },
+      {
+        "address": "0xAf5191B0De278C7286d6C7CC6ab6BB8A73bA2Cd6",
+        "chainId": 1,
+        "name": "StargateToken",
+        "symbol": "STG",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/balancer-labs/assets/master/assets/0xaf5191b0de278c7286d6c7cc6ab6bb8a73ba2cd6.png"
+      },
+      {
+        "address": "0xDEf1CA1fb7FBcDC777520aa7f396b4E015F497aB",
+        "chainId": 1,
+        "name": "CoW Protocol Token",
+        "symbol": "COW",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/balancer-labs/assets/master/assets/0xdef1ca1fb7fbcdc777520aa7f396b4e015f497ab.png"
+      },
+      {
+        "address": "0x5c6Ee304399DBdB9C8Ef030aB642B10820DB8F56",
+        "chainId": 1,
+        "name": "Balancer 80 BAL 20 WETH",
+        "symbol": "B-80BAL-20WETH",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/balancer-labs/assets/master/assets/0x5c6ee304399dbdb9c8ef030ab642b10820db8f56.png"
+      },
+      {
+        "address": "0xEd1480d12bE41d92F36f5f7bDd88212E381A3677",
+        "chainId": 1,
+        "name": "FIAT DAO Token",
+        "symbol": "FDT",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/balancer-labs/assets/master/assets/0xed1480d12be41d92f36f5f7bdd88212e381a3677.png"
+      },
+      {
+        "address": "0x333A4823466879eeF910A04D473505da62142069",
+        "chainId": 1,
+        "name": "Nation3",
+        "symbol": "NATION",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/balancer-labs/assets/master/assets/0x333a4823466879eef910a04d473505da62142069.png"
+      },
+      {
+        "address": "0xF17e65822b568B3903685a7c9F496CF7656Cc6C2",
+        "chainId": 1,
+        "name": "Biconomy Token",
+        "symbol": "BICO",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/balancer-labs/assets/master/assets/0xf17e65822b568b3903685a7c9f496cf7656cc6c2.png"
+      },
+      {
+        "address": "0x226f7b842E0F0120b7E194D05432b3fd14773a9D",
+        "chainId": 1,
+        "name": "UNION Protocol Governance Token",
+        "symbol": "UNN",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x226f7b842E0F0120b7E194D05432b3fd14773a9D/logo.png"
+      },
+      {
+        "address": "0xC0c293ce456fF0ED870ADd98a0828Dd4d2903DBF",
+        "chainId": 1,
+        "name": "Aura",
+        "symbol": "AURA",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/balancer-labs/assets/master/assets/0xc0c293ce456ff0ed870add98a0828dd4d2903dbf.png"
+      },
+      {
+        "address": "0x616e8BfA43F920657B3497DBf40D6b1A02D4608d",
+        "chainId": 1,
+        "name": "Aura BAL",
+        "symbol": "auraBAL",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/balancer-labs/assets/master/assets/0x616e8bfa43f920657b3497dbf40d6b1a02d4608d.png"
+      },
+      {
+        "address": "0xf203Ca1769ca8e9e8FE1DA9D147DB68B6c919817",
+        "chainId": 1,
+        "name": "Wrapped NCG",
+        "symbol": "WNCG",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/balancer-labs/assets/master/assets/0xf203ca1769ca8e9e8fe1da9d147db68b6c919817.png"
+      },
+      {
+        "address": "0x865377367054516e17014CcdED1e7d814EDC9ce4",
+        "chainId": 1,
+        "name": "Dola USD Stablecoin",
+        "symbol": "DOLA",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/balancer-labs/assets/master/assets/0x865377367054516e17014ccded1e7d814edc9ce4.png"
+      },
+      {
+        "address": "0xF24d8651578a55b0C119B9910759a351A3458895",
+        "chainId": 1,
+        "name": "Stake DAO Balancer",
+        "symbol": "sdBal",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/balancer-labs/assets/master/assets/0xf24d8651578a55b0c119b9910759a351a3458895.png"
+      },
+      {
+        "address": "0x586Aa273F262909EEF8fA02d90Ab65F5015e0516",
+        "chainId": 1,
+        "name": "Fixed Income Asset Token",
+        "symbol": "FIAT",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/balancer-labs/assets/master/assets/0x586aa273f262909eef8fa02d90ab65f5015e0516.png"
+      },
+      {
+        "address": "0x888888435FDe8e7d4c54cAb67f206e4199454c60",
+        "chainId": 1,
+        "name": "DFX Token",
+        "symbol": "DFX",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/balancer-labs/assets/master/assets/0x888888435fde8e7d4c54cab67f206e4199454c60.png"
+      },
+      {
+        "address": "0xBA485b556399123261a5F9c95d413B4f93107407",
+        "chainId": 1,
+        "name": "Gravitationally Bound AURA",
+        "symbol": "graviAURA",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/balancer-labs/assets/master/assets/0xba485b556399123261a5f9c95d413b4f93107407.png"
+      },
+      {
+        "address": "0x798D1bE841a82a273720CE31c822C61a67a601C3",
+        "chainId": 1,
+        "name": "Digg",
+        "symbol": "DIGG",
+        "decimals": 9,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x798D1bE841a82a273720CE31c822C61a67a601C3/logo.png"
+      },
+      {
+        "address": "0x35e78b3982E87ecfD5b3f3265B601c046cDBe232",
+        "chainId": 1,
+        "name": "SideShift Token",
+        "symbol": "XAI",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/balancer-labs/assets/master/assets/0x35e78b3982e87ecfd5b3f3265b601c046cdbe232.png"
+      },
+      {
+        "address": "0x24A6A37576377F63f194Caa5F518a60f45b42921",
+        "chainId": 1,
+        "name": "Float Bank",
+        "symbol": "BANK",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x24A6A37576377F63f194Caa5F518a60f45b42921/logo.png"
+      },
+      {
+        "address": "0x758B4684BE769E92eeFeA93f60DDA0181eA303Ec",
+        "chainId": 1,
+        "name": "Phonon DAO",
+        "symbol": "PHONON",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/balancer-labs/assets/master/assets/0x758b4684be769e92eefea93f60dda0181ea303ec.png"
+      },
+      {
+        "address": "0x0C10bF8FcB7Bf5412187A595ab97a3609160b5c6",
+        "chainId": 1,
+        "name": "Decentralized USD",
+        "symbol": "USDD",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/balancer-labs/assets/master/assets/0x0c10bf8fcb7bf5412187a595ab97a3609160b5c6.png"
+      },
+      {
+        "address": "0x853d955aCEf822Db058eb8505911ED77F175b99e",
+        "chainId": 1,
+        "name": "Frax",
+        "symbol": "FRAX",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x853d955aCEf822Db058eb8505911ED77F175b99e/logo.png"
+      },
+      {
+        "address": "0x8888801aF4d980682e47f1A9036e589479e835C5",
+        "chainId": 1,
+        "name": "88mph.app",
+        "symbol": "MPH",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/balancer-labs/assets/master/assets/0x8888801af4d980682e47f1a9036e589479e835c5.png"
+      },
+      {
+        "address": "0x470EBf5f030Ed85Fc1ed4C2d36B9DD02e77CF1b7",
+        "chainId": 1,
+        "name": "Temple",
+        "symbol": "TEMPLE",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/balancer-labs/assets/master/assets/0x470ebf5f030ed85fc1ed4c2d36b9dd02e77cf1b7.png"
+      },
+      {
+        "address": "0xd084944d3c05CD115C09d072B9F44bA3E0E45921",
+        "chainId": 1,
+        "name": "Manifold Finance",
+        "symbol": "FOLD",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/balancer-labs/assets/master/assets/0xd084944d3c05cd115c09d072b9f44ba3e0e45921.png"
+      },
+      {
+        "address": "0x9c354503C38481a7A7a51629142963F98eCC12D0",
+        "chainId": 1,
+        "name": "Origin Dollar Governance",
+        "symbol": "OGV",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/balancer-labs/assets/master/assets/0x9c354503c38481a7a7a51629142963f98ecc12d0.png"
+      },
+      {
+        "address": "0xD2af830E8CBdFed6CC11Bab697bB25496ed6FA62",
+        "chainId": 1,
+        "name": "Wrapped OUSD",
+        "symbol": "WOUSD",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/balancer-labs/assets/master/assets/0xd2af830e8cbdfed6cc11bab697bb25496ed6fa62.png"
+      },
+      {
+        "address": "0xc55126051B22eBb829D00368f4B12Bde432de5Da",
+        "chainId": 1,
+        "name": "BTRFLY",
+        "symbol": "BTRFLY",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/balancer-labs/assets/master/assets/0xc55126051b22ebb829d00368f4b12bde432de5da.png"
+      },
+      {
+        "address": "0x8D6CeBD76f18E1558D4DB88138e2DeFB3909fAD6",
+        "chainId": 1,
+        "name": "Mai Stablecoin",
+        "symbol": "MAI",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/balancer-labs/assets/master/assets/0x8d6cebd76f18e1558d4db88138e2defb3909fad6.png"
+      },
+      {
+        "address": "0xf5f06fFa53Ad7F5914F493F16E57B56C8dd2eA80",
+        "chainId": 1,
+        "name": "Jelly Token",
+        "symbol": "JELLY",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/balancer-labs/assets/master/assets/0xf5f06ffa53ad7f5914f493f16e57b56c8dd2ea80.png"
+      },
+      {
+        "address": "0x81f8f0bb1cB2A06649E51913A151F0E7Ef6FA321",
+        "chainId": 1,
+        "name": "VitaDAO Token",
+        "symbol": "VITA",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/balancer-labs/assets/master/assets/0x81f8f0bb1cb2a06649e51913a151f0e7ef6fa321.png"
+      },
+      {
+        "address": "0x41D5D79431A913C4aE7d69a668ecdfE5fF9DFB68",
+        "chainId": 1,
+        "name": "Inverse DAO",
+        "symbol": "INV",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/balancer-labs/assets/master/assets/0x41d5d79431a913c4ae7d69a668ecdfe5ff9dfb68.png"
+      },
+      {
+        "address": "0xB0B195aEFA3650A6908f15CdaC7D92F8a5791B0B",
+        "chainId": 1,
+        "name": "BOB",
+        "symbol": "BOB",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/balancer-labs/assets/master/assets/0xb0b195aefa3650a6908f15cdac7d92f8a5791b0b.png"
+      }
+    ]
+  },
+  "https://raw.githubusercontent.com/balancer-labs/assets/master/generated/vetted.tokenlist.json": {
+    "name": "Balancer",
+    "timestamp": "2022-08-25T00:00:00.000Z",
+    "logoURI": "https://raw.githubusercontent.com/balancer-labs/pebbles/master/images/pebbles-pad.256w.png",
+    "keywords": ["balancer", "vetted"],
+    "version": { "major": 1, "minor": 0, "patch": 0 },
+    "tokens": [
+      {
+        "address": "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
+        "chainId": 1,
+        "name": "Wrapped Ether",
+        "symbol": "WETH",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2/logo.png"
+      },
+      {
+        "address": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+        "chainId": 1,
+        "name": "USD Coin",
+        "symbol": "USDC",
+        "decimals": 6,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/logo.png"
+      },
+      {
+        "address": "0x6B175474E89094C44Da98b954EedeAC495271d0F",
+        "chainId": 1,
+        "name": "Dai Stablecoin",
+        "symbol": "DAI",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x6B175474E89094C44Da98b954EedeAC495271d0F/logo.png"
+      },
+      {
+        "address": "0xba100000625a3754423978a60c9317c58a424e3D",
+        "chainId": 1,
+        "name": "Balancer",
+        "symbol": "BAL",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xba100000625a3754423978a60c9317c58a424e3D/logo.png"
+      },
+      {
+        "address": "0x514910771AF9Ca656af840dff83E8264EcF986CA",
+        "chainId": 1,
+        "name": "ChainLink Token",
+        "symbol": "LINK",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x514910771AF9Ca656af840dff83E8264EcF986CA/logo.png"
+      },
+      {
+        "address": "0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599",
+        "chainId": 1,
+        "name": "Wrapped BTC",
+        "symbol": "WBTC",
+        "decimals": 8,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599/logo.png"
+      },
+      {
+        "address": "0xC011a73ee8576Fb46F5E1c5751cA3B9Fe0af2a6F",
+        "chainId": 1,
+        "name": "Synthetix Network Token",
+        "symbol": "SNX",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xC011a73ee8576Fb46F5E1c5751cA3B9Fe0af2a6F/logo.png"
+      },
+      {
+        "address": "0xc00e94Cb662C3520282E6f5717214004A7f26888",
+        "chainId": 1,
+        "name": "Compound",
+        "symbol": "COMP",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xc00e94Cb662C3520282E6f5717214004A7f26888/logo.png"
+      },
+      {
+        "address": "0x0bc529c00C6401aEF6D220BE8C6Ea1667F6Ad93e",
+        "chainId": 1,
+        "name": "yearn.finance",
+        "symbol": "YFI",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x0bc529c00C6401aEF6D220BE8C6Ea1667F6Ad93e/logo.png"
+      },
+      {
+        "address": "0x408e41876cCCDC0F92210600ef50372656052a38",
+        "chainId": 1,
+        "name": "Republic Token",
+        "symbol": "REN",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x408e41876cCCDC0F92210600ef50372656052a38/logo.png"
+      },
+      {
+        "address": "0xdd974D5C2e2928deA5F71b9825b8b646686BD200",
+        "chainId": 1,
+        "name": "Kyber Network Crystal",
+        "symbol": "KNC",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xdd974D5C2e2928deA5F71b9825b8b646686BD200/logo.png"
+      },
+      {
+        "address": "0x9f8F72aA9304c8B593d555F12eF6589cC3A579A2",
+        "chainId": 1,
+        "name": "Maker",
+        "symbol": "MKR",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x9f8F72aA9304c8B593d555F12eF6589cC3A579A2/logo.png"
+      },
+      {
+        "address": "0xBBbbCA6A901c926F240b89EacB641d8Aec7AEafD",
+        "chainId": 1,
+        "name": "LoopringCoin V2",
+        "symbol": "LRC",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xBBbbCA6A901c926F240b89EacB641d8Aec7AEafD/logo.png"
+      },
+      {
+        "address": "0x0D8775F648430679A709E98d2b0Cb6250d2887EF",
+        "chainId": 1,
+        "name": "Basic Attention Token",
+        "symbol": "BAT",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x0D8775F648430679A709E98d2b0Cb6250d2887EF/logo.png"
+      },
+      {
+        "address": "0x1F573D6Fb3F13d689FF844B4cE37794d79a7FF1C",
+        "chainId": 1,
+        "name": "Bancor Network Token",
+        "symbol": "BNT",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x1F573D6Fb3F13d689FF844B4cE37794d79a7FF1C/logo.png"
+      },
+      {
+        "address": "0x0d438F3b5175Bebc262bF23753C1E53d03432bDE",
+        "chainId": 1,
+        "name": "Wrapped NXM",
+        "symbol": "wNXM",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x0d438F3b5175Bebc262bF23753C1E53d03432bDE/logo.png"
+      },
+      {
+        "address": "0xa117000000f279D81A1D3cc75430fAA017FA5A2e",
+        "chainId": 1,
+        "name": "Aragon Network Token",
+        "symbol": "ANT",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xa117000000f279D81A1D3cc75430fAA017FA5A2e/logo.png"
+      },
+      {
+        "address": "0x04Fa0d235C4abf4BcF4787aF4CF447DE572eF828",
+        "chainId": 1,
+        "name": "UMA Voting Token v1",
+        "symbol": "UMA",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x04Fa0d235C4abf4BcF4787aF4CF447DE572eF828/logo.png"
+      },
+      {
+        "address": "0x7Fc66500c84A76Ad7e9c93437bFc5Ac33E2DDaE9",
+        "chainId": 1,
+        "name": "Aave Token",
+        "symbol": "AAVE",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x7Fc66500c84A76Ad7e9c93437bFc5Ac33E2DDaE9/logo.png"
+      },
+      {
+        "address": "0x57Ab1ec28D129707052df4dF418D58a2D46d5f51",
+        "chainId": 1,
+        "name": "Synth sUSD",
+        "symbol": "sUSD",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/balancer-labs/assets/master/assets/0x57ab1ec28d129707052df4df418d58a2d46d5f51.png"
+      },
+      {
+        "address": "0xfE18be6b3Bd88A2D2A7f928d00292E7a9963CfC6",
+        "chainId": 1,
+        "name": "Synth sBTC",
+        "symbol": "sBTC",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/balancer-labs/assets/master/assets/0xfe18be6b3bd88a2d2a7f928d00292e7a9963cfc6.png"
+      },
+      {
+        "address": "0x5e74C9036fb86BD7eCdcb084a0673EFc32eA31cb",
+        "chainId": 1,
+        "name": "Synth sETH",
+        "symbol": "sETH",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/balancer-labs/assets/master/assets/0x5e74c9036fb86bd7ecdcb084a0673efc32ea31cb.png"
+      },
+      {
+        "address": "0x261EfCdD24CeA98652B9700800a13DfBca4103fF",
+        "chainId": 1,
+        "name": "Synth sXAU",
+        "symbol": "sXAU",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/balancer-labs/assets/master/assets/0x261efcdd24cea98652b9700800a13dfbca4103ff.png"
+      },
+      {
+        "address": "0x6A22e5e94388464181578Aa7A6B869e00fE27846",
+        "chainId": 1,
+        "name": "Synth sXAG",
+        "symbol": "sXAG",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/balancer-labs/assets/master/assets/0x6a22e5e94388464181578aa7a6b869e00fe27846.png"
+      },
+      {
+        "address": "0x0327112423F3A68efdF1fcF402F6c5CB9f7C33fd",
+        "chainId": 1,
+        "name": "PieDAO BTC++",
+        "symbol": "BTC++",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/balancer-labs/assets/master/assets/0x0327112423f3a68efdf1fcf402f6c5cb9f7c33fd.png"
+      },
+      {
+        "address": "0x9A48BD0EC040ea4f1D3147C025cd4076A2e71e3e",
+        "chainId": 1,
+        "name": "PieDAO USD++ Pool",
+        "symbol": "USD++",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/balancer-labs/assets/master/assets/0x9a48bd0ec040ea4f1d3147c025cd4076a2e71e3e.png"
+      },
+      {
+        "address": "0x39AA39c021dfbaE8faC545936693aC917d5E7563",
+        "chainId": 1,
+        "name": "Compound USD Coin",
+        "symbol": "cUSDC",
+        "decimals": 8,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x39AA39c021dfbaE8faC545936693aC917d5E7563/logo.png"
+      },
+      {
+        "address": "0x5d3a536E4D6DbD6114cc1Ead35777bAB948E3643",
+        "chainId": 1,
+        "name": "Compound Dai",
+        "symbol": "cDAI",
+        "decimals": 8,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x5d3a536E4D6DbD6114cc1Ead35777bAB948E3643/logo.png"
+      },
+      {
+        "address": "0x4Ddc2D193948926D02f9B1fE9e1daa0718270ED5",
+        "chainId": 1,
+        "name": "Compound Ether",
+        "symbol": "cETH",
+        "decimals": 8,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x4Ddc2D193948926D02f9B1fE9e1daa0718270ED5/logo.png"
+      },
+      {
+        "address": "0xf650C3d88D12dB855b8bf7D11Be6C55A4e07dCC9",
+        "chainId": 1,
+        "name": "Compound USDT",
+        "symbol": "cUSDT",
+        "decimals": 8
+      },
+      {
+        "address": "0x158079Ee67Fce2f58472A96584A73C7Ab9AC95c1",
+        "chainId": 1,
+        "name": "Compound Augur",
+        "symbol": "cREP",
+        "decimals": 8,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x158079Ee67Fce2f58472A96584A73C7Ab9AC95c1/logo.png"
+      },
+      {
+        "address": "0xB3319f5D18Bc0D84dD1b4825Dcde5d5f7266d407",
+        "chainId": 1,
+        "name": "Compound 0x",
+        "symbol": "cZRX",
+        "decimals": 8,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xB3319f5D18Bc0D84dD1b4825Dcde5d5f7266d407/logo.png"
+      },
+      {
+        "address": "0x6C8c6b02E7b2BE14d4fA6022Dfd6d75921D90E4E",
+        "chainId": 1,
+        "name": "Compound Basic Attention Token",
+        "symbol": "cBAT",
+        "decimals": 8,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x6C8c6b02E7b2BE14d4fA6022Dfd6d75921D90E4E/logo.png"
+      },
+      {
+        "address": "0xC11b1268C1A384e55C48c2391d8d480264A3A7F4",
+        "chainId": 1,
+        "name": "Compound Wrapped BTC",
+        "symbol": "cWBTC",
+        "decimals": 8
+      },
+      {
+        "address": "0xfC1E690f61EFd961294b3e1Ce3313fBD8aa4f85d",
+        "chainId": 1,
+        "name": "Aave Interest bearing DAI",
+        "symbol": "aDAI",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xfC1E690f61EFd961294b3e1Ce3313fBD8aa4f85d/logo.png"
+      },
+      {
+        "address": "0x71fc860F7D3A592A4a98740e39dB31d25db65ae8",
+        "chainId": 1,
+        "name": "Aave Interest bearing USDT",
+        "symbol": "aUSDT",
+        "decimals": 6,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x71fc860F7D3A592A4a98740e39dB31d25db65ae8/logo.png"
+      },
+      {
+        "address": "0x9bA00D6856a4eDF4665BcA2C2309936572473B7E",
+        "chainId": 1,
+        "name": "Aave Interest bearing USDC",
+        "symbol": "aUSDC",
+        "decimals": 6,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x9bA00D6856a4eDF4665BcA2C2309936572473B7E/logo.png"
+      },
+      {
+        "address": "0x625aE63000f46200499120B906716420bd059240",
+        "chainId": 1,
+        "name": "Aave Interest bearing SUSD",
+        "symbol": "aSUSD",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x625aE63000f46200499120B906716420bd059240/logo.png"
+      },
+      {
+        "address": "0x4DA9b813057D04BAef4e5800E36083717b4a0341",
+        "chainId": 1,
+        "name": "Aave Interest bearing TUSD",
+        "symbol": "aTUSD",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x4DA9b813057D04BAef4e5800E36083717b4a0341/logo.png"
+      },
+      {
+        "address": "0x6Ee0f7BB50a54AB5253dA0667B0Dc2ee526C30a8",
+        "chainId": 1,
+        "name": "Aave Interest bearing Binance USD",
+        "symbol": "aBUSD",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/balancer-labs/assets/master/assets/0x6ee0f7bb50a54ab5253da0667b0dc2ee526c30a8.png"
+      },
+      {
+        "address": "0xE1BA0FB44CCb0D11b80F92f4f8Ed94CA3fF51D00",
+        "chainId": 1,
+        "name": "Aave Interest bearing BAT",
+        "symbol": "aBAT",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xE1BA0FB44CCb0D11b80F92f4f8Ed94CA3fF51D00/logo.png"
+      },
+      {
+        "address": "0x3a3A65aAb0dd2A17E3F1947bA16138cd37d08c04",
+        "chainId": 1,
+        "name": "Aave Interest bearing ETH",
+        "symbol": "aETH",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x3a3A65aAb0dd2A17E3F1947bA16138cd37d08c04/logo.png"
+      },
+      {
+        "address": "0x9D91BE44C06d373a8a226E1f3b146956083803eB",
+        "chainId": 1,
+        "name": "Aave Interest bearing KNC",
+        "symbol": "aKNC",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x9D91BE44C06d373a8a226E1f3b146956083803eB/logo.png"
+      },
+      {
+        "address": "0x7D2D3688Df45Ce7C552E19c27e007673da9204B8",
+        "chainId": 1,
+        "name": "Aave Interest bearing LEND",
+        "symbol": "aLEND",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x7D2D3688Df45Ce7C552E19c27e007673da9204B8/logo.png"
+      },
+      {
+        "address": "0xA64BD6C70Cb9051F6A9ba1F163Fdc07E0DfB5F84",
+        "chainId": 1,
+        "name": "Aave Interest bearing LINK",
+        "symbol": "aLINK",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xA64BD6C70Cb9051F6A9ba1F163Fdc07E0DfB5F84/logo.png"
+      },
+      {
+        "address": "0x6FCE4A401B6B80ACe52baAefE4421Bd188e76F6f",
+        "chainId": 1,
+        "name": "Aave Interest bearing MANA",
+        "symbol": "aMANA",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x6FCE4A401B6B80ACe52baAefE4421Bd188e76F6f/logo.png"
+      },
+      {
+        "address": "0x7deB5e830be29F91E298ba5FF1356BB7f8146998",
+        "chainId": 1,
+        "name": "Aave Interest bearing MKR",
+        "symbol": "aMKR",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x7deB5e830be29F91E298ba5FF1356BB7f8146998/logo.png"
+      },
+      {
+        "address": "0x71010A9D003445aC60C4e6A7017c1E89A477B438",
+        "chainId": 1,
+        "name": "Aave Interest bearing REP",
+        "symbol": "aREP",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x71010A9D003445aC60C4e6A7017c1E89A477B438/logo.png"
+      },
+      {
+        "address": "0x328C4c80BC7aCa0834Db37e6600A6c49E12Da4DE",
+        "chainId": 1,
+        "name": "Aave Interest bearing SNX",
+        "symbol": "aSNX",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x328C4c80BC7aCa0834Db37e6600A6c49E12Da4DE/logo.png"
+      },
+      {
+        "address": "0xFC4B8ED459e00e5400be803A9BB3954234FD50e3",
+        "chainId": 1,
+        "name": "Aave Interest bearing WBTC",
+        "symbol": "aWBTC",
+        "decimals": 8,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xFC4B8ED459e00e5400be803A9BB3954234FD50e3/logo.png"
+      },
+      {
+        "address": "0x6Fb0855c404E09c47C3fBCA25f08d4E41f9F062f",
+        "chainId": 1,
+        "name": "Aave Interest bearing ZRX",
+        "symbol": "aZRX",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x6Fb0855c404E09c47C3fBCA25f08d4E41f9F062f/logo.png"
+      },
+      {
+        "address": "0xE41d2489571d322189246DaFA5ebDe1F4699F498",
+        "chainId": 1,
+        "name": "0x Protocol Token",
+        "symbol": "ZRX",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xE41d2489571d322189246DaFA5ebDe1F4699F498/logo.png"
+      },
+      {
+        "address": "0xEB4C2781e4ebA804CE9a9803C67d0893436bB27D",
+        "chainId": 1,
+        "name": "renBTC",
+        "symbol": "renBTC",
+        "decimals": 8,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xEB4C2781e4ebA804CE9a9803C67d0893436bB27D/logo.png"
+      },
+      {
+        "address": "0x3212b29E33587A00FB1C83346f5dBFA69A458923",
+        "chainId": 1,
+        "name": "The Tokenized Bitcoin",
+        "symbol": "imBTC",
+        "decimals": 8,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x3212b29E33587A00FB1C83346f5dBFA69A458923/logo.png"
+      },
+      {
+        "address": "0x5228a22e72ccC52d415EcFd199F99D0665E7733b",
+        "chainId": 1,
+        "name": "pTokens BTC",
+        "symbol": "pBTC",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x5228a22e72ccC52d415EcFd199F99D0665E7733b/logo.png"
+      },
+      {
+        "address": "0x93ED3FBe21207Ec2E8f2d3c3de6e058Cb73Bc04d",
+        "chainId": 1,
+        "name": "Pinakion",
+        "symbol": "PNK",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x93ED3FBe21207Ec2E8f2d3c3de6e058Cb73Bc04d/logo.png"
+      },
+      {
+        "address": "0x27054b13b1B798B345b591a4d22e6562d47eA75a",
+        "chainId": 1,
+        "name": "AirSwap Token",
+        "symbol": "AST",
+        "decimals": 4,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x27054b13b1B798B345b591a4d22e6562d47eA75a/logo.png"
+      },
+      {
+        "address": "0x04abEdA201850aC0124161F037Efd70c74ddC74C",
+        "chainId": 1,
+        "name": "NEST",
+        "symbol": "NEST",
+        "decimals": 18
+      },
+      {
+        "address": "0xB4EFd85c19999D84251304bDA99E90B92300Bd93",
+        "chainId": 1,
+        "name": "Rocket Pool",
+        "symbol": "RPL",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xB4EFd85c19999D84251304bDA99E90B92300Bd93/logo.png"
+      },
+      {
+        "address": "0x6810e776880C02933D47DB1b9fc05908e5386b96",
+        "chainId": 1,
+        "name": "Gnosis Token",
+        "symbol": "GNO",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x6810e776880C02933D47DB1b9fc05908e5386b96/logo.png"
+      },
+      {
+        "address": "0x543Ff227F64Aa17eA132Bf9886cAb5DB55DCAddf",
+        "chainId": 1,
+        "name": "DAOstack",
+        "symbol": "GEN",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x543Ff227F64Aa17eA132Bf9886cAb5DB55DCAddf/logo.png"
+      },
+      {
+        "address": "0xa1d65E8fB6e87b60FECCBc582F7f97804B725521",
+        "chainId": 1,
+        "name": "DXdao",
+        "symbol": "DXD",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xa1d65E8fB6e87b60FECCBc582F7f97804B725521/logo.png"
+      },
+      {
+        "address": "0x06AF07097C9Eeb7fD685c692751D5C66dB49c215",
+        "chainId": 1,
+        "name": "Chai",
+        "symbol": "CHAI",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x06AF07097C9Eeb7fD685c692751D5C66dB49c215/logo.png"
+      },
+      {
+        "address": "0x1776e1F26f98b1A5dF9cD347953a26dd3Cb46671",
+        "chainId": 1,
+        "name": "Numeraire",
+        "symbol": "NMR",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x1776e1F26f98b1A5dF9cD347953a26dd3Cb46671/logo.png"
+      },
+      {
+        "address": "0xF629cBd94d3791C9250152BD8dfBDF380E2a3B9c",
+        "chainId": 1,
+        "name": "Enjin Coin",
+        "symbol": "ENJ",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xF629cBd94d3791C9250152BD8dfBDF380E2a3B9c/logo.png"
+      },
+      {
+        "address": "0x12B19D3e2ccc14Da04FAe33e63652ce469b3F2FD",
+        "chainId": 1,
+        "name": "GRID Token",
+        "symbol": "GRID",
+        "decimals": 12,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x12B19D3e2ccc14Da04FAe33e63652ce469b3F2FD/logo.png"
+      },
+      {
+        "address": "0x967da4048cD07aB37855c090aAF366e4ce1b9F48",
+        "chainId": 1,
+        "name": "Ocean Token",
+        "symbol": "OCEAN",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x967da4048cD07aB37855c090aAF366e4ce1b9F48/logo.png"
+      },
+      {
+        "address": "0x89Ab32156e46F46D02ade3FEcbe5Fc4243B9AAeD",
+        "chainId": 1,
+        "name": "pNetwork Token",
+        "symbol": "PNT",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x89Ab32156e46F46D02ade3FEcbe5Fc4243B9AAeD/logo.png"
+      },
+      {
+        "address": "0x8E870D67F660D95d5be530380D0eC0bd388289E1",
+        "chainId": 1,
+        "name": "Pax Dollar",
+        "symbol": "USDP",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x8E870D67F660D95d5be530380D0eC0bd388289E1/logo.png"
+      },
+      {
+        "address": "0x107c4504cd79C5d2696Ea0030a8dD4e92601B82e",
+        "chainId": 1,
+        "name": "Bloom Token",
+        "symbol": "BLT",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x107c4504cd79C5d2696Ea0030a8dD4e92601B82e/logo.png"
+      },
+      {
+        "address": "0x41e5560054824eA6B0732E656E3Ad64E20e94E45",
+        "chainId": 1,
+        "name": "Civic",
+        "symbol": "CVC",
+        "decimals": 8,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x41e5560054824eA6B0732E656E3Ad64E20e94E45/logo.png"
+      },
+      {
+        "address": "0x0F5D2fB29fb7d3CFeE444a200298f468908cC942",
+        "chainId": 1,
+        "name": "Decentraland MANA",
+        "symbol": "MANA",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x0F5D2fB29fb7d3CFeE444a200298f468908cC942/logo.png"
+      },
+      {
+        "address": "0x0Cf0Ee63788A0849fE5297F3407f701E122cC023",
+        "chainId": 1,
+        "name": "Streamr (old)",
+        "symbol": "XDATA",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x0Cf0Ee63788A0849fE5297F3407f701E122cC023/logo.png"
+      },
+      {
+        "address": "0x595832F8FC6BF59c85C527fEC3740A1b7a361269",
+        "chainId": 1,
+        "name": "PowerLedger",
+        "symbol": "POWR",
+        "decimals": 6,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x595832F8FC6BF59c85C527fEC3740A1b7a361269/logo.png"
+      },
+      {
+        "address": "0x0AbdAce70D3790235af448C88547603b945604ea",
+        "chainId": 1,
+        "name": "district0x Network Token",
+        "symbol": "DNT",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x0AbdAce70D3790235af448C88547603b945604ea/logo.png"
+      },
+      {
+        "address": "0xe25b0BBA01Dc5630312B6A21927E578061A13f55",
+        "chainId": 1,
+        "name": "ShipChain SHIP",
+        "symbol": "SHIP",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xe25b0BBA01Dc5630312B6A21927E578061A13f55/logo.png"
+      },
+      {
+        "address": "0xaA7a9CA87d3694B5755f213B5D04094b8d0F0A6F",
+        "chainId": 1,
+        "name": "Trace Token",
+        "symbol": "TRAC",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xaA7a9CA87d3694B5755f213B5D04094b8d0F0A6F/logo.png"
+      },
+      {
+        "address": "0x5732046A883704404F284Ce41FfADd5b007FD668",
+        "chainId": 1,
+        "name": "Bluzelle Token",
+        "symbol": "BLZ",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x5732046A883704404F284Ce41FfADd5b007FD668/logo.png"
+      },
+      {
+        "address": "0x7D1AfA7B718fb893dB30A3aBc0Cfc608AaCfeBB0",
+        "chainId": 1,
+        "name": "Matic Token",
+        "symbol": "MATIC",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x7D1AfA7B718fb893dB30A3aBc0Cfc608AaCfeBB0/logo.png"
+      },
+      {
+        "address": "0x4946Fcea7C692606e8908002e55A582af44AC121",
+        "chainId": 1,
+        "name": "FOAM Token",
+        "symbol": "FOAM",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x4946Fcea7C692606e8908002e55A582af44AC121/logo.png"
+      },
+      {
+        "address": "0xc719d010B63E5bbF2C0551872CD5316ED26AcD83",
+        "chainId": 1,
+        "name": "Decentralized Insurance Protocol",
+        "symbol": "DIP",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xc719d010B63E5bbF2C0551872CD5316ED26AcD83/logo.png"
+      },
+      {
+        "address": "0x7b123f53421b1bF8533339BFBdc7C98aA94163db",
+        "chainId": 1,
+        "name": "dfohub",
+        "symbol": "buidl",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x7b123f53421b1bF8533339BFBdc7C98aA94163db/logo.png"
+      },
+      {
+        "address": "0xaaAEBE6Fe48E54f431b0C390CfaF0b017d09D42d",
+        "chainId": 1,
+        "name": "Celsius",
+        "symbol": "CEL",
+        "decimals": 4,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xaaAEBE6Fe48E54f431b0C390CfaF0b017d09D42d/logo.png"
+      },
+      {
+        "address": "0x4a220E6096B25EADb88358cb44068A3248254675",
+        "chainId": 1,
+        "name": "Quant",
+        "symbol": "QNT",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x4a220E6096B25EADb88358cb44068A3248254675/logo.png"
+      },
+      {
+        "address": "0x744d70FDBE2Ba4CF95131626614a1763DF805B9E",
+        "chainId": 1,
+        "name": "Status Network Token",
+        "symbol": "SNT",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x744d70FDBE2Ba4CF95131626614a1763DF805B9E/logo.png"
+      },
+      {
+        "address": "0x3506424F91fD33084466F402d5D97f05F8e3b4AF",
+        "chainId": 1,
+        "name": "chiliZ",
+        "symbol": "CHZ",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x3506424F91fD33084466F402d5D97f05F8e3b4AF/logo.png"
+      },
+      {
+        "address": "0xec67005c4E498Ec7f55E092bd1d35cbC47C91892",
+        "chainId": 1,
+        "name": "Melon Token",
+        "symbol": "MLN",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xec67005c4E498Ec7f55E092bd1d35cbC47C91892/logo.png"
+      },
+      {
+        "address": "0x8762db106B2c2A0bccB3A80d1Ed41273552616E8",
+        "chainId": 1,
+        "name": "Reserve Rights",
+        "symbol": "RSR",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x8762db106B2c2A0bccB3A80d1Ed41273552616E8/logo.png"
+      },
+      {
+        "address": "0x6c6EE5e31d828De241282B9606C8e98Ea48526E2",
+        "chainId": 1,
+        "name": "HoloToken",
+        "symbol": "HOT",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x6c6EE5e31d828De241282B9606C8e98Ea48526E2/logo.png"
+      },
+      {
+        "address": "0xcD62b1C403fa761BAadFC74C525ce2B51780b184",
+        "chainId": 1,
+        "name": "Aragon Network Juror",
+        "symbol": "ANJ",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xcD62b1C403fa761BAadFC74C525ce2B51780b184/logo.png"
+      },
+      {
+        "address": "0x8400D94A5cb0fa0D041a3788e395285d61c9ee5e",
+        "chainId": 1,
+        "name": "UniBright",
+        "symbol": "UBT",
+        "decimals": 8,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x8400D94A5cb0fa0D041a3788e395285d61c9ee5e/logo.png"
+      },
+      {
+        "address": "0x419D0d8BdD9aF5e606Ae2232ed285Aff190E711b",
+        "chainId": 1,
+        "name": "FunFair",
+        "symbol": "FUN",
+        "decimals": 8,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x419D0d8BdD9aF5e606Ae2232ed285Aff190E711b/logo.png"
+      },
+      {
+        "address": "0xB64ef51C888972c908CFacf59B47C1AfBC0Ab8aC",
+        "chainId": 1,
+        "name": "StorjToken",
+        "symbol": "STORJ",
+        "decimals": 8,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xB64ef51C888972c908CFacf59B47C1AfBC0Ab8aC/logo.png"
+      },
+      {
+        "address": "0xd15eCDCF5Ea68e3995b2D0527A0aE0a3258302F8",
+        "chainId": 1,
+        "name": "MachiX Token",
+        "symbol": "MCX",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xd15eCDCF5Ea68e3995b2D0527A0aE0a3258302F8/logo.png"
+      },
+      {
+        "address": "0xAcfa209Fb73bF3Dd5bBfb1101B9Bc999C49062a5",
+        "chainId": 1,
+        "name": "Blockchain Certified Data Token",
+        "symbol": "BCDT",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xAcfa209Fb73bF3Dd5bBfb1101B9Bc999C49062a5/logo.png"
+      },
+      {
+        "address": "0xB705268213D593B8FD88d3FDEFF93AFF5CbDcfAE",
+        "chainId": 1,
+        "name": "IDEX Token",
+        "symbol": "IDEX",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xB705268213D593B8FD88d3FDEFF93AFF5CbDcfAE/logo.png"
+      },
+      {
+        "address": "0xe2f2a5C287993345a840Db3B0845fbC70f5935a5",
+        "chainId": 1,
+        "name": "mStable USD",
+        "symbol": "mUSD",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xe2f2a5C287993345a840Db3B0845fbC70f5935a5/logo.png"
+      },
+      {
+        "address": "0xc12d099be31567add4e4e4d0D45691C3F58f5663",
+        "chainId": 1,
+        "name": "Auctus Token",
+        "symbol": "AUC",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xc12d099be31567add4e4e4d0D45691C3F58f5663/logo.png"
+      },
+      {
+        "address": "0x1A5F9352Af8aF974bFC03399e3767DF6370d82e4",
+        "chainId": 1,
+        "name": "OWL Token",
+        "symbol": "OWL",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x1A5F9352Af8aF974bFC03399e3767DF6370d82e4/logo.png"
+      },
+      {
+        "address": "0x8eB24319393716668D768dCEC29356ae9CfFe285",
+        "chainId": 1,
+        "name": "SingularityNET Token",
+        "symbol": "AGI",
+        "decimals": 8,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x8eB24319393716668D768dCEC29356ae9CfFe285/logo.png"
+      },
+      {
+        "address": "0x58b6A8A3302369DAEc383334672404Ee733aB239",
+        "chainId": 1,
+        "name": "Livepeer Token",
+        "symbol": "LPT",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x58b6A8A3302369DAEc383334672404Ee733aB239/logo.png"
+      },
+      {
+        "address": "0x0000000000085d4780B73119b644AE5ecd22b376",
+        "chainId": 1,
+        "name": "TrueUSD",
+        "symbol": "TUSD",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x0000000000085d4780B73119b644AE5ecd22b376/logo.png"
+      },
+      {
+        "address": "0xEd91879919B71bB6905f23af0A68d231EcF87b14",
+        "chainId": 1,
+        "name": "DMM: Governance",
+        "symbol": "DMG",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xEd91879919B71bB6905f23af0A68d231EcF87b14/logo.png"
+      },
+      {
+        "address": "0x0Ae055097C6d159879521C384F1D2123D1f195e6",
+        "chainId": 1,
+        "name": "STAKE",
+        "symbol": "STAKE",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x0Ae055097C6d159879521C384F1D2123D1f195e6/logo.png"
+      },
+      {
+        "address": "0x607F4C5BB672230e8672085532f7e901544a7375",
+        "chainId": 1,
+        "name": "iEx.ec Network Token",
+        "symbol": "RLC",
+        "decimals": 9,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x607F4C5BB672230e8672085532f7e901544a7375/logo.png"
+      },
+      {
+        "address": "0x8f8221aFbB33998d8584A2B05749bA73c37a938a",
+        "chainId": 1,
+        "name": "Request Token",
+        "symbol": "REQ",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x8f8221aFbB33998d8584A2B05749bA73c37a938a/logo.png"
+      },
+      {
+        "address": "0x8A9C67fee641579dEbA04928c4BC45F66e26343A",
+        "chainId": 1,
+        "name": "Jarvis Reward Token",
+        "symbol": "JRT",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x8A9C67fee641579dEbA04928c4BC45F66e26343A/logo.png"
+      },
+      {
+        "address": "0x8Ab7404063Ec4DBcfd4598215992DC3F8EC853d7",
+        "chainId": 1,
+        "name": "Akropolis",
+        "symbol": "AKRO",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x8Ab7404063Ec4DBcfd4598215992DC3F8EC853d7/logo.png"
+      },
+      {
+        "address": "0x2C537E5624e4af88A7ae4060C022609376C8D0EB",
+        "chainId": 1,
+        "name": "BiLira",
+        "symbol": "TRYB",
+        "decimals": 6,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x2C537E5624e4af88A7ae4060C022609376C8D0EB/logo.png"
+      },
+      {
+        "address": "0x26E75307Fc0C021472fEb8F727839531F112f317",
+        "chainId": 1,
+        "name": "Crypto20",
+        "symbol": "C20",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x26E75307Fc0C021472fEb8F727839531F112f317/logo.png"
+      },
+      {
+        "address": "0xfF20817765cB7f73d4bde2e66e067E58D11095C2",
+        "chainId": 1,
+        "name": "Amp",
+        "symbol": "AMP",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xfF20817765cB7f73d4bde2e66e067E58D11095C2/logo.png"
+      },
+      {
+        "address": "0xaF1250fa68D7DECD34fD75dE8742Bc03B29BD58e",
+        "chainId": 1,
+        "name": "Invictus Hyperion",
+        "symbol": "IHF",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xaF1250fa68D7DECD34fD75dE8742Bc03B29BD58e/logo.png"
+      },
+      {
+        "address": "0x85Eee30c52B0b379b046Fb0F85F4f3Dc3009aFEC",
+        "chainId": 1,
+        "name": "KEEP Token",
+        "symbol": "KEEP",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x85Eee30c52B0b379b046Fb0F85F4f3Dc3009aFEC/logo.png"
+      },
+      {
+        "address": "0xDF2C7238198Ad8B389666574f2d8bc411A4b7428",
+        "chainId": 1,
+        "name": "Mainframe Token",
+        "symbol": "MFT",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xDF2C7238198Ad8B389666574f2d8bc411A4b7428/logo.png"
+      },
+      {
+        "address": "0x8207c1FfC5B6804F6024322CcF34F29c3541Ae26",
+        "chainId": 1,
+        "name": "OriginToken",
+        "symbol": "OGN",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x8207c1FfC5B6804F6024322CcF34F29c3541Ae26/logo.png"
+      },
+      {
+        "address": "0x9992eC3cF6A55b00978cdDF2b27BC6882d88D1eC",
+        "chainId": 1,
+        "name": "Polymath",
+        "symbol": "POLY",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x9992eC3cF6A55b00978cdDF2b27BC6882d88D1eC/logo.png"
+      },
+      {
+        "address": "0x6De037ef9aD2725EB40118Bb1702EBb27e4Aeb24",
+        "chainId": 1,
+        "name": "Render Token",
+        "symbol": "RNDR",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x6De037ef9aD2725EB40118Bb1702EBb27e4Aeb24/logo.png"
+      },
+      {
+        "address": "0xaAAf91D9b90dF800Df4F55c205fd6989c977E73a",
+        "chainId": 1,
+        "name": "Monolith TKN",
+        "symbol": "TKN",
+        "decimals": 8,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xaAAf91D9b90dF800Df4F55c205fd6989c977E73a/logo.png"
+      },
+      {
+        "address": "0x5Af2Be193a6ABCa9c8817001F45744777Db30756",
+        "chainId": 1,
+        "name": "Voyager",
+        "symbol": "VGX",
+        "decimals": 8,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x5Af2Be193a6ABCa9c8817001F45744777Db30756/logo.png"
+      },
+      {
+        "address": "0xbf70A33A13fBe8D0106Df321Da0Cf654d2E9Ab50",
+        "chainId": 1,
+        "name": "ETH/BTC RSI 70/30 Crossover",
+        "symbol": "ETHBTCRSI7030",
+        "decimals": 18
+      },
+      {
+        "address": "0x136faE4333EA36A24bb751E2d505D6ca4Fd9f00b",
+        "chainId": 1,
+        "name": "ETH RSI 60/40 Yield",
+        "symbol": "ETHRSIAPY",
+        "decimals": 18
+      },
+      {
+        "address": "0xbF4a2DdaA16148a9D0fA2093FfAC450ADb7cd4aa",
+        "chainId": 1,
+        "name": "Ethereum Money",
+        "symbol": "ETHMNY",
+        "decimals": 2,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xbF4a2DdaA16148a9D0fA2093FfAC450ADb7cd4aa/logo.png"
+      },
+      {
+        "address": "0x9f49ed43C90A540d1cF12f6170aCE8d0B88a14E6",
+        "chainId": 1,
+        "name": "ETH RSI 60/40 Yield II",
+        "symbol": "ETHRSIAPY",
+        "decimals": 18
+      },
+      {
+        "address": "0xC7D79021CD127A2f35b1E26fe3c4aAD67f5c28b8",
+        "chainId": 1,
+        "name": "100 Waves",
+        "symbol": "100W",
+        "decimals": 18
+      },
+      {
+        "address": "0x54355Ae0485F9420e6cE4c00C10172dc8E5728A3",
+        "chainId": 1,
+        "name": "100 Waves ETH/USD Ether Hoard",
+        "symbol": "100WETH",
+        "decimals": 18
+      },
+      {
+        "address": "0x07509c281B55A1675D3f71F1c4ab67829eb731d3",
+        "chainId": 1,
+        "name": "100 Waves ETH/BTC Set",
+        "symbol": "100WRatio",
+        "decimals": 18
+      },
+      {
+        "address": "0x0BF54992649C19bd8Db4080078a32383827352f3",
+        "chainId": 1,
+        "name": "Asian ETH Sentiment Set",
+        "symbol": "ASETH",
+        "decimals": 18
+      },
+      {
+        "address": "0x58723C7Afcd33A2Db6Ae06C37521725D65F0cC15",
+        "chainId": 1,
+        "name": "BullBearBitcoin Set II",
+        "symbol": "BBB",
+        "decimals": 18
+      },
+      {
+        "address": "0xF43B2f981eFC5a611a97951Ce4fd7d3Bd87f4902",
+        "chainId": 1,
+        "name": "BullBearEthereum Set II",
+        "symbol": "BBE",
+        "decimals": 18
+      },
+      {
+        "address": "0x48ac44f4E29e602f851B84C271c22B85B9447251",
+        "chainId": 1,
+        "name": "Bitcoin High Yield Set",
+        "symbol": "BHY",
+        "decimals": 18
+      },
+      {
+        "address": "0xc7088fAc73c55bfaE5c2A963C3029B072c7dfF25",
+        "chainId": 1,
+        "name": "BTC AI Limit Loss",
+        "symbol": "BLL",
+        "decimals": 18
+      },
+      {
+        "address": "0xe6404a4472E5222b440F8faFb795553046000841",
+        "chainId": 1,
+        "name": "BTC Long-Only Alpha Portfolio",
+        "symbol": "BLOAP",
+        "decimals": 18
+      },
+      {
+        "address": "0xc39835d32428728cbDe6903f84c76750976C0323",
+        "chainId": 1,
+        "name": "BTC OnChain Beta Portfolio",
+        "symbol": "BOCBP",
+        "decimals": 18
+      },
+      {
+        "address": "0x8abf3a95862619A55fA00CB3e4eeDBe113ff468C",
+        "chainId": 1,
+        "name": "Money Printer Go Brrr",
+        "symbol": "BRRR",
+        "decimals": 18
+      },
+      {
+        "address": "0x2409D6059e2A8130c099e49F3cb418fd6C3d9AFf",
+        "chainId": 1,
+        "name": "BTC Fund Active Trading Set",
+        "symbol": "BTCFUND",
+        "decimals": 18
+      },
+      {
+        "address": "0xd218D75BA0fC45858a4E9EF57A257Ed9977dB5f4",
+        "chainId": 1,
+        "name": "BTC TA Set",
+        "symbol": "BTCTA",
+        "decimals": 18
+      },
+      {
+        "address": "0xAC8Ea871e2d5F4Be618905F36f73c760f8cFDC8E",
+        "chainId": 1,
+        "name": "BTC Network Demand Set",
+        "symbol": "BYTE",
+        "decimals": 18
+      },
+      {
+        "address": "0x19F4a2f8E21915376F1429C26a3A9B9b1db5FF5A",
+        "chainId": 1,
+        "name": "Chad Link Set",
+        "symbol": "CHADLINK",
+        "decimals": 18
+      },
+      {
+        "address": "0xBddD682E63dd9f9fA3b97aEa88772E77cf3e5013",
+        "chainId": 1,
+        "name": "CoindicatorBTC Set",
+        "symbol": "COINBTC",
+        "decimals": 18
+      },
+      {
+        "address": "0x253444bd9ECf11E5516d6D00974e91c9F0857CCB",
+        "chainId": 1,
+        "name": "ETHBTC Long-Only Alpha Portfolio",
+        "symbol": "EBLOAP",
+        "decimals": 18
+      },
+      {
+        "address": "0x78481fB80CAabb252909218164266Ac83F815000",
+        "chainId": 1,
+        "name": "Ethereum High Yield Set",
+        "symbol": "EHY",
+        "decimals": 18
+      },
+      {
+        "address": "0x7E4d1Cd8927Ce41bcbfa4f32cADa1a6998cb5a51",
+        "chainId": 1,
+        "name": "ETH AI Limit Loss",
+        "symbol": "ELL",
+        "decimals": 18
+      },
+      {
+        "address": "0xC19216eea17b2f4DD677f1024CdA59C7D142F189",
+        "chainId": 1,
+        "name": "ETH Long-Only Alpha Portfolio",
+        "symbol": "ELOAP",
+        "decimals": 18
+      },
+      {
+        "address": "0x1003eC54F51565fF86Ac611184Ea23d6310CaE71",
+        "chainId": 1,
+        "name": "ETH Trending Alpha LT",
+        "symbol": "ETA",
+        "decimals": 18
+      },
+      {
+        "address": "0x856c4388C56c2a613c60507a4701af627157Fed6",
+        "chainId": 1,
+        "name": "ETH Trending Alpha ST Set",
+        "symbol": "ETAS",
+        "decimals": 18
+      },
+      {
+        "address": "0xAbC754aC2161B557D28062F41DcC0fc18440ac7E",
+        "chainId": 1,
+        "name": "ETH Maximalist Set",
+        "symbol": "ETH10K",
+        "decimals": 18
+      },
+      {
+        "address": "0x2c5a9980B41861D91D30d0E0271d1c093452DcA5",
+        "chainId": 1,
+        "name": "ETH 12 EMA Crossover Set",
+        "symbol": "ETH12EMACO",
+        "decimals": 18
+      },
+      {
+        "address": "0x9ea463Ec4cE9E9E5bc9cFd0187C4Ac3a70DD951D",
+        "chainId": 1,
+        "name": "ETH 20 SMA Crossover Set",
+        "symbol": "ETH20SMACO",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x9ea463Ec4cE9E9E5bc9cFd0187C4Ac3a70DD951D/logo.png"
+      },
+      {
+        "address": "0x614857C755739354d68AE0abD53849cf45d6A41D",
+        "chainId": 1,
+        "name": "ETH 26 EMA Crossover Set",
+        "symbol": "ETH26EMACO",
+        "decimals": 18
+      },
+      {
+        "address": "0xa360F2aF3F957906468c0FD7526391AeD08aE3DB",
+        "chainId": 1,
+        "name": "ETH 50 SMA Crossover Set",
+        "symbol": "ETH50SMACO",
+        "decimals": 18
+      },
+      {
+        "address": "0xB9FfE0b8Ee2d1Af94202FFED366520300748A4d8",
+        "chainId": 1,
+        "name": "ETH/BTC Ratio 26 EMA Crossover",
+        "symbol": "ETHBTC26EMACO",
+        "decimals": 18
+      },
+      {
+        "address": "0x1bcCA39aE82e53dede8eC5500c3BCd76Cd1e0072",
+        "chainId": 1,
+        "name": "ETH/BTC PA Candlestick",
+        "symbol": "ETHBTCPA",
+        "decimals": 18
+      },
+      {
+        "address": "0xa12a696B9B11788076A6cb384CAc6986b82545E1",
+        "chainId": 1,
+        "name": "ETH Super Set",
+        "symbol": "ETHDAIS",
+        "decimals": 18
+      },
+      {
+        "address": "0x54e8371C1EC43e58fB53D4ef4eD463C17Ba8a6bE",
+        "chainId": 1,
+        "name": "ETH 26 EMA Crossover Yield II",
+        "symbol": "ETHEMAAPY",
+        "decimals": 18
+      },
+      {
+        "address": "0xB647a1D7633c6C4d434e22eE9756b36F2b219525",
+        "chainId": 1,
+        "name": "ETH 20 MA Crossover Yield II",
+        "symbol": "ETHMACOAPY",
+        "decimals": 18
+      },
+      {
+        "address": "0x98A25bA4c3793B9029652cBc1a8875cBe223dF13",
+        "chainId": 1,
+        "name": "ETH Momentum Trigger Set",
+        "symbol": "ETHMO",
+        "decimals": 18
+      },
+      {
+        "address": "0xB1CA7E6714263a64659A3a89E1C313af30fD660A",
+        "chainId": 1,
+        "name": "ETH Moonshot X Yield Set",
+        "symbol": "ETHMOONX",
+        "decimals": 18
+      },
+      {
+        "address": "0x2Bf417FdA6E73B8Ea605DF0F33aD029F8d4b795A",
+        "chainId": 1,
+        "name": "ETH Moonshot X Disc Yield Set",
+        "symbol": "ETHMOONX2",
+        "decimals": 18
+      },
+      {
+        "address": "0x09E4BDFb273245063eF5E800D891eFF7d04f9B83",
+        "chainId": 1,
+        "name": "ETH Price Action Candlestick Set",
+        "symbol": "ETHPA",
+        "decimals": 18
+      },
+      {
+        "address": "0x93E01899c10532d76C0E864537a1D26433dBbDdB",
+        "chainId": 1,
+        "name": "ETH RSI 60/40 Crossover Set",
+        "symbol": "ETHRSI6040",
+        "decimals": 18
+      },
+      {
+        "address": "0x1Ce9200C98b6D9999B60bFf53860475A993a8b68",
+        "chainId": 1,
+        "name": "ETH TA Set",
+        "symbol": "ETHTA",
+        "decimals": 18
+      },
+      {
+        "address": "0xB8243B4eeca27A4191e879760b88fE2270561796",
+        "chainId": 1,
+        "name": "ETHUSD ADL 4H Set",
+        "symbol": "ETHUSDADL4",
+        "decimals": 18
+      },
+      {
+        "address": "0xffEE21B4Bb7084a9416205544101Ae9f472c7159",
+        "chainId": 1,
+        "name": "Fart Set",
+        "symbol": "FART",
+        "decimals": 18
+      },
+      {
+        "address": "0xCAE169AFDE69f297c7817ed5F4A6816C0E38137D",
+        "chainId": 1,
+        "name": "Flex BTC Set",
+        "symbol": "FLEXBTC",
+        "decimals": 18
+      },
+      {
+        "address": "0x654424F4b3ed6DE828C9CA30484dc1A626bb5fBA",
+        "chainId": 1,
+        "name": "Flex ETH Set",
+        "symbol": "FLEXETH",
+        "decimals": 18
+      },
+      {
+        "address": "0xdBf5c7D8ac5007667617a15DB2c1B1D616c9D302",
+        "chainId": 1,
+        "name": "FlexETH/BTC Set",
+        "symbol": "FLEXETHBTC",
+        "decimals": 18
+      },
+      {
+        "address": "0xF5c0E24ACA5217BcBAe662871caE1A86873F02db",
+        "chainId": 1,
+        "name": "Alligator + Fractal Set",
+        "symbol": "GATOR",
+        "decimals": 18
+      },
+      {
+        "address": "0x15822A64c8Cb27D7828C45E0aAFC3e6C5DeCd172",
+        "chainId": 1,
+        "name": "Fear & Greed Sentiment Set II",
+        "symbol": "GREED2",
+        "decimals": 18
+      },
+      {
+        "address": "0x5cD487CE4dB7091292F2E914F7B31445Bd4A5E1b",
+        "chainId": 1,
+        "name": "Inverse ETH 20 SMA Crossover",
+        "symbol": "iETH20SMACO",
+        "decimals": 18
+      },
+      {
+        "address": "0xAC1565e473F69FAdA09661A6B4103FBbF801CeEE",
+        "chainId": 1,
+        "name": "Inverse ETH 50 SMA Crossover",
+        "symbol": "iETH50SMACO",
+        "decimals": 18
+      },
+      {
+        "address": "0xB32c960c46f28059C2B5F1C3eCC2b9DD77aB0aA0",
+        "chainId": 1,
+        "name": "Intelligent BTC Set",
+        "symbol": "INTBTC",
+        "decimals": 18
+      },
+      {
+        "address": "0x89C0b027bD7cc2D17854B06F8322e29451192CE3",
+        "chainId": 1,
+        "name": "Intelligent ETH Set",
+        "symbol": "INTETH",
+        "decimals": 18
+      },
+      {
+        "address": "0xBA8Ea15b647F54D9ff849670FcaAcF35Df21A457",
+        "chainId": 1,
+        "name": "Intelligent Ratio Set",
+        "symbol": "INTRATIO",
+        "decimals": 18
+      },
+      {
+        "address": "0xC166F976ce9926A3205b145Af104eB0E4b38b5C0",
+        "chainId": 1,
+        "name": "LINK/ETH Growth Alpha Set",
+        "symbol": "LEGA",
+        "decimals": 18
+      },
+      {
+        "address": "0x8a63bE90F095F6777be3Ed25D9fC7CD2a63DDb30",
+        "chainId": 1,
+        "name": "Long-Only Alpha Portfolio",
+        "symbol": "LELOAP",
+        "decimals": 18
+      },
+      {
+        "address": "0x542156d51D10Db5acCB99f9Db7e7C91B74E80a2c",
+        "chainId": 1,
+        "name": "ETH/LINK PA Candlestick Set",
+        "symbol": "LINKETHPA",
+        "decimals": 18
+      },
+      {
+        "address": "0x8933ea1Ce67B946BdF2436cE860fFBb53Ce814d2",
+        "chainId": 1,
+        "name": "LINK/ETH RSI Ratio Trading",
+        "symbol": "LINKETHRSI",
+        "decimals": 18
+      },
+      {
+        "address": "0x78E29d35573beA6265aEDfCb9F45481B717EBFdE",
+        "chainId": 1,
+        "name": "LINK Profit Taker Set",
+        "symbol": "LINKPT",
+        "decimals": 18
+      },
+      {
+        "address": "0x0329d23fC7B1b1e6Cca57aFA3F0090F1189069e8",
+        "chainId": 1,
+        "name": "LINK RSI Crossover Set",
+        "symbol": "LINKRSICO",
+        "decimals": 18
+      },
+      {
+        "address": "0x621E3b71D07b51242bcca167928e184235A4bb87",
+        "chainId": 1,
+        "name": "Mountains and Valleys ETH/BTC",
+        "symbol": "MAVC",
+        "decimals": 18
+      },
+      {
+        "address": "0x57e83505827788c9F92bCfd398A51A7b0C83DD8e",
+        "chainId": 1,
+        "name": "Chainlink Trading Set",
+        "symbol": "CTS",
+        "decimals": 18
+      },
+      {
+        "address": "0x924E26fEe8E10c20726006CC2Bd307A538B0eBE5",
+        "chainId": 1,
+        "name": "BTC RSI Crossover Yield Set",
+        "symbol": "BTCRSIAPY",
+        "decimals": 18
+      },
+      {
+        "address": "0x77b1465b0e01ba085e515324e30fEe6555C623EA",
+        "chainId": 1,
+        "name": "Set of Sets Trailblazer Fund",
+        "symbol": "MQSS",
+        "decimals": 18
+      },
+      {
+        "address": "0x7510D6fac98A6eCa2DB7c9357619715a7f5049d4",
+        "chainId": 1,
+        "name": "Holistic BTC Set",
+        "symbol": "TCapBTCUSDC",
+        "decimals": 18
+      },
+      {
+        "address": "0x8e4dBF540Bf814c044785218B58C930B20a56BE1",
+        "chainId": 1,
+        "name": "Holistic ETH",
+        "symbol": "TCapETHDAI",
+        "decimals": 18
+      },
+      {
+        "address": "0x8DDF05C42C698329053c4F39B5bb05A350fd8132",
+        "chainId": 1,
+        "name": "ETH Smart Beta Set",
+        "symbol": "ETHSB",
+        "decimals": 18
+      },
+      {
+        "address": "0xbE9375C6a420D2eEB258962efB95551A5b722803",
+        "chainId": 1,
+        "name": "StormX",
+        "symbol": "STMX",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xbE9375C6a420D2eEB258962efB95551A5b722803/logo.png"
+      },
+      {
+        "address": "0x3505F494c3f0fed0B594E01Fa41Dd3967645ca39",
+        "chainId": 1,
+        "name": "SWARM",
+        "symbol": "SWM",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x3505F494c3f0fed0B594E01Fa41Dd3967645ca39/logo.png"
+      },
+      {
+        "address": "0x0C6f5F7D555E7518f6841a79436BD2b1Eef03381",
+        "chainId": 1,
+        "name": "CocosToken",
+        "symbol": "COCOS",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x0C6f5F7D555E7518f6841a79436BD2b1Eef03381/logo.png"
+      },
+      {
+        "address": "0x0A913beaD80F321E7Ac35285Ee10d9d922659cB7",
+        "chainId": 1,
+        "name": "DOS Network Token",
+        "symbol": "DOS",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x0A913beaD80F321E7Ac35285Ee10d9d922659cB7/logo.png"
+      },
+      {
+        "address": "0x255Aa6DF07540Cb5d3d297f0D0D4D84cb52bc8e6",
+        "chainId": 1,
+        "name": "Raiden Token",
+        "symbol": "RDN",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x255Aa6DF07540Cb5d3d297f0D0D4D84cb52bc8e6/logo.png"
+      },
+      {
+        "address": "0x08d967bb0134F2d07f7cfb6E246680c53927DD30",
+        "chainId": 1,
+        "name": "MATH Token",
+        "symbol": "MATH",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x08d967bb0134F2d07f7cfb6E246680c53927DD30/logo.png"
+      },
+      {
+        "address": "0x56d811088235F11C8920698a204A5010a788f4b3",
+        "chainId": 1,
+        "name": "bZx Protocol Token",
+        "symbol": "BZRX",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x56d811088235F11C8920698a204A5010a788f4b3/logo.png"
+      },
+      {
+        "address": "0x940a2dB1B7008B6C776d4faaCa729d6d4A4AA551",
+        "chainId": 1,
+        "name": "Dusk Network",
+        "symbol": "DUSK",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x940a2dB1B7008B6C776d4faaCa729d6d4A4AA551/logo.png"
+      },
+      {
+        "address": "0x4FbB350052Bca5417566f188eB2EBCE5b19BC964",
+        "chainId": 1,
+        "name": "Rigo Token",
+        "symbol": "GRG",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x4FbB350052Bca5417566f188eB2EBCE5b19BC964/logo.png"
+      },
+      {
+        "address": "0x4e352cF164E64ADCBad318C3a1e222E9EBa4Ce42",
+        "chainId": 1,
+        "name": "MCDEX Token",
+        "symbol": "MCB",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x4e352cF164E64ADCBad318C3a1e222E9EBa4Ce42/logo.png"
+      },
+      {
+        "address": "0xa3BeD4E1c75D00fa6f4E5E6922DB7261B5E9AcD2",
+        "chainId": 1,
+        "name": "Meta",
+        "symbol": "MTA",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xa3BeD4E1c75D00fa6f4E5E6922DB7261B5E9AcD2/logo.png"
+      },
+      {
+        "address": "0xd341d1680Eeee3255b8C4c75bCCE7EB57f144dAe",
+        "chainId": 1,
+        "name": "onG",
+        "symbol": "ONG",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xd341d1680Eeee3255b8C4c75bCCE7EB57f144dAe/logo.png"
+      },
+      {
+        "address": "0xFca59Cd816aB1eaD66534D82bc21E7515cE441CF",
+        "chainId": 1,
+        "name": "Rarible",
+        "symbol": "RARI",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xFca59Cd816aB1eaD66534D82bc21E7515cE441CF/logo.png"
+      },
+      {
+        "address": "0xCC4304A31d09258b0029eA7FE63d032f52e44EFe",
+        "chainId": 1,
+        "name": "TrustSwap Token",
+        "symbol": "SWAP",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xCC4304A31d09258b0029eA7FE63d032f52e44EFe/logo.png"
+      },
+      {
+        "address": "0xB6eD7644C69416d67B522e20bC294A9a9B405B31",
+        "chainId": 1,
+        "name": "0xBitcoin Token",
+        "symbol": "0xBTC",
+        "decimals": 8,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xB6eD7644C69416d67B522e20bC294A9a9B405B31/logo.png"
+      },
+      {
+        "address": "0x035dF12E0F3ac6671126525f1015E47D79dFEDDF",
+        "chainId": 1,
+        "name": "0xMonero",
+        "symbol": "0xMR",
+        "decimals": 18
+      },
+      {
+        "address": "0x1a7a8BD9106F2B8D977E08582DC7d24c723ab0DB",
+        "chainId": 1,
+        "name": "AppCoins",
+        "symbol": "APPC",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x1a7a8BD9106F2B8D977E08582DC7d24c723ab0DB/logo.png"
+      },
+      {
+        "address": "0xfc05987bd2be489ACCF0f509E44B0145d68240f7",
+        "chainId": 1,
+        "name": "ESSENTIA",
+        "symbol": "ESS",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xfc05987bd2be489ACCF0f509E44B0145d68240f7/logo.png"
+      },
+      {
+        "address": "0xdF5e0e81Dff6FAF3A7e52BA697820c5e32D806A8",
+        "chainId": 1,
+        "name": "Curve.fi Y Pool Token",
+        "symbol": "yCRV",
+        "decimals": 18
+      },
+      {
+        "address": "0x81ab848898b5ffD3354dbbEfb333D5D183eEDcB5",
+        "chainId": 1,
+        "name": "yUSD Synthetic Token Expiring 1 September 2020",
+        "symbol": "yUSD-SEP20",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/balancer-labs/assets/master/assets/0x81ab848898b5ffd3354dbbefb333d5d183eedcb5.png"
+      },
+      {
+        "address": "0x27702a26126e0B3702af63Ee09aC4d1A084EF628",
+        "chainId": 1,
+        "name": "aleph.im v2",
+        "symbol": "ALEPH",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x27702a26126e0B3702af63Ee09aC4d1A084EF628/logo.png"
+      },
+      {
+        "address": "0xBA50933C268F567BDC86E1aC131BE072C6B0b71a",
+        "chainId": 1,
+        "name": "ARPA Token",
+        "symbol": "ARPA",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xBA50933C268F567BDC86E1aC131BE072C6B0b71a/logo.png"
+      },
+      {
+        "address": "0x34612903Db071e888a4dADcaA416d3EE263a87b9",
+        "chainId": 1,
+        "name": "ethart",
+        "symbol": "arte",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x34612903Db071e888a4dADcaA416d3EE263a87b9/logo.png"
+      },
+      {
+        "address": "0x954b890704693af242613edEf1B603825afcD708",
+        "chainId": 1,
+        "name": "Cardstack",
+        "symbol": "CARD",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x954b890704693af242613edEf1B603825afcD708/logo.png"
+      },
+      {
+        "address": "0x13339fD07934CD674269726EdF3B5ccEE9DD93de",
+        "chainId": 1,
+        "name": "CurToken",
+        "symbol": "CUR",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x13339fD07934CD674269726EdF3B5ccEE9DD93de/logo.png"
+      },
+      {
+        "address": "0xCc80C051057B774cD75067Dc48f8987C4Eb97A5e",
+        "chainId": 1,
+        "name": "Ethfinex Nectar Token",
+        "symbol": "NEC",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xCc80C051057B774cD75067Dc48f8987C4Eb97A5e/logo.png"
+      },
+      {
+        "address": "0x12f649A9E821F90BB143089a6e56846945892ffB",
+        "chainId": 1,
+        "name": "uDOO",
+        "symbol": "uDOO",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x12f649A9E821F90BB143089a6e56846945892ffB/logo.png"
+      },
+      {
+        "address": "0xaD6A626aE2B43DCb1B39430Ce496d2FA0365BA9C",
+        "chainId": 1,
+        "name": "PieDAO DEFI Small Cap",
+        "symbol": "DEFI+S",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/balancer-labs/assets/master/assets/0xad6a626ae2b43dcb1b39430ce496d2fa0365ba9c.png"
+      },
+      {
+        "address": "0x221657776846890989a759BA2973e427DfF5C9bB",
+        "chainId": 1,
+        "name": "Reputation",
+        "symbol": "REPv2",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x221657776846890989a759BA2973e427DfF5C9bB/logo.png"
+      },
+      {
+        "address": "0x476c5E26a75bd202a9683ffD34359C0CC15be0fF",
+        "chainId": 1,
+        "name": "Serum",
+        "symbol": "SRM",
+        "decimals": 6,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x476c5E26a75bd202a9683ffD34359C0CC15be0fF/logo.png"
+      },
+      {
+        "address": "0xD533a949740bb3306d119CC777fa900bA034cd52",
+        "chainId": 1,
+        "name": "Curve DAO Token",
+        "symbol": "CRV",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xD533a949740bb3306d119CC777fa900bA034cd52/logo.png"
+      },
+      {
+        "address": "0x84cA8bc7997272c7CfB4D0Cd3D55cd942B3c9419",
+        "chainId": 1,
+        "name": "DIAToken",
+        "symbol": "DIA",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x84cA8bc7997272c7CfB4D0Cd3D55cd942B3c9419/logo.png"
+      },
+      {
+        "address": "0x6fe56C0bcdD471359019FcBC48863d6c3e9d4F41",
+        "chainId": 1,
+        "name": "Props Token",
+        "symbol": "PROPS",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x6fe56C0bcdD471359019FcBC48863d6c3e9d4F41/logo.png"
+      },
+      {
+        "address": "0x40FD72257597aA14C7231A7B1aaa29Fce868F677",
+        "chainId": 1,
+        "name": "Sora Token",
+        "symbol": "XOR",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x40FD72257597aA14C7231A7B1aaa29Fce868F677/logo.png"
+      },
+      {
+        "address": "0xBA11D00c5f74255f56a5E366F4F77f5A186d7f55",
+        "chainId": 1,
+        "name": "BandToken",
+        "symbol": "BAND",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xBA11D00c5f74255f56a5E366F4F77f5A186d7f55/logo.png"
+      },
+      {
+        "address": "0xF80D589b3Dbe130c270a69F1a69D050f268786Df",
+        "chainId": 1,
+        "name": "Datamine",
+        "symbol": "DAM",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xF80D589b3Dbe130c270a69F1a69D050f268786Df/logo.png"
+      },
+      {
+        "address": "0x29E9fDF5933824ad21Bc6dbb8BF156EFA3735e32",
+        "chainId": 1,
+        "name": "Meter Stable mapped by Meter.io",
+        "symbol": "eMTR",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x29E9fDF5933824ad21Bc6dbb8BF156EFA3735e32/logo.png"
+      },
+      {
+        "address": "0xBd2949F67DcdC549c6Ebe98696449Fa79D988A9F",
+        "chainId": 1,
+        "name": "Meter Governance mapped by Meter.io",
+        "symbol": "eMTRG",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xBd2949F67DcdC549c6Ebe98696449Fa79D988A9F/logo.png"
+      },
+      {
+        "address": "0x89E3aC6Dd69C15e9223BE7649025d6F68Dab1d6a",
+        "chainId": 1,
+        "name": "EVAN",
+        "symbol": "EVAN",
+        "decimals": 18
+      },
+      {
+        "address": "0x469eDA64aEd3A3Ad6f868c44564291aA415cB1d9",
+        "chainId": 1,
+        "name": "FLUX",
+        "symbol": "FLUX",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x469eDA64aEd3A3Ad6f868c44564291aA415cB1d9/logo.png"
+      },
+      {
+        "address": "0xb83Cd8d39462B761bb0092437d38b37812dd80A2",
+        "chainId": 1,
+        "name": "GoldenRatio",
+        "symbol": "GRT",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xb83Cd8d39462B761bb0092437d38b37812dd80A2/logo.png"
+      },
+      {
+        "address": "0x95172ccBe8344fecD73D0a30F54123652981BD6F",
+        "chainId": 1,
+        "name": "Meridian Network",
+        "symbol": "LOCK",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x95172ccBe8344fecD73D0a30F54123652981BD6F/logo.png"
+      },
+      {
+        "address": "0x3166C570935a7D8554c8f4eA792ff965D2EFe1f2",
+        "chainId": 1,
+        "name": "Q DAO Governance token v1.0",
+        "symbol": "QDAO",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x3166C570935a7D8554c8f4eA792ff965D2EFe1f2/logo.png"
+      },
+      {
+        "address": "0x89d24A6b4CcB1B6fAA2625fE562bDD9a23260359",
+        "chainId": 1,
+        "name": "Sai Stablecoin v1.0",
+        "symbol": "SAI",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x89d24A6b4CcB1B6fAA2625fE562bDD9a23260359/logo.png"
+      },
+      {
+        "address": "0x5299d6F7472DCc137D7f3C4BcfBBB514BaBF341A",
+        "chainId": 1,
+        "name": "Synth sXMR",
+        "symbol": "sXMR",
+        "decimals": 18
+      },
+      {
+        "address": "0x8CE9137d39326AD0cD6491fb5CC0CbA0e089b6A9",
+        "chainId": 1,
+        "name": "Swipe",
+        "symbol": "SXP",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x8CE9137d39326AD0cD6491fb5CC0CbA0e089b6A9/logo.png"
+      },
+      {
+        "address": "0x1453Dbb8A29551ADe11D89825CA812e05317EAEB",
+        "chainId": 1,
+        "name": "Tendies Token",
+        "symbol": "TEND",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x1453Dbb8A29551ADe11D89825CA812e05317EAEB/logo.png"
+      },
+      {
+        "address": "0x4954Db6391F4feB5468b6B943D4935353596aEC9",
+        "chainId": 1,
+        "name": "USDQ Stablecoin by Q DAO v1.0",
+        "symbol": "USDQ",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x4954Db6391F4feB5468b6B943D4935353596aEC9/logo.png"
+      },
+      {
+        "address": "0x6b785a0322126826d8226d77e173d75DAfb84d11",
+        "chainId": 1,
+        "name": "Bankroll Vault",
+        "symbol": "VLT",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x6b785a0322126826d8226d77e173d75DAfb84d11/logo.png"
+      },
+      {
+        "address": "0xAba8cAc6866B83Ae4eec97DD07ED254282f6aD8A",
+        "chainId": 1,
+        "name": "YAMv2",
+        "symbol": "YAMv2",
+        "decimals": 24
+      },
+      {
+        "address": "0xa1d0E215a23d7030842FC67cE582a6aFa3CCaB83",
+        "chainId": 1,
+        "name": "YFII.finance",
+        "symbol": "YFII",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xa1d0E215a23d7030842FC67cE582a6aFa3CCaB83/logo.png"
+      },
+      {
+        "address": "0xeca82185adCE47f39c684352B0439f030f860318",
+        "chainId": 1,
+        "name": "Perlin",
+        "symbol": "PERL",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xeca82185adCE47f39c684352B0439f030f860318/logo.png"
+      },
+      {
+        "address": "0x2ba592F78dB6436527729929AAf6c908497cB200",
+        "chainId": 1,
+        "name": "Cream",
+        "symbol": "CREAM",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x2ba592F78dB6436527729929AAf6c908497cB200/logo.png"
+      },
+      {
+        "address": "0x26E43759551333e57F073bb0772F50329A957b30",
+        "chainId": 1,
+        "name": "DegenVC",
+        "symbol": "DGVC",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x26E43759551333e57F073bb0772F50329A957b30/logo.png"
+      },
+      {
+        "address": "0x4730fB1463A6F1F44AEB45F6c5c422427f37F4D0",
+        "chainId": 1,
+        "name": "The 4th Pillar Token",
+        "symbol": "FOUR",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x4730fB1463A6F1F44AEB45F6c5c422427f37F4D0/logo.png"
+      },
+      {
+        "address": "0xDcfE18bc46f5A0Cd0d3Af0c2155d2bCB5AdE2fc5",
+        "chainId": 1,
+        "name": "Hue",
+        "symbol": "HUE",
+        "decimals": 4,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xDcfE18bc46f5A0Cd0d3Af0c2155d2bCB5AdE2fc5/logo.png"
+      },
+      {
+        "address": "0x0a50C93c762fDD6E56D86215C24AaAD43aB629aa",
+        "chainId": 1,
+        "name": "LGO Token",
+        "symbol": "LGO",
+        "decimals": 8,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x0a50C93c762fDD6E56D86215C24AaAD43aB629aa/logo.png"
+      },
+      {
+        "address": "0xa3d58c4E56fedCae3a7c43A725aeE9A71F0ece4e",
+        "chainId": 1,
+        "name": "Metronome",
+        "symbol": "MET",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xa3d58c4E56fedCae3a7c43A725aeE9A71F0ece4e/logo.png"
+      },
+      {
+        "address": "0x7865af71cf0b288b4E7F654f4F7851EB46a2B7F8",
+        "chainId": 1,
+        "name": "Sentivate",
+        "symbol": "SNTVT",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x7865af71cf0b288b4E7F654f4F7851EB46a2B7F8/logo.png"
+      },
+      {
+        "address": "0x9E78b8274e1D6a76a0dBbf90418894DF27cBCEb5",
+        "chainId": 1,
+        "name": "UniFi",
+        "symbol": "UniFi",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x9E78b8274e1D6a76a0dBbf90418894DF27cBCEb5/logo.png"
+      },
+      {
+        "address": "0xB2279B6769CFBa691416F00609b16244c0cF4b20",
+        "chainId": 1,
+        "name": "Waifu",
+        "symbol": "WAIF",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xB2279B6769CFBa691416F00609b16244c0cF4b20/logo.png"
+      },
+      {
+        "address": "0x45f24BaEef268BB6d63AEe5129015d69702BCDfa",
+        "chainId": 1,
+        "name": "YFValue",
+        "symbol": "YFV",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x45f24BaEef268BB6d63AEe5129015d69702BCDfa/logo.png"
+      },
+      {
+        "address": "0xB2FdD60AD80ca7bA89B9BAb3b5336c2601C020b4",
+        "chainId": 1,
+        "name": "yUSD Synthetic Token Expiring 1 October 2020",
+        "symbol": "yUSD-OCT20",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/balancer-labs/assets/master/assets/0xb2fdd60ad80ca7ba89b9bab3b5336c2601c020b4.png"
+      },
+      {
+        "address": "0x5dbcF33D8c2E976c6b560249878e6F1491Bca25c",
+        "chainId": 1,
+        "name": "yearn Curve.fi yDAI/yUSDC/yUSDT/yTUSD",
+        "symbol": "yyDAI+yUSDC+yUSDT+yTUSD",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x5dbcF33D8c2E976c6b560249878e6F1491Bca25c/logo.png"
+      },
+      {
+        "address": "0x94d863173EE77439E4292284fF13fAD54b3BA182",
+        "chainId": 1,
+        "name": "Akropolis Delphi",
+        "symbol": "ADEL",
+        "decimals": 18
+      },
+      {
+        "address": "0x8BA6DcC667d3FF64C1A2123cE72FF5F0199E5315",
+        "chainId": 1,
+        "name": "AlexMasmej",
+        "symbol": "ALEX",
+        "decimals": 4,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x8BA6DcC667d3FF64C1A2123cE72FF5F0199E5315/logo.png"
+      },
+      {
+        "address": "0xbBe319b73744dB9d54F5D29df7D8256B7e43995C",
+        "chainId": 1,
+        "name": "Aragon China Token",
+        "symbol": "ANC",
+        "decimals": 18
+      },
+      {
+        "address": "0x4F9254C83EB525f9FCf346490bbb3ed28a81C667",
+        "chainId": 1,
+        "name": "CelerToken",
+        "symbol": "CELR",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x4F9254C83EB525f9FCf346490bbb3ed28a81C667/logo.png"
+      },
+      {
+        "address": "0x38e4adB44ef08F22F5B5b76A8f0c2d0dCbE7DcA1",
+        "chainId": 1,
+        "name": "Concentrated Voting Power",
+        "symbol": "CVP",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x38e4adB44ef08F22F5B5b76A8f0c2d0dCbE7DcA1/logo.png"
+      },
+      {
+        "address": "0xa0246c9032bC3A600820415aE600c6388619A14D",
+        "chainId": 1,
+        "name": "FARM Reward Token",
+        "symbol": "FARM",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xa0246c9032bC3A600820415aE600c6388619A14D/logo.png"
+      },
+      {
+        "address": "0xaea46A60368A7bD060eec7DF8CBa43b7EF41Ad85",
+        "chainId": 1,
+        "name": "Fetch",
+        "symbol": "FET",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xaea46A60368A7bD060eec7DF8CBa43b7EF41Ad85/logo.png"
+      },
+      {
+        "address": "0x916885426255235DA7a0BD90447986c00675f9EC",
+        "chainId": 1,
+        "name": "GoalTime N",
+        "symbol": "GTX",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x916885426255235DA7a0BD90447986c00675f9EC/logo.png"
+      },
+      {
+        "address": "0xD5525D397898e5502075Ea5E830d8914f6F0affe",
+        "chainId": 1,
+        "name": "MEME",
+        "symbol": "MEME",
+        "decimals": 8,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xD5525D397898e5502075Ea5E830d8914f6F0affe/logo.png"
+      },
+      {
+        "address": "0x8a6f3BF52A26a21531514E23016eEAe8Ba7e7018",
+        "chainId": 1,
+        "name": "Multiplier",
+        "symbol": "MXX",
+        "decimals": 8,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x8a6f3BF52A26a21531514E23016eEAe8Ba7e7018/logo.png"
+      },
+      {
+        "address": "0xc813EA5e3b48BEbeedb796ab42A30C5599b01740",
+        "chainId": 1,
+        "name": "Autonio",
+        "symbol": "NIOX",
+        "decimals": 4,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xc813EA5e3b48BEbeedb796ab42A30C5599b01740/logo.png"
+      },
+      {
+        "address": "0xbC396689893D065F41bc2C6EcbeE5e0085233447",
+        "chainId": 1,
+        "name": "Perpetual",
+        "symbol": "PERP",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xbC396689893D065F41bc2C6EcbeE5e0085233447/logo.png"
+      },
+      {
+        "address": "0x557B933a7C2c45672B610F8954A3deB39a51A8Ca",
+        "chainId": 1,
+        "name": "REVV",
+        "symbol": "REVV",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x557B933a7C2c45672B610F8954A3deB39a51A8Ca/logo.png"
+      },
+      {
+        "address": "0x6B3595068778DD592e39A122f4f5a5cF09C90fE2",
+        "chainId": 1,
+        "name": "SushiToken",
+        "symbol": "SUSHI",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x6B3595068778DD592e39A122f4f5a5cF09C90fE2/logo.png"
+      },
+      {
+        "address": "0xB8BAa0e4287890a5F79863aB62b7F175ceCbD433",
+        "chainId": 1,
+        "name": "Swerve DAO Token",
+        "symbol": "SWRV",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xB8BAa0e4287890a5F79863aB62b7F175ceCbD433/logo.png"
+      },
+      {
+        "address": "0x00D1793D7C3aAE506257Ba985b34C76AaF642557",
+        "chainId": 1,
+        "name": "Tacos",
+        "symbol": "TACO",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x00D1793D7C3aAE506257Ba985b34C76AaF642557/logo.png"
+      },
+      {
+        "address": "0x208D174775dc39fe18B1b374972F77ddEc6c0F73",
+        "chainId": 1,
+        "name": "uUSDrBTC Synthetic Token Expiring 1 October 2020",
+        "symbol": "uUSDrBTC-OCT",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/balancer-labs/assets/master/assets/0x208d174775dc39fe18b1b374972f77ddec6c0f73.png"
+      },
+      {
+        "address": "0xCee1d3c3A02267e37E6B373060F79d5d7b9e1669",
+        "chainId": 1,
+        "name": "yffi.finance",
+        "symbol": "YFFI",
+        "decimals": 18
+      },
+      {
+        "address": "0x28cb7e841ee97947a86B06fA4090C8451f64c0be",
+        "chainId": 1,
+        "name": "YFLink",
+        "symbol": "YFL",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x28cb7e841ee97947a86B06fA4090C8451f64c0be/logo.png"
+      },
+      {
+        "address": "0x3e780920601D61cEdb860fe9c4a90c9EA6A35E78",
+        "chainId": 1,
+        "name": "Boosted Finance",
+        "symbol": "BOOST",
+        "decimals": 18
+      },
+      {
+        "address": "0x0cf58006B2400ebec3eB8C05b73170138a340563",
+        "chainId": 1,
+        "name": "Good Boy Points",
+        "symbol": "GBP",
+        "decimals": 18
+      },
+      {
+        "address": "0x09e64c2B61a5f1690Ee6fbeD9baf5D6990F8dFd0",
+        "chainId": 1,
+        "name": "Growth",
+        "symbol": "GRO",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x09e64c2B61a5f1690Ee6fbeD9baf5D6990F8dFd0/logo.png"
+      },
+      {
+        "address": "0x0E29e5AbbB5FD88e28b2d355774e73BD47dE3bcd",
+        "chainId": 1,
+        "name": "Hakka Finance",
+        "symbol": "HAKKA",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x0E29e5AbbB5FD88e28b2d355774e73BD47dE3bcd/logo.png"
+      },
+      {
+        "address": "0xa8c8CfB141A3bB59FEA1E2ea6B79b5ECBCD7b6ca",
+        "chainId": 1,
+        "name": "NOIA Token",
+        "symbol": "NOIA",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xa8c8CfB141A3bB59FEA1E2ea6B79b5ECBCD7b6ca/logo.png"
+      },
+      {
+        "address": "0x429881672B9AE42b8EbA0E26cD9C73711b891Ca5",
+        "chainId": 1,
+        "name": "PickleToken",
+        "symbol": "PICKLE",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x429881672B9AE42b8EbA0E26cD9C73711b891Ca5/logo.png"
+      },
+      {
+        "address": "0x4Fabb145d64652a948d72533023f6E7A623C7C53",
+        "chainId": 1,
+        "name": "Binance USD",
+        "symbol": "BUSD",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x4Fabb145d64652a948d72533023f6E7A623C7C53/logo.png"
+      },
+      {
+        "address": "0xca1207647Ff814039530D7d35df0e1Dd2e91Fa84",
+        "chainId": 1,
+        "name": "dHedge DAO Token",
+        "symbol": "DHT",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xca1207647Ff814039530D7d35df0e1Dd2e91Fa84/logo.png"
+      },
+      {
+        "address": "0x1494CA1F11D487c2bBe4543E90080AeBa4BA3C2b",
+        "chainId": 1,
+        "name": "DefiPulse Index",
+        "symbol": "DPI",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x1494CA1F11D487c2bBe4543E90080AeBa4BA3C2b/logo.png"
+      },
+      {
+        "address": "0x5BC25f649fc4e26069dDF4cF4010F9f706c23831",
+        "chainId": 1,
+        "name": "DefiDollar",
+        "symbol": "DUSD",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/balancer-labs/assets/master/assets/0x5bc25f649fc4e26069ddf4cf4010f9f706c23831.png"
+      },
+      {
+        "address": "0xf8C3527CC04340b208C854E985240c02F7B7793f",
+        "chainId": 1,
+        "name": "Frontier Token",
+        "symbol": "FRONT",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xf8C3527CC04340b208C854E985240c02F7B7793f/logo.png"
+      },
+      {
+        "address": "0x3F382DbD960E3a9bbCeaE22651E88158d2791550",
+        "chainId": 1,
+        "name": "Aavegotchi GHST Token",
+        "symbol": "GHST",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x3F382DbD960E3a9bbCeaE22651E88158d2791550/logo.png"
+      },
+      {
+        "address": "0x7968bc6a03017eA2de509AAA816F163Db0f35148",
+        "chainId": 1,
+        "name": "Hedget",
+        "symbol": "HGET",
+        "decimals": 6,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x7968bc6a03017eA2de509AAA816F163Db0f35148/logo.png"
+      },
+      {
+        "address": "0x3E9BC21C9b189C09dF3eF1B824798658d5011937",
+        "chainId": 1,
+        "name": "Linear Token",
+        "symbol": "LINA",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x3E9BC21C9b189C09dF3eF1B824798658d5011937/logo.png"
+      },
+      {
+        "address": "0x4D807509aECe24C0fa5A102b6a3B059Ec6E14392",
+        "chainId": 1,
+        "name": "Menlo One",
+        "symbol": "ONE",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x4D807509aECe24C0fa5A102b6a3B059Ec6E14392/logo.png"
+      },
+      {
+        "address": "0xbc16da9df0A22f01A16BC0620a27e7D6d6488550",
+        "chainId": 1,
+        "name": "Percent",
+        "symbol": "PCT",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xbc16da9df0A22f01A16BC0620a27e7D6d6488550/logo.png"
+      },
+      {
+        "address": "0xF2f9A7e93f845b3ce154EfbeB64fB9346FCCE509",
+        "chainId": 1,
+        "name": "UniPower",
+        "symbol": "POWER",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xF2f9A7e93f845b3ce154EfbeB64fB9346FCCE509/logo.png"
+      },
+      {
+        "address": "0x4688a8b1F292FDaB17E9a90c8Bc379dC1DBd8713",
+        "chainId": 1,
+        "name": "Cover Protocol Governance Token",
+        "symbol": "COVER",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/balancer-labs/assets/master/assets/0x4688a8b1f292fdab17e9a90c8bc379dc1dbd8713.png"
+      },
+      {
+        "address": "0x1f9840a85d5aF5bf1D1762F925BDADdC4201F984",
+        "chainId": 1,
+        "name": "Uniswap",
+        "symbol": "UNI",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x1f9840a85d5aF5bf1D1762F925BDADdC4201F984/logo.png"
+      },
+      {
+        "address": "0x54C9EA2E9C9E8eD865Db4A4ce6711C2a0d5063Ba",
+        "chainId": 1,
+        "name": "BarterTrade",
+        "symbol": "BART",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x54C9EA2E9C9E8eD865Db4A4ce6711C2a0d5063Ba/logo.png"
+      },
+      {
+        "address": "0xB81D70802a816B5DacBA06D708B5acF19DcD436D",
+        "chainId": 1,
+        "name": "Dextoken Governance",
+        "symbol": "DEXG",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xB81D70802a816B5DacBA06D708B5acF19DcD436D/logo.png"
+      },
+      {
+        "address": "0xad32A8e6220741182940c5aBF610bDE99E737b2D",
+        "chainId": 1,
+        "name": "PieDAO DOUGH v2",
+        "symbol": "DOUGH",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/balancer-labs/assets/master/assets/0xad32a8e6220741182940c5abf610bde99e737b2d.png"
+      },
+      {
+        "address": "0xbCa3C97837A39099eC3082DF97e28CE91BE14472",
+        "chainId": 1,
+        "name": "Distant Universe Stardust Token",
+        "symbol": "DUST",
+        "decimals": 8,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xbCa3C97837A39099eC3082DF97e28CE91BE14472/logo.png"
+      },
+      {
+        "address": "0x056Fd409E1d7A124BD7017459dFEa2F387b6d5Cd",
+        "chainId": 1,
+        "name": "Gemini dollar",
+        "symbol": "GUSD",
+        "decimals": 2,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x056Fd409E1d7A124BD7017459dFEa2F387b6d5Cd/logo.png"
+      },
+      {
+        "address": "0xDaFF85B6f5787b2d9eE11CCDf5e852816063326A",
+        "chainId": 1,
+        "name": "pxUSD Synthetic USD Expiring 1 November 2020",
+        "symbol": "pxUSD-OCT2020",
+        "decimals": 18
+      },
+      {
+        "address": "0x8a6ACA71A218301c7081d4e96D64292D3B275ce0",
+        "chainId": 1,
+        "name": "Stable Finance Governance Token",
+        "symbol": "SFG",
+        "decimals": 18
+      },
+      {
+        "address": "0x8dAEBADE922dF735c38C80C7eBD708Af50815fAa",
+        "chainId": 1,
+        "name": "tBTC",
+        "symbol": "TBTC",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x8dAEBADE922dF735c38C80C7eBD708Af50815fAa/logo.png"
+      },
+      {
+        "address": "0x467Bccd9d29f223BcE8043b84E8C8B282827790F",
+        "chainId": 1,
+        "name": "Telcoin",
+        "symbol": "TEL",
+        "decimals": 2,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x467Bccd9d29f223BcE8043b84E8C8B282827790F/logo.png"
+      },
+      {
+        "address": "0xF06DdacF71e2992E2122A1a0168C6967aFdf63ce",
+        "chainId": 1,
+        "name": "uUSDrBTC Synthetic Token Expiring 31 December 2020",
+        "symbol": "uUSDrBTC-DEC",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/balancer-labs/assets/master/assets/0xf06ddacf71e2992e2122a1a0168c6967afdf63ce.png"
+      },
+      {
+        "address": "0xD16c79c8A39D44B2F3eB45D2019cd6A42B03E2A9",
+        "chainId": 1,
+        "name": "uUSDwETH Synthetic Token Expiring 31 December 2020",
+        "symbol": "uUSDwETH-DEC",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/balancer-labs/assets/master/assets/0xd16c79c8a39d44b2f3eb45d2019cd6a42b03e2a9.png"
+      },
+      {
+        "address": "0x9355372396e3F6daF13359B7b607a3374cc638e0",
+        "chainId": 1,
+        "name": "WHALE",
+        "symbol": "WHALE",
+        "decimals": 4,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x9355372396e3F6daF13359B7b607a3374cc638e0/logo.png"
+      },
+      {
+        "address": "0xb052F8A33D8bb068414EaDE06AF6955199f9f010",
+        "chainId": 1,
+        "name": "EcoRealEstate",
+        "symbol": "ECOREAL",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xb052F8A33D8bb068414EaDE06AF6955199f9f010/logo.png"
+      },
+      {
+        "address": "0xf6537FE0df7F0Cc0985Cf00792CC98249E73EFa0",
+        "chainId": 1,
+        "name": "GIVToken",
+        "symbol": "GIV",
+        "decimals": 8,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xf6537FE0df7F0Cc0985Cf00792CC98249E73EFa0/logo.png"
+      },
+      {
+        "address": "0xDea67845A51E24461D5fED8084E69B426AF3D5Db",
+        "chainId": 1,
+        "name": "HodlTree",
+        "symbol": "HTRE",
+        "decimals": 18
+      },
+      {
+        "address": "0x2BF91c18Cd4AE9C2f2858ef9FE518180F7B5096D",
+        "chainId": 1,
+        "name": "KIWI Token",
+        "symbol": "KIWI",
+        "decimals": 8,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x2BF91c18Cd4AE9C2f2858ef9FE518180F7B5096D/logo.png"
+      },
+      {
+        "address": "0xfe5F141Bf94fE84bC28deD0AB966c16B17490657",
+        "chainId": 1,
+        "name": "LibraToken",
+        "symbol": "LBA",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xfe5F141Bf94fE84bC28deD0AB966c16B17490657/logo.png"
+      },
+      {
+        "address": "0x26cF82e4aE43D31eA51e72B663d26e26a75AF729",
+        "chainId": 1,
+        "name": "Moonbase",
+        "symbol": "mbBASED",
+        "decimals": 18
+      },
+      {
+        "address": "0x44Ea84a85616F8e9cD719Fc843DE31D852ad7240",
+        "chainId": 1,
+        "name": "NO Donald Trump",
+        "symbol": "nTrump",
+        "decimals": 15
+      },
+      {
+        "address": "0x459086F2376525BdCebA5bDDA135e4E9d3FeF5bf",
+        "chainId": 1,
+        "name": "renBCH",
+        "symbol": "renBCH",
+        "decimals": 8,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x459086F2376525BdCebA5bDDA135e4E9d3FeF5bf/logo.png"
+      },
+      {
+        "address": "0x1C5db575E2Ff833E46a2E9864C22F4B22E0B37C2",
+        "chainId": 1,
+        "name": "renZEC",
+        "symbol": "renZEC",
+        "decimals": 8,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x1C5db575E2Ff833E46a2E9864C22F4B22E0B37C2/logo.png"
+      },
+      {
+        "address": "0x7e8539D1E5cB91d63E46B8e188403b3f262a949B",
+        "chainId": 1,
+        "name": "SOMIDAX",
+        "symbol": "SMDX",
+        "decimals": 18
+      },
+      {
+        "address": "0xb1dC9124c395c1e97773ab855d66E879f053A289",
+        "chainId": 1,
+        "name": "yAxis",
+        "symbol": "YAX",
+        "decimals": 18
+      },
+      {
+        "address": "0x3af375d9f77Ddd4F16F86A5D51a9386b7B4493Fa",
+        "chainId": 1,
+        "name": "YES Donald Trump",
+        "symbol": "yTrump",
+        "decimals": 15
+      },
+      {
+        "address": "0xD46bA6D942050d489DBd938a2C909A5d5039A161",
+        "chainId": 1,
+        "name": "Ampleforth",
+        "symbol": "AMPL",
+        "decimals": 9,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xD46bA6D942050d489DBd938a2C909A5d5039A161/logo.png"
+      },
+      {
+        "address": "0xADE00C28244d5CE17D72E40330B1c318cD12B7c3",
+        "chainId": 1,
+        "name": "AdEx Network",
+        "symbol": "ADX",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xADE00C28244d5CE17D72E40330B1c318cD12B7c3/logo.png"
+      },
+      {
+        "address": "0x78F225869c08d478c34e5f645d07A87d3fe8eb78",
+        "chainId": 1,
+        "name": "PieDAO DEFI Large Cap",
+        "symbol": "DEFI+L",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/balancer-labs/assets/master/assets/0x78f225869c08d478c34e5f645d07a87d3fe8eb78.png"
+      },
+      {
+        "address": "0x50D1c9771902476076eCFc8B2A83Ad6b9355a4c9",
+        "chainId": 1,
+        "name": "FTT",
+        "symbol": "FTX Token",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x50D1c9771902476076eCFc8B2A83Ad6b9355a4c9/logo.png"
+      },
+      {
+        "address": "0x584bC13c7D411c00c01A62e8019472dE68768430",
+        "chainId": 1,
+        "name": "Hegic",
+        "symbol": "HEGIC",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x584bC13c7D411c00c01A62e8019472dE68768430/logo.png"
+      },
+      {
+        "address": "0x2e1E15C44Ffe4Df6a0cb7371CD00d5028e571d14",
+        "chainId": 1,
+        "name": "Mettalex",
+        "symbol": "MTLX",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x2e1E15C44Ffe4Df6a0cb7371CD00d5028e571d14/logo.png"
+      },
+      {
+        "address": "0x2367012aB9c3da91290F71590D5ce217721eEfE4",
+        "chainId": 1,
+        "name": "xSNX",
+        "symbol": "xSNXa",
+        "decimals": 18
+      },
+      {
+        "address": "0x35A18000230DA775CAc24873d00Ff85BccdeD550",
+        "chainId": 1,
+        "name": "Compound Uniswap",
+        "symbol": "cUNI",
+        "decimals": 8
+      },
+      {
+        "address": "0xE0B7927c4aF23765Cb51314A0E0521A9645F0E2A",
+        "chainId": 1,
+        "name": "DigixDAO DGD Token",
+        "symbol": "DGD",
+        "decimals": 9,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xE0B7927c4aF23765Cb51314A0E0521A9645F0E2A/logo.png"
+      },
+      {
+        "address": "0x0954906da0Bf32d5479e25f46056d22f08464cab",
+        "chainId": 1,
+        "name": "Index",
+        "symbol": "INDEX",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x0954906da0Bf32d5479e25f46056d22f08464cab/logo.png"
+      },
+      {
+        "address": "0x4FE5851C9af07df9e5AD8217aFAE1ea72737Ebda",
+        "chainId": 1,
+        "name": "Open Predict Token",
+        "symbol": "OPT",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x4FE5851C9af07df9e5AD8217aFAE1ea72737Ebda/logo.png"
+      },
+      {
+        "address": "0xf1f955016EcbCd7321c7266BccFB96c68ea5E49b",
+        "chainId": 1,
+        "name": "Rally",
+        "symbol": "RLY",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/balancer-labs/assets/master/assets/0xf1f955016ecbcd7321c7266bccfb96c68ea5e49b.png"
+      },
+      {
+        "address": "0xABe580E7ee158dA464b51ee1a83Ac0289622e6be",
+        "chainId": 1,
+        "name": "Offshift",
+        "symbol": "XFT",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xABe580E7ee158dA464b51ee1a83Ac0289622e6be/logo.png"
+      },
+      {
+        "address": "0xB1e9157c2Fdcc5a856C8DA8b2d89b6C32b3c1229",
+        "chainId": 1,
+        "name": "Zenfuse Trading Platform Token",
+        "symbol": "ZEFU",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xB1e9157c2Fdcc5a856C8DA8b2d89b6C32b3c1229/logo.png"
+      },
+      {
+        "address": "0xEEF9f339514298C6A857EfCfC1A762aF84438dEE",
+        "chainId": 1,
+        "name": "Hermez Network Token",
+        "symbol": "HEZ",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xEEF9f339514298C6A857EfCfC1A762aF84438dEE/logo.png"
+      },
+      {
+        "address": "0x0202Be363B8a4820f3F4DE7FaF5224fF05943AB1",
+        "chainId": 1,
+        "name": "UniLend Finance Token",
+        "symbol": "UFT",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x0202Be363B8a4820f3F4DE7FaF5224fF05943AB1/logo.png"
+      },
+      {
+        "address": "0x1cEB5cB57C4D4E2b2433641b95Dd330A33185A44",
+        "chainId": 1,
+        "name": "Keep3rV1",
+        "symbol": "KP3R",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x1cEB5cB57C4D4E2b2433641b95Dd330A33185A44/logo.png"
+      },
+      {
+        "address": "0x83e6f1E41cdd28eAcEB20Cb649155049Fac3D5Aa",
+        "chainId": 1,
+        "name": "PolkastarterToken",
+        "symbol": "POLS",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x83e6f1E41cdd28eAcEB20Cb649155049Fac3D5Aa/logo.png"
+      },
+      {
+        "address": "0xf93340b1a3aDf7eedcAEc25Fae8171D4b736e89F",
+        "chainId": 1,
+        "name": "pxUSD Synthetic USD Expiring 1 April 2021",
+        "symbol": "pxUSD_MAR2021",
+        "decimals": 18
+      },
+      {
+        "address": "0x20c36f062a31865bED8a5B1e512D9a1A20AA333A",
+        "chainId": 1,
+        "name": "DefiDollar DAO",
+        "symbol": "DFD",
+        "decimals": 18
+      },
+      {
+        "address": "0xCa3FE04C7Ee111F0bbb02C328c699226aCf9Fd33",
+        "chainId": 1,
+        "name": "seen.haus",
+        "symbol": "SEEN",
+        "decimals": 18
+      },
+      {
+        "address": "0x0E8d6b471e332F140e7d9dbB99E5E3822F728DA6",
+        "chainId": 1,
+        "name": "ABYSS",
+        "symbol": "ABYSS",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x0E8d6b471e332F140e7d9dbB99E5E3822F728DA6/logo.png"
+      },
+      {
+        "address": "0x00a8b738E453fFd858a7edf03bcCfe20412f0Eb0",
+        "chainId": 1,
+        "name": "AllianceBlock Token",
+        "symbol": "ALBT",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x00a8b738E453fFd858a7edf03bcCfe20412f0Eb0/logo.png"
+      },
+      {
+        "address": "0x18aAA7115705e8be94bfFEBDE57Af9BFc265B998",
+        "chainId": 1,
+        "name": "Audius",
+        "symbol": "AUDIO",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x18aAA7115705e8be94bfFEBDE57Af9BFc265B998/logo.png"
+      },
+      {
+        "address": "0x87b008E57F640D94Ee44Fd893F0323AF933F9195",
+        "chainId": 1,
+        "name": "coin_artist",
+        "symbol": "COIN",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x87b008E57F640D94Ee44Fd893F0323AF933F9195/logo.png"
+      },
+      {
+        "address": "0xeF9Cd7882c067686691B6fF49e650b43AFBBCC6B",
+        "chainId": 1,
+        "name": "FinNexus",
+        "symbol": "FNX",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xeF9Cd7882c067686691B6fF49e650b43AFBBCC6B/logo.png"
+      },
+      {
+        "address": "0x7d91e637589EC3Bb54D8213a9e92Dc6E8D12da91",
+        "chainId": 1,
+        "name": "FRIENDS WITH BENEFITS",
+        "symbol": "FWB",
+        "decimals": 4,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x7d91e637589EC3Bb54D8213a9e92Dc6E8D12da91/logo.png"
+      },
+      {
+        "address": "0x56687cf29Ac9751Ce2a4E764680B6aD7E668942e",
+        "chainId": 1,
+        "name": "FlynnJamm",
+        "symbol": "JAMM",
+        "decimals": 4,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x56687cf29Ac9751Ce2a4E764680B6aD7E668942e/logo.png"
+      },
+      {
+        "address": "0x23B608675a2B2fB1890d3ABBd85c5775c51691d5",
+        "chainId": 1,
+        "name": "Unisocks Edition 0",
+        "symbol": "SOCKS",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x23B608675a2B2fB1890d3ABBd85c5775c51691d5/logo.png"
+      },
+      {
+        "address": "0x4691937a7508860F876c9c0a2a617E7d9E945D4B",
+        "chainId": 1,
+        "name": "Wootrade Network",
+        "symbol": "WOO",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x4691937a7508860F876c9c0a2a617E7d9E945D4B/logo.png"
+      },
+      {
+        "address": "0xE48972fCd82a274411c01834e2f031D4377Fa2c0",
+        "chainId": 1,
+        "name": "TwoKeyEconomy",
+        "symbol": "2KEY",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xE48972fCd82a274411c01834e2f031D4377Fa2c0/logo.png"
+      },
+      {
+        "address": "0x95a4492F028aa1fd432Ea71146b433E7B4446611",
+        "chainId": 1,
+        "name": "APY Governance Token",
+        "symbol": "APY",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x95a4492F028aa1fd432Ea71146b433E7B4446611/logo.png"
+      },
+      {
+        "address": "0xF5D669627376EBd411E34b98F19C868c8ABA5ADA",
+        "chainId": 1,
+        "name": "Axie Infinity Shard",
+        "symbol": "AXS",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xF5D669627376EBd411E34b98F19C868c8ABA5ADA/logo.png"
+      },
+      {
+        "address": "0x32C4ADB9cF57f972bc375129de91C897b4F364F1",
+        "chainId": 1,
+        "name": "Flowchain",
+        "symbol": "FLC",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x32C4ADB9cF57f972bc375129de91C897b4F364F1/logo.png"
+      },
+      {
+        "address": "0xe28b3B32B6c345A34Ff64674606124Dd5Aceca30",
+        "chainId": 1,
+        "name": "Injective Token",
+        "symbol": "INJ",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xe28b3B32B6c345A34Ff64674606124Dd5Aceca30/logo.png"
+      },
+      {
+        "address": "0x4CC19356f2D37338b9802aa8E8fc58B0373296E7",
+        "chainId": 1,
+        "name": "SelfKey",
+        "symbol": "KEY",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x4CC19356f2D37338b9802aa8E8fc58B0373296E7/logo.png"
+      },
+      {
+        "address": "0x5B09A0371C1DA44A8E24D36Bf5DEb1141a84d875",
+        "chainId": 1,
+        "name": "MADToken",
+        "symbol": "MAD",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x5B09A0371C1DA44A8E24D36Bf5DEb1141a84d875/logo.png"
+      },
+      {
+        "address": "0x20945cA1df56D237fD40036d47E866C7DcCD2114",
+        "chainId": 1,
+        "name": "Nsure Network Token",
+        "symbol": "Nsure",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/balancer-labs/assets/master/assets/0x20945ca1df56d237fd40036d47e866c7dccd2114.png"
+      },
+      {
+        "address": "0x0258F474786DdFd37ABCE6df6BBb1Dd5dfC4434a",
+        "chainId": 1,
+        "name": "Orion Protocol",
+        "symbol": "ORN",
+        "decimals": 8,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x0258F474786DdFd37ABCE6df6BBb1Dd5dfC4434a/logo.png"
+      },
+      {
+        "address": "0xE59064a8185Ed1Fca1D17999621eFedfab4425c9",
+        "chainId": 1,
+        "name": "PrimeDAO Token",
+        "symbol": "PRIME",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/balancer-labs/assets/master/assets/0xe59064a8185ed1fca1d17999621efedfab4425c9.png"
+      },
+      {
+        "address": "0x99ea4dB9EE77ACD40B119BD1dC4E33e1C070b80d",
+        "chainId": 1,
+        "name": "Quantstamp Token",
+        "symbol": "QSP",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x99ea4dB9EE77ACD40B119BD1dC4E33e1C070b80d/logo.png"
+      },
+      {
+        "address": "0x340D2bdE5Eb28c1eed91B2f790723E3B160613B7",
+        "chainId": 1,
+        "name": "BLOCKv Token",
+        "symbol": "VEE",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x340D2bdE5Eb28c1eed91B2f790723E3B160613B7/logo.png"
+      },
+      {
+        "address": "0x286BDA1413a2Df81731D4930ce2F862a35A609fE",
+        "chainId": 1,
+        "name": "WaBi",
+        "symbol": "WaBi",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x286BDA1413a2Df81731D4930ce2F862a35A609fE/logo.png"
+      },
+      {
+        "address": "0x837010619aeb2AE24141605aFC8f66577f6fb2e7",
+        "chainId": 1,
+        "name": "zHEGIC",
+        "symbol": "zHEGIC",
+        "decimals": 18
+      },
+      {
+        "address": "0xA8e7AD77C60eE6f30BaC54E2E7c0617Bd7B5A03E",
+        "chainId": 1,
+        "name": "zLOT",
+        "symbol": "zLOT",
+        "decimals": 18
+      },
+      {
+        "address": "0xBbff34E47E559ef680067a6B1c980639EEb64D24",
+        "chainId": 1,
+        "name": "Leverj Gluon",
+        "symbol": "L2",
+        "decimals": 18
+      },
+      {
+        "address": "0x362bc847A3a9637d3af6624EeC853618a43ed7D2",
+        "chainId": 1,
+        "name": "Parsiq Token",
+        "symbol": "PRQ",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x362bc847A3a9637d3af6624EeC853618a43ed7D2/logo.png"
+      },
+      {
+        "address": "0x4C19596f5aAfF459fA38B0f7eD92F11AE6543784",
+        "chainId": 1,
+        "name": "TrueFi",
+        "symbol": "TRU",
+        "decimals": 8,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x4C19596f5aAfF459fA38B0f7eD92F11AE6543784/logo.png"
+      },
+      {
+        "address": "0x4A64515E5E1d1073e83f30cB97BEd20400b66E10",
+        "chainId": 1,
+        "name": "Wrapped ZEC",
+        "symbol": "WZEC",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x4A64515E5E1d1073e83f30cB97BEd20400b66E10/logo.png"
+      },
+      {
+        "address": "0x80DC468671316E50D4E9023D3db38D3105c1C146",
+        "chainId": 1,
+        "name": "xAAVE",
+        "symbol": "xAAVEa",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/balancer-labs/assets/master/assets/0x80dc468671316e50d4e9023d3db38d3105c1c146.png"
+      },
+      {
+        "address": "0x704De5696dF237c5B9ba0De9ba7e0C63dA8eA0Df",
+        "chainId": 1,
+        "name": "xAAVE",
+        "symbol": "xAAVEb",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/balancer-labs/assets/master/assets/0x704de5696df237c5b9ba0de9ba7e0c63da8ea0df.png"
+      },
+      {
+        "address": "0x0b38210ea11411557c13457D4dA7dC6ea731B88a",
+        "chainId": 1,
+        "name": "API3",
+        "symbol": "API3",
+        "decimals": 18
+      },
+      {
+        "address": "0x998b3B82bC9dBA173990Be7afb772788B5aCB8Bd",
+        "chainId": 1,
+        "name": "BANCA Token",
+        "symbol": "BANCA",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x998b3B82bC9dBA173990Be7afb772788B5aCB8Bd/logo.png"
+      },
+      {
+        "address": "0xC57d533c50bC22247d49a368880fb49a1caA39F7",
+        "chainId": 1,
+        "name": "PowerTrade Fuel Token",
+        "symbol": "PTF",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xC57d533c50bC22247d49a368880fb49a1caA39F7/logo.png"
+      },
+      {
+        "address": "0x1695936d6a953df699C38CA21c2140d497C08BD9",
+        "chainId": 1,
+        "name": "SynLev",
+        "symbol": "SYN",
+        "decimals": 18
+      },
+      {
+        "address": "0x6e1A19F235bE7ED8E3369eF73b196C07257494DE",
+        "chainId": 1,
+        "name": "Wrapped Filecoin",
+        "symbol": "WFIL",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x6e1A19F235bE7ED8E3369eF73b196C07257494DE/logo.png"
+      },
+      {
+        "address": "0x6368e1E18c4C419DDFC608A0BEd1ccb87b9250fc",
+        "chainId": 1,
+        "name": "Tap",
+        "symbol": "XTP",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x6368e1E18c4C419DDFC608A0BEd1ccb87b9250fc/logo.png"
+      },
+      {
+        "address": "0xf0Bc1ae4eF7ffb126A8347D06Ac6f8AdD770e1CE",
+        "chainId": 1,
+        "name": "1Million Token",
+        "symbol": "1MT",
+        "decimals": 7
+      },
+      {
+        "address": "0x3449FC1Cd036255BA1EB19d65fF4BA2b8903A69a",
+        "chainId": 1,
+        "name": "BAC",
+        "symbol": "BAC",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x3449FC1Cd036255BA1EB19d65fF4BA2b8903A69a/logo.png"
+      },
+      {
+        "address": "0x3472A5A71965499acd81997a54BBA8D852C6E53d",
+        "chainId": 1,
+        "name": "Badger",
+        "symbol": "BADGER",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x3472A5A71965499acd81997a54BBA8D852C6E53d/logo.png"
+      },
+      {
+        "address": "0xa7ED29B253D8B4E3109ce07c80fc570f81B63696",
+        "chainId": 1,
+        "name": "BAS",
+        "symbol": "BAS",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xa7ED29B253D8B4E3109ce07c80fc570f81B63696/logo.png"
+      },
+      {
+        "address": "0x36F3FD68E7325a35EB768F1AedaAe9EA0689d723",
+        "chainId": 1,
+        "name": "Empty Set Dollar",
+        "symbol": "ESD",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x36F3FD68E7325a35EB768F1AedaAe9EA0689d723/logo.png"
+      },
+      {
+        "address": "0x70e8dE73cE538DA2bEEd35d14187F6959a8ecA96",
+        "chainId": 1,
+        "name": "XSGD",
+        "symbol": "XSGD",
+        "decimals": 6,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x70e8dE73cE538DA2bEEd35d14187F6959a8ecA96/logo.png"
+      },
+      {
+        "address": "0x167E2A574669b0EeB552aaF3Da47c728cb348a41",
+        "chainId": 1,
+        "name": "Spartan",
+        "symbol": "300",
+        "decimals": 7
+      },
+      {
+        "address": "0xc944E90C64B2c07662A292be6244BDf05Cda44a7",
+        "chainId": 1,
+        "name": "Graph Token",
+        "symbol": "GRT",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xc944E90C64B2c07662A292be6244BDf05Cda44a7/logo.png"
+      },
+      {
+        "address": "0xD5147bc8e386d91Cc5DBE72099DAC6C9b99276F5",
+        "chainId": 1,
+        "name": "renFIL",
+        "symbol": "renFIL",
+        "decimals": 18
+      },
+      {
+        "address": "0x111111111117dC0aa78b770fA6A738034120C302",
+        "chainId": 1,
+        "name": "1INCH Token",
+        "symbol": "1INCH",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x111111111117dC0aa78b770fA6A738034120C302/logo.png"
+      },
+      {
+        "address": "0x002f0B1A71C5730CF2F4dA1970A889207BdB6D0D",
+        "chainId": 1,
+        "name": "Yield Dollar [renBTC Mar 2021]",
+        "symbol": "YD-BTC-MAR21",
+        "decimals": 18
+      },
+      {
+        "address": "0x90f802C7E8fb5D40B0De583e34C065A3bd2020D8",
+        "chainId": 1,
+        "name": "Yield Dollar [WETH Mar 2021]",
+        "symbol": "YD-ETH-MAR21",
+        "decimals": 18
+      },
+      {
+        "address": "0xDcB01cc464238396E213a6fDd933E36796eAfF9f",
+        "chainId": 1,
+        "name": "Yield",
+        "symbol": "YLD",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xDcB01cc464238396E213a6fDd933E36796eAfF9f/logo.png"
+      },
+      {
+        "address": "0x875773784Af8135eA0ef43b5a374AaD105c5D39e",
+        "chainId": 1,
+        "name": "Idle",
+        "symbol": "IDLE",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/balancer-labs/assets/master/assets/0x875773784af8135ea0ef43b5a374aad105c5d39e.png"
+      },
+      {
+        "address": "0x69e8b9528CABDA89fe846C67675B5D73d463a916",
+        "chainId": 1,
+        "name": "OPEN Governance Token",
+        "symbol": "OPEN",
+        "decimals": 18
+      },
+      {
+        "address": "0x93dfaf57D986B9cA77Df9376c50878E013D9c7C8",
+        "chainId": 1,
+        "name": "RARE.UNIQUE",
+        "symbol": "RARE",
+        "decimals": 18
+      },
+      {
+        "address": "0x30cF203b48edaA42c3B4918E955fED26Cd012A3F",
+        "chainId": 1,
+        "name": "Seed",
+        "symbol": "SEED",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/balancer-labs/assets/master/assets/0x30cf203b48edaa42c3b4918e955fed26cd012a3f.png"
+      },
+      {
+        "address": "0xa47c8bf37f92aBed4A126BDA807A7b7498661acD",
+        "chainId": 1,
+        "name": "Wrapped UST Token",
+        "symbol": "UST",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xa47c8bf37f92aBed4A126BDA807A7b7498661acD/logo.png"
+      },
+      {
+        "address": "0xfFffFffF2ba8F66D4e51811C5190992176930278",
+        "chainId": 1,
+        "name": "Furucombo",
+        "symbol": "COMBO",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/balancer-labs/assets/master/assets/0xffffffff2ba8f66d4e51811c5190992176930278.png"
+      },
+      {
+        "address": "0x5A98FcBEA516Cf06857215779Fd812CA3beF1B32",
+        "chainId": 1,
+        "name": "Lido DAO Token",
+        "symbol": "LDO",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/balancer-labs/assets/master/assets/0x5a98fcbea516cf06857215779fd812ca3bef1b32.png"
+      },
+      {
+        "address": "0x87d73E916D7057945c9BcD8cdd94e42A6F47f776",
+        "chainId": 1,
+        "name": "NFTX",
+        "symbol": "NFTX",
+        "decimals": 18
+      },
+      {
+        "address": "0xeDEec5691f23E4914cF0183A4196bBEb30d027a0",
+        "chainId": 1,
+        "name": "Wrapped STA",
+        "symbol": "WSTA",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xeDEec5691f23E4914cF0183A4196bBEb30d027a0/logo.png"
+      },
+      {
+        "address": "0x53352e7d6620cc931c0C9318166ae2a92c1A4666",
+        "chainId": 1,
+        "name": "AIM",
+        "symbol": "AIM",
+        "decimals": 18
+      },
+      {
+        "address": "0xAE1eaAE3F627AAca434127644371b67B18444051",
+        "chainId": 1,
+        "name": "YOP",
+        "symbol": "YOP",
+        "decimals": 8,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xAE1eaAE3F627AAca434127644371b67B18444051/logo.png"
+      },
+      {
+        "address": "0x6c972b70c533E2E045F333Ee28b9fFb8D717bE69",
+        "chainId": 1,
+        "name": "Foundry Logistics Token",
+        "symbol": "FRY",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x6c972b70c533E2E045F333Ee28b9fFb8D717bE69/logo.png"
+      },
+      {
+        "address": "0xbEa98c05eEAe2f3bC8c3565Db7551Eb738c8CCAb",
+        "chainId": 1,
+        "name": "Geyser",
+        "symbol": "GYSR",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xbEa98c05eEAe2f3bC8c3565Db7551Eb738c8CCAb/logo.png"
+      },
+      {
+        "address": "0x7866E48C74CbFB8183cd1a929cd9b95a7a5CB4F4",
+        "chainId": 1,
+        "name": "DexKit",
+        "symbol": "KIT",
+        "decimals": 18
+      },
+      {
+        "address": "0xff56Cc6b1E6dEd347aA0B7676C85AB0B3D08B0FA",
+        "chainId": 1,
+        "name": "Orbs",
+        "symbol": "ORBS",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xff56Cc6b1E6dEd347aA0B7676C85AB0B3D08B0FA/logo.png"
+      },
+      {
+        "address": "0x79C75E2e8720B39e258F41c37cC4f309E0b0fF80",
+        "chainId": 1,
+        "name": "Phantasma Stake",
+        "symbol": "SOUL",
+        "decimals": 8
+      },
+      {
+        "address": "0xE452E6Ea2dDeB012e20dB73bf5d3863A3Ac8d77a",
+        "chainId": 1,
+        "name": "Wrapped Celo",
+        "symbol": "wCELO",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xE452E6Ea2dDeB012e20dB73bf5d3863A3Ac8d77a/logo.png"
+      },
+      {
+        "address": "0x817bbDbC3e8A1204f3691d14bB44992841e3dB35",
+        "chainId": 1,
+        "name": "CudosToken",
+        "symbol": "CUDOS",
+        "decimals": 18
+      },
+      {
+        "address": "0x8D1ce361eb68e9E05573443C407D4A3Bed23B033",
+        "chainId": 1,
+        "name": "PieDAO DEFI++",
+        "symbol": "DEFI++",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/balancer-labs/assets/master/assets/0x8d1ce361eb68e9e05573443c407d4a3bed23b033.png"
+      },
+      {
+        "address": "0x6e36556B3ee5Aa28Def2a8EC3DAe30eC2B208739",
+        "chainId": 1,
+        "name": "BUILD Finance",
+        "symbol": "BUILD",
+        "decimals": 18
+      },
+      {
+        "address": "0x43044f861ec040DB59A7e324c40507adDb673142",
+        "chainId": 1,
+        "name": "Cap",
+        "symbol": "CAP",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x43044f861ec040DB59A7e324c40507adDb673142/logo.png"
+      },
+      {
+        "address": "0x7DD9c5Cba05E151C895FDe1CF355C9A1D5DA6429",
+        "chainId": 1,
+        "name": "Golem Network Token",
+        "symbol": "GLM",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/balancer-labs/assets/master/assets/0x7dd9c5cba05e151c895fde1cf355c9a1d5da6429.png"
+      },
+      {
+        "address": "0x8A9c4dfe8b9D8962B31e4e16F8321C44d48e246E",
+        "chainId": 1,
+        "name": "NameChangeToken",
+        "symbol": "NCT",
+        "decimals": 18
+      },
+      {
+        "address": "0x50DE6856358Cc35f3A9a57eAAA34BD4cB707d2cd",
+        "chainId": 1,
+        "name": "RAZOR",
+        "symbol": "RAZOR",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/balancer-labs/assets/master/assets/0x50de6856358cc35f3a9a57eaaa34bd4cb707d2cd.png"
+      },
+      {
+        "address": "0x0f51bb10119727a7e5eA3538074fb341F56B09Ad",
+        "chainId": 1,
+        "name": "DAO Maker",
+        "symbol": "DAO",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x0f51bb10119727a7e5eA3538074fb341F56B09Ad/logo.png"
+      },
+      {
+        "address": "0xac3211a5025414Af2866FF09c23FC18bc97e79b1",
+        "chainId": 1,
+        "name": "DOVU",
+        "symbol": "DOV",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xac3211a5025414Af2866FF09c23FC18bc97e79b1/logo.png"
+      },
+      {
+        "address": "0xEfc1C73A3D8728Dc4Cf2A18ac5705FE93E5914AC",
+        "chainId": 1,
+        "name": "Metric.exchange",
+        "symbol": "METRIC",
+        "decimals": 18
+      },
+      {
+        "address": "0x92E187a03B6CD19CB6AF293ba17F2745Fd2357D5",
+        "chainId": 1,
+        "name": "Unit Protocol",
+        "symbol": "DUCK",
+        "decimals": 18
+      },
+      {
+        "address": "0xFd09911130e6930Bf87F2B0554c44F400bD80D3e",
+        "chainId": 1,
+        "name": "Ethix",
+        "symbol": "ETHIX",
+        "decimals": 18
+      },
+      {
+        "address": "0x59fec83eC709c893aedD1A144Cf1828Eb04127Cd",
+        "chainId": 1,
+        "name": "pxGOLD Synthetic GOLD Expiring 31 May 2021",
+        "symbol": "pxGOLD_MAY2021",
+        "decimals": 18
+      },
+      {
+        "address": "0x31c8EAcBFFdD875c74b94b077895Bd78CF1E64A3",
+        "chainId": 1,
+        "name": "Radicle",
+        "symbol": "RAD",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/balancer-labs/assets/master/assets/0x31c8eacbffdd875c74b94b077895bd78cf1e64a3.png"
+      },
+      {
+        "address": "0xD23Ac27148aF6A2f339BD82D0e3CFF380b5093de",
+        "chainId": 1,
+        "name": "SIREN",
+        "symbol": "SI",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xD23Ac27148aF6A2f339BD82D0e3CFF380b5093de/logo.png"
+      },
+      {
+        "address": "0x7f1F2D3dFa99678675ECE1C243d3f7bC3746db5D",
+        "chainId": 1,
+        "name": "Tapmydata",
+        "symbol": "TAP",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/balancer-labs/assets/master/assets/0x7f1f2d3dfa99678675ece1c243d3f7bc3746db5d.png"
+      },
+      {
+        "address": "0x1456688345527bE1f37E9e627DA0837D6f08C925",
+        "chainId": 1,
+        "name": "USDP Stablecoin",
+        "symbol": "USDP",
+        "decimals": 18
+      },
+      {
+        "address": "0xdBdb4d16EdA451D0503b854CF79D55697F90c8DF",
+        "chainId": 1,
+        "name": "Alchemix",
+        "symbol": "ALCX",
+        "decimals": 18
+      },
+      {
+        "address": "0xc4De189Abf94c57f396bD4c52ab13b954FebEfD8",
+        "chainId": 1,
+        "name": "B.20",
+        "symbol": "B20",
+        "decimals": 18
+      },
+      {
+        "address": "0xF5581dFeFD8Fb0e4aeC526bE659CFaB1f8c781dA",
+        "chainId": 1,
+        "name": "HOPR Token",
+        "symbol": "HOPR",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/balancer-labs/assets/master/assets/0xf5581dfefd8fb0e4aec526be659cfab1f8c781da.png"
+      },
+      {
+        "address": "0x903bEF1736CDdf2A537176cf3C64579C3867A881",
+        "chainId": 1,
+        "name": "ichi.farm",
+        "symbol": "ICHI",
+        "decimals": 9,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x903bEF1736CDdf2A537176cf3C64579C3867A881/logo.png"
+      },
+      {
+        "address": "0x0fe629d1E84E171f8fF0C1Ded2Cc2221Caa48a3f",
+        "chainId": 1,
+        "name": "Mask",
+        "symbol": "MASK",
+        "decimals": 18
+      },
+      {
+        "address": "0x69af81e73A73B40adF4f3d4223Cd9b1ECE623074",
+        "chainId": 1,
+        "name": "Mask Network",
+        "symbol": "MASK",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/balancer-labs/assets/master/assets/0x69af81e73a73b40adf4f3d4223cd9b1ece623074.png"
+      },
+      {
+        "address": "0x9cea2eD9e47059260C97d697f82b8A14EfA61EA5",
+        "chainId": 1,
+        "name": "Punk",
+        "symbol": "PUNK",
+        "decimals": 18
+      },
+      {
+        "address": "0xfb5453340C03db5aDe474b27E68B6a9c6b2823Eb",
+        "chainId": 1,
+        "name": "MetaFactory",
+        "symbol": "ROBOT",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/balancer-labs/assets/master/assets/0xfb5453340c03db5ade474b27e68b6a9c6b2823eb.png"
+      },
+      {
+        "address": "0x86ed939B500E121C0C5f493F399084Db596dAd20",
+        "chainId": 1,
+        "name": "SpaceChainV2",
+        "symbol": "SPC",
+        "decimals": 18
+      },
+      {
+        "address": "0x918dA91Ccbc32B7a6A0cc4eCd5987bbab6E31e6D",
+        "chainId": 1,
+        "name": "Synth sTSLA",
+        "symbol": "sTSLA",
+        "decimals": 18
+      },
+      {
+        "address": "0x48Fb253446873234F2fEBbF9BdeAA72d9d387f94",
+        "chainId": 1,
+        "name": "Bancor Governance Token",
+        "symbol": "vBNT",
+        "decimals": 18
+      },
+      {
+        "address": "0x1b40183EFB4Dd766f11bDa7A7c3AD8982e998421",
+        "chainId": 1,
+        "name": "VesperToken",
+        "symbol": "VSP",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x1b40183EFB4Dd766f11bDa7A7c3AD8982e998421/logo.png"
+      },
+      {
+        "address": "0xcaDC0acd4B445166f12d2C07EAc6E2544FbE2Eef",
+        "chainId": 1,
+        "name": "CAD Coin",
+        "symbol": "CADC",
+        "decimals": 18
+      },
+      {
+        "address": "0x59E9261255644c411AfDd00bD89162d09D862e38",
+        "chainId": 1,
+        "name": "ETHA",
+        "symbol": "ETHA",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/balancer-labs/assets/master/assets/0x59e9261255644c411afdd00bd89162d09d862e38.png"
+      },
+      {
+        "address": "0x544c42fBB96B39B21DF61cf322b5EDC285EE7429",
+        "chainId": 1,
+        "name": "InsurAce",
+        "symbol": "INSUR",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/balancer-labs/assets/master/assets/0x544c42fbb96b39b21df61cf322b5edc285ee7429.png"
+      },
+      {
+        "address": "0x67B6D479c7bB412C54e03dCA8E1Bc6740ce6b99C",
+        "chainId": 1,
+        "name": "Kylin Network",
+        "symbol": "KYL",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/balancer-labs/assets/master/assets/0x67b6d479c7bb412c54e03dca8e1bc6740ce6b99c.png"
+      },
+      {
+        "address": "0xCbfef8fdd706cde6F208460f2Bf39Aa9c785F05D",
+        "chainId": 1,
+        "name": "Kine Governance Token",
+        "symbol": "KINE",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/balancer-labs/assets/master/assets/0xcbfef8fdd706cde6f208460f2bf39aa9c785f05d.png"
+      },
+      {
+        "address": "0x945Facb997494CC2570096c74b5F66A3507330a1",
+        "chainId": 1,
+        "name": "mStable BTC",
+        "symbol": "mBTC",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/balancer-labs/assets/master/assets/0x945facb997494cc2570096c74b5f66a3507330a1.png"
+      },
+      {
+        "address": "0xEC6a5D88bF56Fd3F96957AE65916C69F29DB35c5",
+        "chainId": 1,
+        "name": "apeUSD-AAVE Synthetic USD (Dec 2021)",
+        "symbol": "apeUSD-AAVE-DEC21",
+        "decimals": 18
+      },
+      {
+        "address": "0x0f775aD69e3c93D599D3315A130Bd82A0cDda397",
+        "chainId": 1,
+        "name": "apeUSD-LINK Synthetic USD (Dec 2021)",
+        "symbol": "apeUSD-LINK-DEC21",
+        "decimals": 18
+      },
+      {
+        "address": "0x5C6Af72cBd740b90528C8Fe226125413b6bd7E5A",
+        "chainId": 1,
+        "name": "apeUSD-SNX Synthetic USD (Dec 2021)",
+        "symbol": "apeUSD-SNX-DEC21",
+        "decimals": 18
+      },
+      {
+        "address": "0xfA5e27893aee4805283D86e4283Da64F8c72dd56",
+        "chainId": 1,
+        "name": "apeUSD-UMA Synthetic USD (Dec 2021)",
+        "symbol": "apeUSD-UMA-DEC21",
+        "decimals": 18
+      },
+      {
+        "address": "0xFbB6B34DD77274a06EA2E5462a5e0B9E23ce478e",
+        "chainId": 1,
+        "name": "apeUSD-UNI Synthetic USD (Dec 2021)",
+        "symbol": "apeUSD-UNI-DEC21",
+        "decimals": 18
+      },
+      {
+        "address": "0xAa6E8127831c9DE45ae56bB1b0d4D4Da6e5665BD",
+        "chainId": 1,
+        "name": "ETH 2x Flexible Leverage Index",
+        "symbol": "ETH2x-FLI",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xAa6E8127831c9DE45ae56bB1b0d4D4Da6e5665BD/logo.png"
+      },
+      {
+        "address": "0xaac41EC512808d64625576EDdd580e7Ea40ef8B2",
+        "chainId": 1,
+        "name": "gameswap.org",
+        "symbol": "GSWAP",
+        "decimals": 18
+      },
+      {
+        "address": "0x5247C0DB4044FB6F97f32C7E1B48758019A5A912",
+        "chainId": 1,
+        "name": "pxGOLD Synthetic Gold Expiring 31 Mar 2022",
+        "symbol": "pxGOLD_MAR2022",
+        "decimals": 18
+      },
+      {
+        "address": "0xEd0439EACf4c4965AE4613D77a5C2Efe10e5f183",
+        "chainId": 1,
+        "name": "shroom.finance",
+        "symbol": "SHROOM",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xEd0439EACf4c4965AE4613D77a5C2Efe10e5f183/logo.png"
+      },
+      {
+        "address": "0x29CbD0510EEc0327992CD6006e63F9Fa8E7f33B7",
+        "chainId": 1,
+        "name": "Tidal Token",
+        "symbol": "TIDAL",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/balancer-labs/assets/master/assets/0x29cbd0510eec0327992cd6006e63f9fa8e7f33b7.png"
+      },
+      {
+        "address": "0x67c597624B17b16fb77959217360B7cD18284253",
+        "chainId": 1,
+        "name": "Benchmark",
+        "symbol": "MARK",
+        "decimals": 9,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x67c597624B17b16fb77959217360B7cD18284253/logo.png"
+      },
+      {
+        "address": "0x06147110022B768BA8F99A8f385df11a151A9cc8",
+        "chainId": 1,
+        "name": "ACE Token",
+        "symbol": "ACE",
+        "decimals": 0,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x06147110022B768BA8F99A8f385df11a151A9cc8/logo.png"
+      },
+      {
+        "address": "0x5F64Ab1544D28732F0A24F4713c2C8ec0dA089f0",
+        "chainId": 1,
+        "name": "DEXTF Token",
+        "symbol": "DEXTF",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x5F64Ab1544D28732F0A24F4713c2C8ec0dA089f0/logo.png"
+      },
+      {
+        "address": "0x53C8395465A84955c95159814461466053DedEDE",
+        "chainId": 1,
+        "name": "DeGate Token",
+        "symbol": "DG",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/balancer-labs/assets/master/assets/0x53c8395465a84955c95159814461466053dedede.png"
+      },
+      {
+        "address": "0xbc4171f45EF0EF66E76F979dF021a34B46DCc81d",
+        "chainId": 1,
+        "name": "Dorayaki",
+        "symbol": "DORA",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/balancer-labs/assets/master/assets/0xbc4171f45ef0ef66e76f979df021a34b46dcc81d.png"
+      },
+      {
+        "address": "0x4B606e9Eb2228c70f44453AFe5a73e1FeA258Ce1",
+        "chainId": 1,
+        "name": " pxUSD Synthetic USD Expiring 31 Mar 2022",
+        "symbol": "pxUSD_MAR2022",
+        "decimals": 18
+      },
+      {
+        "address": "0xae7ab96520DE3A18E5e111B5EaAb095312D7fE84",
+        "chainId": 1,
+        "name": "Liquid staked Ether 2.0",
+        "symbol": "stETH",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/balancer-labs/assets/master/assets/0xae7ab96520de3a18e5e111b5eaab095312d7fe84.png"
+      },
+      {
+        "address": "0xBa21Ef4c9f433Ede00badEFcC2754B8E74bd538A",
+        "chainId": 1,
+        "name": "Swapfolio",
+        "symbol": "SWFL",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xBa21Ef4c9f433Ede00badEFcC2754B8E74bd538A/logo.png"
+      },
+      {
+        "address": "0xB6ff96B8A8d214544Ca0dBc9B33f7AD6503eFD32",
+        "chainId": 1,
+        "name": "SYNC",
+        "symbol": "SYNC",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xB6ff96B8A8d214544Ca0dBc9B33f7AD6503eFD32/logo.png"
+      },
+      {
+        "address": "0x1c79ab32C66aCAa1e9E81952B8AAa581B43e54E7",
+        "chainId": 1,
+        "name": "TEAM",
+        "symbol": "TEAM",
+        "decimals": 4,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x1c79ab32C66aCAa1e9E81952B8AAa581B43e54E7/logo.png"
+      },
+      {
+        "address": "0xE4CFE9eAa8Cdb0942A80B7bC68fD8Ab0F6D44903",
+        "chainId": 1,
+        "name": "XEND",
+        "symbol": "XEND",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/balancer-labs/assets/master/assets/0xe4cfe9eaa8cdb0942a80b7bc68fd8ab0f6d44903.png"
+      },
+      {
+        "address": "0x4b7Fb448dF91C8Ed973494F8C8c4f12DAF3A8521",
+        "chainId": 1,
+        "name": "Yield Dollar [renBTC Jun 2021]",
+        "symbol": "YD-BTC-JUN21",
+        "decimals": 8
+      },
+      {
+        "address": "0xcBE430927370e95B4B10cFc702c6017EC7abEfC3",
+        "chainId": 1,
+        "name": "Yield Dollar [WETH Jun 2021]",
+        "symbol": "YD-ETH-JUN21",
+        "decimals": 18
+      },
+      {
+        "address": "0x767FE9EDC9E0dF98E07454847909b5E959D7ca0E",
+        "chainId": 1,
+        "name": "Illuvium",
+        "symbol": "ILV",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/balancer-labs/assets/master/assets/0x767fe9edc9e0df98e07454847909b5e959d7ca0e.png"
+      },
+      {
+        "address": "0x3A810ff7211b40c4fA76205a14efe161615d0385",
+        "chainId": 1,
+        "name": "AI Network",
+        "symbol": "AIN",
+        "decimals": 18
+      },
+      {
+        "address": "0xC12D1c73eE7DC3615BA4e37E4ABFdbDDFA38907E",
+        "chainId": 1,
+        "name": "KickToken",
+        "symbol": "KICK",
+        "decimals": 8,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xC12D1c73eE7DC3615BA4e37E4ABFdbDDFA38907E/logo.png"
+      },
+      {
+        "address": "0x68037790A0229e9Ce6EaA8A99ea92964106C4703",
+        "chainId": 1,
+        "name": "PAR Stablecoin",
+        "symbol": "PAR",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x68037790A0229e9Ce6EaA8A99ea92964106C4703/logo.png"
+      },
+      {
+        "address": "0xC96c1609A1a45CcC667B2b7FA6508e29617f7b69",
+        "chainId": 1,
+        "name": "2GT_token",
+        "symbol": "2GT",
+        "decimals": 18
+      },
+      {
+        "address": "0x7d4B1d793239707445305D8d2456D2c735F6B25B",
+        "chainId": 1,
+        "name": "BSNcommunitynet",
+        "symbol": "cBSN",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/balancer-labs/assets/master/assets/0x7d4b1d793239707445305d8d2456d2c735f6b25b.png"
+      },
+      {
+        "address": "0xdB25f211AB05b1c97D595516F45794528a807ad8",
+        "chainId": 1,
+        "name": "STASIS EURS Token",
+        "symbol": "EURS",
+        "decimals": 2,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xdB25f211AB05b1c97D595516F45794528a807ad8/logo.png"
+      },
+      {
+        "address": "0x5Eaa69B29f99C84Fe5dE8200340b4e9b4Ab38EaC",
+        "chainId": 1,
+        "name": "Raze Network",
+        "symbol": "RAZE",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/balancer-labs/assets/master/assets/0x5eaa69b29f99c84fe5de8200340b4e9b4ab38eac.png"
+      },
+      {
+        "address": "0xD71eCFF9342A5Ced620049e616c5035F1dB98620",
+        "chainId": 1,
+        "name": "Synth sEUR",
+        "symbol": "sEUR",
+        "decimals": 18
+      },
+      {
+        "address": "0xED30Dd7E50EdF3581AD970eFC5D9379Ce2614AdB",
+        "chainId": 1,
+        "name": "ARC Governance Token",
+        "symbol": "ARCX",
+        "decimals": 18
+      },
+      {
+        "address": "0x33349B282065b0284d756F0577FB39c158F935e6",
+        "chainId": 1,
+        "name": "Maple Token",
+        "symbol": "MPL",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/balancer-labs/assets/master/assets/0x33349b282065b0284d756f0577fb39c158f935e6.png"
+      },
+      {
+        "address": "0x24D8C2163D6B13A6B8770B794d00c98Cb4E0cBCa",
+        "chainId": 1,
+        "name": "OPEN Dollar [OCEAN Mar 2022]",
+        "symbol": "O-OCEAN-MAR22",
+        "decimals": 18
+      },
+      {
+        "address": "0x4156D3342D5c385a87D264F90653733592000581",
+        "chainId": 1,
+        "name": "Salt",
+        "symbol": "SALT",
+        "decimals": 8,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x4156D3342D5c385a87D264F90653733592000581/logo.png"
+      },
+      {
+        "address": "0x358AA737e033F34df7c54306960a38d09AaBd523",
+        "chainId": 1,
+        "name": "Ares Protocol",
+        "symbol": "ARES",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/balancer-labs/assets/master/assets/0x358aa737e033f34df7c54306960a38d09aabd523.png"
+      },
+      {
+        "address": "0xC88F47067dB2E25851317A2FDaE73a22c0777c37",
+        "chainId": 1,
+        "name": "oneBTC",
+        "symbol": "oneBTC",
+        "decimals": 9,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xC88F47067dB2E25851317A2FDaE73a22c0777c37/logo.png"
+      },
+      {
+        "address": "0xEc0d77a58528a218cBf41Fa6E1585c8D7A085868",
+        "chainId": 1,
+        "name": "oneETH",
+        "symbol": "oneETH",
+        "decimals": 9,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xEc0d77a58528a218cBf41Fa6E1585c8D7A085868/logo.png"
+      },
+      {
+        "address": "0x18Cc17a1EeD37C02A77B0B96b7890C7730E2a2CF",
+        "chainId": 1,
+        "name": "oneLINK",
+        "symbol": "oneLINK",
+        "decimals": 9,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x18Cc17a1EeD37C02A77B0B96b7890C7730E2a2CF/logo.png"
+      },
+      {
+        "address": "0x8F041A3940a5e6FB580075C3774E15FcFA0E1618",
+        "chainId": 1,
+        "name": "oneWING",
+        "symbol": "oneWING",
+        "decimals": 9,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x8F041A3940a5e6FB580075C3774E15FcFA0E1618/logo.png"
+      },
+      {
+        "address": "0x7BD198b9107496fD5cC3d7655AF52f43a8eDBc4C",
+        "chainId": 1,
+        "name": "oneVBTC",
+        "symbol": "oneVBTC",
+        "decimals": 9,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x7BD198b9107496fD5cC3d7655AF52f43a8eDBc4C/logo.png"
+      },
+      {
+        "address": "0xbA4cFE5741b357FA371b506e5db0774aBFeCf8Fc",
+        "chainId": 1,
+        "name": "vVSP pool",
+        "symbol": "vVSP",
+        "decimals": 18
+      },
+      {
+        "address": "0xc67B12049c2D0CF6e476BC64c7F82fc6C63cFFc5",
+        "chainId": 1,
+        "name": "GDT",
+        "symbol": "GDT",
+        "decimals": 8,
+        "logoURI": "https://raw.githubusercontent.com/balancer-labs/assets/master/assets/0xc67b12049c2d0cf6e476bc64c7f82fc6c63cffc5.png"
+      },
+      {
+        "address": "0xBf6Ff49FfD3d104302Ef0AB0F10f5a84324c091c",
+        "chainId": 1,
+        "name": "Nftfy Token",
+        "symbol": "NFTFY",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/balancer-labs/assets/master/assets/0xbf6ff49ffd3d104302ef0ab0f10f5a84324c091c.png"
+      },
+      {
+        "address": "0x0275E1001e293C46CFe158B3702AADe0B99f88a5",
+        "chainId": 1,
+        "name": "Oiler",
+        "symbol": "OIL",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/balancer-labs/assets/master/assets/0x0275e1001e293c46cfe158b3702aade0b99f88a5.png"
+      },
+      {
+        "address": "0x9CF7E61853ea30A41b02169391b393B901eac457",
+        "chainId": 1,
+        "name": "Synth sAMZN",
+        "symbol": "sAMZN",
+        "decimals": 18
+      },
+      {
+        "address": "0xf50B5e535F62a56A9BD2d8e2434204E726c027Fa",
+        "chainId": 1,
+        "name": "Synth sFB",
+        "symbol": "sFB",
+        "decimals": 18
+      },
+      {
+        "address": "0xC63B8ECCE56aB9C46184eC6aB85e4771fEa4c8AD",
+        "chainId": 1,
+        "name": "Synth sGOOG",
+        "symbol": "sGOOG",
+        "decimals": 18
+      },
+      {
+        "address": "0x5A7E3c07604EB515C16b36cd51906a65f021F609",
+        "chainId": 1,
+        "name": "Synth sNFLX",
+        "symbol": "sNFLX",
+        "decimals": 18
+      },
+      {
+        "address": "0xd0345D30FD918D7682398ACbCdf139C808998709",
+        "chainId": 1,
+        "name": "Lixir Token",
+        "symbol": "LIX",
+        "decimals": 18
+      },
+      {
+        "address": "0xEe9801669C6138E84bD50dEB500827b776777d28",
+        "chainId": 1,
+        "name": "O3 Swap Token",
+        "symbol": "O3",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/balancer-labs/assets/master/assets/0xee9801669c6138e84bd50deb500827b776777d28.png"
+      },
+      {
+        "address": "0x4104b135DBC9609Fc1A9490E61369036497660c8",
+        "chainId": 1,
+        "name": "APWine Token",
+        "symbol": "APW",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/balancer-labs/assets/master/assets/0x4104b135dbc9609fc1a9490e61369036497660c8.png"
+      },
+      {
+        "address": "0x1571eD0bed4D987fe2b498DdBaE7DFA19519F651",
+        "chainId": 1,
+        "name": "iFARM",
+        "symbol": "iFARM",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x1571eD0bed4D987fe2b498DdBaE7DFA19519F651/logo.png"
+      },
+      {
+        "address": "0xfb62AE373acA027177D1c18Ee0862817f9080d08",
+        "chainId": 1,
+        "name": "My DeFi Pet Token",
+        "symbol": "DPET",
+        "decimals": 18
+      },
+      {
+        "address": "0xDe30da39c46104798bB5aA3fe8B9e0e1F348163F",
+        "chainId": 1,
+        "name": "Gitcoin",
+        "symbol": "GTC",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/balancer-labs/assets/master/assets/0xde30da39c46104798bb5aa3fe8b9e0e1f348163f.png"
+      },
+      {
+        "address": "0x677ddbd918637E5F2c79e164D402454dE7dA8619",
+        "chainId": 1,
+        "name": "VUSD",
+        "symbol": "VUSD",
+        "decimals": 18
+      },
+      {
+        "address": "0xD33526068D116cE69F19A9ee46F0bd304F21A51f",
+        "chainId": 1,
+        "name": "Rocket Pool Protocol",
+        "symbol": "RPL",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/balancer-labs/assets/master/assets/0xd33526068d116ce69f19a9ee46f0bd304f21a51f.png"
+      },
+      {
+        "address": "0xae78736Cd615f374D3085123A210448E74Fc6393",
+        "chainId": 1,
+        "name": "Rocket Pool ETH",
+        "symbol": "rETH",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/balancer-labs/assets/master/assets/0xae78736cd615f374d3085123a210448e74fc6393.png"
+      },
+      {
+        "address": "0x9041Fe5B3FDEA0f5e4afDC17e75180738D877A01",
+        "chainId": 1,
+        "name": "ProToken",
+        "symbol": "PRO",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x9041Fe5B3FDEA0f5e4afDC17e75180738D877A01/logo.png"
+      },
+      {
+        "address": "0x1985365e9f78359a9B6AD760e32412f4a445E862",
+        "chainId": 1,
+        "name": "Reputation",
+        "symbol": "REP",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x1985365e9f78359a9B6AD760e32412f4a445E862/logo.png"
+      },
+      {
+        "address": "0x0000852600CEB001E08e00bC008be620d60031F2",
+        "chainId": 1,
+        "name": "TrueHKD",
+        "symbol": "THKD",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x0000852600CEB001E08e00bC008be620d60031F2/logo.png"
+      },
+      {
+        "address": "0x00000100F2A2bd000715001920eB70D229700085",
+        "chainId": 1,
+        "name": "TrueCAD",
+        "symbol": "TCAD",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x00000100F2A2bd000715001920eB70D229700085/logo.png"
+      },
+      {
+        "address": "0x00006100F7090010005F1bd7aE6122c3C2CF0090",
+        "chainId": 1,
+        "name": "TrueAUD",
+        "symbol": "TAUD",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x00006100F7090010005F1bd7aE6122c3C2CF0090/logo.png"
+      },
+      {
+        "address": "0x00000000441378008EA67F4284A57932B1c000a5",
+        "chainId": 1,
+        "name": "TrueGBP",
+        "symbol": "TGBP",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x00000000441378008EA67F4284A57932B1c000a5/logo.png"
+      },
+      {
+        "address": "0x705C71b262C511B66bAA4791cC2BE61B971bD784",
+        "chainId": 1,
+        "name": "Bankless Season 0",
+        "symbol": "BAP0",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/balancer-labs/assets/master/assets/0x705c71b262c511b66baa4791cc2be61b971bd784.png"
+      },
+      {
+        "address": "0xa0afAA285Ce85974c3C881256cB7F225e3A1178a",
+        "chainId": 1,
+        "name": "Wrapped CRES",
+        "symbol": "wCRES",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/balancer-labs/assets/master/assets/0xa0afaa285ce85974c3c881256cb7f225e3a1178a.png"
+      },
+      {
+        "address": "0x67B66C99D3Eb37Fa76Aa3Ed1ff33E8e39F0b9c7A",
+        "chainId": 1,
+        "name": "Interest Bearing ETH",
+        "symbol": "ibETH",
+        "decimals": 18
+      },
+      {
+        "address": "0x4c327471C44B2dacD6E90525f9D629bd2e4f662C",
+        "chainId": 1,
+        "name": "GHOST",
+        "symbol": "GHOST",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x4c327471C44B2dacD6E90525f9D629bd2e4f662C/logo.png"
+      },
+      {
+        "address": "0xBD6467a31899590474cE1e84F70594c53D628e46",
+        "chainId": 1,
+        "name": "KardiaChain Token",
+        "symbol": "KAI",
+        "decimals": 18
+      },
+      {
+        "address": "0xa645264C5603E96c3b0B078cdab68733794B0A71",
+        "chainId": 1,
+        "name": "Mysterium",
+        "symbol": "MYST",
+        "decimals": 8
+      },
+      {
+        "address": "0x261b45D85cCFeAbb11F022eBa346ee8D1cd488c0",
+        "chainId": 1,
+        "name": "Redeemable DAI",
+        "symbol": "rDAI",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x261b45D85cCFeAbb11F022eBa346ee8D1cd488c0/logo.png"
+      },
+      {
+        "address": "0xE5F166c0D8872B68790061317BB6CcA04582C912",
+        "chainId": 1,
+        "name": "TE-FOOD",
+        "symbol": "TFD",
+        "decimals": 18
+      },
+      {
+        "address": "0x70a72833d6bF7F508C8224CE59ea1Ef3d0Ea3A38",
+        "chainId": 1,
+        "name": "UTRUST Token",
+        "symbol": "UTK",
+        "decimals": 18
+      },
+      {
+        "address": "0x46bFA3Bb807B5c3b3Ce7F7e0E667397020B6dc15",
+        "chainId": 1,
+        "name": "DefiStarter",
+        "symbol": "DFST",
+        "decimals": 18
+      },
+      {
+        "address": "0xF938424F7210f31dF2Aee3011291b658f872e91e",
+        "chainId": 1,
+        "name": "VISOR",
+        "symbol": "VISR",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/balancer-labs/assets/master/assets/0xf938424f7210f31df2aee3011291b658f872e91e.png"
+      },
+      {
+        "address": "0x178c820f862B14f316509ec36b13123DA19A6054",
+        "chainId": 1,
+        "name": "Energy Web Token Bridged",
+        "symbol": "EWTB",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x178c820f862B14f316509ec36b13123DA19A6054/logo.png"
+      },
+      {
+        "address": "0xbD9908b0Cdd50386F92efCC8e1d71766C2782Df0",
+        "chainId": 1,
+        "name": "DAOSquare Governance Token",
+        "symbol": "RICE",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/balancer-labs/assets/master/assets/0xbd9908b0cdd50386f92efcc8e1d71766c2782df0.png"
+      },
+      {
+        "address": "0x5AA7C403c7dE4B3bb0cc07079a03e389671a4771",
+        "chainId": 1,
+        "name": "IBIZA Token",
+        "symbol": "IBZ",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/balancer-labs/assets/master/assets/0x5aa7c403c7de4b3bb0cc07079a03e389671a4771.png"
+      },
+      {
+        "address": "0x3301Ee63Fb29F863f2333Bd4466acb46CD8323E6",
+        "chainId": 1,
+        "name": "Akita Inu",
+        "symbol": "AKITA",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x3301Ee63Fb29F863f2333Bd4466acb46CD8323E6/logo.png"
+      },
+      {
+        "address": "0x7f39C581F595B53c5cb19bD0b3f8dA6c935E2Ca0",
+        "chainId": 1,
+        "name": "Wrapped liquid staked Ether 2.0",
+        "symbol": "wstETH",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/balancer-labs/assets/master/assets/0x7f39c581f595b53c5cb19bd0b3f8da6c935e2ca0.png"
+      },
+      {
+        "address": "0x1e83916Ea2EF2D7a6064775662E163b2D4C330a7",
+        "chainId": 1,
+        "name": "EthereumGasLimit",
+        "symbol": "EGL",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/balancer-labs/assets/master/assets/0x1e83916ea2ef2d7a6064775662e163b2d4c330a7.png"
+      },
+      {
+        "address": "0x123151402076fc819B7564510989e475c9cD93CA",
+        "chainId": 1,
+        "name": "wrapped-DGLD",
+        "symbol": "wDGLD",
+        "decimals": 8,
+        "logoURI": "https://raw.githubusercontent.com/balancer-labs/assets/master/assets/0x123151402076fc819b7564510989e475c9cd93ca.png"
+      },
+      {
+        "address": "0x3Ec8798B81485A254928B70CDA1cf0A2BB0B74D7",
+        "chainId": 1,
+        "name": "Gro DAO Token",
+        "symbol": "GRO",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/balancer-labs/assets/master/assets/0x3ec8798b81485a254928b70cda1cf0a2bb0b74d7.png"
+      },
+      {
+        "address": "0x332E824e46FcEeB9E59ba9491B80d3e6d42B0B59",
+        "chainId": 1,
+        "name": "CheeseFry",
+        "symbol": "CHEESE",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/balancer-labs/assets/master/assets/0x332e824e46fceeb9e59ba9491b80d3e6d42b0b59.png"
+      },
+      {
+        "address": "0xe93a27d4ED64F44a2B356d78C06115e5C9D97DA0",
+        "chainId": 1,
+        "name": "KNX",
+        "symbol": "KNX",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/balancer-labs/assets/master/assets/0xe93a27d4ed64f44a2b356d78c06115e5c9d97da0.png"
+      },
+      {
+        "address": "0x804CdB9116a10bB78768D3252355a1b18067bF8f",
+        "chainId": 1,
+        "name": "Balancer Aave Boosted Pool (DAI)",
+        "symbol": "bb-a-DAI",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/balancer-labs/assets/master/assets/0x804cdb9116a10bb78768d3252355a1b18067bf8f.png"
+      },
+      {
+        "address": "0x9210F1204b5a24742Eba12f710636D76240dF3d0",
+        "chainId": 1,
+        "name": "Balancer Aave Boosted Pool (USDC)",
+        "symbol": "bb-a-USDC",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/balancer-labs/assets/master/assets/0x9210f1204b5a24742eba12f710636d76240df3d0.png"
+      },
+      {
+        "address": "0x2BBf681cC4eb09218BEe85EA2a5d3D13Fa40fC0C",
+        "chainId": 1,
+        "name": "Balancer Aave Boosted Pool (USDT)",
+        "symbol": "bb-a-USDT",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/balancer-labs/assets/master/assets/0x2bbf681cc4eb09218bee85ea2a5d3d13fa40fc0c.png"
+      },
+      {
+        "address": "0x7B50775383d3D6f0215A8F290f2C9e2eEBBEceb2",
+        "chainId": 1,
+        "name": "Balancer Aave Boosted StablePool (USD)",
+        "symbol": "bb-a-USD",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/balancer-labs/assets/master/assets/0x7b50775383d3d6f0215a8f290f2c9e2eebbeceb2.png"
+      },
+      {
+        "address": "0x43D4A3cd90ddD2F8f4f693170C9c8098163502ad",
+        "chainId": 1,
+        "name": "Prime",
+        "symbol": "D2D",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/balancer-labs/assets/master/assets/0x43d4a3cd90ddd2f8f4f693170c9c8098163502ad.png"
+      },
+      {
+        "address": "0x02d60b84491589974263d922D9cC7a3152618Ef6",
+        "chainId": 1,
+        "name": "Wrapped aDAI",
+        "symbol": "aDAI",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/balancer-labs/assets/master/assets/0x02d60b84491589974263d922d9cc7a3152618ef6.png"
+      },
+      {
+        "address": "0xd093fA4Fb80D09bB30817FDcd442d4d02eD3E5de",
+        "chainId": 1,
+        "name": "Wrapped aUSDC",
+        "symbol": "aUSDC",
+        "decimals": 6,
+        "logoURI": "https://raw.githubusercontent.com/balancer-labs/assets/master/assets/0xd093fa4fb80d09bb30817fdcd442d4d02ed3e5de.png"
+      },
+      {
+        "address": "0xf8Fd466F12e236f4c96F7Cce6c79EAdB819abF58",
+        "chainId": 1,
+        "name": "Wrapped aUSDT",
+        "symbol": "aUSDT",
+        "decimals": 6,
+        "logoURI": "https://raw.githubusercontent.com/balancer-labs/assets/master/assets/0xf8fd466f12e236f4c96f7cce6c79eadb819abf58.png"
+      },
+      {
+        "address": "0xcAfE001067cDEF266AfB7Eb5A286dCFD277f3dE5",
+        "chainId": 1,
+        "name": "ParaSwap",
+        "symbol": "PSP",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/balancer-labs/assets/master/assets/0xcafe001067cdef266afb7eb5a286dcfd277f3de5.png"
+      },
+      {
+        "address": "0xEDB171C18cE90B633DB442f2A6F72874093b49Ef",
+        "chainId": 1,
+        "name": "Wrapped Ampleforth",
+        "symbol": "WAMPL",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/balancer-labs/assets/master/assets/0xedb171c18ce90b633db442f2a6f72874093b49ef.png"
+      },
+      {
+        "address": "0x64aa3364F17a4D01c6f1751Fd97C2BD3D7e7f1D5",
+        "chainId": 1,
+        "name": "Olympus",
+        "symbol": "OHM",
+        "decimals": 9,
+        "logoURI": "https://raw.githubusercontent.com/balancer-labs/assets/master/assets/0x64aa3364f17a4d01c6f1751fd97c2bd3d7e7f1d5.png"
+      },
+      {
+        "address": "0x10010078a54396F62c96dF8532dc2B4847d47ED3",
+        "chainId": 1,
+        "name": "Hundred Finance",
+        "symbol": "HND",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/balancer-labs/assets/master/assets/0x10010078a54396f62c96df8532dc2b4847d47ed3.png"
+      },
+      {
+        "address": "0x88ACDd2a6425c3FaAE4Bc9650Fd7E27e0Bebb7aB",
+        "chainId": 1,
+        "name": "Alchemist",
+        "symbol": "⚗️",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x88ACDd2a6425c3FaAE4Bc9650Fd7E27e0Bebb7aB/logo.png"
+      },
+      {
+        "address": "0x6f80310CA7F2C654691D1383149Fa1A57d8AB1f8",
+        "chainId": 1,
+        "name": "Silo Governance Token",
+        "symbol": "Silo",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/balancer-labs/assets/master/assets/0x6f80310ca7f2c654691d1383149fa1a57d8ab1f8.png"
+      },
+      {
+        "address": "0x06Df3b2bbB68adc8B0e302443692037ED9f91b42",
+        "chainId": 1,
+        "name": "Balancer USD Stable Pool",
+        "symbol": "staBAL3",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/balancer-labs/assets/master/assets/0x06df3b2bbb68adc8b0e302443692037ed9f91b42.png"
+      },
+      {
+        "address": "0xf2051511B9b121394FA75B8F7d4E7424337af687",
+        "chainId": 1,
+        "name": "DAOhaus Token",
+        "symbol": "HAUS",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/balancer-labs/assets/master/assets/0xf2051511b9b121394fa75b8f7d4e7424337af687.png"
+      },
+      {
+        "address": "0xc976BE9DdBB3e2B2eFFd9af4845C38b6195dAB71",
+        "chainId": 1,
+        "name": "Wrapped SYS",
+        "symbol": "WSYS",
+        "decimals": 18
+      },
+      {
+        "address": "0x9C4A4204B79dd291D6b6571C5BE8BbcD0622F050",
+        "chainId": 1,
+        "name": "Tracer",
+        "symbol": "TCR",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/balancer-labs/assets/master/assets/0x9c4a4204b79dd291d6b6571c5be8bbcd0622f050.png"
+      },
+      {
+        "address": "0xAB846Fb6C81370327e784Ae7CbB6d6a6af6Ff4BF",
+        "chainId": 1,
+        "name": "Paladin Token",
+        "symbol": "PAL",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/balancer-labs/assets/master/assets/0xab846fb6c81370327e784ae7cbb6d6a6af6ff4bf.png"
+      },
+      {
+        "address": "0x12E457a5FC7707d0FDDA849068DF6e664d7a8569",
+        "chainId": 1,
+        "name": "Launch Paladin Token",
+        "symbol": "lPAL",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/balancer-labs/assets/master/assets/0x12e457a5fc7707d0fdda849068df6e664d7a8569.png"
+      },
+      {
+        "address": "0xAf5191B0De278C7286d6C7CC6ab6BB8A73bA2Cd6",
+        "chainId": 1,
+        "name": "StargateToken",
+        "symbol": "STG",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/balancer-labs/assets/master/assets/0xaf5191b0de278c7286d6c7cc6ab6bb8a73ba2cd6.png"
+      },
+      {
+        "address": "0xDEf1CA1fb7FBcDC777520aa7f396b4E015F497aB",
+        "chainId": 1,
+        "name": "CoW Protocol Token",
+        "symbol": "COW",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/balancer-labs/assets/master/assets/0xdef1ca1fb7fbcdc777520aa7f396b4e015f497ab.png"
+      },
+      {
+        "address": "0x5c6Ee304399DBdB9C8Ef030aB642B10820DB8F56",
+        "chainId": 1,
+        "name": "Balancer 80 BAL 20 WETH",
+        "symbol": "B-80BAL-20WETH",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/balancer-labs/assets/master/assets/0x5c6ee304399dbdb9c8ef030ab642b10820db8f56.png"
+      },
+      {
+        "address": "0xEd1480d12bE41d92F36f5f7bDd88212E381A3677",
+        "chainId": 1,
+        "name": "FIAT DAO Token",
+        "symbol": "FDT",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/balancer-labs/assets/master/assets/0xed1480d12be41d92f36f5f7bdd88212e381a3677.png"
+      },
+      {
+        "address": "0x333A4823466879eeF910A04D473505da62142069",
+        "chainId": 1,
+        "name": "Nation3",
+        "symbol": "NATION",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/balancer-labs/assets/master/assets/0x333a4823466879eef910a04d473505da62142069.png"
+      },
+      {
+        "address": "0xF17e65822b568B3903685a7c9F496CF7656Cc6C2",
+        "chainId": 1,
+        "name": "Biconomy Token",
+        "symbol": "BICO",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/balancer-labs/assets/master/assets/0xf17e65822b568b3903685a7c9f496cf7656cc6c2.png"
+      },
+      {
+        "address": "0x226f7b842E0F0120b7E194D05432b3fd14773a9D",
+        "chainId": 1,
+        "name": "UNION Protocol Governance Token",
+        "symbol": "UNN",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x226f7b842E0F0120b7E194D05432b3fd14773a9D/logo.png"
+      },
+      {
+        "address": "0xC0c293ce456fF0ED870ADd98a0828Dd4d2903DBF",
+        "chainId": 1,
+        "name": "Aura",
+        "symbol": "AURA",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/balancer-labs/assets/master/assets/0xc0c293ce456ff0ed870add98a0828dd4d2903dbf.png"
+      },
+      {
+        "address": "0x616e8BfA43F920657B3497DBf40D6b1A02D4608d",
+        "chainId": 1,
+        "name": "Aura BAL",
+        "symbol": "auraBAL",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/balancer-labs/assets/master/assets/0x616e8bfa43f920657b3497dbf40d6b1a02d4608d.png"
+      },
+      {
+        "address": "0xf203Ca1769ca8e9e8FE1DA9D147DB68B6c919817",
+        "chainId": 1,
+        "name": "Wrapped NCG",
+        "symbol": "WNCG",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/balancer-labs/assets/master/assets/0xf203ca1769ca8e9e8fe1da9d147db68b6c919817.png"
+      },
+      {
+        "address": "0x865377367054516e17014CcdED1e7d814EDC9ce4",
+        "chainId": 1,
+        "name": "Dola USD Stablecoin",
+        "symbol": "DOLA",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/balancer-labs/assets/master/assets/0x865377367054516e17014ccded1e7d814edc9ce4.png"
+      },
+      {
+        "address": "0xF24d8651578a55b0C119B9910759a351A3458895",
+        "chainId": 1,
+        "name": "Stake DAO Balancer",
+        "symbol": "sdBal",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/balancer-labs/assets/master/assets/0xf24d8651578a55b0c119b9910759a351a3458895.png"
+      },
+      {
+        "address": "0x586Aa273F262909EEF8fA02d90Ab65F5015e0516",
+        "chainId": 1,
+        "name": "Fixed Income Asset Token",
+        "symbol": "FIAT",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/balancer-labs/assets/master/assets/0x586aa273f262909eef8fa02d90ab65f5015e0516.png"
+      },
+      {
+        "address": "0x888888435FDe8e7d4c54cAb67f206e4199454c60",
+        "chainId": 1,
+        "name": "DFX Token",
+        "symbol": "DFX",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/balancer-labs/assets/master/assets/0x888888435fde8e7d4c54cab67f206e4199454c60.png"
+      },
+      {
+        "address": "0xBA485b556399123261a5F9c95d413B4f93107407",
+        "chainId": 1,
+        "name": "Gravitationally Bound AURA",
+        "symbol": "graviAURA",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/balancer-labs/assets/master/assets/0xba485b556399123261a5f9c95d413b4f93107407.png"
+      },
+      {
+        "address": "0x798D1bE841a82a273720CE31c822C61a67a601C3",
+        "chainId": 1,
+        "name": "Digg",
+        "symbol": "DIGG",
+        "decimals": 9,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x798D1bE841a82a273720CE31c822C61a67a601C3/logo.png"
+      },
+      {
+        "address": "0x35e78b3982E87ecfD5b3f3265B601c046cDBe232",
+        "chainId": 1,
+        "name": "SideShift Token",
+        "symbol": "XAI",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/balancer-labs/assets/master/assets/0x35e78b3982e87ecfd5b3f3265b601c046cdbe232.png"
+      },
+      {
+        "address": "0x24A6A37576377F63f194Caa5F518a60f45b42921",
+        "chainId": 1,
+        "name": "Float Bank",
+        "symbol": "BANK",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x24A6A37576377F63f194Caa5F518a60f45b42921/logo.png"
+      },
+      {
+        "address": "0x758B4684BE769E92eeFeA93f60DDA0181eA303Ec",
+        "chainId": 1,
+        "name": "Phonon DAO",
+        "symbol": "PHONON",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/balancer-labs/assets/master/assets/0x758b4684be769e92eefea93f60dda0181ea303ec.png"
+      },
+      {
+        "address": "0x0C10bF8FcB7Bf5412187A595ab97a3609160b5c6",
+        "chainId": 1,
+        "name": "Decentralized USD",
+        "symbol": "USDD",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/balancer-labs/assets/master/assets/0x0c10bf8fcb7bf5412187a595ab97a3609160b5c6.png"
+      },
+      {
+        "address": "0x853d955aCEf822Db058eb8505911ED77F175b99e",
+        "chainId": 1,
+        "name": "Frax",
+        "symbol": "FRAX",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x853d955aCEf822Db058eb8505911ED77F175b99e/logo.png"
+      },
+      {
+        "address": "0x8888801aF4d980682e47f1A9036e589479e835C5",
+        "chainId": 1,
+        "name": "88mph.app",
+        "symbol": "MPH",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/balancer-labs/assets/master/assets/0x8888801af4d980682e47f1a9036e589479e835c5.png"
+      },
+      {
+        "address": "0x470EBf5f030Ed85Fc1ed4C2d36B9DD02e77CF1b7",
+        "chainId": 1,
+        "name": "Temple",
+        "symbol": "TEMPLE",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/balancer-labs/assets/master/assets/0x470ebf5f030ed85fc1ed4c2d36b9dd02e77cf1b7.png"
+      },
+      {
+        "address": "0xd084944d3c05CD115C09d072B9F44bA3E0E45921",
+        "chainId": 1,
+        "name": "Manifold Finance",
+        "symbol": "FOLD",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/balancer-labs/assets/master/assets/0xd084944d3c05cd115c09d072b9f44ba3e0e45921.png"
+      },
+      {
+        "address": "0xc55126051B22eBb829D00368f4B12Bde432de5Da",
+        "chainId": 1,
+        "name": "BTRFLY",
+        "symbol": "BTRFLY",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/balancer-labs/assets/master/assets/0xc55126051b22ebb829d00368f4b12bde432de5da.png"
+      },
+      {
+        "address": "0xdFCeA9088c8A88A76FF74892C1457C17dfeef9C1",
+        "chainId": 42,
+        "name": "Wrapped Ether",
+        "symbol": "WETH",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2/logo.png"
+      },
+      {
+        "address": "0x41286Bb1D3E870f3F750eB7E1C25d7E48c8A1Ac7",
+        "chainId": 42,
+        "name": "BAL",
+        "symbol": "BAL",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xba100000625a3754423978a60c9317c58a424e3D/logo.png"
+      },
+      {
+        "address": "0xc2569dd7d0fd715B054fBf16E75B001E5c0C1115",
+        "chainId": 42,
+        "name": "USDC",
+        "symbol": "USDC",
+        "decimals": 6,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/logo.png"
+      },
+      {
+        "address": "0xAf9ac3235be96eD496db7969f60D354fe5e426B0",
+        "chainId": 42,
+        "name": "MKR",
+        "symbol": "MKR",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x9f8F72aA9304c8B593d555F12eF6589cC3A579A2/logo.png"
+      },
+      {
+        "address": "0x04DF6e4121c27713ED22341E7c7Df330F56f289B",
+        "chainId": 42,
+        "name": "DAI",
+        "symbol": "DAI",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x6B175474E89094C44Da98b954EedeAC495271d0F/logo.png"
+      },
+      {
+        "address": "0x8F4beBF498cc624a0797Fe64114A6Ff169EEe078",
+        "chainId": 42,
+        "name": "PERP",
+        "symbol": "PERP",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xbC396689893D065F41bc2C6EcbeE5e0085233447/logo.png"
+      },
+      {
+        "address": "0x1C8E3Bcb3378a443CC591f154c5CE0EBb4dA9648",
+        "chainId": 42,
+        "name": "WBTC",
+        "symbol": "WBTC",
+        "decimals": 8,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599/logo.png"
+      }
+    ]
+  },
+  "ipns://tokens.uniswap.org": {
+    "name": "Uniswap Labs Default",
+    "timestamp": "2022-10-20T17:29:34.056Z",
+    "version": { "major": 5, "minor": 2, "patch": 0 },
+    "tags": {},
+    "logoURI": "ipfs://QmNa8mQkrNKp1WEEeGjFezDmDeodkWRevGFN8JCV7b4Xir",
+    "keywords": ["uniswap", "default"],
+    "tokens": [
+      {
+        "chainId": 1,
+        "address": "0x111111111117dC0aa78b770fA6A738034120C302",
+        "name": "1inch",
+        "symbol": "1INCH",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/13469/thumb/1inch-token.png?1608803028",
+        "extensions": {
+          "bridgeInfo": {
+            "137": {
+              "tokenAddress": "0x9c2C5fd7b07E95EE044DDeba0E97a665F142394f"
+            },
+            "42161": {
+              "tokenAddress": "0x6314C31A7a1652cE482cffe247E9CB7c3f4BB9aF"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "address": "0x7Fc66500c84A76Ad7e9c93437bFc5Ac33E2DDaE9",
+        "name": "Aave",
+        "symbol": "AAVE",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/12645/thumb/AAVE.png?1601374110",
+        "extensions": {
+          "bridgeInfo": {
+            "10": {
+              "tokenAddress": "0x76FB31fb4af56892A25e32cFC43De717950c9278"
+            },
+            "137": {
+              "tokenAddress": "0xD6DF932A45C0f255f85145f286eA0b292B21C90B"
+            },
+            "42161": {
+              "tokenAddress": "0xba5DdD1f9d7F570dc94a51479a000E3BCE967196"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "address": "0xB98d4C97425d9908E66E53A6fDf673ACcA0BE986",
+        "name": "Arcblock",
+        "symbol": "ABT",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/2341/thumb/arcblock.png?1547036543"
+      },
+      {
+        "chainId": 1,
+        "address": "0xEd04915c23f00A313a544955524EB7DBD823143d",
+        "name": "Alchemy Pay",
+        "symbol": "ACH",
+        "decimals": 8,
+        "logoURI": "https://assets.coingecko.com/coins/images/12390/thumb/ACH_%281%29.png?1599691266"
+      },
+      {
+        "chainId": 1,
+        "address": "0xADE00C28244d5CE17D72E40330B1c318cD12B7c3",
+        "name": "Ambire AdEx",
+        "symbol": "ADX",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/847/thumb/Ambire_AdEx_Symbol_color.png?1655432540",
+        "extensions": {
+          "bridgeInfo": {
+            "137": {
+              "tokenAddress": "0xdDa7b23D2D72746663E7939743f929a3d85FC975"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "address": "0x91Af0fBB28ABA7E31403Cb457106Ce79397FD4E6",
+        "name": "Aergo",
+        "symbol": "AERGO",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/4490/thumb/aergo.png?1647696770"
+      },
+      {
+        "chainId": 1,
+        "address": "0x32353A6C91143bfd6C7d363B546e62a9A2489A20",
+        "name": "Adventure Gold",
+        "symbol": "AGLD",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/18125/thumb/lpgblc4h_400x400.jpg?1630570955",
+        "extensions": {
+          "bridgeInfo": {
+            "137": {
+              "tokenAddress": "0x6a6bD53d677F8632631662C48bD47b1D4D6524ee"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "address": "0x626E8036dEB333b408Be468F951bdB42433cBF18",
+        "name": "AIOZ Network",
+        "symbol": "AIOZ",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/14631/thumb/aioz_logo.png?1617413126",
+        "extensions": {
+          "bridgeInfo": {
+            "137": {
+              "tokenAddress": "0xe2341718c6C0CbFa8e6686102DD8FbF4047a9e9B"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "address": "0xdBdb4d16EdA451D0503b854CF79D55697F90c8DF",
+        "name": "Alchemix",
+        "symbol": "ALCX",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/14113/thumb/Alchemix.png?1614409874",
+        "extensions": {
+          "bridgeInfo": {
+            "137": {
+              "tokenAddress": "0x95c300e7740D2A88a44124B424bFC1cB2F9c3b89"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "address": "0x27702a26126e0B3702af63Ee09aC4d1A084EF628",
+        "name": "Aleph im",
+        "symbol": "ALEPH",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/11676/thumb/Monochram-aleph.png?1608483725",
+        "extensions": {
+          "bridgeInfo": {
+            "137": {
+              "tokenAddress": "0x82dCf1Df86AdA26b2dCd9ba6334CeDb8c2448e9e"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "address": "0x6B0b3a982b4634aC68dD83a4DBF02311cE324181",
+        "name": "Alethea Artificial Liquid Intelligence",
+        "symbol": "ALI",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/22062/thumb/alethea-logo-transparent-colored.png?1642748848"
+      },
+      {
+        "chainId": 1,
+        "address": "0xAC51066d7bEC65Dc4589368da368b212745d63E8",
+        "name": "My Neighbor Alice",
+        "symbol": "ALICE",
+        "decimals": 6,
+        "logoURI": "https://assets.coingecko.com/coins/images/14375/thumb/alice_logo.jpg?1615782968",
+        "extensions": {
+          "bridgeInfo": {
+            "137": {
+              "tokenAddress": "0x50858d870FAF55da2fD90FB6DF7c34b5648305C6"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "address": "0xa1faa113cbE53436Df28FF0aEe54275c13B40975",
+        "name": "Alpha Venture DAO",
+        "symbol": "ALPHA",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/12738/thumb/AlphaToken_256x256.png?1617160876",
+        "extensions": {
+          "bridgeInfo": {
+            "137": {
+              "tokenAddress": "0x3AE490db48d74B1bC626400135d4616377D0109f"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "address": "0xfF20817765cB7f73d4bde2e66e067E58D11095C2",
+        "name": "Amp",
+        "symbol": "AMP",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/12409/thumb/amp-200x200.png?1599625397",
+        "extensions": {
+          "bridgeInfo": {
+            "137": {
+              "tokenAddress": "0x0621d647cecbFb64b79E44302c1933cB4f27054d"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "address": "0x8290333ceF9e6D528dD5618Fb97a76f268f3EDD4",
+        "name": "Ankr",
+        "symbol": "ANKR",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/4324/thumb/U85xTl2.png?1608111978",
+        "extensions": {
+          "bridgeInfo": {
+            "137": {
+              "tokenAddress": "0x101A023270368c0D50BFfb62780F4aFd4ea79C35"
+            }
+          }
+        }
+      },
+      {
+        "name": "Aragon",
+        "address": "0xa117000000f279D81A1D3cc75430fAA017FA5A2e",
+        "symbol": "ANT",
+        "decimals": 18,
+        "chainId": 1,
+        "logoURI": "https://assets.coingecko.com/coins/images/681/thumb/JelZ58cv_400x400.png?1601449653",
+        "extensions": {
+          "bridgeInfo": {
+            "137": {
+              "tokenAddress": "0x2b8504ab5eFc246d0eC5Ec7E74565683227497de"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "address": "0x4d224452801ACEd8B2F0aebE155379bb5D594381",
+        "name": "ApeCoin",
+        "symbol": "APE",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/24383/small/apecoin.jpg?1647476455",
+        "extensions": {
+          "bridgeInfo": {
+            "137": {
+              "tokenAddress": "0xB7b31a6BC18e48888545CE79e83E06003bE70930"
+            },
+            "42161": {
+              "tokenAddress": "0x74885b4D524d497261259B38900f54e6dbAd2210"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "address": "0x0b38210ea11411557c13457D4dA7dC6ea731B88a",
+        "name": "API3",
+        "symbol": "API3",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/13256/thumb/api3.jpg?1606751424",
+        "extensions": {
+          "bridgeInfo": {
+            "137": {
+              "tokenAddress": "0x45C27821E80F8789b60Fd8B600C73815d34DDa6C"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "address": "0xBA50933C268F567BDC86E1aC131BE072C6B0b71a",
+        "name": "ARPA Chain",
+        "symbol": "ARPA",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/8506/thumb/9u0a23XY_400x400.jpg?1559027357",
+        "extensions": {
+          "bridgeInfo": {
+            "137": {
+              "tokenAddress": "0xEE800B277A96B0f490a1A732e1D6395FAD960A26"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "address": "0x64D91f12Ece7362F91A6f8E7940Cd55F05060b92",
+        "name": "ASH",
+        "symbol": "ASH",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/15714/thumb/omnPqaTY.png?1622820503"
+      },
+      {
+        "chainId": 1,
+        "address": "0x2565ae0385659badCada1031DB704442E1b69982",
+        "name": "Assemble Protocol",
+        "symbol": "ASM",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/11605/thumb/gpvrlkSq_400x400_%281%29.jpg?1591775789"
+      },
+      {
+        "chainId": 1,
+        "address": "0x27054b13b1B798B345b591a4d22e6562d47eA75a",
+        "name": "AirSwap",
+        "symbol": "AST",
+        "decimals": 4,
+        "logoURI": "https://assets.coingecko.com/coins/images/1019/thumb/Airswap.png?1630903484",
+        "extensions": {
+          "bridgeInfo": {
+            "137": {
+              "tokenAddress": "0x04bEa9FCE76943E90520489cCAb84E84C0198E29"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "address": "0xA2120b9e674d3fC3875f415A7DF52e382F141225",
+        "name": "Automata",
+        "symbol": "ATA",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/15985/thumb/ATA.jpg?1622535745",
+        "extensions": {
+          "bridgeInfo": {
+            "137": {
+              "tokenAddress": "0x0df0f72EE0e5c9B7ca761ECec42754992B2Da5BF"
+            },
+            "42161": {
+              "tokenAddress": "0xAC9Ac2C17cdFED4AbC80A53c5553388575714d03"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "address": "0xA9B1Eb5908CfC3cdf91F9B8B3a74108598009096",
+        "name": "Bounce",
+        "symbol": "AUCTION",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/13860/thumb/1_KtgpRIJzuwfHe0Rl0avP_g.jpeg?1612412025"
+      },
+      {
+        "chainId": 1,
+        "address": "0x18aAA7115705e8be94bfFEBDE57Af9BFc265B998",
+        "name": "Audius",
+        "symbol": "AUDIO",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/12913/thumb/AudiusCoinLogo_2x.png?1603425727",
+        "extensions": {
+          "bridgeInfo": {
+            "137": {
+              "tokenAddress": "0x5eB8D998371971D01954205c7AFE90A7AF6a95AC"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "address": "0x845576c64f9754CF09d87e45B720E82F3EeF522C",
+        "name": "Artverse Token",
+        "symbol": "AVT",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/19727/thumb/ewnektoB_400x400.png?1635767094"
+      },
+      {
+        "chainId": 1,
+        "address": "0xBB0E17EF65F82Ab018d8EDd776e8DD940327B28b",
+        "name": "Axie Infinity",
+        "symbol": "AXS",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/13029/thumb/axie_infinity_logo.png?1604471082",
+        "extensions": {
+          "bridgeInfo": {
+            "137": {
+              "tokenAddress": "0x61BDD9C7d4dF4Bf47A4508c0c8245505F2Af5b7b"
+            },
+            "42161": {
+              "tokenAddress": "0xe88998Fb579266628aF6a03e3821d5983e5D0089"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "address": "0x3472A5A71965499acd81997a54BBA8D852C6E53d",
+        "name": "Badger DAO",
+        "symbol": "BADGER",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/13287/thumb/badger_dao_logo.jpg?1607054976",
+        "extensions": {
+          "bridgeInfo": {
+            "137": {
+              "tokenAddress": "0x1FcbE5937B0cc2adf69772D228fA4205aCF4D9b2"
+            },
+            "42161": {
+              "tokenAddress": "0xBfa641051Ba0a0Ad1b0AcF549a89536A0D76472E"
+            }
+          }
+        }
+      },
+      {
+        "name": "Balancer",
+        "address": "0xba100000625a3754423978a60c9317c58a424e3D",
+        "symbol": "BAL",
+        "decimals": 18,
+        "chainId": 1,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xba100000625a3754423978a60c9317c58a424e3D/logo.png",
+        "extensions": {
+          "bridgeInfo": {
+            "137": {
+              "tokenAddress": "0x9a71012B13CA4d3D0Cdc72A177DF3ef03b0E76A3"
+            },
+            "42161": {
+              "tokenAddress": "0x040d1EdC9569d4Bab2D15287Dc5A4F10F56a56B8"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "address": "0xBA11D00c5f74255f56a5E366F4F77f5A186d7f55",
+        "name": "Band Protocol",
+        "symbol": "BAND",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/9545/thumb/band-protocol.png?1568730326",
+        "extensions": {
+          "bridgeInfo": {
+            "137": {
+              "tokenAddress": "0xA8b1E0764f85f53dfe21760e8AfE5446D82606ac"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "address": "0x0D8775F648430679A709E98d2b0Cb6250d2887EF",
+        "name": "Basic Attention Token",
+        "symbol": "BAT",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/677/thumb/basic-attention-token.png?1547034427",
+        "extensions": {
+          "bridgeInfo": {
+            "137": {
+              "tokenAddress": "0x3Cef98bb43d732E2F285eE605a8158cDE967D219"
+            },
+            "42161": {
+              "tokenAddress": "0x3450687EF141dCd6110b77c2DC44B008616AeE75"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "address": "0xF17e65822b568B3903685a7c9F496CF7656Cc6C2",
+        "name": "Biconomy",
+        "symbol": "BICO",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/21061/thumb/biconomy_logo.jpg?1638269749",
+        "extensions": {
+          "bridgeInfo": {
+            "137": {
+              "tokenAddress": "0x91c89A94567980f0e9723b487b0beD586eE96aa7"
+            },
+            "42161": {
+              "tokenAddress": "0xa68Ec98D7ca870cF1Dd0b00EBbb7c4bF60A8e74d"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "address": "0x1A4b46696b2bB4794Eb3D4c26f1c55F9170fa4C5",
+        "name": "BitDAO",
+        "symbol": "BIT",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/17627/thumb/rI_YptK8.png?1653983088",
+        "extensions": {
+          "bridgeInfo": {
+            "42161": {
+              "tokenAddress": "0x406C8dB506653D882295875F633bEC0bEb921C2A"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "address": "0x5732046A883704404F284Ce41FfADd5b007FD668",
+        "name": "Bluzelle",
+        "symbol": "BLZ",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/2848/thumb/ColorIcon_3x.png?1622516510",
+        "extensions": {
+          "bridgeInfo": {
+            "137": {
+              "tokenAddress": "0x438B28C5AA5F00a817b7Def7cE2Fb3d5d1970974"
+            }
+          }
+        }
+      },
+      {
+        "name": "Bancor Network Token",
+        "address": "0x1F573D6Fb3F13d689FF844B4cE37794d79a7FF1C",
+        "symbol": "BNT",
+        "decimals": 18,
+        "chainId": 1,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x1F573D6Fb3F13d689FF844B4cE37794d79a7FF1C/logo.png",
+        "extensions": {
+          "bridgeInfo": {
+            "137": {
+              "tokenAddress": "0xc26D47d5c33aC71AC5CF9F776D63Ba292a4F7842"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "address": "0x42bBFa2e77757C645eeaAd1655E0911a7553Efbc",
+        "name": "Boba Network",
+        "symbol": "BOBA",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/20285/thumb/BOBA.png?1636811576",
+        "extensions": {
+          "bridgeInfo": {
+            "137": {
+              "tokenAddress": "0xa4B2B20b2C73c7046ED19AC6bfF5E5285c58F20a"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "address": "0x0391D2021f89DC339F60Fff84546EA23E337750f",
+        "name": "BarnBridge",
+        "symbol": "BOND",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/12811/thumb/barnbridge.jpg?1602728853",
+        "extensions": {
+          "bridgeInfo": {
+            "10": {
+              "tokenAddress": "0x3e7eF8f50246f725885102E8238CBba33F276747"
+            },
+            "137": {
+              "tokenAddress": "0xA041544fe2BE56CCe31Ebb69102B965E06aacE80"
+            },
+            "42161": {
+              "tokenAddress": "0x0D81E50bC677fa67341c44D7eaA9228DEE64A4e1"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "address": "0x799ebfABE77a6E34311eeEe9825190B9ECe32824",
+        "name": "Braintrust",
+        "symbol": "BTRST",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/18100/thumb/braintrust.PNG?1630475394"
+      },
+      {
+        "chainId": 1,
+        "address": "0x4Fabb145d64652a948d72533023f6E7A623C7C53",
+        "name": "Binance USD",
+        "symbol": "BUSD",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/9576/thumb/BUSD.png?1568947766",
+        "extensions": {
+          "bridgeInfo": {
+            "137": {
+              "tokenAddress": "0xdAb529f40E671A1D4bF91361c21bf9f0C9712ab7"
+            },
+            "42161": {
+              "tokenAddress": "0x31190254504622cEFdFA55a7d3d272e6462629a2"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "address": "0xAE12C5930881c53715B369ceC7606B70d8EB229f",
+        "name": "Coin98",
+        "symbol": "C98",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/17117/thumb/logo.png?1626412904"
+      },
+      {
+        "chainId": 1,
+        "address": "0x4F9254C83EB525f9FCf346490bbb3ed28a81C667",
+        "name": "Celer Network",
+        "symbol": "CELR",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/4379/thumb/Celr.png?1554705437",
+        "extensions": {
+          "bridgeInfo": {
+            "137": {
+              "tokenAddress": "0x91a4635F620766145C099E15889Bd2766906A559"
+            },
+            "42161": {
+              "tokenAddress": "0x3a8B787f78D775AECFEEa15706D4221B40F345AB"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "address": "0x8A2279d4A90B6fe1C4B30fa660cC9f926797bAA2",
+        "name": "Chromia",
+        "symbol": "CHR",
+        "decimals": 6,
+        "logoURI": "https://assets.coingecko.com/coins/images/5000/thumb/Chromia.png?1559038018",
+        "extensions": {
+          "bridgeInfo": {
+            "137": {
+              "tokenAddress": "0x594C984E3318e91313f881B021A0C4203fF5E59F"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "address": "0x3506424F91fD33084466F402d5D97f05F8e3b4AF",
+        "name": "Chiliz",
+        "symbol": "CHZ",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/8834/thumb/Chiliz.png?1561970540",
+        "extensions": {
+          "bridgeInfo": {
+            "137": {
+              "tokenAddress": "0xf1938Ce12400f9a761084E7A80d37e732a4dA056"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "address": "0x80C62FE4487E1351b47Ba49809EBD60ED085bf52",
+        "name": "Clover Finance",
+        "symbol": "CLV",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/15278/thumb/clover.png?1645084454"
+      },
+      {
+        "name": "Compound",
+        "address": "0xc00e94Cb662C3520282E6f5717214004A7f26888",
+        "symbol": "COMP",
+        "decimals": 18,
+        "chainId": 1,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xc00e94Cb662C3520282E6f5717214004A7f26888/logo.png",
+        "extensions": {
+          "bridgeInfo": {
+            "137": {
+              "tokenAddress": "0x8505b9d2254A7Ae468c0E9dd10Ccea3A837aef5c"
+            },
+            "42161": {
+              "tokenAddress": "0x354A6dA3fcde098F8389cad84b0182725c6C91dE"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "address": "0xDDB3422497E61e13543BeA06989C0789117555c5",
+        "name": "COTI",
+        "symbol": "COTI",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/2962/thumb/Coti.png?1559653863",
+        "extensions": {
+          "bridgeInfo": {
+            "42161": {
+              "tokenAddress": "0x6FE14d3CC2f7bDdffBa5CdB3BBE7467dd81ea101"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "address": "0x3D658390460295FB963f54dC0899cfb1c30776Df",
+        "name": "Circuits of Value",
+        "symbol": "COVAL",
+        "decimals": 8,
+        "logoURI": "https://assets.coingecko.com/coins/images/588/thumb/coval-logo.png?1599493950"
+      },
+      {
+        "chainId": 1,
+        "address": "0xD417144312DbF50465b1C641d016962017Ef6240",
+        "name": "Covalent",
+        "symbol": "CQT",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/14168/thumb/covalent-cqt.png?1624545218",
+        "extensions": {
+          "bridgeInfo": {
+            "137": {
+              "tokenAddress": "0x93B0fF1C8828F6eB039D345Ff681eD735086d925"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "address": "0xA0b73E1Ff0B80914AB6fe0444E65848C4C34450b",
+        "name": "Cronos",
+        "symbol": "CRO",
+        "decimals": 8,
+        "logoURI": "https://assets.coingecko.com/coins/images/7310/thumb/oCw2s3GI_400x400.jpeg?1645172042",
+        "extensions": {
+          "bridgeInfo": {
+            "137": {
+              "tokenAddress": "0xAdA58DF0F643D959C2A47c9D4d4c1a4deFe3F11C"
+            },
+            "42161": {
+              "tokenAddress": "0x8ea3156f834A0dfC78F1A5304fAC2CdA676F354C"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "address": "0x08389495D7456E1951ddF7c3a1314A4bfb646d8B",
+        "name": "Crypterium",
+        "symbol": "CRPT",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/1901/thumb/crypt.png?1547036205"
+      },
+      {
+        "name": "Curve DAO Token",
+        "address": "0xD533a949740bb3306d119CC777fa900bA034cd52",
+        "symbol": "CRV",
+        "decimals": 18,
+        "chainId": 1,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xD533a949740bb3306d119CC777fa900bA034cd52/logo.png",
+        "extensions": {
+          "bridgeInfo": {
+            "10": {
+              "tokenAddress": "0x0994206dfE8De6Ec6920FF4D779B0d950605Fb53"
+            },
+            "137": {
+              "tokenAddress": "0x172370d5Cd63279eFa6d502DAB29171933a610AF"
+            },
+            "42161": {
+              "tokenAddress": "0x11cDb42B0EB46D95f990BeDD4695A6e3fA034978"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "address": "0x491604c0FDF08347Dd1fa4Ee062a822A5DD06B5D",
+        "name": "Cartesi",
+        "symbol": "CTSI",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/11038/thumb/cartesi.png?1592288021",
+        "extensions": {
+          "bridgeInfo": {
+            "137": {
+              "tokenAddress": "0x2727Ab1c2D22170ABc9b595177B2D5C6E1Ab7B7B"
+            },
+            "42161": {
+              "tokenAddress": "0x319f865b287fCC10b30d8cE6144e8b6D1b476999"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "address": "0x321C2fE4446C7c963dc41Dd58879AF648838f98D",
+        "name": "Cryptex Finance",
+        "symbol": "CTX",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/14932/thumb/glossy_icon_-_C200px.png?1619073171",
+        "extensions": {
+          "bridgeInfo": {
+            "137": {
+              "tokenAddress": "0x8c208BC2A808a088a78398fed8f2640cab0b6EDb"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "address": "0xDf801468a808a32656D2eD2D2d80B72A129739f4",
+        "name": "Somnium Space CUBEs",
+        "symbol": "CUBE",
+        "decimals": 8,
+        "logoURI": "https://assets.coingecko.com/coins/images/10687/thumb/CUBE_icon.png?1617026861",
+        "extensions": {
+          "bridgeInfo": {
+            "137": {
+              "tokenAddress": "0x276C9cbaa4BDf57d7109a41e67BD09699536FA3d"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "address": "0x41e5560054824eA6B0732E656E3Ad64E20e94E45",
+        "name": "Civic",
+        "symbol": "CVC",
+        "decimals": 8,
+        "logoURI": "https://assets.coingecko.com/coins/images/788/thumb/civic.png?1547034556",
+        "extensions": {
+          "bridgeInfo": {
+            "137": {
+              "tokenAddress": "0x66Dc5A08091d1968e08C16aA5b27BAC8398b02Be"
+            },
+            "42161": {
+              "tokenAddress": "0x9DfFB23CAd3322440bCcFF7aB1C58E781dDBF144"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "address": "0x4e3FBD56CD56c3e72c1403e103b45Db9da5B9D2B",
+        "name": "Convex Finance",
+        "symbol": "CVX",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/15585/thumb/convex.png?1621256328",
+        "extensions": {
+          "bridgeInfo": {
+            "137": {
+              "tokenAddress": "0x4257EA7637c355F81616050CbB6a9b709fd72683"
+            }
+          }
+        }
+      },
+      {
+        "name": "Dai Stablecoin",
+        "address": "0x6B175474E89094C44Da98b954EedeAC495271d0F",
+        "symbol": "DAI",
+        "decimals": 18,
+        "chainId": 1,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x6B175474E89094C44Da98b954EedeAC495271d0F/logo.png",
+        "extensions": {
+          "bridgeInfo": {
+            "10": {
+              "tokenAddress": "0xDA10009cBd5D07dd0CeCc66161FC93D7c9000da1"
+            },
+            "137": {
+              "tokenAddress": "0x8f3Cf7ad23Cd3CaDbD9735AFf958023239c6A063"
+            },
+            "42161": {
+              "tokenAddress": "0xDA10009cBd5D07dd0CeCc66161FC93D7c9000da1"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "address": "0x081131434f93063751813C619Ecca9C4dC7862a3",
+        "name": "Mines of Dalarnia",
+        "symbol": "DAR",
+        "decimals": 6,
+        "logoURI": "https://assets.coingecko.com/coins/images/19837/thumb/dar.png?1636014223"
+      },
+      {
+        "chainId": 1,
+        "address": "0x3A880652F47bFaa771908C07Dd8673A787dAEd3A",
+        "name": "DerivaDAO",
+        "symbol": "DDX",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/13453/thumb/ddx_logo.png?1608741641",
+        "extensions": {
+          "bridgeInfo": {
+            "137": {
+              "tokenAddress": "0x26f5FB1e6C8a65b3A873fF0a213FA16EFF5a7828"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "address": "0x3597bfD533a99c9aa083587B074434E61Eb0A258",
+        "name": "Dent",
+        "symbol": "DENT",
+        "decimals": 8,
+        "logoURI": "https://assets.coingecko.com/coins/images/1152/thumb/gLCEA2G.png?1604543239"
+      },
+      {
+        "chainId": 1,
+        "address": "0xfB7B4564402E5500dB5bB6d63Ae671302777C75a",
+        "name": "DexTools",
+        "symbol": "DEXT",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/11603/thumb/dext.png?1605790188",
+        "extensions": {
+          "bridgeInfo": {
+            "137": {
+              "tokenAddress": "0xff835562C761205659939B64583dd381a6AA4D92"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "address": "0x84cA8bc7997272c7CfB4D0Cd3D55cd942B3c9419",
+        "name": "DIA",
+        "symbol": "DIA",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/11955/thumb/image.png?1646041751",
+        "extensions": {
+          "bridgeInfo": {
+            "137": {
+              "tokenAddress": "0x993f2CafE9dbE525243f4A78BeBC69DAc8D36000"
+            },
+            "42161": {
+              "tokenAddress": "0xca642467C6Ebe58c13cB4A7091317f34E17ac05e"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "address": "0x0AbdAce70D3790235af448C88547603b945604ea",
+        "name": "district0x",
+        "symbol": "DNT",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/849/thumb/district0x.png?1547223762"
+      },
+      {
+        "chainId": 1,
+        "address": "0x1494CA1F11D487c2bBe4543E90080AeBa4BA3C2b",
+        "name": "DeFi Pulse Index",
+        "symbol": "DPI",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/12465/thumb/defi_pulse_index_set.png?1600051053",
+        "extensions": {
+          "bridgeInfo": {
+            "137": {
+              "tokenAddress": "0x85955046DF4668e1DD369D2DE9f3AEB98DD2A369"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "address": "0x3Ab6Ed69Ef663bd986Ee59205CCaD8A20F98b4c2",
+        "name": "Drep",
+        "symbol": "DREP",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/14578/thumb/KotgsCgS_400x400.jpg?1617094445"
+      },
+      {
+        "chainId": 1,
+        "address": "0x92D6C1e31e14520e676a687F0a93788B716BEff5",
+        "name": "dYdX",
+        "symbol": "DYDX",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/17500/thumb/hjnIm9bV.jpg?1628009360",
+        "extensions": {
+          "bridgeInfo": {
+            "137": {
+              "tokenAddress": "0x4C3bF0a3DE9524aF68327d1D2558a3B70d17D42a"
+            },
+            "42161": {
+              "tokenAddress": "0x51863cB90Ce5d6dA9663106F292fA27c8CC90c5a"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "address": "0x961C8c0B1aaD0c0b10a51FeF6a867E3091BCef17",
+        "name": "DeFi Yield Protocol",
+        "symbol": "DYP",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/13480/thumb/DYP_Logo_Symbol-8.png?1655809066"
+      },
+      {
+        "chainId": 1,
+        "address": "0xe6fd75ff38Adca4B97FBCD938c86b98772431867",
+        "name": "Elastos",
+        "symbol": "ELA",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/2780/thumb/Elastos.png?1597048112"
+      },
+      {
+        "chainId": 1,
+        "address": "0x761D38e5ddf6ccf6Cf7c55759d5210750B5D60F3",
+        "name": "Dogelon Mars",
+        "symbol": "ELON",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/14962/thumb/6GxcPRo3_400x400.jpg?1619157413",
+        "extensions": {
+          "bridgeInfo": {
+            "137": {
+              "tokenAddress": "0xE0339c80fFDE91F3e20494Df88d4206D86024cdF"
+            },
+            "42161": {
+              "tokenAddress": "0x3e4Cff6E50F37F731284A92d44AE943e17077fD4"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "address": "0xF629cBd94d3791C9250152BD8dfBDF380E2a3B9c",
+        "name": "Enjin Coin",
+        "symbol": "ENJ",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/1102/thumb/enjin-coin-logo.png?1547035078",
+        "extensions": {
+          "bridgeInfo": {
+            "137": {
+              "tokenAddress": "0x7eC26842F195c852Fa843bB9f6D8B583a274a157"
+            },
+            "42161": {
+              "tokenAddress": "0x7fa9549791EFc9030e1Ed3F25D18014163806758"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "address": "0xC18360217D8F7Ab5e7c516566761Ea12Ce7F9D72",
+        "name": "Ethereum Name Service",
+        "symbol": "ENS",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/19785/thumb/acatxTm8_400x400.jpg?1635850140",
+        "extensions": {
+          "bridgeInfo": {
+            "10": {
+              "tokenAddress": "0x65559aA14915a70190438eF90104769e5E890A00"
+            },
+            "137": {
+              "tokenAddress": "0xbD7A5Cf51d22930B8B3Df6d834F9BCEf90EE7c4f"
+            },
+            "42161": {
+              "tokenAddress": "0xfeA31d704DEb0975dA8e77Bf13E04239e70d7c28"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "address": "0xBBc2AE13b23d715c30720F079fcd9B4a74093505",
+        "name": "Ethernity Chain",
+        "symbol": "ERN",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/14238/thumb/LOGO_HIGH_QUALITY.png?1647831402",
+        "extensions": {
+          "bridgeInfo": {
+            "137": {
+              "tokenAddress": "0x0E50BEA95Fe001A370A4F1C220C49AEdCB982DeC"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "address": "0xd9Fcd98c322942075A5C3860693e9f4f03AAE07b",
+        "name": "Euler",
+        "symbol": "EUL",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/26149/thumb/YCvKDfl8_400x400.jpeg?1656041509"
+      },
+      {
+        "chainId": 1,
+        "address": "0x1aBaEA1f7C830bD89Acc67eC4af516284b1bC33c",
+        "name": "Euro Coin",
+        "symbol": "EUROC",
+        "decimals": 6,
+        "logoURI": "https://assets.coingecko.com/coins/images/26045/thumb/euro-coin.png?1655394420",
+        "extensions": {
+          "bridgeInfo": {
+            "137": {
+              "tokenAddress": "0x8a037dbcA8134FFc72C362e394e35E0Cad618F85"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "address": "0xa0246c9032bC3A600820415aE600c6388619A14D",
+        "name": "Harvest Finance",
+        "symbol": "FARM",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/12304/thumb/Harvest.png?1613016180",
+        "extensions": {
+          "bridgeInfo": {
+            "137": {
+              "tokenAddress": "0x176f5AB638cf4Ff3B6239Ba609C3fadAA46ef5B0"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "address": "0xaea46A60368A7bD060eec7DF8CBa43b7EF41Ad85",
+        "name": "Fetch ai",
+        "symbol": "FET",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/5681/thumb/Fetch.jpg?1572098136",
+        "extensions": {
+          "bridgeInfo": {
+            "137": {
+              "tokenAddress": "0x7583FEDDbceFA813dc18259940F76a02710A8905"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "address": "0xef3A930e1FfFFAcd2fc13434aC81bD278B0ecC8d",
+        "name": "Stafi",
+        "symbol": "FIS",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/12423/thumb/stafi_logo.jpg?1599730991",
+        "extensions": {
+          "bridgeInfo": {
+            "137": {
+              "tokenAddress": "0x7A7B94F18EF6AD056CDa648588181CDA84800f94"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "address": "0x41545f8b9472D758bB669ed8EaEEEcD7a9C4Ec29",
+        "name": "Forta",
+        "symbol": "FORT",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/25060/thumb/Forta_lgo_%281%29.png?1655353696",
+        "extensions": {
+          "bridgeInfo": {
+            "137": {
+              "tokenAddress": "0x9ff62d1FC52A907B6DCbA8077c2DDCA6E6a9d3e1"
+            },
+            "42161": {
+              "tokenAddress": "0x3A1429d50E0cBBc45c997aF600541Fe1cc3D2923"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "address": "0x77FbA179C79De5B7653F68b5039Af940AdA60ce0",
+        "name": "Ampleforth Governance Token",
+        "symbol": "FORTH",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/14917/thumb/photo_2021-04-22_00.00.03.jpeg?1619020835",
+        "extensions": {
+          "bridgeInfo": {
+            "137": {
+              "tokenAddress": "0x5eCbA59DAcc1ADc5bDEA35f38A732823fc3dE977"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "address": "0xc770EEfAd204B5180dF6a14Ee197D99d808ee52d",
+        "name": "ShapeShift FOX Token",
+        "symbol": "FOX",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/9988/thumb/FOX.png?1574330622",
+        "extensions": {
+          "bridgeInfo": {
+            "137": {
+              "tokenAddress": "0x65A05DB8322701724c197AF82C9CaE41195B0aA8"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "address": "0x853d955aCEf822Db058eb8505911ED77F175b99e",
+        "name": "Frax",
+        "symbol": "FRAX",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/13422/thumb/frax_logo.png?1608476506",
+        "extensions": {
+          "bridgeInfo": {
+            "137": {
+              "tokenAddress": "0x104592a158490a9228070E0A8e5343B499e125D0"
+            },
+            "42161": {
+              "tokenAddress": "0x7468a5d8E02245B00E8C0217fCE021C70Bc51305"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "address": "0x4E15361FD6b4BB609Fa63C81A2be19d873717870",
+        "name": "Fantom",
+        "symbol": "FTM",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/4001/thumb/Fantom.png?1558015016",
+        "extensions": {
+          "bridgeInfo": {
+            "137": {
+              "tokenAddress": "0xC9c1c1c20B3658F8787CC2FD702267791f224Ce1"
+            },
+            "42161": {
+              "tokenAddress": "0xd42785D323e608B9E99fa542bd8b1000D4c2Df37"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "address": "0x8c15Ef5b4B21951d50E53E4fbdA8298FFAD25057",
+        "name": "Function X",
+        "symbol": "FX",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/8186/thumb/47271330_590071468072434_707260356350705664_n.jpg?1556096683"
+      },
+      {
+        "chainId": 1,
+        "address": "0x3432B6A60D23Ca0dFCa7761B7ab56459D9C964D0",
+        "name": "Frax Share",
+        "symbol": "FXS",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/13423/thumb/frax_share.png?1608478989",
+        "extensions": {
+          "bridgeInfo": {
+            "137": {
+              "tokenAddress": "0x3e121107F6F22DA4911079845a470757aF4e1A1b"
+            },
+            "42161": {
+              "tokenAddress": "0xd9f9d2Ee2d3EFE420699079f16D9e924affFdEA4"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "address": "0x5fAa989Af96Af85384b8a938c2EdE4A7378D9875",
+        "name": "Project Galaxy",
+        "symbol": "GAL",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/24530/thumb/GAL-Token-Icon.png?1651483533"
+      },
+      {
+        "chainId": 1,
+        "address": "0x15D4c048F83bd7e37d49eA4C83a07267Ec4203dA",
+        "name": "Gala",
+        "symbol": "GALA",
+        "decimals": 8,
+        "logoURI": "https://assets.coingecko.com/coins/images/12493/thumb/GALA-COINGECKO.png?1600233435",
+        "extensions": {
+          "bridgeInfo": {
+            "137": {
+              "tokenAddress": "0x09E1943Dd2A4e82032773594f50CF54453000b97"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "address": "0xdab396cCF3d84Cf2D07C4454e10C8A6F5b008D2b",
+        "name": "Goldfinch",
+        "symbol": "GFI",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/19081/thumb/GOLDFINCH.png?1634369662"
+      },
+      {
+        "chainId": 1,
+        "address": "0x3F382DbD960E3a9bbCeaE22651E88158d2791550",
+        "name": "Aavegotchi",
+        "symbol": "GHST",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/12467/thumb/ghst_200.png?1600750321",
+        "extensions": {
+          "bridgeInfo": {
+            "137": {
+              "tokenAddress": "0x385Eeac5cB85A38A9a07A70c73e0a3271CfB54A7"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "address": "0x7DD9c5Cba05E151C895FDe1CF355C9A1D5DA6429",
+        "name": "Golem",
+        "symbol": "GLM",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/542/thumb/Golem_Submark_Positive_RGB.png?1606392013",
+        "extensions": {
+          "bridgeInfo": {
+            "137": {
+              "tokenAddress": "0x0B220b82F3eA3B7F6d9A1D8ab58930C064A2b5Bf"
+            }
+          }
+        }
+      },
+      {
+        "name": "Gnosis Token",
+        "address": "0x6810e776880C02933D47DB1b9fc05908e5386b96",
+        "symbol": "GNO",
+        "decimals": 18,
+        "chainId": 1,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x6810e776880C02933D47DB1b9fc05908e5386b96/logo.png",
+        "extensions": {
+          "bridgeInfo": {
+            "137": {
+              "tokenAddress": "0x5FFD62D3C3eE2E81C00A7b9079FB248e7dF024A8"
+            },
+            "42161": {
+              "tokenAddress": "0xa0b862F60edEf4452F25B4160F177db44DeB6Cf1"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "address": "0xccC8cb5229B0ac8069C51fd58367Fd1e622aFD97",
+        "name": "Gods Unchained",
+        "symbol": "GODS",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/17139/thumb/10631.png?1635718182",
+        "extensions": {
+          "bridgeInfo": {
+            "137": {
+              "tokenAddress": "0xF88fc6b493eda7650E4bcf7A290E8d108F677CfE"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "address": "0xc944E90C64B2c07662A292be6244BDf05Cda44a7",
+        "name": "The Graph",
+        "symbol": "GRT",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/13397/thumb/Graph_Token.png?1608145566",
+        "extensions": {
+          "bridgeInfo": {
+            "137": {
+              "tokenAddress": "0x5fe2B58c013d7601147DcdD68C143A77499f5531"
+            },
+            "42161": {
+              "tokenAddress": "0x23A941036Ae778Ac51Ab04CEa08Ed6e2FE103614"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "address": "0xDe30da39c46104798bB5aA3fe8B9e0e1F348163F",
+        "name": "Gitcoin",
+        "symbol": "GTC",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/15810/thumb/gitcoin.png?1621992929",
+        "extensions": {
+          "bridgeInfo": {
+            "137": {
+              "tokenAddress": "0xdb95f9188479575F3F718a245EcA1B3BF74567EC"
+            },
+            "42161": {
+              "tokenAddress": "0x7f9a7DB853Ca816B9A138AEe3380Ef34c437dEe0"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "address": "0x056Fd409E1d7A124BD7017459dFEa2F387b6d5Cd",
+        "name": "Gemini Dollar",
+        "symbol": "GUSD",
+        "decimals": 2,
+        "logoURI": "https://assets.coingecko.com/coins/images/5992/thumb/gemini-dollar-gusd.png?1536745278",
+        "extensions": {
+          "bridgeInfo": {
+            "137": {
+              "tokenAddress": "0xC8A94a3d3D2dabC3C1CaffFFDcA6A7543c3e3e65"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "address": "0xC08512927D12348F6620a698105e1BAac6EcD911",
+        "name": "GYEN",
+        "symbol": "GYEN",
+        "decimals": 6,
+        "logoURI": "https://assets.coingecko.com/coins/images/14191/thumb/icon_gyen_200_200.png?1614843343",
+        "extensions": {
+          "bridgeInfo": {
+            "137": {
+              "tokenAddress": "0x482bc619eE7662759CDc0685B4E78f464Da39C73"
+            },
+            "42161": {
+              "tokenAddress": "0x3fEcB65993e4835884baF6452d1ebfdBC3A78480"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "address": "0x71Ab77b7dbB4fa7e017BC15090b2163221420282",
+        "name": "Highstreet",
+        "symbol": "HIGH",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/18973/thumb/logosq200200Coingecko.png?1634090470"
+      },
+      {
+        "chainId": 1,
+        "name": "HOPR",
+        "symbol": "HOPR",
+        "logoURI": "https://assets.coingecko.com/coins/images/14061/thumb/Shared_HOPR_logo_512px.png?1614073468",
+        "address": "0xF5581dFeFD8Fb0e4aeC526bE659CFaB1f8c781dA",
+        "decimals": 18,
+        "extensions": {
+          "bridgeInfo": {
+            "137": {
+              "tokenAddress": "0x6cCBF3627b2C83AFEF05bf2F035E7f7B210Fe30D"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "address": "0xB705268213D593B8FD88d3FDEFF93AFF5CbDcfAE",
+        "name": "IDEX",
+        "symbol": "IDEX",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/2565/thumb/logomark-purple-286x286.png?1638362736",
+        "extensions": {
+          "bridgeInfo": {
+            "137": {
+              "tokenAddress": "0x9Cb74C8032b007466865f060ad2c46145d45553D"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "address": "0xF57e7e7C23978C3cAEC3C3548E3D615c346e79fF",
+        "name": "Immutable X",
+        "symbol": "IMX",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/17233/thumb/imx.png?1636691817",
+        "extensions": {
+          "bridgeInfo": {
+            "137": {
+              "tokenAddress": "0x183070C90B34A63292cC908Ce1b263Cb56D49A7F"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "name": "Index Cooperative",
+        "symbol": "INDEX",
+        "logoURI": "https://assets.coingecko.com/coins/images/12729/thumb/index.png?1634894321",
+        "address": "0x0954906da0Bf32d5479e25f46056d22f08464cab",
+        "decimals": 18,
+        "extensions": {
+          "bridgeInfo": {
+            "137": {
+              "tokenAddress": "0xfBd8A3b908e764dBcD51e27992464B4432A1132b"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "address": "0xe28b3B32B6c345A34Ff64674606124Dd5Aceca30",
+        "name": "Injective",
+        "symbol": "INJ",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/12882/thumb/Secondary_Symbol.png?1628233237",
+        "extensions": {
+          "bridgeInfo": {
+            "137": {
+              "tokenAddress": "0x4E8dc2149EaC3f3dEf36b1c281EA466338249371"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "address": "0x41D5D79431A913C4aE7d69a668ecdfE5fF9DFB68",
+        "name": "Inverse Finance",
+        "symbol": "INV",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/14205/thumb/inverse_finance.jpg?1614921871",
+        "extensions": {
+          "bridgeInfo": {
+            "137": {
+              "tokenAddress": "0xF18Ac368001b0DdC80aA6a8374deb49e868EFDb8"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "address": "0x6fB3e0A217407EFFf7Ca062D46c26E5d60a14d69",
+        "name": "IoTeX",
+        "symbol": "IOTX",
+        "decimals": 18,
+        "logoURI": "https://s2.coinmarketcap.com/static/img/coins/64x64/2777.png",
+        "extensions": {
+          "bridgeInfo": {
+            "137": {
+              "tokenAddress": "0xf6372cDb9c1d3674E83842e3800F2A62aC9F3C66"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "name": "Geojam",
+        "symbol": "JAM",
+        "logoURI": "https://assets.coingecko.com/coins/images/24648/thumb/ey40AzBN_400x400.jpg?1648507272",
+        "address": "0x23894DC9da6c94ECb439911cAF7d337746575A72",
+        "decimals": 18
+      },
+      {
+        "chainId": 1,
+        "address": "0x7420B4b9a0110cdC71fB720908340C03F9Bc03EC",
+        "name": "JasmyCoin",
+        "symbol": "JASMY",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/13876/thumb/JASMY200x200.jpg?1612473259",
+        "extensions": {
+          "bridgeInfo": {
+            "137": {
+              "tokenAddress": "0xb87f5c1E81077FfcfE821dA240fd20C99c533aF1"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "name": "Jupiter",
+        "symbol": "JUP",
+        "logoURI": "https://assets.coingecko.com/coins/images/10351/thumb/logo512.png?1632480932",
+        "address": "0x4B1E80cAC91e2216EEb63e29B957eB91Ae9C2Be8",
+        "decimals": 18
+      },
+      {
+        "chainId": 1,
+        "address": "0x85Eee30c52B0b379b046Fb0F85F4f3Dc3009aFEC",
+        "name": "Keep Network",
+        "symbol": "KEEP",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/3373/thumb/IuNzUb5b_400x400.jpg?1589526336",
+        "extensions": {
+          "bridgeInfo": {
+            "137": {
+              "tokenAddress": "0x42f37A1296b2981F7C3cAcEd84c5096b2Eb0C72C"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "name": "SelfKey",
+        "symbol": "KEY",
+        "logoURI": "https://assets.coingecko.com/coins/images/2034/thumb/selfkey.png?1548608934",
+        "address": "0x4CC19356f2D37338b9802aa8E8fc58B0373296E7",
+        "decimals": 18
+      },
+      {
+        "name": "Kyber Network Crystal",
+        "address": "0xdd974D5C2e2928deA5F71b9825b8b646686BD200",
+        "symbol": "KNC",
+        "decimals": 18,
+        "chainId": 1,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xdd974D5C2e2928deA5F71b9825b8b646686BD200/logo.png",
+        "extensions": {
+          "bridgeInfo": {
+            "137": {
+              "tokenAddress": "0x324b28d6565f784d596422B0F2E5aB6e9CFA1Dc7"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "address": "0x1cEB5cB57C4D4E2b2433641b95Dd330A33185A44",
+        "name": "Keep3rV1",
+        "symbol": "KP3R",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/12966/thumb/kp3r_logo.jpg?1607057458",
+        "extensions": {
+          "bridgeInfo": {
+            "137": {
+              "tokenAddress": "0x53AEc293212E3B792563Bc16f1be26956adb12e9"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "address": "0x464eBE77c293E473B48cFe96dDCf88fcF7bFDAC0",
+        "name": "KRYLL",
+        "symbol": "KRL",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/2807/thumb/krl.png?1547036979"
+      },
+      {
+        "chainId": 1,
+        "address": "0x037A54AaB062628C9Bbae1FDB1583c195585fe41",
+        "name": "LCX",
+        "symbol": "LCX",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/9985/thumb/zRPSu_0o_400x400.jpg?1574327008",
+        "extensions": {
+          "bridgeInfo": {
+            "137": {
+              "tokenAddress": "0xE8A51D0dD1b4525189ddA2187F90ddF0932b5482"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "address": "0x5A98FcBEA516Cf06857215779Fd812CA3beF1B32",
+        "name": "Lido DAO",
+        "symbol": "LDO",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/13573/thumb/Lido_DAO.png?1609873644",
+        "extensions": {
+          "bridgeInfo": {
+            "137": {
+              "tokenAddress": "0xC3C7d422809852031b44ab29EEC9F1EfF2A58756"
+            },
+            "42161": {
+              "tokenAddress": "0x13Ad51ed4F1B7e9Dc168d8a00cB3f4dDD85EfA60"
+            }
+          }
+        }
+      },
+      {
+        "name": "ChainLink Token",
+        "address": "0x514910771AF9Ca656af840dff83E8264EcF986CA",
+        "symbol": "LINK",
+        "decimals": 18,
+        "chainId": 1,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x514910771AF9Ca656af840dff83E8264EcF986CA/logo.png",
+        "extensions": {
+          "bridgeInfo": {
+            "10": {
+              "tokenAddress": "0x350a791Bfc2C21F9Ed5d10980Dad2e2638ffa7f6"
+            },
+            "137": {
+              "tokenAddress": "0x53E0bca35eC356BD5ddDFebbD1Fc0fD03FaBad39"
+            },
+            "42161": {
+              "tokenAddress": "0xf97f4df75117a78c1A5a0DBb814Af92458539FB4"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "name": "League of Kingdoms",
+        "symbol": "LOKA",
+        "logoURI": "https://assets.coingecko.com/coins/images/22572/thumb/loka_64pix.png?1642643271",
+        "address": "0x61E90A50137E1F645c9eF4a0d3A4f01477738406",
+        "decimals": 18
+      },
+      {
+        "name": "Loom Network",
+        "address": "0xA4e8C3Ec456107eA67d3075bF9e3DF3A75823DB0",
+        "symbol": "LOOM",
+        "decimals": 18,
+        "chainId": 1,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xA4e8C3Ec456107eA67d3075bF9e3DF3A75823DB0/logo.png",
+        "extensions": {
+          "bridgeInfo": {
+            "137": {
+              "tokenAddress": "0x66EfB7cC647e0efab02eBA4316a2d2941193F6b3"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "address": "0x58b6A8A3302369DAEc383334672404Ee733aB239",
+        "name": "Livepeer",
+        "symbol": "LPT",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/7137/thumb/logo-circle-green.png?1619593365",
+        "extensions": {
+          "bridgeInfo": {
+            "137": {
+              "tokenAddress": "0x3962F4A0A0051DccE0be73A7e09cEf5756736712"
+            },
+            "42161": {
+              "tokenAddress": "0x289ba1701C2F088cf0faf8B3705246331cB8A839"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "address": "0x6DEA81C8171D0bA574754EF6F8b412F2Ed88c54D",
+        "name": "Liquity",
+        "symbol": "LQTY",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/14665/thumb/200-lqty-icon.png?1617631180",
+        "extensions": {
+          "bridgeInfo": {
+            "137": {
+              "tokenAddress": "0x8Ab2Fec94d17ae69FB90E7c773f2C85Ed1802c01"
+            }
+          }
+        }
+      },
+      {
+        "name": "LoopringCoin V2",
+        "address": "0xBBbbCA6A901c926F240b89EacB641d8Aec7AEafD",
+        "symbol": "LRC",
+        "decimals": 18,
+        "chainId": 1,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xBBbbCA6A901c926F240b89EacB641d8Aec7AEafD/logo.png",
+        "extensions": {
+          "bridgeInfo": {
+            "10": {
+              "tokenAddress": "0xFEaA9194F9F8c1B65429E31341a103071464907E"
+            },
+            "137": {
+              "tokenAddress": "0x84e1670F61347CDaeD56dcc736FB990fBB47ddC1"
+            },
+            "42161": {
+              "tokenAddress": "0x46d0cE7de6247b0A95f67b43B589b4041BaE7fbE"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "name": "Liquity USD",
+        "symbol": "LUSD",
+        "logoURI": "https://assets.coingecko.com/coins/images/14666/thumb/Group_3.png?1617631327",
+        "address": "0x5f98805A4E8be255a32880FDeC7F6728C6568bA0",
+        "decimals": 18,
+        "extensions": {
+          "bridgeInfo": {
+            "10": {
+              "tokenAddress": "0xc40F949F8a4e094D1b49a23ea9241D289B7b2819"
+            },
+            "137": {
+              "tokenAddress": "0x23001f892c0C82b79303EDC9B9033cD190BB21c7"
+            },
+            "42161": {
+              "tokenAddress": "0x93b346b6BC2548dA6A1E7d98E9a421B42541425b"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "address": "0x0F5D2fB29fb7d3CFeE444a200298f468908cC942",
+        "name": "Decentraland",
+        "symbol": "MANA",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/878/thumb/decentraland-mana.png?1550108745",
+        "extensions": {
+          "bridgeInfo": {
+            "137": {
+              "tokenAddress": "0xA1c57f48F0Deb89f569dFbE6E2B7f46D33606fD4"
+            },
+            "42161": {
+              "tokenAddress": "0x442d24578A564EF628A65e6a7E3e7be2a165E231"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "address": "0x69af81e73A73B40adF4f3d4223Cd9b1ECE623074",
+        "name": "Mask Network",
+        "symbol": "MASK",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/14051/thumb/Mask_Network.jpg?1614050316",
+        "extensions": {
+          "bridgeInfo": {
+            "10": {
+              "tokenAddress": "0x3390108E913824B8eaD638444cc52B9aBdF63798"
+            },
+            "137": {
+              "tokenAddress": "0x2B9E7ccDF0F4e5B24757c1E1a80e311E34Cb10c7"
+            },
+            "42161": {
+              "tokenAddress": "0x533A7B414CD1236815a5e09F1E97FC7d5c313739"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "name": "MATH",
+        "symbol": "MATH",
+        "logoURI": "https://assets.coingecko.com/coins/images/11335/thumb/2020-05-19-token-200.png?1589940590",
+        "address": "0x08d967bb0134F2d07f7cfb6E246680c53927DD30",
+        "decimals": 18,
+        "extensions": {
+          "bridgeInfo": {
+            "137": {
+              "tokenAddress": "0x347ACCAFdA7F8c5BdeC57fa34a5b663CBd1aeca7"
+            },
+            "42161": {
+              "tokenAddress": "0x99F40b01BA9C469193B360f72740E416B17Ac332"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "address": "0x7D1AfA7B718fb893dB30A3aBc0Cfc608AaCfeBB0",
+        "name": "Polygon",
+        "symbol": "MATIC",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/4713/thumb/matic-token-icon.png?1624446912",
+        "extensions": {
+          "bridgeInfo": {
+            "137": {
+              "tokenAddress": "0x0000000000000000000000000000000000001010"
+            },
+            "42161": {
+              "tokenAddress": "0x561877b6b3DD7651313794e5F2894B2F18bE0766"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "address": "0x949D48EcA67b17269629c7194F4b727d4Ef9E5d6",
+        "name": "Merit Circle",
+        "symbol": "MC",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/19304/thumb/Db4XqML.png?1634972154"
+      },
+      {
+        "chainId": 1,
+        "address": "0xfC98e825A2264D890F9a1e68ed50E1526abCcacD",
+        "name": "Moss Carbon Credit",
+        "symbol": "MCO2",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/14414/thumb/ENtxnThA_400x400.jpg?1615948522",
+        "extensions": {
+          "bridgeInfo": {
+            "137": {
+              "tokenAddress": "0xAa7DbD1598251f856C12f63557A4C4397c253Cea"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "address": "0x814e0908b12A99FeCf5BC101bB5d0b8B5cDf7d26",
+        "name": "Measurable Data Token",
+        "symbol": "MDT",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/2441/thumb/mdt_logo.png?1569813574"
+      },
+      {
+        "chainId": 1,
+        "name": "Metis",
+        "symbol": "METIS",
+        "logoURI": "https://assets.coingecko.com/coins/images/15595/thumb/metis.jpeg?1660285312",
+        "address": "0x9E32b13ce7f2E80A01932B42553652E053D6ed8e",
+        "decimals": 18,
+        "extensions": {
+          "bridgeInfo": {
+            "137": {
+              "tokenAddress": "0x1B9D40715E757Bdb9bdEC3215B898E46d8a3b71a"
+            },
+            "42161": {
+              "tokenAddress": "0x7F728F3595db17B0B359f4FC47aE80FAd2e33769"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "address": "0x99D8a9C45b2ecA8864373A26D1459e3Dff1e17F3",
+        "name": "Magic Internet Money",
+        "symbol": "MIM",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/16786/thumb/mimlogopng.png?1624979612",
+        "extensions": {
+          "bridgeInfo": {
+            "137": {
+              "tokenAddress": "0x01288e04435bFcd4718FF203D6eD18146C17Cd4b"
+            },
+            "42161": {
+              "tokenAddress": "0xB20A02dfFb172C474BC4bDa3fD6f4eE70C04daf2"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "address": "0x09a3EcAFa817268f77BE1283176B946C4ff2E608",
+        "name": "Mirror Protocol",
+        "symbol": "MIR",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/13295/thumb/mirror_logo_transparent.png?1611554658",
+        "extensions": {
+          "bridgeInfo": {
+            "137": {
+              "tokenAddress": "0x1C5cccA2CB59145A4B25F452660cbA6436DDce9b"
+            }
+          }
+        }
+      },
+      {
+        "name": "Maker",
+        "address": "0x9f8F72aA9304c8B593d555F12eF6589cC3A579A2",
+        "symbol": "MKR",
+        "decimals": 18,
+        "chainId": 1,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x9f8F72aA9304c8B593d555F12eF6589cC3A579A2/logo.png",
+        "extensions": {
+          "bridgeInfo": {
+            "10": {
+              "tokenAddress": "0xab7bAdEF82E9Fe11f6f33f87BC9bC2AA27F2fCB5"
+            },
+            "137": {
+              "tokenAddress": "0x6f7C932e7684666C9fd1d44527765433e01fF61d"
+            },
+            "42161": {
+              "tokenAddress": "0x2e9a6Df78E42a30712c10a9Dc4b1C8656f8F2879"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "address": "0xec67005c4E498Ec7f55E092bd1d35cbC47C91892",
+        "name": "Melon",
+        "symbol": "MLN",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/605/thumb/melon.png?1547034295",
+        "extensions": {
+          "bridgeInfo": {
+            "137": {
+              "tokenAddress": "0xa9f37D84c856fDa3812ad0519Dad44FA0a3Fe207"
+            },
+            "42161": {
+              "tokenAddress": "0x8f5c1A99b1df736Ad685006Cb6ADCA7B7Ae4b514"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "name": "Monavale",
+        "symbol": "MONA",
+        "logoURI": "https://assets.coingecko.com/coins/images/13298/thumb/monavale_logo.jpg?1607232721",
+        "address": "0x275f5Ad03be0Fa221B4C6649B8AeE09a42D9412A",
+        "decimals": 18,
+        "extensions": {
+          "bridgeInfo": {
+            "137": {
+              "tokenAddress": "0x6968105460f67c3BF751bE7C15f92F5286Fd0CE5"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "address": "0x33349B282065b0284d756F0577FB39c158F935e6",
+        "name": "Maple",
+        "symbol": "MPL",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/14097/thumb/photo_2021-05-03_14.20.41.jpeg?1620022863"
+      },
+      {
+        "chainId": 1,
+        "name": "Metal",
+        "symbol": "MTL",
+        "logoURI": "https://assets.coingecko.com/coins/images/763/thumb/Metal.png?1592195010",
+        "address": "0xF433089366899D83a9f26A773D59ec7eCF30355e",
+        "decimals": 8
+      },
+      {
+        "chainId": 1,
+        "address": "0x65Ef703f5594D2573eb71Aaf55BC0CB548492df4",
+        "name": "Multichain",
+        "symbol": "MULTI",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/22087/thumb/1_Wyot-SDGZuxbjdkaOeT2-A.png?1640764238"
+      },
+      {
+        "chainId": 1,
+        "address": "0xe2f2a5C287993345a840Db3B0845fbC70f5935a5",
+        "name": "mStable USD",
+        "symbol": "MUSD",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/11576/thumb/mStable_USD.png?1595591803"
+      },
+      {
+        "chainId": 1,
+        "name": "Muse DAO",
+        "symbol": "MUSE",
+        "logoURI": "https://assets.coingecko.com/coins/images/13230/thumb/muse_logo.png?1606460453",
+        "address": "0xB6Ca7399B4F9CA56FC27cBfF44F4d2e4Eef1fc81",
+        "decimals": 18
+      },
+      {
+        "chainId": 1,
+        "name": "GensoKishi Metaverse",
+        "symbol": "MV",
+        "logoURI": "https://s2.coinmarketcap.com/static/img/coins/64x64/17704.png",
+        "address": "0xAE788F80F2756A86aa2F410C651F2aF83639B95b",
+        "decimals": 18,
+        "extensions": {
+          "bridgeInfo": {
+            "137": {
+              "tokenAddress": "0xA3c322Ad15218fBFAEd26bA7f616249f7705D945"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "name": "MXC",
+        "symbol": "MXC",
+        "logoURI": "https://assets.coingecko.com/coins/images/4604/thumb/mxc.png?1655534336",
+        "address": "0x5Ca381bBfb58f0092df149bD3D243b08B9a8386e",
+        "decimals": 18
+      },
+      {
+        "chainId": 1,
+        "address": "0x9E46A38F5DaaBe8683E10793b06749EEF7D733d1",
+        "name": "PolySwarm",
+        "symbol": "NCT",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/2843/thumb/ImcYCVfX_400x400.jpg?1628519767",
+        "extensions": {
+          "bridgeInfo": {
+            "137": {
+              "tokenAddress": "0x4985E0B13554fB521840e893574D3848C10Fcc6f"
+            },
+            "42161": {
+              "tokenAddress": "0x53236015A675fcB937485F1AE58040e4Fb920d5b"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "name": "Nest Protocol",
+        "symbol": "NEST",
+        "logoURI": "https://assets.coingecko.com/coins/images/11284/thumb/52954052.png?1589868539",
+        "address": "0x04abEdA201850aC0124161F037Efd70c74ddC74C",
+        "decimals": 18
+      },
+      {
+        "chainId": 1,
+        "address": "0x5Cf04716BA20127F1E2297AdDCf4B5035000c9eb",
+        "name": "NKN",
+        "symbol": "NKN",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/3375/thumb/nkn.png?1548329212"
+      },
+      {
+        "name": "Numeraire",
+        "address": "0x1776e1F26f98b1A5dF9cD347953a26dd3Cb46671",
+        "symbol": "NMR",
+        "decimals": 18,
+        "chainId": 1,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x1776e1F26f98b1A5dF9cD347953a26dd3Cb46671/logo.png",
+        "extensions": {
+          "bridgeInfo": {
+            "137": {
+              "tokenAddress": "0x0Bf519071b02F22C17E7Ed5F4002ee1911f46729"
+            },
+            "42161": {
+              "tokenAddress": "0x597701b32553b9fa473e21362D480b3a6B569711"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "address": "0x4fE83213D56308330EC302a8BD641f1d0113A4Cc",
+        "name": "NuCypher",
+        "symbol": "NU",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/3318/thumb/photo1198982838879365035.jpg?1547037916"
+      },
+      {
+        "chainId": 1,
+        "address": "0x967da4048cD07aB37855c090aAF366e4ce1b9F48",
+        "name": "Ocean Protocol",
+        "symbol": "OCEAN",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/3687/thumb/ocean-protocol-logo.jpg?1547038686",
+        "extensions": {
+          "bridgeInfo": {
+            "137": {
+              "tokenAddress": "0x282d8efCe846A88B159800bd4130ad77443Fa1A1"
+            },
+            "42161": {
+              "tokenAddress": "0x933d31561e470478079FEB9A6Dd2691fAD8234DF"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "address": "0x8207c1FfC5B6804F6024322CcF34F29c3541Ae26",
+        "name": "Origin Protocol",
+        "symbol": "OGN",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/3296/thumb/op.jpg?1547037878",
+        "extensions": {
+          "bridgeInfo": {
+            "137": {
+              "tokenAddress": "0xa63Beffd33AB3a2EfD92a39A7D2361CEE14cEbA8"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "address": "0xd26114cd6EE289AccF82350c8d8487fedB8A0C07",
+        "name": "OMG Network",
+        "symbol": "OMG",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/776/thumb/OMG_Network.jpg?1591167168",
+        "extensions": {
+          "bridgeInfo": {
+            "137": {
+              "tokenAddress": "0x62414D03084EeB269E18C970a21f45D2967F0170"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "address": "0x6F59e0461Ae5E2799F1fB3847f05a63B16d0DbF8",
+        "name": "ORCA Alliance",
+        "symbol": "ORCA",
+        "decimals": 18,
+        "logoURI": "https://s2.coinmarketcap.com/static/img/coins/64x64/5183.png"
+      },
+      {
+        "chainId": 1,
+        "address": "0x0258F474786DdFd37ABCE6df6BBb1Dd5dfC4434a",
+        "name": "Orion Protocol",
+        "symbol": "ORN",
+        "decimals": 8,
+        "logoURI": "https://assets.coingecko.com/coins/images/11841/thumb/orion_logo.png?1594943318",
+        "extensions": {
+          "bridgeInfo": {
+            "137": {
+              "tokenAddress": "0x0EE392bA5ef1354c9bd75a98044667d307C0e773"
+            }
+          }
+        }
+      },
+      {
+        "name": "Orchid",
+        "address": "0x4575f41308EC1483f3d399aa9a2826d74Da13Deb",
+        "symbol": "OXT",
+        "decimals": 18,
+        "chainId": 1,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x4575f41308EC1483f3d399aa9a2826d74Da13Deb/logo.png",
+        "extensions": {
+          "bridgeInfo": {
+            "137": {
+              "tokenAddress": "0x9880e3dDA13c8e7D4804691A45160102d31F6060"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "address": "0xc1D204d77861dEf49b6E769347a883B15EC397Ff",
+        "name": "PayperEx",
+        "symbol": "PAX",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/1601/thumb/pax.png?1547035800"
+      },
+      {
+        "chainId": 1,
+        "address": "0x45804880De22913dAFE09f4980848ECE6EcbAf78",
+        "name": "PAX Gold",
+        "symbol": "PAXG",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/9519/thumb/paxg.PNG?1568542565",
+        "extensions": {
+          "bridgeInfo": {
+            "137": {
+              "tokenAddress": "0x553d3D295e0f695B9228246232eDF400ed3560B5"
+            },
+            "42161": {
+              "tokenAddress": "0xfEb4DfC8C4Cf7Ed305bb08065D08eC6ee6728429"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "address": "0xbC396689893D065F41bc2C6EcbeE5e0085233447",
+        "name": "Perpetual Protocol",
+        "symbol": "PERP",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/12381/thumb/60d18e06844a844ad75901a9_mark_only_03.png?1628674771",
+        "extensions": {
+          "bridgeInfo": {
+            "10": {
+              "tokenAddress": "0x9e1028F5F1D5eDE59748FFceE5532509976840E0"
+            },
+            "137": {
+              "tokenAddress": "0x263534a4Fe3cb249dF46810718B7B612a30ebbff"
+            },
+            "42161": {
+              "tokenAddress": "0x753D224bCf9AAFaCD81558c32341416df61D3DAC"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "address": "0x3a4f40631a4f906c2BaD353Ed06De7A5D3fCb430",
+        "name": "PlayDapp",
+        "symbol": "PLA",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/14316/thumb/54023228.png?1615366911",
+        "extensions": {
+          "bridgeInfo": {
+            "137": {
+              "tokenAddress": "0x8765f05ADce126d70bcdF1b0a48Db573316662eB"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "address": "0xD8912C10681D8B21Fd3742244f44658dBA12264E",
+        "name": "Pluton",
+        "symbol": "PLU",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/1241/thumb/pluton.png?1548331624",
+        "extensions": {
+          "bridgeInfo": {
+            "137": {
+              "tokenAddress": "0x7dc0cb65EC6019330a6841e9c274f2EE57A6CA6C"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "address": "0x83e6f1E41cdd28eAcEB20Cb649155049Fac3D5Aa",
+        "name": "Polkastarter",
+        "symbol": "POLS",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/12648/thumb/polkastarter.png?1609813702",
+        "extensions": {
+          "bridgeInfo": {
+            "137": {
+              "tokenAddress": "0x8dc302e2141DA59c934d900886DbF1518Fd92cd4"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "address": "0x9992eC3cF6A55b00978cdDF2b27BC6882d88D1eC",
+        "name": "Polymath",
+        "symbol": "POLY",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/2784/thumb/inKkF01.png?1605007034",
+        "extensions": {
+          "bridgeInfo": {
+            "137": {
+              "tokenAddress": "0xcB059C5573646047D6d88dDdb87B745C18161d3b"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "name": "Marlin",
+        "symbol": "POND",
+        "logoURI": "https://assets.coingecko.com/coins/images/8903/thumb/POND_200x200.png?1622515451",
+        "address": "0x57B946008913B82E4dF85f501cbAeD910e58D26C",
+        "decimals": 18,
+        "extensions": {
+          "bridgeInfo": {
+            "137": {
+              "tokenAddress": "0x73580A2416A57f1C4b6391DBA688A9e4f7DBECE0"
+            },
+            "42161": {
+              "tokenAddress": "0xdA0a57B710768ae17941a9Fa33f8B720c8bD9ddD"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "address": "0x595832F8FC6BF59c85C527fEC3740A1b7a361269",
+        "name": "Power Ledger",
+        "symbol": "POWR",
+        "decimals": 6,
+        "logoURI": "https://assets.coingecko.com/coins/images/1104/thumb/power-ledger.png?1547035082",
+        "extensions": {
+          "bridgeInfo": {
+            "137": {
+              "tokenAddress": "0x0AaB8DC887D34f00D50E19aee48371a941390d14"
+            },
+            "42161": {
+              "tokenAddress": "0x4e91F2AF1ee0F84B529478f19794F5AFD423e4A6"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "address": "0x226bb599a12C826476e3A771454697EA52E9E220",
+        "name": "Propy",
+        "symbol": "PRO",
+        "decimals": 8,
+        "logoURI": "https://assets.coingecko.com/coins/images/869/thumb/propy.png?1548332100",
+        "extensions": {
+          "bridgeInfo": {
+            "137": {
+              "tokenAddress": "0x82FFdFD1d8699E8886a4e77CeFA9dd9710a7FefD"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "name": "PARSIQ",
+        "symbol": "PRQ",
+        "logoURI": "https://assets.coingecko.com/coins/images/11973/thumb/DsNgK0O.png?1596590280",
+        "address": "0x362bc847A3a9637d3af6624EeC853618a43ed7D2",
+        "decimals": 18,
+        "extensions": {
+          "bridgeInfo": {
+            "137": {
+              "tokenAddress": "0x9377Eeb7419486FD4D485671d50baa4BF77c2222"
+            },
+            "42161": {
+              "tokenAddress": "0x82164a8B646401a8776F9dC5c8Cba35DcAf60Cd2"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "name": "pSTAKE Finance",
+        "symbol": "PSTAKE",
+        "logoURI": "https://assets.coingecko.com/coins/images/23931/thumb/PSTAKE_Dark.png?1645709930",
+        "address": "0xfB5c6815cA3AC72Ce9F5006869AE67f18bF77006",
+        "decimals": 18
+      },
+      {
+        "chainId": 1,
+        "address": "0x4a220E6096B25EADb88358cb44068A3248254675",
+        "name": "Quant",
+        "symbol": "QNT",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/3370/thumb/5ZOu7brX_400x400.jpg?1612437252",
+        "extensions": {
+          "bridgeInfo": {
+            "137": {
+              "tokenAddress": "0x36B77a184bE8ee56f5E81C56727B20647A42e28E"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "name": "Qredo",
+        "symbol": "QRDO",
+        "logoURI": "https://assets.coingecko.com/coins/images/17541/thumb/qrdo.png?1630637735",
+        "address": "0x4123a133ae3c521FD134D7b13A2dEC35b56c2463",
+        "decimals": 8
+      },
+      {
+        "chainId": 1,
+        "address": "0x99ea4dB9EE77ACD40B119BD1dC4E33e1C070b80d",
+        "name": "Quantstamp",
+        "symbol": "QSP",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/1219/thumb/0_E0kZjb4dG4hUnoDD_.png?1604815917"
+      },
+      {
+        "chainId": 1,
+        "address": "0x6c28AeF8977c9B773996d0e8376d2EE379446F2f",
+        "name": "Quickswap",
+        "symbol": "QUICK",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/13970/thumb/1_pOU6pBMEmiL-ZJVb0CYRjQ.png?1613386659",
+        "extensions": {
+          "bridgeInfo": {
+            "137": {
+              "tokenAddress": "0x831753DD7087CaC61aB5644b308642cc1c33Dc13"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "address": "0x31c8EAcBFFdD875c74b94b077895Bd78CF1E64A3",
+        "name": "Radicle",
+        "symbol": "RAD",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/14013/thumb/radicle.png?1614402918",
+        "extensions": {
+          "bridgeInfo": {
+            "137": {
+              "tokenAddress": "0x2f81e176471CC57fDC76f7d332FB4511bF2bebDD"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "address": "0x03ab458634910AaD20eF5f1C8ee96F1D6ac54919",
+        "name": "Rai Reflex Index",
+        "symbol": "RAI",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/14004/thumb/RAI-logo-coin.png?1613592334",
+        "extensions": {
+          "bridgeInfo": {
+            "10": {
+              "tokenAddress": "0x7FB688CCf682d58f86D7e38e03f9D22e7705448B"
+            },
+            "137": {
+              "tokenAddress": "0x00e5646f60AC6Fb446f621d146B6E1886f002905"
+            },
+            "42161": {
+              "tokenAddress": "0xaeF5bbcbFa438519a5ea80B4c7181B4E78d419f2"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "address": "0xba5BDe662c17e2aDFF1075610382B9B691296350",
+        "name": "SuperRare",
+        "symbol": "RARE",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/17753/thumb/RARE.jpg?1629220534"
+      },
+      {
+        "chainId": 1,
+        "address": "0xFca59Cd816aB1eaD66534D82bc21E7515cE441CF",
+        "name": "Rarible",
+        "symbol": "RARI",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/11845/thumb/Rari.png?1594946953",
+        "extensions": {
+          "bridgeInfo": {
+            "137": {
+              "tokenAddress": "0x780053837cE2CeEaD2A90D9151aA21FC89eD49c2"
+            },
+            "42161": {
+              "tokenAddress": "0xCF8600347Dc375C5f2FdD6Dab9BB66e0b6773cd7"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "address": "0xA4EED63db85311E22dF4473f87CcfC3DaDCFA3E3",
+        "name": "Rubic",
+        "symbol": "RBC",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/12629/thumb/200x200.png?1607952509",
+        "extensions": {
+          "bridgeInfo": {
+            "137": {
+              "tokenAddress": "0xc3cFFDAf8F3fdF07da6D5e3A89B8723D5E385ff8"
+            },
+            "42161": {
+              "tokenAddress": "0x2E9AE8f178d5Ea81970C7799A377B3985cbC335F"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "address": "0x6123B0049F904d730dB3C36a31167D9d4121fA6B",
+        "name": "Ribbon Finance",
+        "symbol": "RBN",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/15823/thumb/RBN_64x64.png?1633529723"
+      },
+      {
+        "name": "Republic Token",
+        "address": "0x408e41876cCCDC0F92210600ef50372656052a38",
+        "symbol": "REN",
+        "decimals": 18,
+        "chainId": 1,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x408e41876cCCDC0F92210600ef50372656052a38/logo.png",
+        "extensions": {
+          "bridgeInfo": {
+            "137": {
+              "tokenAddress": "0x19782D3Dc4701cEeeDcD90f0993f0A9126ed89d0"
+            },
+            "42161": {
+              "tokenAddress": "0x9fA891e1dB0a6D1eEAC4B929b5AAE1011C79a204"
+            }
+          }
+        }
+      },
+      {
+        "name": "Reputation Augur v1",
+        "address": "0x1985365e9f78359a9B6AD760e32412f4a445E862",
+        "symbol": "REP",
+        "decimals": 18,
+        "chainId": 1,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x1985365e9f78359a9B6AD760e32412f4a445E862/logo.png"
+      },
+      {
+        "name": "Reputation Augur v2",
+        "address": "0x221657776846890989a759BA2973e427DfF5C9bB",
+        "symbol": "REPv2",
+        "decimals": 18,
+        "chainId": 1,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x221657776846890989a759BA2973e427DfF5C9bB/logo.png",
+        "extensions": {
+          "bridgeInfo": {
+            "137": {
+              "tokenAddress": "0x6563c1244820CfBd6Ca8820FBdf0f2847363F733"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "address": "0x8f8221aFbB33998d8584A2B05749bA73c37a938a",
+        "name": "Request",
+        "symbol": "REQ",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/1031/thumb/Request_icon_green.png?1643250951",
+        "extensions": {
+          "bridgeInfo": {
+            "137": {
+              "tokenAddress": "0xAdf2F2Ed91755eA3f4bcC9107a494879f633ae7C"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "name": "REVV",
+        "symbol": "REVV",
+        "logoURI": "https://assets.coingecko.com/coins/images/12373/thumb/REVV_TOKEN_Refined_2021_%281%29.png?1627652390",
+        "address": "0x557B933a7C2c45672B610F8954A3deB39a51A8Ca",
+        "decimals": 18,
+        "extensions": {
+          "bridgeInfo": {
+            "137": {
+              "tokenAddress": "0x70c006878a5A50Ed185ac4C87d837633923De296"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "address": "0xD291E7a03283640FDc51b121aC401383A46cC623",
+        "name": "Rari Governance Token",
+        "symbol": "RGT",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/12900/thumb/Rari_Logo_Transparent.png?1613978014",
+        "extensions": {
+          "bridgeInfo": {
+            "10": {
+              "tokenAddress": "0xB548f63D4405466B36C0c0aC3318a22fDcec711a"
+            },
+            "137": {
+              "tokenAddress": "0x3b9dB434F08003A89554CDB43b3e0b1f8734BdE7"
+            },
+            "42161": {
+              "tokenAddress": "0xef888bcA6AB6B1d26dbeC977C455388ecd794794"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "address": "0x607F4C5BB672230e8672085532f7e901544a7375",
+        "name": "iExec RLC",
+        "symbol": "RLC",
+        "decimals": 9,
+        "logoURI": "https://assets.coingecko.com/coins/images/646/thumb/pL1VuXm.png?1604543202",
+        "extensions": {
+          "bridgeInfo": {
+            "137": {
+              "tokenAddress": "0xbe662058e00849C3Eef2AC9664f37fEfdF2cdbFE"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "address": "0xf1f955016EcbCd7321c7266BccFB96c68ea5E49b",
+        "name": "Rally",
+        "symbol": "RLY",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/12843/thumb/image.png?1611212077",
+        "extensions": {
+          "bridgeInfo": {
+            "137": {
+              "tokenAddress": "0x76b8D57e5ac6afAc5D415a054453d1DD2c3C0094"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "address": "0x6De037ef9aD2725EB40118Bb1702EBb27e4Aeb24",
+        "name": "Render Token",
+        "symbol": "RNDR",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/11636/thumb/rndr.png?1638840934",
+        "extensions": {
+          "bridgeInfo": {
+            "137": {
+              "tokenAddress": "0x61299774020dA444Af134c82fa83E3810b309991"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "name": "Rook",
+        "symbol": "ROOK",
+        "logoURI": "https://assets.coingecko.com/coins/images/13005/thumb/keeper_dao_logo.jpg?1604316506",
+        "address": "0xfA5047c9c78B8877af97BDcb85Db743fD7313d4a",
+        "decimals": 18,
+        "extensions": {
+          "bridgeInfo": {
+            "137": {
+              "tokenAddress": "0xF92501c8213da1D6C74A76372CCc720Dc8818407"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "address": "0x3845badAde8e6dFF049820680d1F14bD3903a5d0",
+        "name": "The Sandbox",
+        "symbol": "SAND",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/12129/thumb/sandbox_logo.jpg?1597397942",
+        "extensions": {
+          "bridgeInfo": {
+            "137": {
+              "tokenAddress": "0xBbba073C31bF03b8ACf7c28EF0738DeCF3695683"
+            },
+            "42161": {
+              "tokenAddress": "0xd1318eb19DBF2647743c720ed35174efd64e3DAC"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "address": "0x95aD61b0a150d79219dCF64E1E6Cc01f0B64C4cE",
+        "name": "Shiba Inu",
+        "symbol": "SHIB",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/11939/thumb/shiba.png?1622619446",
+        "extensions": {
+          "bridgeInfo": {
+            "137": {
+              "tokenAddress": "0x6f8a06447Ff6FcF75d803135a7de15CE88C1d4ec"
+            },
+            "42161": {
+              "tokenAddress": "0x5033833c9fe8B9d3E09EEd2f73d2aaF7E3872fd1"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "address": "0x7C84e62859D0715eb77d1b1C4154Ecd6aBB21BEC",
+        "name": "Shping",
+        "symbol": "SHPING",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/2588/thumb/r_yabKKi_400x400.jpg?1639470164"
+      },
+      {
+        "chainId": 1,
+        "address": "0x00c83aeCC790e8a4453e5dD3B0B4b3680501a7A7",
+        "name": "SKALE",
+        "symbol": "SKL",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/13245/thumb/SKALE_token_300x300.png?1606789574"
+      },
+      {
+        "chainId": 1,
+        "address": "0xCC8Fa225D80b9c7D42F96e9570156c65D6cAAa25",
+        "name": "Smooth Love Potion",
+        "symbol": "SLP",
+        "decimals": 0,
+        "logoURI": "https://assets.coingecko.com/coins/images/10366/thumb/SLP.png?1578640057",
+        "extensions": {
+          "bridgeInfo": {
+            "137": {
+              "tokenAddress": "0x0C7304fBAf2A320a1c50c46FE03752722F729946"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "address": "0x744d70FDBE2Ba4CF95131626614a1763DF805B9E",
+        "name": "Status",
+        "symbol": "SNT",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/779/thumb/status.png?1548610778"
+      },
+      {
+        "name": "Synthetix Network Token",
+        "address": "0xC011a73ee8576Fb46F5E1c5751cA3B9Fe0af2a6F",
+        "symbol": "SNX",
+        "decimals": 18,
+        "chainId": 1,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xC011a73ee8576Fb46F5E1c5751cA3B9Fe0af2a6F/logo.png",
+        "extensions": {
+          "bridgeInfo": {
+            "10": {
+              "tokenAddress": "0x8700dAec35aF8Ff88c16BdF0418774CB3D7599B4"
+            },
+            "137": {
+              "tokenAddress": "0x50B728D8D964fd00C2d0AAD81718b71311feF68a"
+            },
+            "42161": {
+              "tokenAddress": "0xcBA56Cd8216FCBBF3fA6DF6137F3147cBcA37D60"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "address": "0x23B608675a2B2fB1890d3ABBd85c5775c51691d5",
+        "name": "Unisocks",
+        "symbol": "SOCKS",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/10717/thumb/qFrcoiM.png?1582525244",
+        "extensions": {
+          "bridgeInfo": {
+            "42161": {
+              "tokenAddress": "0xb2BE52744a804Cc732d606817C2572C5A3B264e7"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "address": "0xD31a59c85aE9D8edEFeC411D448f90841571b89c",
+        "name": "SOL Wormhole ",
+        "symbol": "SOL",
+        "decimals": 9,
+        "logoURI": "https://assets.coingecko.com/coins/images/22876/thumb/SOL_wh_small.png?1644224316",
+        "extensions": {
+          "bridgeInfo": {
+            "42161": {
+              "tokenAddress": "0xb74Da9FE2F96B9E0a5f4A3cf0b92dd2bEC617124"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "address": "0x090185f2135308BaD17527004364eBcC2D37e5F6",
+        "name": "Spell Token",
+        "symbol": "SPELL",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/15861/thumb/abracadabra-3.png?1622544862",
+        "extensions": {
+          "bridgeInfo": {
+            "137": {
+              "tokenAddress": "0xcdB3C70CD25FD15307D84C4F9D37d5C043B33Fb2"
+            },
+            "42161": {
+              "tokenAddress": "0x3E6648C5a70A150A88bCE65F4aD4d506Fe15d2AF"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "name": "Stargate Finance",
+        "symbol": "STG",
+        "logoURI": "https://assets.coingecko.com/coins/images/24413/thumb/STG_LOGO.png?1647654518",
+        "address": "0xAf5191B0De278C7286d6C7CC6ab6BB8A73bA2Cd6",
+        "decimals": 18,
+        "extensions": {
+          "bridgeInfo": {
+            "42161": {
+              "tokenAddress": "0xe018C7a3d175Fb0fE15D70Da2c874d3CA16313EC"
+            }
+          }
+        }
+      },
+      {
+        "name": "Storj Token",
+        "address": "0xB64ef51C888972c908CFacf59B47C1AfBC0Ab8aC",
+        "symbol": "STORJ",
+        "decimals": 8,
+        "chainId": 1,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xB64ef51C888972c908CFacf59B47C1AfBC0Ab8aC/logo.png",
+        "extensions": {
+          "bridgeInfo": {
+            "137": {
+              "tokenAddress": "0xd72357dAcA2cF11A5F155b9FF7880E595A3F5792"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "address": "0x006BeA43Baa3f7A6f765F14f10A1a1b08334EF45",
+        "name": "Stox",
+        "symbol": "STX",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/1230/thumb/stox-token.png?1547035256",
+        "extensions": {
+          "bridgeInfo": {
+            "137": {
+              "tokenAddress": "0xB36e3391B22a970d31A9b620Ae1A414C6c256d2a"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "address": "0x0763fdCCF1aE541A5961815C0872A8c5Bc6DE4d7",
+        "name": "SUKU",
+        "symbol": "SUKU",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/11969/thumb/UmfW5S6f_400x400.jpg?1596602238",
+        "extensions": {
+          "bridgeInfo": {
+            "137": {
+              "tokenAddress": "0x60Ea918FC64360269Da4efBDA11d8fC6514617C6"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "address": "0xe53EC727dbDEB9E2d5456c3be40cFF031AB40A55",
+        "name": "SuperFarm",
+        "symbol": "SUPER",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/14040/thumb/6YPdWn6.png?1613975899",
+        "extensions": {
+          "bridgeInfo": {
+            "137": {
+              "tokenAddress": "0xa1428174F516F527fafdD146b883bB4428682737"
+            },
+            "42161": {
+              "tokenAddress": "0x7f9cf5a2630a0d58567122217dF7609c26498956"
+            }
+          }
+        }
+      },
+      {
+        "name": "Synth sUSD",
+        "address": "0x57Ab1ec28D129707052df4dF418D58a2D46d5f51",
+        "symbol": "sUSD",
+        "decimals": 18,
+        "chainId": 1,
+        "logoURI": "https://assets.coingecko.com/coins/images/5013/thumb/sUSD.png?1616150765",
+        "extensions": {
+          "bridgeInfo": {
+            "137": {
+              "tokenAddress": "0xF81b4Bec6Ca8f9fe7bE01CA734F55B2b6e03A7a0"
+            },
+            "42161": {
+              "tokenAddress": "0xA970AF1a584579B618be4d69aD6F73459D112F95"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "address": "0x6B3595068778DD592e39A122f4f5a5cF09C90fE2",
+        "name": "Sushi",
+        "symbol": "SUSHI",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/12271/thumb/512x512_Logo_no_chop.png?1606986688",
+        "extensions": {
+          "bridgeInfo": {
+            "137": {
+              "tokenAddress": "0x0b3F868E0BE5597D5DB7fEB59E1CADBb0fdDa50a"
+            },
+            "42161": {
+              "tokenAddress": "0xd4d42F0b6DEF4CE0383636770eF773390d85c61A"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "name": "SWFTCOIN",
+        "symbol": "SWFTC",
+        "logoURI": "https://assets.coingecko.com/coins/images/2346/thumb/SWFTCoin.jpg?1618392022",
+        "address": "0x0bb217E40F8a5Cb79Adf04E1aAb60E5abd0dfC1e",
+        "decimals": 8
+      },
+      {
+        "chainId": 1,
+        "name": "Swipe",
+        "symbol": "SXP",
+        "logoURI": "https://assets.coingecko.com/coins/images/9368/thumb/swipe.png?1566792311",
+        "address": "0x8CE9137d39326AD0cD6491fb5CC0CbA0e089b6A9",
+        "decimals": 18,
+        "extensions": {
+          "bridgeInfo": {
+            "137": {
+              "tokenAddress": "0x6aBB753C1893194DE4a83c6e8B4EadFc105Fd5f5"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "name": "Sylo",
+        "symbol": "SYLO",
+        "logoURI": "https://assets.coingecko.com/coins/images/6430/thumb/SYLO.svg?1589527756",
+        "address": "0xf293d23BF2CDc05411Ca0edDD588eb1977e8dcd4",
+        "decimals": 18
+      },
+      {
+        "chainId": 1,
+        "address": "0x0f2D719407FdBeFF09D87557AbB7232601FD9F29",
+        "name": "Synapse",
+        "symbol": "SYN",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/18024/thumb/syn.png?1635002049",
+        "extensions": {
+          "bridgeInfo": {
+            "42161": {
+              "tokenAddress": "0x1bCfc0B4eE1471674cd6A9F6B363A034375eAD84"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "name": "Threshold Network",
+        "symbol": "T",
+        "logoURI": "https://assets.coingecko.com/coins/images/22228/thumb/nFPNiSbL_400x400.jpg?1641220340",
+        "address": "0xCdF7028ceAB81fA0C6971208e83fa7872994beE5",
+        "decimals": 18
+      },
+      {
+        "chainId": 1,
+        "address": "0x8dAEBADE922dF735c38C80C7eBD708Af50815fAa",
+        "name": "tBTC",
+        "symbol": "TBTC",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/11224/thumb/tBTC.png?1589620754",
+        "extensions": {
+          "bridgeInfo": {
+            "137": {
+              "tokenAddress": "0x50a4a434247089848991DD8f09b889D4e2870aB6"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "name": "ChronoTech",
+        "symbol": "TIME",
+        "logoURI": "https://assets.coingecko.com/coins/images/604/thumb/time-32x32.png?1627130666",
+        "address": "0x485d17A6f1B8780392d53D64751824253011A260",
+        "decimals": 8
+      },
+      {
+        "chainId": 1,
+        "name": "Alien Worlds",
+        "symbol": "TLM",
+        "logoURI": "https://assets.coingecko.com/coins/images/14676/thumb/kY-C4o7RThfWrDQsLCAG4q4clZhBDDfJQVhWUEKxXAzyQYMj4Jmq1zmFwpRqxhAJFPOa0AsW_PTSshoPuMnXNwq3rU7Imp15QimXTjlXMx0nC088mt1rIwRs75GnLLugWjSllxgzvQ9YrP4tBgclK4_rb17hjnusGj_c0u2fx0AvVokjSNB-v2poTj0xT9BZRCbzRE3-lF1.jpg?1617700061",
+        "address": "0x888888848B652B3E3a0f34c96E00EEC0F3a23F72",
+        "decimals": 4
+      },
+      {
+        "chainId": 1,
+        "address": "0x2e9d63788249371f1DFC918a52f8d799F4a38C94",
+        "name": "Tokemak",
+        "symbol": "TOKE",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/17495/thumb/tokemak-avatar-200px-black.png?1628131614",
+        "extensions": {
+          "bridgeInfo": {
+            "137": {
+              "tokenAddress": "0xe1708AbDE4847B4929b70547E5197F1Ba1db2250"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "name": "TE FOOD",
+        "symbol": "TONE",
+        "logoURI": "https://assets.coingecko.com/coins/images/2325/thumb/tec.png?1547036538",
+        "address": "0x2Ab6Bb8408ca3199B8Fa6C92d5b455F820Af03c4",
+        "decimals": 18
+      },
+      {
+        "chainId": 1,
+        "address": "0xaA7a9CA87d3694B5755f213B5D04094b8d0F0A6F",
+        "name": "OriginTrail",
+        "symbol": "TRAC",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/1877/thumb/TRAC.jpg?1635134367",
+        "extensions": {
+          "bridgeInfo": {
+            "137": {
+              "tokenAddress": "0xA7b98d63a137bF402b4570799ac4caD0BB1c4B1c"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "address": "0x88dF592F8eb5D7Bd38bFeF7dEb0fBc02cf3778a0",
+        "name": "Tellor",
+        "symbol": "TRB",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/9644/thumb/Blk_icon_current.png?1584980686",
+        "extensions": {
+          "bridgeInfo": {
+            "137": {
+              "tokenAddress": "0xE3322702BEdaaEd36CdDAb233360B939775ae5f1"
+            },
+            "42161": {
+              "tokenAddress": "0xd58D345Fd9c82262E087d2D0607624B410D88242"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "address": "0xc7283b66Eb1EB5FB86327f08e1B5816b0720212B",
+        "name": "Tribe",
+        "symbol": "TRIBE",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/14575/thumb/tribe.PNG?1617487954",
+        "extensions": {
+          "bridgeInfo": {
+            "137": {
+              "tokenAddress": "0x8676815789211E799a6DC86d02748ADF9cF86836"
+            },
+            "42161": {
+              "tokenAddress": "0xBfAE6fecD8124ba33cbB2180aAb0Fe4c03914A5A"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "address": "0x4C19596f5aAfF459fA38B0f7eD92F11AE6543784",
+        "name": "TrueFi",
+        "symbol": "TRU",
+        "decimals": 8,
+        "logoURI": "https://assets.coingecko.com/coins/images/13180/thumb/truefi_glyph_color.png?1617610941",
+        "extensions": {
+          "bridgeInfo": {
+            "137": {
+              "tokenAddress": "0x5b77bCA482bd3E7958b1103d123888EfCCDaF803"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "name": "The Virtua Kolect",
+        "symbol": "TVK",
+        "logoURI": "https://assets.coingecko.com/coins/images/13330/thumb/virtua_original.png?1656043619",
+        "address": "0xd084B83C305daFD76AE3E1b4E1F1fe2eCcCb3988",
+        "decimals": 18,
+        "extensions": {
+          "bridgeInfo": {
+            "137": {
+              "tokenAddress": "0x5667dcC0ab74D1b1355C3b2061893399331B57e2"
+            }
+          }
+        }
+      },
+      {
+        "name": "UMA Voting Token v1",
+        "address": "0x04Fa0d235C4abf4BcF4787aF4CF447DE572eF828",
+        "symbol": "UMA",
+        "decimals": 18,
+        "chainId": 1,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x04Fa0d235C4abf4BcF4787aF4CF447DE572eF828/logo.png",
+        "extensions": {
+          "bridgeInfo": {
+            "10": {
+              "tokenAddress": "0xE7798f023fC62146e8Aa1b36Da45fb70855a77Ea"
+            },
+            "137": {
+              "tokenAddress": "0x3066818837c5e6eD6601bd5a91B0762877A6B731"
+            },
+            "42161": {
+              "tokenAddress": "0xd693Ec944A85eeca4247eC1c3b130DCa9B0C3b22"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "address": "0x441761326490cACF7aF299725B6292597EE822c2",
+        "name": "Unifi Protocol DAO",
+        "symbol": "UNFI",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/13152/thumb/logo-2.png?1605748967"
+      },
+      {
+        "name": "Uniswap",
+        "address": "0x1f9840a85d5aF5bf1D1762F925BDADdC4201F984",
+        "symbol": "UNI",
+        "decimals": 18,
+        "chainId": 1,
+        "logoURI": "ipfs://QmXttGpZrECX5qCyXbBQiqgQNytVGeZW5Anewvh2jc4psg",
+        "extensions": {
+          "bridgeInfo": {
+            "10": {
+              "tokenAddress": "0x6fd9d7AD17242c41f7131d257212c54A0e816691"
+            },
+            "137": {
+              "tokenAddress": "0xb33EaAd8d922B1083446DC23f610c2567fB5180f"
+            },
+            "42161": {
+              "tokenAddress": "0xFa7F8980b0f1E64A2062791cc3b0871572f1F7f0"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "address": "0x70D2b7C19352bB76e4409858FF5746e500f2B67c",
+        "name": "Pawtocol",
+        "symbol": "UPI",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/12186/thumb/pawtocol.jpg?1597962008"
+      },
+      {
+        "name": "USDCoin",
+        "address": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+        "symbol": "USDC",
+        "decimals": 6,
+        "chainId": 1,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/logo.png",
+        "extensions": {
+          "bridgeInfo": {
+            "10": {
+              "tokenAddress": "0x7F5c764cBc14f9669B88837ca1490cCa17c31607"
+            },
+            "137": {
+              "tokenAddress": "0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174"
+            },
+            "42161": {
+              "tokenAddress": "0xFF970A61A04b1cA14834A43f5dE4533eBDDB5CC8"
+            }
+          }
+        }
+      },
+      {
+        "name": "Tether USD",
+        "address": "0xdAC17F958D2ee523a2206206994597C13D831ec7",
+        "symbol": "USDT",
+        "decimals": 6,
+        "chainId": 1,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xdAC17F958D2ee523a2206206994597C13D831ec7/logo.png",
+        "extensions": {
+          "bridgeInfo": {
+            "10": {
+              "tokenAddress": "0x94b008aA00579c1307B0EF2c499aD98a8ce58e58"
+            },
+            "137": {
+              "tokenAddress": "0xc2132D05D31c914a87C6611C10748AEb04B58e8F"
+            },
+            "42161": {
+              "tokenAddress": "0xFd086bC7CD5C481DCC9C85ebE478A1C0b69FCbb9"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "address": "0x3C4B6E6e1eA3D4863700D7F76b36B7f3D3f13E3d",
+        "name": "Voyager Token",
+        "symbol": "VGX",
+        "decimals": 8,
+        "logoURI": "https://assets.coingecko.com/coins/images/794/thumb/Voyager-vgx.png?1575693595"
+      },
+      {
+        "chainId": 1,
+        "name": "Wrapped Ampleforth",
+        "symbol": "WAMPL",
+        "logoURI": "https://assets.coingecko.com/coins/images/20825/thumb/photo_2021-11-25_02-05-11.jpg?1637811951",
+        "address": "0xEDB171C18cE90B633DB442f2A6F72874093b49Ef",
+        "decimals": 18
+      },
+      {
+        "name": "Wrapped BTC",
+        "address": "0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599",
+        "symbol": "WBTC",
+        "decimals": 8,
+        "chainId": 1,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599/logo.png",
+        "extensions": {
+          "bridgeInfo": {
+            "10": {
+              "tokenAddress": "0x68f180fcCe6836688e9084f035309E29Bf0A2095"
+            },
+            "137": {
+              "tokenAddress": "0x1BFD67037B42Cf73acF2047067bd4F2C47D9BfD6"
+            },
+            "42161": {
+              "tokenAddress": "0x2f2a2543B76A4166549F7aaB2e75Bef0aefC5B0f"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "name": "Wrapped Centrifuge",
+        "symbol": "WCFG",
+        "logoURI": "https://assets.coingecko.com/coins/images/17106/thumb/WCFG.jpg?1626266462",
+        "address": "0xc221b7E65FfC80DE234bbB6667aBDd46593D34F0",
+        "decimals": 18,
+        "extensions": {
+          "bridgeInfo": {
+            "137": {
+              "tokenAddress": "0x90bb6fEB70A9a43CfAaA615F856BA309FD759A90"
+            }
+          }
+        }
+      },
+      {
+        "name": "Wrapped Ether",
+        "address": "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
+        "symbol": "WETH",
+        "decimals": 18,
+        "chainId": 1,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2/logo.png",
+        "extensions": {
+          "bridgeInfo": {
+            "10": {
+              "tokenAddress": "0x4200000000000000000000000000000000000006"
+            },
+            "137": {
+              "tokenAddress": "0x7ceB23fD6bC0adD59E62ac25578270cFf1b9f619"
+            },
+            "42161": {
+              "tokenAddress": "0x82aF49447D8a07e3bd95BD0d56f35241523fBab1"
+            },
+            "42220": {
+              "tokenAddress": "0x2DEf4285787d58a2f811AF24755A8150622f4361"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "name": "WOO Network",
+        "symbol": "WOO",
+        "logoURI": "https://assets.coingecko.com/coins/images/12921/thumb/w2UiemF__400x400.jpg?1603670367",
+        "address": "0x4691937a7508860F876c9c0a2a617E7d9E945D4B",
+        "decimals": 18,
+        "extensions": {
+          "bridgeInfo": {
+            "137": {
+              "tokenAddress": "0x1B815d120B3eF02039Ee11dC2d33DE7aA4a8C603"
+            },
+            "42161": {
+              "tokenAddress": "0xcAFcD85D8ca7Ad1e1C6F82F651fA15E33AEfD07b"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "name": "Chain",
+        "symbol": "XCN",
+        "logoURI": "https://assets.coingecko.com/coins/images/24210/thumb/Chain_icon_200x200.png?1646895054",
+        "address": "0xA2cd3D43c775978A96BdBf12d733D5A1ED94fb18",
+        "decimals": 18
+      },
+      {
+        "chainId": 1,
+        "address": "0x55296f69f40Ea6d20E478533C15A6B08B654E758",
+        "name": "XYO Network",
+        "symbol": "XYO",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/4519/thumb/XYO_Network-logo.png?1547039819",
+        "extensions": {
+          "bridgeInfo": {
+            "137": {
+              "tokenAddress": "0xd2507e7b5794179380673870d88B22F94da6abe0"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "address": "0x0bc529c00C6401aEF6D220BE8C6Ea1667F6Ad93e",
+        "name": "yearn finance",
+        "symbol": "YFI",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/11849/thumb/yfi-192x192.png?1598325330",
+        "extensions": {
+          "bridgeInfo": {
+            "137": {
+              "tokenAddress": "0xDA537104D6A5edd53c6fBba9A898708E465260b6"
+            },
+            "42161": {
+              "tokenAddress": "0x82e3A8F066a6989666b031d916c43672085b1582"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "address": "0xa1d0E215a23d7030842FC67cE582a6aFa3CCaB83",
+        "name": "DFI money",
+        "symbol": "YFII",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/11902/thumb/YFII-logo.78631676.png?1598677348",
+        "extensions": {
+          "bridgeInfo": {
+            "137": {
+              "tokenAddress": "0xb8cb8a7F4C2885C03e57E973C74827909Fdc2032"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "name": "Yield Guild Games",
+        "symbol": "YGG",
+        "logoURI": "https://assets.coingecko.com/coins/images/17358/thumb/le1nzlO6_400x400.jpg?1632465691",
+        "address": "0x25f8087EAD173b73D6e8B84329989A8eEA16CF73",
+        "decimals": 18,
+        "extensions": {
+          "bridgeInfo": {
+            "137": {
+              "tokenAddress": "0x82617aA52dddf5Ed9Bb7B370ED777b3182A30fd1"
+            }
+          }
+        }
+      },
+      {
+        "name": "0x Protocol Token",
+        "address": "0xE41d2489571d322189246DaFA5ebDe1F4699F498",
+        "symbol": "ZRX",
+        "decimals": 18,
+        "chainId": 1,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xE41d2489571d322189246DaFA5ebDe1F4699F498/logo.png",
+        "extensions": {
+          "bridgeInfo": {
+            "137": {
+              "tokenAddress": "0x5559Edb74751A0edE9DeA4DC23aeE72cCA6bE3D5"
+            },
+            "42161": {
+              "tokenAddress": "0xBD591Bd4DdB64b77B5f76Eab8f03d02519235Ae2"
+            }
+          }
+        }
+      },
+      {
+        "name": "Dai Stablecoin",
+        "address": "0xaD6D458402F60fD3Bd25163575031ACDce07538D",
+        "symbol": "DAI",
+        "decimals": 18,
+        "chainId": 3,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xaD6D458402F60fD3Bd25163575031ACDce07538D/logo.png"
+      },
+      {
+        "name": "Uniswap",
+        "address": "0x1f9840a85d5aF5bf1D1762F925BDADdC4201F984",
+        "symbol": "UNI",
+        "decimals": 18,
+        "chainId": 3,
+        "logoURI": "ipfs://QmXttGpZrECX5qCyXbBQiqgQNytVGeZW5Anewvh2jc4psg"
+      },
+      {
+        "name": "Wrapped Ether",
+        "address": "0xc778417E063141139Fce010982780140Aa0cD5Ab",
+        "symbol": "WETH",
+        "decimals": 18,
+        "chainId": 3,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xc778417E063141139Fce010982780140Aa0cD5Ab/logo.png"
+      },
+      {
+        "name": "Dai Stablecoin",
+        "address": "0xc7AD46e0b8a400Bb3C915120d284AafbA8fc4735",
+        "symbol": "DAI",
+        "decimals": 18,
+        "chainId": 4,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xc7AD46e0b8a400Bb3C915120d284AafbA8fc4735/logo.png"
+      },
+      {
+        "name": "Maker",
+        "address": "0xF9bA5210F91D0474bd1e1DcDAeC4C58E359AaD85",
+        "symbol": "MKR",
+        "decimals": 18,
+        "chainId": 4,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xF9bA5210F91D0474bd1e1DcDAeC4C58E359AaD85/logo.png"
+      },
+      {
+        "name": "Uniswap",
+        "address": "0x1f9840a85d5aF5bf1D1762F925BDADdC4201F984",
+        "symbol": "UNI",
+        "decimals": 18,
+        "chainId": 4,
+        "logoURI": "ipfs://QmXttGpZrECX5qCyXbBQiqgQNytVGeZW5Anewvh2jc4psg"
+      },
+      {
+        "name": "Wrapped Ether",
+        "address": "0xc778417E063141139Fce010982780140Aa0cD5Ab",
+        "symbol": "WETH",
+        "decimals": 18,
+        "chainId": 4,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xc778417E063141139Fce010982780140Aa0cD5Ab/logo.png"
+      },
+      {
+        "name": "Uniswap",
+        "address": "0x1f9840a85d5aF5bf1D1762F925BDADdC4201F984",
+        "symbol": "UNI",
+        "decimals": 18,
+        "chainId": 5,
+        "logoURI": "ipfs://QmXttGpZrECX5qCyXbBQiqgQNytVGeZW5Anewvh2jc4psg"
+      },
+      {
+        "name": "Wrapped Ether",
+        "address": "0xB4FBF271143F4FBf7B91A5ded31805e42b2208d6",
+        "symbol": "WETH",
+        "decimals": 18,
+        "chainId": 5,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xB4FBF271143F4FBf7B91A5ded31805e42b2208d6/logo.png"
+      },
+      {
+        "chainId": 10,
+        "address": "0x76FB31fb4af56892A25e32cFC43De717950c9278",
+        "name": "Aave",
+        "symbol": "AAVE",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/12645/thumb/AAVE.png?1601374110",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x7Fc66500c84A76Ad7e9c93437bFc5Ac33E2DDaE9"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 10,
+        "address": "0x3e7eF8f50246f725885102E8238CBba33F276747",
+        "name": "BarnBridge",
+        "symbol": "BOND",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/12811/thumb/barnbridge.jpg?1602728853",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x0391D2021f89DC339F60Fff84546EA23E337750f"
+            }
+          }
+        }
+      },
+      {
+        "name": "Curve DAO Token",
+        "address": "0x0994206dfE8De6Ec6920FF4D779B0d950605Fb53",
+        "symbol": "CRV",
+        "decimals": 18,
+        "chainId": 10,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xD533a949740bb3306d119CC777fa900bA034cd52/logo.png",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0xD533a949740bb3306d119CC777fa900bA034cd52"
+            }
+          }
+        }
+      },
+      {
+        "name": "Dai Stablecoin",
+        "address": "0xDA10009cBd5D07dd0CeCc66161FC93D7c9000da1",
+        "symbol": "DAI",
+        "decimals": 18,
+        "chainId": 10,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x6B175474E89094C44Da98b954EedeAC495271d0F/logo.png",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x6B175474E89094C44Da98b954EedeAC495271d0F"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 10,
+        "address": "0x65559aA14915a70190438eF90104769e5E890A00",
+        "name": "Ethereum Name Service",
+        "symbol": "ENS",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/19785/thumb/acatxTm8_400x400.jpg?1635850140",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0xC18360217D8F7Ab5e7c516566761Ea12Ce7F9D72"
+            }
+          }
+        }
+      },
+      {
+        "name": "ChainLink Token",
+        "address": "0x350a791Bfc2C21F9Ed5d10980Dad2e2638ffa7f6",
+        "symbol": "LINK",
+        "decimals": 18,
+        "chainId": 10,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x514910771AF9Ca656af840dff83E8264EcF986CA/logo.png",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x514910771AF9Ca656af840dff83E8264EcF986CA"
+            }
+          }
+        }
+      },
+      {
+        "name": "LoopringCoin V2",
+        "address": "0xFEaA9194F9F8c1B65429E31341a103071464907E",
+        "symbol": "LRC",
+        "decimals": 18,
+        "chainId": 10,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xBBbbCA6A901c926F240b89EacB641d8Aec7AEafD/logo.png",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0xBBbbCA6A901c926F240b89EacB641d8Aec7AEafD"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 10,
+        "name": "Liquity USD",
+        "symbol": "LUSD",
+        "logoURI": "https://assets.coingecko.com/coins/images/14666/thumb/Group_3.png?1617631327",
+        "address": "0xc40F949F8a4e094D1b49a23ea9241D289B7b2819",
+        "decimals": 18,
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x5f98805A4E8be255a32880FDeC7F6728C6568bA0"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 10,
+        "address": "0x3390108E913824B8eaD638444cc52B9aBdF63798",
+        "name": "Mask Network",
+        "symbol": "MASK",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/14051/thumb/Mask_Network.jpg?1614050316",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x69af81e73A73B40adF4f3d4223Cd9b1ECE623074"
+            }
+          }
+        }
+      },
+      {
+        "name": "Maker",
+        "address": "0xab7bAdEF82E9Fe11f6f33f87BC9bC2AA27F2fCB5",
+        "symbol": "MKR",
+        "decimals": 18,
+        "chainId": 10,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x9f8F72aA9304c8B593d555F12eF6589cC3A579A2/logo.png",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x9f8F72aA9304c8B593d555F12eF6589cC3A579A2"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 10,
+        "address": "0x4200000000000000000000000000000000000042",
+        "name": "Optimism",
+        "symbol": "OP",
+        "decimals": 18,
+        "logoURI": "https://ethereum-optimism.github.io/data/OP/logo.png"
+      },
+      {
+        "chainId": 10,
+        "address": "0x9e1028F5F1D5eDE59748FFceE5532509976840E0",
+        "name": "Perpetual Protocol",
+        "symbol": "PERP",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/12381/thumb/60d18e06844a844ad75901a9_mark_only_03.png?1628674771",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0xbC396689893D065F41bc2C6EcbeE5e0085233447"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 10,
+        "address": "0x7FB688CCf682d58f86D7e38e03f9D22e7705448B",
+        "name": "Rai Reflex Index",
+        "symbol": "RAI",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/14004/thumb/RAI-logo-coin.png?1613592334",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x03ab458634910AaD20eF5f1C8ee96F1D6ac54919"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 10,
+        "address": "0xB548f63D4405466B36C0c0aC3318a22fDcec711a",
+        "name": "Rari Governance Token",
+        "symbol": "RGT",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/12900/thumb/Rari_Logo_Transparent.png?1613978014",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0xD291E7a03283640FDc51b121aC401383A46cC623"
+            }
+          }
+        }
+      },
+      {
+        "name": "Synthetix Network Token",
+        "address": "0x8700dAec35aF8Ff88c16BdF0418774CB3D7599B4",
+        "symbol": "SNX",
+        "decimals": 18,
+        "chainId": 10,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xC011a73ee8576Fb46F5E1c5751cA3B9Fe0af2a6F/logo.png",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0xC011a73ee8576Fb46F5E1c5751cA3B9Fe0af2a6F"
+            }
+          }
+        }
+      },
+      {
+        "name": "UMA Voting Token v1",
+        "address": "0xE7798f023fC62146e8Aa1b36Da45fb70855a77Ea",
+        "symbol": "UMA",
+        "decimals": 18,
+        "chainId": 10,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x04Fa0d235C4abf4BcF4787aF4CF447DE572eF828/logo.png",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x04Fa0d235C4abf4BcF4787aF4CF447DE572eF828"
+            }
+          }
+        }
+      },
+      {
+        "name": "Uniswap",
+        "address": "0x6fd9d7AD17242c41f7131d257212c54A0e816691",
+        "symbol": "UNI",
+        "decimals": 18,
+        "chainId": 10,
+        "logoURI": "ipfs://QmXttGpZrECX5qCyXbBQiqgQNytVGeZW5Anewvh2jc4psg",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x1f9840a85d5aF5bf1D1762F925BDADdC4201F984"
+            }
+          }
+        }
+      },
+      {
+        "name": "USDCoin",
+        "address": "0x7F5c764cBc14f9669B88837ca1490cCa17c31607",
+        "symbol": "USDC",
+        "decimals": 6,
+        "chainId": 10,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/logo.png",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"
+            }
+          }
+        }
+      },
+      {
+        "name": "Tether USD",
+        "address": "0x94b008aA00579c1307B0EF2c499aD98a8ce58e58",
+        "symbol": "USDT",
+        "decimals": 6,
+        "chainId": 10,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xdAC17F958D2ee523a2206206994597C13D831ec7/logo.png",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0xdAC17F958D2ee523a2206206994597C13D831ec7"
+            }
+          }
+        }
+      },
+      {
+        "name": "Wrapped BTC",
+        "address": "0x68f180fcCe6836688e9084f035309E29Bf0A2095",
+        "symbol": "WBTC",
+        "decimals": 8,
+        "chainId": 10,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599/logo.png",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599"
+            }
+          }
+        }
+      },
+      {
+        "name": "Wrapped Ether",
+        "address": "0x4200000000000000000000000000000000000006",
+        "symbol": "WETH",
+        "decimals": 18,
+        "chainId": 10,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2/logo.png",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2"
+            }
+          }
+        }
+      },
+      {
+        "name": "Dai Stablecoin",
+        "address": "0x4F96Fe3b7A6Cf9725f59d353F723c1bDb64CA6Aa",
+        "symbol": "DAI",
+        "decimals": 18,
+        "chainId": 42,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x4F96Fe3b7A6Cf9725f59d353F723c1bDb64CA6Aa/logo.png"
+      },
+      {
+        "name": "Maker",
+        "address": "0xAaF64BFCC32d0F15873a02163e7E500671a4ffcD",
+        "symbol": "MKR",
+        "decimals": 18,
+        "chainId": 42,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xAaF64BFCC32d0F15873a02163e7E500671a4ffcD/logo.png"
+      },
+      {
+        "name": "Uniswap",
+        "address": "0x1f9840a85d5aF5bf1D1762F925BDADdC4201F984",
+        "symbol": "UNI",
+        "decimals": 18,
+        "chainId": 42,
+        "logoURI": "ipfs://QmXttGpZrECX5qCyXbBQiqgQNytVGeZW5Anewvh2jc4psg"
+      },
+      {
+        "name": "Wrapped Ether",
+        "address": "0xd0A1E359811322d97991E03f863a0C30C2cF029C",
+        "symbol": "WETH",
+        "decimals": 18,
+        "chainId": 42,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xd0A1E359811322d97991E03f863a0C30C2cF029C/logo.png"
+      },
+      {
+        "chainId": 137,
+        "address": "0x9c2C5fd7b07E95EE044DDeba0E97a665F142394f",
+        "name": "1inch",
+        "symbol": "1INCH",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/13469/thumb/1inch-token.png?1608803028",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x111111111117dC0aa78b770fA6A738034120C302"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 137,
+        "address": "0xD6DF932A45C0f255f85145f286eA0b292B21C90B",
+        "name": "Aave",
+        "symbol": "AAVE",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/12645/thumb/AAVE.png?1601374110",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x7Fc66500c84A76Ad7e9c93437bFc5Ac33E2DDaE9"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 137,
+        "address": "0xdDa7b23D2D72746663E7939743f929a3d85FC975",
+        "name": "Ambire AdEx",
+        "symbol": "ADX",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/847/thumb/Ambire_AdEx_Symbol_color.png?1655432540",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0xADE00C28244d5CE17D72E40330B1c318cD12B7c3"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 137,
+        "address": "0x6a6bD53d677F8632631662C48bD47b1D4D6524ee",
+        "name": "Adventure Gold",
+        "symbol": "AGLD",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/18125/thumb/lpgblc4h_400x400.jpg?1630570955",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x32353A6C91143bfd6C7d363B546e62a9A2489A20"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 137,
+        "address": "0xe2341718c6C0CbFa8e6686102DD8FbF4047a9e9B",
+        "name": "AIOZ Network",
+        "symbol": "AIOZ",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/14631/thumb/aioz_logo.png?1617413126",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x626E8036dEB333b408Be468F951bdB42433cBF18"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 137,
+        "address": "0x95c300e7740D2A88a44124B424bFC1cB2F9c3b89",
+        "name": "Alchemix",
+        "symbol": "ALCX",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/14113/thumb/Alchemix.png?1614409874",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0xdBdb4d16EdA451D0503b854CF79D55697F90c8DF"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 137,
+        "address": "0x82dCf1Df86AdA26b2dCd9ba6334CeDb8c2448e9e",
+        "name": "Aleph im",
+        "symbol": "ALEPH",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/11676/thumb/Monochram-aleph.png?1608483725",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x27702a26126e0B3702af63Ee09aC4d1A084EF628"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 137,
+        "address": "0x50858d870FAF55da2fD90FB6DF7c34b5648305C6",
+        "name": "My Neighbor Alice",
+        "symbol": "ALICE",
+        "decimals": 6,
+        "logoURI": "https://assets.coingecko.com/coins/images/14375/thumb/alice_logo.jpg?1615782968",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0xAC51066d7bEC65Dc4589368da368b212745d63E8"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 137,
+        "address": "0x3AE490db48d74B1bC626400135d4616377D0109f",
+        "name": "Alpha Venture DAO",
+        "symbol": "ALPHA",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/12738/thumb/AlphaToken_256x256.png?1617160876",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0xa1faa113cbE53436Df28FF0aEe54275c13B40975"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 137,
+        "address": "0x0621d647cecbFb64b79E44302c1933cB4f27054d",
+        "name": "Amp",
+        "symbol": "AMP",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/12409/thumb/amp-200x200.png?1599625397",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0xfF20817765cB7f73d4bde2e66e067E58D11095C2"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 137,
+        "address": "0x101A023270368c0D50BFfb62780F4aFd4ea79C35",
+        "name": "Ankr",
+        "symbol": "ANKR",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/4324/thumb/U85xTl2.png?1608111978",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x8290333ceF9e6D528dD5618Fb97a76f268f3EDD4"
+            }
+          }
+        }
+      },
+      {
+        "name": "Aragon",
+        "address": "0x2b8504ab5eFc246d0eC5Ec7E74565683227497de",
+        "symbol": "ANT",
+        "decimals": 18,
+        "chainId": 137,
+        "logoURI": "https://assets.coingecko.com/coins/images/681/thumb/JelZ58cv_400x400.png?1601449653",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0xa117000000f279D81A1D3cc75430fAA017FA5A2e"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 137,
+        "address": "0xB7b31a6BC18e48888545CE79e83E06003bE70930",
+        "name": "ApeCoin",
+        "symbol": "APE",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/24383/small/apecoin.jpg?1647476455",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x4d224452801ACEd8B2F0aebE155379bb5D594381"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 137,
+        "address": "0x45C27821E80F8789b60Fd8B600C73815d34DDa6C",
+        "name": "API3",
+        "symbol": "API3",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/13256/thumb/api3.jpg?1606751424",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x0b38210ea11411557c13457D4dA7dC6ea731B88a"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 137,
+        "address": "0xEE800B277A96B0f490a1A732e1D6395FAD960A26",
+        "name": "ARPA Chain",
+        "symbol": "ARPA",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/8506/thumb/9u0a23XY_400x400.jpg?1559027357",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0xBA50933C268F567BDC86E1aC131BE072C6B0b71a"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 137,
+        "address": "0x04bEa9FCE76943E90520489cCAb84E84C0198E29",
+        "name": "AirSwap",
+        "symbol": "AST",
+        "decimals": 4,
+        "logoURI": "https://assets.coingecko.com/coins/images/1019/thumb/Airswap.png?1630903484",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x27054b13b1B798B345b591a4d22e6562d47eA75a"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 137,
+        "address": "0x0df0f72EE0e5c9B7ca761ECec42754992B2Da5BF",
+        "name": "Automata",
+        "symbol": "ATA",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/15985/thumb/ATA.jpg?1622535745",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0xA2120b9e674d3fC3875f415A7DF52e382F141225"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 137,
+        "address": "0x5eB8D998371971D01954205c7AFE90A7AF6a95AC",
+        "name": "Audius",
+        "symbol": "AUDIO",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/12913/thumb/AudiusCoinLogo_2x.png?1603425727",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x18aAA7115705e8be94bfFEBDE57Af9BFc265B998"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 137,
+        "address": "0x61BDD9C7d4dF4Bf47A4508c0c8245505F2Af5b7b",
+        "name": "Axie Infinity",
+        "symbol": "AXS",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/13029/thumb/axie_infinity_logo.png?1604471082",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0xBB0E17EF65F82Ab018d8EDd776e8DD940327B28b"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 137,
+        "address": "0x1FcbE5937B0cc2adf69772D228fA4205aCF4D9b2",
+        "name": "Badger DAO",
+        "symbol": "BADGER",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/13287/thumb/badger_dao_logo.jpg?1607054976",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x3472A5A71965499acd81997a54BBA8D852C6E53d"
+            }
+          }
+        }
+      },
+      {
+        "name": "Balancer",
+        "address": "0x9a71012B13CA4d3D0Cdc72A177DF3ef03b0E76A3",
+        "symbol": "BAL",
+        "decimals": 18,
+        "chainId": 137,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xba100000625a3754423978a60c9317c58a424e3D/logo.png",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0xba100000625a3754423978a60c9317c58a424e3D"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 137,
+        "address": "0xA8b1E0764f85f53dfe21760e8AfE5446D82606ac",
+        "name": "Band Protocol",
+        "symbol": "BAND",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/9545/thumb/band-protocol.png?1568730326",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0xBA11D00c5f74255f56a5E366F4F77f5A186d7f55"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 137,
+        "address": "0x3Cef98bb43d732E2F285eE605a8158cDE967D219",
+        "name": "Basic Attention Token",
+        "symbol": "BAT",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/677/thumb/basic-attention-token.png?1547034427",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x0D8775F648430679A709E98d2b0Cb6250d2887EF"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 137,
+        "address": "0x91c89A94567980f0e9723b487b0beD586eE96aa7",
+        "name": "Biconomy",
+        "symbol": "BICO",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/21061/thumb/biconomy_logo.jpg?1638269749",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0xF17e65822b568B3903685a7c9F496CF7656Cc6C2"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 137,
+        "address": "0x438B28C5AA5F00a817b7Def7cE2Fb3d5d1970974",
+        "name": "Bluzelle",
+        "symbol": "BLZ",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/2848/thumb/ColorIcon_3x.png?1622516510",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x5732046A883704404F284Ce41FfADd5b007FD668"
+            }
+          }
+        }
+      },
+      {
+        "name": "Bancor Network Token",
+        "address": "0xc26D47d5c33aC71AC5CF9F776D63Ba292a4F7842",
+        "symbol": "BNT",
+        "decimals": 18,
+        "chainId": 137,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x1F573D6Fb3F13d689FF844B4cE37794d79a7FF1C/logo.png",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x1F573D6Fb3F13d689FF844B4cE37794d79a7FF1C"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 137,
+        "address": "0xa4B2B20b2C73c7046ED19AC6bfF5E5285c58F20a",
+        "name": "Boba Network",
+        "symbol": "BOBA",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/20285/thumb/BOBA.png?1636811576",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x42bBFa2e77757C645eeaAd1655E0911a7553Efbc"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 137,
+        "address": "0xA041544fe2BE56CCe31Ebb69102B965E06aacE80",
+        "name": "BarnBridge",
+        "symbol": "BOND",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/12811/thumb/barnbridge.jpg?1602728853",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x0391D2021f89DC339F60Fff84546EA23E337750f"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 137,
+        "address": "0xdAb529f40E671A1D4bF91361c21bf9f0C9712ab7",
+        "name": "Binance USD",
+        "symbol": "BUSD",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/9576/thumb/BUSD.png?1568947766",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x4Fabb145d64652a948d72533023f6E7A623C7C53"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 137,
+        "address": "0x91a4635F620766145C099E15889Bd2766906A559",
+        "name": "Celer Network",
+        "symbol": "CELR",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/4379/thumb/Celr.png?1554705437",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x4F9254C83EB525f9FCf346490bbb3ed28a81C667"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 137,
+        "address": "0x594C984E3318e91313f881B021A0C4203fF5E59F",
+        "name": "Chromia",
+        "symbol": "CHR",
+        "decimals": 6,
+        "logoURI": "https://assets.coingecko.com/coins/images/5000/thumb/Chromia.png?1559038018",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x8A2279d4A90B6fe1C4B30fa660cC9f926797bAA2"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 137,
+        "address": "0xf1938Ce12400f9a761084E7A80d37e732a4dA056",
+        "name": "Chiliz",
+        "symbol": "CHZ",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/8834/thumb/Chiliz.png?1561970540",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x3506424F91fD33084466F402d5D97f05F8e3b4AF"
+            }
+          }
+        }
+      },
+      {
+        "name": "Compound",
+        "address": "0x8505b9d2254A7Ae468c0E9dd10Ccea3A837aef5c",
+        "symbol": "COMP",
+        "decimals": 18,
+        "chainId": 137,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xc00e94Cb662C3520282E6f5717214004A7f26888/logo.png",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0xc00e94Cb662C3520282E6f5717214004A7f26888"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 137,
+        "address": "0x93B0fF1C8828F6eB039D345Ff681eD735086d925",
+        "name": "Covalent",
+        "symbol": "CQT",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/14168/thumb/covalent-cqt.png?1624545218",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0xD417144312DbF50465b1C641d016962017Ef6240"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 137,
+        "address": "0xAdA58DF0F643D959C2A47c9D4d4c1a4deFe3F11C",
+        "name": "Cronos",
+        "symbol": "CRO",
+        "decimals": 8,
+        "logoURI": "https://assets.coingecko.com/coins/images/7310/thumb/oCw2s3GI_400x400.jpeg?1645172042",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0xA0b73E1Ff0B80914AB6fe0444E65848C4C34450b"
+            }
+          }
+        }
+      },
+      {
+        "name": "Curve DAO Token",
+        "address": "0x172370d5Cd63279eFa6d502DAB29171933a610AF",
+        "symbol": "CRV",
+        "decimals": 18,
+        "chainId": 137,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xD533a949740bb3306d119CC777fa900bA034cd52/logo.png",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0xD533a949740bb3306d119CC777fa900bA034cd52"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 137,
+        "address": "0x2727Ab1c2D22170ABc9b595177B2D5C6E1Ab7B7B",
+        "name": "Cartesi",
+        "symbol": "CTSI",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/11038/thumb/cartesi.png?1592288021",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x491604c0FDF08347Dd1fa4Ee062a822A5DD06B5D"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 137,
+        "address": "0x8c208BC2A808a088a78398fed8f2640cab0b6EDb",
+        "name": "Cryptex Finance",
+        "symbol": "CTX",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/14932/thumb/glossy_icon_-_C200px.png?1619073171",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x321C2fE4446C7c963dc41Dd58879AF648838f98D"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 137,
+        "address": "0x276C9cbaa4BDf57d7109a41e67BD09699536FA3d",
+        "name": "Somnium Space CUBEs",
+        "symbol": "CUBE",
+        "decimals": 8,
+        "logoURI": "https://assets.coingecko.com/coins/images/10687/thumb/CUBE_icon.png?1617026861",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0xDf801468a808a32656D2eD2D2d80B72A129739f4"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 137,
+        "address": "0x66Dc5A08091d1968e08C16aA5b27BAC8398b02Be",
+        "name": "Civic",
+        "symbol": "CVC",
+        "decimals": 8,
+        "logoURI": "https://assets.coingecko.com/coins/images/788/thumb/civic.png?1547034556",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x41e5560054824eA6B0732E656E3Ad64E20e94E45"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 137,
+        "address": "0x4257EA7637c355F81616050CbB6a9b709fd72683",
+        "name": "Convex Finance",
+        "symbol": "CVX",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/15585/thumb/convex.png?1621256328",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x4e3FBD56CD56c3e72c1403e103b45Db9da5B9D2B"
+            }
+          }
+        }
+      },
+      {
+        "name": "Dai Stablecoin",
+        "address": "0x8f3Cf7ad23Cd3CaDbD9735AFf958023239c6A063",
+        "symbol": "DAI",
+        "decimals": 18,
+        "chainId": 137,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x6B175474E89094C44Da98b954EedeAC495271d0F/logo.png",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x6B175474E89094C44Da98b954EedeAC495271d0F"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 137,
+        "address": "0x26f5FB1e6C8a65b3A873fF0a213FA16EFF5a7828",
+        "name": "DerivaDAO",
+        "symbol": "DDX",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/13453/thumb/ddx_logo.png?1608741641",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x3A880652F47bFaa771908C07Dd8673A787dAEd3A"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 137,
+        "address": "0xff835562C761205659939B64583dd381a6AA4D92",
+        "name": "DexTools",
+        "symbol": "DEXT",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/11603/thumb/dext.png?1605790188",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0xfB7B4564402E5500dB5bB6d63Ae671302777C75a"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 137,
+        "address": "0x993f2CafE9dbE525243f4A78BeBC69DAc8D36000",
+        "name": "DIA",
+        "symbol": "DIA",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/11955/thumb/image.png?1646041751",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x84cA8bc7997272c7CfB4D0Cd3D55cd942B3c9419"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 137,
+        "address": "0x85955046DF4668e1DD369D2DE9f3AEB98DD2A369",
+        "name": "DeFi Pulse Index",
+        "symbol": "DPI",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/12465/thumb/defi_pulse_index_set.png?1600051053",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x1494CA1F11D487c2bBe4543E90080AeBa4BA3C2b"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 137,
+        "address": "0x4C3bF0a3DE9524aF68327d1D2558a3B70d17D42a",
+        "name": "dYdX",
+        "symbol": "DYDX",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/17500/thumb/hjnIm9bV.jpg?1628009360",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x92D6C1e31e14520e676a687F0a93788B716BEff5"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 137,
+        "address": "0xE0339c80fFDE91F3e20494Df88d4206D86024cdF",
+        "name": "Dogelon Mars",
+        "symbol": "ELON",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/14962/thumb/6GxcPRo3_400x400.jpg?1619157413",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x761D38e5ddf6ccf6Cf7c55759d5210750B5D60F3"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 137,
+        "address": "0x7eC26842F195c852Fa843bB9f6D8B583a274a157",
+        "name": "Enjin Coin",
+        "symbol": "ENJ",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/1102/thumb/enjin-coin-logo.png?1547035078",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0xF629cBd94d3791C9250152BD8dfBDF380E2a3B9c"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 137,
+        "address": "0xbD7A5Cf51d22930B8B3Df6d834F9BCEf90EE7c4f",
+        "name": "Ethereum Name Service",
+        "symbol": "ENS",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/19785/thumb/acatxTm8_400x400.jpg?1635850140",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0xC18360217D8F7Ab5e7c516566761Ea12Ce7F9D72"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 137,
+        "address": "0x0E50BEA95Fe001A370A4F1C220C49AEdCB982DeC",
+        "name": "Ethernity Chain",
+        "symbol": "ERN",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/14238/thumb/LOGO_HIGH_QUALITY.png?1647831402",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0xBBc2AE13b23d715c30720F079fcd9B4a74093505"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 137,
+        "address": "0x8a037dbcA8134FFc72C362e394e35E0Cad618F85",
+        "name": "Euro Coin",
+        "symbol": "EUROC",
+        "decimals": 6,
+        "logoURI": "https://assets.coingecko.com/coins/images/26045/thumb/euro-coin.png?1655394420",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x1aBaEA1f7C830bD89Acc67eC4af516284b1bC33c"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 137,
+        "address": "0x176f5AB638cf4Ff3B6239Ba609C3fadAA46ef5B0",
+        "name": "Harvest Finance",
+        "symbol": "FARM",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/12304/thumb/Harvest.png?1613016180",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0xa0246c9032bC3A600820415aE600c6388619A14D"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 137,
+        "address": "0x7583FEDDbceFA813dc18259940F76a02710A8905",
+        "name": "Fetch ai",
+        "symbol": "FET",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/5681/thumb/Fetch.jpg?1572098136",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0xaea46A60368A7bD060eec7DF8CBa43b7EF41Ad85"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 137,
+        "address": "0x7A7B94F18EF6AD056CDa648588181CDA84800f94",
+        "name": "Stafi",
+        "symbol": "FIS",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/12423/thumb/stafi_logo.jpg?1599730991",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0xef3A930e1FfFFAcd2fc13434aC81bD278B0ecC8d"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 137,
+        "address": "0x9ff62d1FC52A907B6DCbA8077c2DDCA6E6a9d3e1",
+        "name": "Forta",
+        "symbol": "FORT",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/25060/thumb/Forta_lgo_%281%29.png?1655353696",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x41545f8b9472D758bB669ed8EaEEEcD7a9C4Ec29"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 137,
+        "address": "0x5eCbA59DAcc1ADc5bDEA35f38A732823fc3dE977",
+        "name": "Ampleforth Governance Token",
+        "symbol": "FORTH",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/14917/thumb/photo_2021-04-22_00.00.03.jpeg?1619020835",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x77FbA179C79De5B7653F68b5039Af940AdA60ce0"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 137,
+        "address": "0x65A05DB8322701724c197AF82C9CaE41195B0aA8",
+        "name": "ShapeShift FOX Token",
+        "symbol": "FOX",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/9988/thumb/FOX.png?1574330622",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0xc770EEfAd204B5180dF6a14Ee197D99d808ee52d"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 137,
+        "address": "0x104592a158490a9228070E0A8e5343B499e125D0",
+        "name": "Frax",
+        "symbol": "FRAX",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/13422/thumb/frax_logo.png?1608476506",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x853d955aCEf822Db058eb8505911ED77F175b99e"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 137,
+        "address": "0xC9c1c1c20B3658F8787CC2FD702267791f224Ce1",
+        "name": "Fantom",
+        "symbol": "FTM",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/4001/thumb/Fantom.png?1558015016",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x4E15361FD6b4BB609Fa63C81A2be19d873717870"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 137,
+        "address": "0x3e121107F6F22DA4911079845a470757aF4e1A1b",
+        "name": "Frax Share",
+        "symbol": "FXS",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/13423/thumb/frax_share.png?1608478989",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x3432B6A60D23Ca0dFCa7761B7ab56459D9C964D0"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 137,
+        "address": "0x09E1943Dd2A4e82032773594f50CF54453000b97",
+        "name": "Gala",
+        "symbol": "GALA",
+        "decimals": 8,
+        "logoURI": "https://assets.coingecko.com/coins/images/12493/thumb/GALA-COINGECKO.png?1600233435",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x15D4c048F83bd7e37d49eA4C83a07267Ec4203dA"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 137,
+        "address": "0x385Eeac5cB85A38A9a07A70c73e0a3271CfB54A7",
+        "name": "Aavegotchi",
+        "symbol": "GHST",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/12467/thumb/ghst_200.png?1600750321",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x3F382DbD960E3a9bbCeaE22651E88158d2791550"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 137,
+        "address": "0x0B220b82F3eA3B7F6d9A1D8ab58930C064A2b5Bf",
+        "name": "Golem",
+        "symbol": "GLM",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/542/thumb/Golem_Submark_Positive_RGB.png?1606392013",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x7DD9c5Cba05E151C895FDe1CF355C9A1D5DA6429"
+            }
+          }
+        }
+      },
+      {
+        "name": "Gnosis Token",
+        "address": "0x5FFD62D3C3eE2E81C00A7b9079FB248e7dF024A8",
+        "symbol": "GNO",
+        "decimals": 18,
+        "chainId": 137,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x6810e776880C02933D47DB1b9fc05908e5386b96/logo.png",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x6810e776880C02933D47DB1b9fc05908e5386b96"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 137,
+        "address": "0xF88fc6b493eda7650E4bcf7A290E8d108F677CfE",
+        "name": "Gods Unchained",
+        "symbol": "GODS",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/17139/thumb/10631.png?1635718182",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0xccC8cb5229B0ac8069C51fd58367Fd1e622aFD97"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 137,
+        "address": "0x5fe2B58c013d7601147DcdD68C143A77499f5531",
+        "name": "The Graph",
+        "symbol": "GRT",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/13397/thumb/Graph_Token.png?1608145566",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0xc944E90C64B2c07662A292be6244BDf05Cda44a7"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 137,
+        "address": "0xdb95f9188479575F3F718a245EcA1B3BF74567EC",
+        "name": "Gitcoin",
+        "symbol": "GTC",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/15810/thumb/gitcoin.png?1621992929",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0xDe30da39c46104798bB5aA3fe8B9e0e1F348163F"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 137,
+        "address": "0xC8A94a3d3D2dabC3C1CaffFFDcA6A7543c3e3e65",
+        "name": "Gemini Dollar",
+        "symbol": "GUSD",
+        "decimals": 2,
+        "logoURI": "https://assets.coingecko.com/coins/images/5992/thumb/gemini-dollar-gusd.png?1536745278",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x056Fd409E1d7A124BD7017459dFEa2F387b6d5Cd"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 137,
+        "address": "0x482bc619eE7662759CDc0685B4E78f464Da39C73",
+        "name": "GYEN",
+        "symbol": "GYEN",
+        "decimals": 6,
+        "logoURI": "https://assets.coingecko.com/coins/images/14191/thumb/icon_gyen_200_200.png?1614843343",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0xC08512927D12348F6620a698105e1BAac6EcD911"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 137,
+        "name": "HOPR",
+        "symbol": "HOPR",
+        "logoURI": "https://assets.coingecko.com/coins/images/14061/thumb/Shared_HOPR_logo_512px.png?1614073468",
+        "address": "0x6cCBF3627b2C83AFEF05bf2F035E7f7B210Fe30D",
+        "decimals": 18,
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0xF5581dFeFD8Fb0e4aeC526bE659CFaB1f8c781dA"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 137,
+        "address": "0x9Cb74C8032b007466865f060ad2c46145d45553D",
+        "name": "IDEX",
+        "symbol": "IDEX",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/2565/thumb/logomark-purple-286x286.png?1638362736",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0xB705268213D593B8FD88d3FDEFF93AFF5CbDcfAE"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 137,
+        "address": "0x183070C90B34A63292cC908Ce1b263Cb56D49A7F",
+        "name": "Immutable X",
+        "symbol": "IMX",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/17233/thumb/imx.png?1636691817",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0xF57e7e7C23978C3cAEC3C3548E3D615c346e79fF"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 137,
+        "name": "Index Cooperative",
+        "symbol": "INDEX",
+        "logoURI": "https://assets.coingecko.com/coins/images/12729/thumb/index.png?1634894321",
+        "address": "0xfBd8A3b908e764dBcD51e27992464B4432A1132b",
+        "decimals": 18,
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x0954906da0Bf32d5479e25f46056d22f08464cab"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 137,
+        "address": "0x4E8dc2149EaC3f3dEf36b1c281EA466338249371",
+        "name": "Injective",
+        "symbol": "INJ",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/12882/thumb/Secondary_Symbol.png?1628233237",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0xe28b3B32B6c345A34Ff64674606124Dd5Aceca30"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 137,
+        "address": "0xF18Ac368001b0DdC80aA6a8374deb49e868EFDb8",
+        "name": "Inverse Finance",
+        "symbol": "INV",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/14205/thumb/inverse_finance.jpg?1614921871",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x41D5D79431A913C4aE7d69a668ecdfE5fF9DFB68"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 137,
+        "address": "0xf6372cDb9c1d3674E83842e3800F2A62aC9F3C66",
+        "name": "IoTeX",
+        "symbol": "IOTX",
+        "decimals": 18,
+        "logoURI": "https://s2.coinmarketcap.com/static/img/coins/64x64/2777.png",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x6fB3e0A217407EFFf7Ca062D46c26E5d60a14d69"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 137,
+        "address": "0xb87f5c1E81077FfcfE821dA240fd20C99c533aF1",
+        "name": "JasmyCoin",
+        "symbol": "JASMY",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/13876/thumb/JASMY200x200.jpg?1612473259",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x7420B4b9a0110cdC71fB720908340C03F9Bc03EC"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 137,
+        "address": "0x42f37A1296b2981F7C3cAcEd84c5096b2Eb0C72C",
+        "name": "Keep Network",
+        "symbol": "KEEP",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/3373/thumb/IuNzUb5b_400x400.jpg?1589526336",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x85Eee30c52B0b379b046Fb0F85F4f3Dc3009aFEC"
+            }
+          }
+        }
+      },
+      {
+        "name": "Kyber Network Crystal",
+        "address": "0x324b28d6565f784d596422B0F2E5aB6e9CFA1Dc7",
+        "symbol": "KNC",
+        "decimals": 18,
+        "chainId": 137,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xdd974D5C2e2928deA5F71b9825b8b646686BD200/logo.png",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0xdd974D5C2e2928deA5F71b9825b8b646686BD200"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 137,
+        "address": "0x53AEc293212E3B792563Bc16f1be26956adb12e9",
+        "name": "Keep3rV1",
+        "symbol": "KP3R",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/12966/thumb/kp3r_logo.jpg?1607057458",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x1cEB5cB57C4D4E2b2433641b95Dd330A33185A44"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 137,
+        "address": "0xE8A51D0dD1b4525189ddA2187F90ddF0932b5482",
+        "name": "LCX",
+        "symbol": "LCX",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/9985/thumb/zRPSu_0o_400x400.jpg?1574327008",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x037A54AaB062628C9Bbae1FDB1583c195585fe41"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 137,
+        "address": "0xC3C7d422809852031b44ab29EEC9F1EfF2A58756",
+        "name": "Lido DAO",
+        "symbol": "LDO",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/13573/thumb/Lido_DAO.png?1609873644",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x5A98FcBEA516Cf06857215779Fd812CA3beF1B32"
+            }
+          }
+        }
+      },
+      {
+        "name": "ChainLink Token",
+        "address": "0x53E0bca35eC356BD5ddDFebbD1Fc0fD03FaBad39",
+        "symbol": "LINK",
+        "decimals": 18,
+        "chainId": 137,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x514910771AF9Ca656af840dff83E8264EcF986CA/logo.png",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x514910771AF9Ca656af840dff83E8264EcF986CA"
+            }
+          }
+        }
+      },
+      {
+        "name": "Loom Network",
+        "address": "0x66EfB7cC647e0efab02eBA4316a2d2941193F6b3",
+        "symbol": "LOOM",
+        "decimals": 18,
+        "chainId": 137,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xA4e8C3Ec456107eA67d3075bF9e3DF3A75823DB0/logo.png",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0xA4e8C3Ec456107eA67d3075bF9e3DF3A75823DB0"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 137,
+        "address": "0x3962F4A0A0051DccE0be73A7e09cEf5756736712",
+        "name": "Livepeer",
+        "symbol": "LPT",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/7137/thumb/logo-circle-green.png?1619593365",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x58b6A8A3302369DAEc383334672404Ee733aB239"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 137,
+        "address": "0x8Ab2Fec94d17ae69FB90E7c773f2C85Ed1802c01",
+        "name": "Liquity",
+        "symbol": "LQTY",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/14665/thumb/200-lqty-icon.png?1617631180",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x6DEA81C8171D0bA574754EF6F8b412F2Ed88c54D"
+            }
+          }
+        }
+      },
+      {
+        "name": "LoopringCoin V2",
+        "address": "0x84e1670F61347CDaeD56dcc736FB990fBB47ddC1",
+        "symbol": "LRC",
+        "decimals": 18,
+        "chainId": 137,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xBBbbCA6A901c926F240b89EacB641d8Aec7AEafD/logo.png",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0xBBbbCA6A901c926F240b89EacB641d8Aec7AEafD"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 137,
+        "name": "Liquity USD",
+        "symbol": "LUSD",
+        "logoURI": "https://assets.coingecko.com/coins/images/14666/thumb/Group_3.png?1617631327",
+        "address": "0x23001f892c0C82b79303EDC9B9033cD190BB21c7",
+        "decimals": 18,
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x5f98805A4E8be255a32880FDeC7F6728C6568bA0"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 137,
+        "address": "0xA1c57f48F0Deb89f569dFbE6E2B7f46D33606fD4",
+        "name": "Decentraland",
+        "symbol": "MANA",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/878/thumb/decentraland-mana.png?1550108745",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x0F5D2fB29fb7d3CFeE444a200298f468908cC942"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 137,
+        "address": "0x2B9E7ccDF0F4e5B24757c1E1a80e311E34Cb10c7",
+        "name": "Mask Network",
+        "symbol": "MASK",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/14051/thumb/Mask_Network.jpg?1614050316",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x69af81e73A73B40adF4f3d4223Cd9b1ECE623074"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 137,
+        "name": "MATH",
+        "symbol": "MATH",
+        "logoURI": "https://assets.coingecko.com/coins/images/11335/thumb/2020-05-19-token-200.png?1589940590",
+        "address": "0x347ACCAFdA7F8c5BdeC57fa34a5b663CBd1aeca7",
+        "decimals": 18,
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x08d967bb0134F2d07f7cfb6E246680c53927DD30"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 137,
+        "address": "0x0000000000000000000000000000000000001010",
+        "name": "Polygon",
+        "symbol": "MATIC",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/4713/thumb/matic-token-icon.png?1624446912",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x7D1AfA7B718fb893dB30A3aBc0Cfc608AaCfeBB0"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 137,
+        "address": "0xAa7DbD1598251f856C12f63557A4C4397c253Cea",
+        "name": "Moss Carbon Credit",
+        "symbol": "MCO2",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/14414/thumb/ENtxnThA_400x400.jpg?1615948522",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0xfC98e825A2264D890F9a1e68ed50E1526abCcacD"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 137,
+        "name": "Metis",
+        "symbol": "METIS",
+        "logoURI": "https://assets.coingecko.com/coins/images/15595/thumb/metis.jpeg?1660285312",
+        "address": "0x1B9D40715E757Bdb9bdEC3215B898E46d8a3b71a",
+        "decimals": 18,
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x9E32b13ce7f2E80A01932B42553652E053D6ed8e"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 137,
+        "address": "0x01288e04435bFcd4718FF203D6eD18146C17Cd4b",
+        "name": "Magic Internet Money",
+        "symbol": "MIM",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/16786/thumb/mimlogopng.png?1624979612",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x99D8a9C45b2ecA8864373A26D1459e3Dff1e17F3"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 137,
+        "address": "0x1C5cccA2CB59145A4B25F452660cbA6436DDce9b",
+        "name": "Mirror Protocol",
+        "symbol": "MIR",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/13295/thumb/mirror_logo_transparent.png?1611554658",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x09a3EcAFa817268f77BE1283176B946C4ff2E608"
+            }
+          }
+        }
+      },
+      {
+        "name": "Maker",
+        "address": "0x6f7C932e7684666C9fd1d44527765433e01fF61d",
+        "symbol": "MKR",
+        "decimals": 18,
+        "chainId": 137,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x9f8F72aA9304c8B593d555F12eF6589cC3A579A2/logo.png",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x9f8F72aA9304c8B593d555F12eF6589cC3A579A2"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 137,
+        "address": "0xa9f37D84c856fDa3812ad0519Dad44FA0a3Fe207",
+        "name": "Melon",
+        "symbol": "MLN",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/605/thumb/melon.png?1547034295",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0xec67005c4E498Ec7f55E092bd1d35cbC47C91892"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 137,
+        "name": "Monavale",
+        "symbol": "MONA",
+        "logoURI": "https://assets.coingecko.com/coins/images/13298/thumb/monavale_logo.jpg?1607232721",
+        "address": "0x6968105460f67c3BF751bE7C15f92F5286Fd0CE5",
+        "decimals": 18,
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x275f5Ad03be0Fa221B4C6649B8AeE09a42D9412A"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 137,
+        "name": "GensoKishi Metaverse",
+        "symbol": "MV",
+        "logoURI": "https://s2.coinmarketcap.com/static/img/coins/64x64/17704.png",
+        "address": "0xA3c322Ad15218fBFAEd26bA7f616249f7705D945",
+        "decimals": 18,
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0xAE788F80F2756A86aa2F410C651F2aF83639B95b"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 137,
+        "address": "0x4985E0B13554fB521840e893574D3848C10Fcc6f",
+        "name": "PolySwarm",
+        "symbol": "NCT",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/2843/thumb/ImcYCVfX_400x400.jpg?1628519767",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x9E46A38F5DaaBe8683E10793b06749EEF7D733d1"
+            }
+          }
+        }
+      },
+      {
+        "name": "Numeraire",
+        "address": "0x0Bf519071b02F22C17E7Ed5F4002ee1911f46729",
+        "symbol": "NMR",
+        "decimals": 18,
+        "chainId": 137,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x1776e1F26f98b1A5dF9cD347953a26dd3Cb46671/logo.png",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x1776e1F26f98b1A5dF9cD347953a26dd3Cb46671"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 137,
+        "address": "0x282d8efCe846A88B159800bd4130ad77443Fa1A1",
+        "name": "Ocean Protocol",
+        "symbol": "OCEAN",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/3687/thumb/ocean-protocol-logo.jpg?1547038686",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x967da4048cD07aB37855c090aAF366e4ce1b9F48"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 137,
+        "address": "0xa63Beffd33AB3a2EfD92a39A7D2361CEE14cEbA8",
+        "name": "Origin Protocol",
+        "symbol": "OGN",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/3296/thumb/op.jpg?1547037878",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x8207c1FfC5B6804F6024322CcF34F29c3541Ae26"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 137,
+        "address": "0x62414D03084EeB269E18C970a21f45D2967F0170",
+        "name": "OMG Network",
+        "symbol": "OMG",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/776/thumb/OMG_Network.jpg?1591167168",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0xd26114cd6EE289AccF82350c8d8487fedB8A0C07"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 137,
+        "address": "0x0EE392bA5ef1354c9bd75a98044667d307C0e773",
+        "name": "Orion Protocol",
+        "symbol": "ORN",
+        "decimals": 8,
+        "logoURI": "https://assets.coingecko.com/coins/images/11841/thumb/orion_logo.png?1594943318",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x0258F474786DdFd37ABCE6df6BBb1Dd5dfC4434a"
+            }
+          }
+        }
+      },
+      {
+        "name": "Orchid",
+        "address": "0x9880e3dDA13c8e7D4804691A45160102d31F6060",
+        "symbol": "OXT",
+        "decimals": 18,
+        "chainId": 137,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x4575f41308EC1483f3d399aa9a2826d74Da13Deb/logo.png",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x4575f41308EC1483f3d399aa9a2826d74Da13Deb"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 137,
+        "address": "0x553d3D295e0f695B9228246232eDF400ed3560B5",
+        "name": "PAX Gold",
+        "symbol": "PAXG",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/9519/thumb/paxg.PNG?1568542565",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x45804880De22913dAFE09f4980848ECE6EcbAf78"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 137,
+        "address": "0x263534a4Fe3cb249dF46810718B7B612a30ebbff",
+        "name": "Perpetual Protocol",
+        "symbol": "PERP",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/12381/thumb/60d18e06844a844ad75901a9_mark_only_03.png?1628674771",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0xbC396689893D065F41bc2C6EcbeE5e0085233447"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 137,
+        "address": "0x8765f05ADce126d70bcdF1b0a48Db573316662eB",
+        "name": "PlayDapp",
+        "symbol": "PLA",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/14316/thumb/54023228.png?1615366911",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x3a4f40631a4f906c2BaD353Ed06De7A5D3fCb430"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 137,
+        "address": "0x7dc0cb65EC6019330a6841e9c274f2EE57A6CA6C",
+        "name": "Pluton",
+        "symbol": "PLU",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/1241/thumb/pluton.png?1548331624",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0xD8912C10681D8B21Fd3742244f44658dBA12264E"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 137,
+        "address": "0x8dc302e2141DA59c934d900886DbF1518Fd92cd4",
+        "name": "Polkastarter",
+        "symbol": "POLS",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/12648/thumb/polkastarter.png?1609813702",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x83e6f1E41cdd28eAcEB20Cb649155049Fac3D5Aa"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 137,
+        "address": "0xcB059C5573646047D6d88dDdb87B745C18161d3b",
+        "name": "Polymath",
+        "symbol": "POLY",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/2784/thumb/inKkF01.png?1605007034",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x9992eC3cF6A55b00978cdDF2b27BC6882d88D1eC"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 137,
+        "name": "Marlin",
+        "symbol": "POND",
+        "logoURI": "https://assets.coingecko.com/coins/images/8903/thumb/POND_200x200.png?1622515451",
+        "address": "0x73580A2416A57f1C4b6391DBA688A9e4f7DBECE0",
+        "decimals": 18,
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x57B946008913B82E4dF85f501cbAeD910e58D26C"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 137,
+        "address": "0x0AaB8DC887D34f00D50E19aee48371a941390d14",
+        "name": "Power Ledger",
+        "symbol": "POWR",
+        "decimals": 6,
+        "logoURI": "https://assets.coingecko.com/coins/images/1104/thumb/power-ledger.png?1547035082",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x595832F8FC6BF59c85C527fEC3740A1b7a361269"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 137,
+        "address": "0x82FFdFD1d8699E8886a4e77CeFA9dd9710a7FefD",
+        "name": "Propy",
+        "symbol": "PRO",
+        "decimals": 8,
+        "logoURI": "https://assets.coingecko.com/coins/images/869/thumb/propy.png?1548332100",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x226bb599a12C826476e3A771454697EA52E9E220"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 137,
+        "name": "PARSIQ",
+        "symbol": "PRQ",
+        "logoURI": "https://assets.coingecko.com/coins/images/11973/thumb/DsNgK0O.png?1596590280",
+        "address": "0x9377Eeb7419486FD4D485671d50baa4BF77c2222",
+        "decimals": 18,
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x362bc847A3a9637d3af6624EeC853618a43ed7D2"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 137,
+        "address": "0x36B77a184bE8ee56f5E81C56727B20647A42e28E",
+        "name": "Quant",
+        "symbol": "QNT",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/3370/thumb/5ZOu7brX_400x400.jpg?1612437252",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x4a220E6096B25EADb88358cb44068A3248254675"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 137,
+        "address": "0x831753DD7087CaC61aB5644b308642cc1c33Dc13",
+        "name": "Quickswap",
+        "symbol": "QUICK",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/13970/thumb/1_pOU6pBMEmiL-ZJVb0CYRjQ.png?1613386659",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x6c28AeF8977c9B773996d0e8376d2EE379446F2f"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 137,
+        "address": "0x2f81e176471CC57fDC76f7d332FB4511bF2bebDD",
+        "name": "Radicle",
+        "symbol": "RAD",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/14013/thumb/radicle.png?1614402918",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x31c8EAcBFFdD875c74b94b077895Bd78CF1E64A3"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 137,
+        "address": "0x00e5646f60AC6Fb446f621d146B6E1886f002905",
+        "name": "Rai Reflex Index",
+        "symbol": "RAI",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/14004/thumb/RAI-logo-coin.png?1613592334",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x03ab458634910AaD20eF5f1C8ee96F1D6ac54919"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 137,
+        "address": "0x780053837cE2CeEaD2A90D9151aA21FC89eD49c2",
+        "name": "Rarible",
+        "symbol": "RARI",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/11845/thumb/Rari.png?1594946953",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0xFca59Cd816aB1eaD66534D82bc21E7515cE441CF"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 137,
+        "address": "0xc3cFFDAf8F3fdF07da6D5e3A89B8723D5E385ff8",
+        "name": "Rubic",
+        "symbol": "RBC",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/12629/thumb/200x200.png?1607952509",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0xA4EED63db85311E22dF4473f87CcfC3DaDCFA3E3"
+            }
+          }
+        }
+      },
+      {
+        "name": "Republic Token",
+        "address": "0x19782D3Dc4701cEeeDcD90f0993f0A9126ed89d0",
+        "symbol": "REN",
+        "decimals": 18,
+        "chainId": 137,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x408e41876cCCDC0F92210600ef50372656052a38/logo.png",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x408e41876cCCDC0F92210600ef50372656052a38"
+            }
+          }
+        }
+      },
+      {
+        "name": "Reputation Augur v2",
+        "address": "0x6563c1244820CfBd6Ca8820FBdf0f2847363F733",
+        "symbol": "REPv2",
+        "decimals": 18,
+        "chainId": 137,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x221657776846890989a759BA2973e427DfF5C9bB/logo.png",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x221657776846890989a759BA2973e427DfF5C9bB"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 137,
+        "address": "0xAdf2F2Ed91755eA3f4bcC9107a494879f633ae7C",
+        "name": "Request",
+        "symbol": "REQ",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/1031/thumb/Request_icon_green.png?1643250951",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x8f8221aFbB33998d8584A2B05749bA73c37a938a"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 137,
+        "name": "REVV",
+        "symbol": "REVV",
+        "logoURI": "https://assets.coingecko.com/coins/images/12373/thumb/REVV_TOKEN_Refined_2021_%281%29.png?1627652390",
+        "address": "0x70c006878a5A50Ed185ac4C87d837633923De296",
+        "decimals": 18,
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x557B933a7C2c45672B610F8954A3deB39a51A8Ca"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 137,
+        "address": "0x3b9dB434F08003A89554CDB43b3e0b1f8734BdE7",
+        "name": "Rari Governance Token",
+        "symbol": "RGT",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/12900/thumb/Rari_Logo_Transparent.png?1613978014",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0xD291E7a03283640FDc51b121aC401383A46cC623"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 137,
+        "address": "0xbe662058e00849C3Eef2AC9664f37fEfdF2cdbFE",
+        "name": "iExec RLC",
+        "symbol": "RLC",
+        "decimals": 9,
+        "logoURI": "https://assets.coingecko.com/coins/images/646/thumb/pL1VuXm.png?1604543202",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x607F4C5BB672230e8672085532f7e901544a7375"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 137,
+        "address": "0x76b8D57e5ac6afAc5D415a054453d1DD2c3C0094",
+        "name": "Rally",
+        "symbol": "RLY",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/12843/thumb/image.png?1611212077",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0xf1f955016EcbCd7321c7266BccFB96c68ea5E49b"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 137,
+        "address": "0x61299774020dA444Af134c82fa83E3810b309991",
+        "name": "Render Token",
+        "symbol": "RNDR",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/11636/thumb/rndr.png?1638840934",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x6De037ef9aD2725EB40118Bb1702EBb27e4Aeb24"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 137,
+        "name": "Rook",
+        "symbol": "ROOK",
+        "logoURI": "https://assets.coingecko.com/coins/images/13005/thumb/keeper_dao_logo.jpg?1604316506",
+        "address": "0xF92501c8213da1D6C74A76372CCc720Dc8818407",
+        "decimals": 18,
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0xfA5047c9c78B8877af97BDcb85Db743fD7313d4a"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 137,
+        "address": "0xBbba073C31bF03b8ACf7c28EF0738DeCF3695683",
+        "name": "The Sandbox",
+        "symbol": "SAND",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/12129/thumb/sandbox_logo.jpg?1597397942",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x3845badAde8e6dFF049820680d1F14bD3903a5d0"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 137,
+        "address": "0x6f8a06447Ff6FcF75d803135a7de15CE88C1d4ec",
+        "name": "Shiba Inu",
+        "symbol": "SHIB",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/11939/thumb/shiba.png?1622619446",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x95aD61b0a150d79219dCF64E1E6Cc01f0B64C4cE"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 137,
+        "address": "0x0C7304fBAf2A320a1c50c46FE03752722F729946",
+        "name": "Smooth Love Potion",
+        "symbol": "SLP",
+        "decimals": 0,
+        "logoURI": "https://assets.coingecko.com/coins/images/10366/thumb/SLP.png?1578640057",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0xCC8Fa225D80b9c7D42F96e9570156c65D6cAAa25"
+            }
+          }
+        }
+      },
+      {
+        "name": "Synthetix Network Token",
+        "address": "0x50B728D8D964fd00C2d0AAD81718b71311feF68a",
+        "symbol": "SNX",
+        "decimals": 18,
+        "chainId": 137,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xC011a73ee8576Fb46F5E1c5751cA3B9Fe0af2a6F/logo.png",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0xC011a73ee8576Fb46F5E1c5751cA3B9Fe0af2a6F"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 137,
+        "address": "0xcdB3C70CD25FD15307D84C4F9D37d5C043B33Fb2",
+        "name": "Spell Token",
+        "symbol": "SPELL",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/15861/thumb/abracadabra-3.png?1622544862",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x090185f2135308BaD17527004364eBcC2D37e5F6"
+            }
+          }
+        }
+      },
+      {
+        "name": "Storj Token",
+        "address": "0xd72357dAcA2cF11A5F155b9FF7880E595A3F5792",
+        "symbol": "STORJ",
+        "decimals": 8,
+        "chainId": 137,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xB64ef51C888972c908CFacf59B47C1AfBC0Ab8aC/logo.png",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0xB64ef51C888972c908CFacf59B47C1AfBC0Ab8aC"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 137,
+        "address": "0xB36e3391B22a970d31A9b620Ae1A414C6c256d2a",
+        "name": "Stox",
+        "symbol": "STX",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/1230/thumb/stox-token.png?1547035256",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x006BeA43Baa3f7A6f765F14f10A1a1b08334EF45"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 137,
+        "address": "0x60Ea918FC64360269Da4efBDA11d8fC6514617C6",
+        "name": "SUKU",
+        "symbol": "SUKU",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/11969/thumb/UmfW5S6f_400x400.jpg?1596602238",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x0763fdCCF1aE541A5961815C0872A8c5Bc6DE4d7"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 137,
+        "address": "0xa1428174F516F527fafdD146b883bB4428682737",
+        "name": "SuperFarm",
+        "symbol": "SUPER",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/14040/thumb/6YPdWn6.png?1613975899",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0xe53EC727dbDEB9E2d5456c3be40cFF031AB40A55"
+            }
+          }
+        }
+      },
+      {
+        "name": "Synth sUSD",
+        "address": "0xF81b4Bec6Ca8f9fe7bE01CA734F55B2b6e03A7a0",
+        "symbol": "sUSD",
+        "decimals": 18,
+        "chainId": 137,
+        "logoURI": "https://assets.coingecko.com/coins/images/5013/thumb/sUSD.png?1616150765",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x57Ab1ec28D129707052df4dF418D58a2D46d5f51"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 137,
+        "address": "0x0b3F868E0BE5597D5DB7fEB59E1CADBb0fdDa50a",
+        "name": "Sushi",
+        "symbol": "SUSHI",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/12271/thumb/512x512_Logo_no_chop.png?1606986688",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x6B3595068778DD592e39A122f4f5a5cF09C90fE2"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 137,
+        "name": "Swipe",
+        "symbol": "SXP",
+        "logoURI": "https://assets.coingecko.com/coins/images/9368/thumb/swipe.png?1566792311",
+        "address": "0x6aBB753C1893194DE4a83c6e8B4EadFc105Fd5f5",
+        "decimals": 18,
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x8CE9137d39326AD0cD6491fb5CC0CbA0e089b6A9"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 137,
+        "address": "0x50a4a434247089848991DD8f09b889D4e2870aB6",
+        "name": "tBTC",
+        "symbol": "TBTC",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/11224/thumb/tBTC.png?1589620754",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x8dAEBADE922dF735c38C80C7eBD708Af50815fAa"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 137,
+        "address": "0xe1708AbDE4847B4929b70547E5197F1Ba1db2250",
+        "name": "Tokemak",
+        "symbol": "TOKE",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/17495/thumb/tokemak-avatar-200px-black.png?1628131614",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x2e9d63788249371f1DFC918a52f8d799F4a38C94"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 137,
+        "address": "0xA7b98d63a137bF402b4570799ac4caD0BB1c4B1c",
+        "name": "OriginTrail",
+        "symbol": "TRAC",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/1877/thumb/TRAC.jpg?1635134367",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0xaA7a9CA87d3694B5755f213B5D04094b8d0F0A6F"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 137,
+        "address": "0xE3322702BEdaaEd36CdDAb233360B939775ae5f1",
+        "name": "Tellor",
+        "symbol": "TRB",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/9644/thumb/Blk_icon_current.png?1584980686",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x88dF592F8eb5D7Bd38bFeF7dEb0fBc02cf3778a0"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 137,
+        "address": "0x8676815789211E799a6DC86d02748ADF9cF86836",
+        "name": "Tribe",
+        "symbol": "TRIBE",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/14575/thumb/tribe.PNG?1617487954",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0xc7283b66Eb1EB5FB86327f08e1B5816b0720212B"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 137,
+        "address": "0x5b77bCA482bd3E7958b1103d123888EfCCDaF803",
+        "name": "TrueFi",
+        "symbol": "TRU",
+        "decimals": 8,
+        "logoURI": "https://assets.coingecko.com/coins/images/13180/thumb/truefi_glyph_color.png?1617610941",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x4C19596f5aAfF459fA38B0f7eD92F11AE6543784"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 137,
+        "name": "The Virtua Kolect",
+        "symbol": "TVK",
+        "logoURI": "https://assets.coingecko.com/coins/images/13330/thumb/virtua_original.png?1656043619",
+        "address": "0x5667dcC0ab74D1b1355C3b2061893399331B57e2",
+        "decimals": 18,
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0xd084B83C305daFD76AE3E1b4E1F1fe2eCcCb3988"
+            }
+          }
+        }
+      },
+      {
+        "name": "UMA Voting Token v1",
+        "address": "0x3066818837c5e6eD6601bd5a91B0762877A6B731",
+        "symbol": "UMA",
+        "decimals": 18,
+        "chainId": 137,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x04Fa0d235C4abf4BcF4787aF4CF447DE572eF828/logo.png",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x04Fa0d235C4abf4BcF4787aF4CF447DE572eF828"
+            }
+          }
+        }
+      },
+      {
+        "name": "Uniswap",
+        "address": "0xb33EaAd8d922B1083446DC23f610c2567fB5180f",
+        "symbol": "UNI",
+        "decimals": 18,
+        "chainId": 137,
+        "logoURI": "ipfs://QmXttGpZrECX5qCyXbBQiqgQNytVGeZW5Anewvh2jc4psg",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x1f9840a85d5aF5bf1D1762F925BDADdC4201F984"
+            }
+          }
+        }
+      },
+      {
+        "name": "USDCoin",
+        "address": "0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174",
+        "symbol": "USDC",
+        "decimals": 6,
+        "chainId": 137,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/logo.png",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"
+            }
+          }
+        }
+      },
+      {
+        "name": "Tether USD",
+        "address": "0xc2132D05D31c914a87C6611C10748AEb04B58e8F",
+        "symbol": "USDT",
+        "decimals": 6,
+        "chainId": 137,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xdAC17F958D2ee523a2206206994597C13D831ec7/logo.png",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0xdAC17F958D2ee523a2206206994597C13D831ec7"
+            }
+          }
+        }
+      },
+      {
+        "name": "Wrapped BTC",
+        "address": "0x1BFD67037B42Cf73acF2047067bd4F2C47D9BfD6",
+        "symbol": "WBTC",
+        "decimals": 8,
+        "chainId": 137,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599/logo.png",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 137,
+        "name": "Wrapped Centrifuge",
+        "symbol": "WCFG",
+        "logoURI": "https://assets.coingecko.com/coins/images/17106/thumb/WCFG.jpg?1626266462",
+        "address": "0x90bb6fEB70A9a43CfAaA615F856BA309FD759A90",
+        "decimals": 18,
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0xc221b7E65FfC80DE234bbB6667aBDd46593D34F0"
+            }
+          }
+        }
+      },
+      {
+        "name": "Wrapped Ether",
+        "address": "0x7ceB23fD6bC0adD59E62ac25578270cFf1b9f619",
+        "symbol": "WETH",
+        "decimals": 18,
+        "chainId": 137,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2/logo.png",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2"
+            }
+          }
+        }
+      },
+      {
+        "name": "Wrapped Matic",
+        "address": "0x0d500B1d8E8eF31E21C99d1Db9A6444d3ADf1270",
+        "symbol": "WMATIC",
+        "decimals": 18,
+        "chainId": 137,
+        "logoURI": "https://assets.coingecko.com/coins/images/4713/thumb/matic-token-icon.png?1624446912"
+      },
+      {
+        "chainId": 137,
+        "name": "WOO Network",
+        "symbol": "WOO",
+        "logoURI": "https://assets.coingecko.com/coins/images/12921/thumb/w2UiemF__400x400.jpg?1603670367",
+        "address": "0x1B815d120B3eF02039Ee11dC2d33DE7aA4a8C603",
+        "decimals": 18,
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x4691937a7508860F876c9c0a2a617E7d9E945D4B"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 137,
+        "address": "0xd2507e7b5794179380673870d88B22F94da6abe0",
+        "name": "XYO Network",
+        "symbol": "XYO",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/4519/thumb/XYO_Network-logo.png?1547039819",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x55296f69f40Ea6d20E478533C15A6B08B654E758"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 137,
+        "address": "0xDA537104D6A5edd53c6fBba9A898708E465260b6",
+        "name": "yearn finance",
+        "symbol": "YFI",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/11849/thumb/yfi-192x192.png?1598325330",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x0bc529c00C6401aEF6D220BE8C6Ea1667F6Ad93e"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 137,
+        "address": "0xb8cb8a7F4C2885C03e57E973C74827909Fdc2032",
+        "name": "DFI money",
+        "symbol": "YFII",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/11902/thumb/YFII-logo.78631676.png?1598677348",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0xa1d0E215a23d7030842FC67cE582a6aFa3CCaB83"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 137,
+        "name": "Yield Guild Games",
+        "symbol": "YGG",
+        "logoURI": "https://assets.coingecko.com/coins/images/17358/thumb/le1nzlO6_400x400.jpg?1632465691",
+        "address": "0x82617aA52dddf5Ed9Bb7B370ED777b3182A30fd1",
+        "decimals": 18,
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x25f8087EAD173b73D6e8B84329989A8eEA16CF73"
+            }
+          }
+        }
+      },
+      {
+        "name": "0x Protocol Token",
+        "address": "0x5559Edb74751A0edE9DeA4DC23aeE72cCA6bE3D5",
+        "symbol": "ZRX",
+        "decimals": 18,
+        "chainId": 137,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xE41d2489571d322189246DaFA5ebDe1F4699F498/logo.png",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0xE41d2489571d322189246DaFA5ebDe1F4699F498"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 42161,
+        "address": "0x6314C31A7a1652cE482cffe247E9CB7c3f4BB9aF",
+        "name": "1inch",
+        "symbol": "1INCH",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/13469/thumb/1inch-token.png?1608803028",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x111111111117dC0aa78b770fA6A738034120C302"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 42161,
+        "address": "0xba5DdD1f9d7F570dc94a51479a000E3BCE967196",
+        "name": "Aave",
+        "symbol": "AAVE",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/12645/thumb/AAVE.png?1601374110",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x7Fc66500c84A76Ad7e9c93437bFc5Ac33E2DDaE9"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 42161,
+        "address": "0x74885b4D524d497261259B38900f54e6dbAd2210",
+        "name": "ApeCoin",
+        "symbol": "APE",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/24383/small/apecoin.jpg?1647476455",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x4d224452801ACEd8B2F0aebE155379bb5D594381"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 42161,
+        "address": "0xAC9Ac2C17cdFED4AbC80A53c5553388575714d03",
+        "name": "Automata",
+        "symbol": "ATA",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/15985/thumb/ATA.jpg?1622535745",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0xA2120b9e674d3fC3875f415A7DF52e382F141225"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 42161,
+        "address": "0xe88998Fb579266628aF6a03e3821d5983e5D0089",
+        "name": "Axie Infinity",
+        "symbol": "AXS",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/13029/thumb/axie_infinity_logo.png?1604471082",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0xBB0E17EF65F82Ab018d8EDd776e8DD940327B28b"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 42161,
+        "address": "0xBfa641051Ba0a0Ad1b0AcF549a89536A0D76472E",
+        "name": "Badger DAO",
+        "symbol": "BADGER",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/13287/thumb/badger_dao_logo.jpg?1607054976",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x3472A5A71965499acd81997a54BBA8D852C6E53d"
+            }
+          }
+        }
+      },
+      {
+        "name": "Balancer",
+        "address": "0x040d1EdC9569d4Bab2D15287Dc5A4F10F56a56B8",
+        "symbol": "BAL",
+        "decimals": 18,
+        "chainId": 42161,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xba100000625a3754423978a60c9317c58a424e3D/logo.png",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0xba100000625a3754423978a60c9317c58a424e3D"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 42161,
+        "address": "0x3450687EF141dCd6110b77c2DC44B008616AeE75",
+        "name": "Basic Attention Token",
+        "symbol": "BAT",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/677/thumb/basic-attention-token.png?1547034427",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x0D8775F648430679A709E98d2b0Cb6250d2887EF"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 42161,
+        "address": "0xa68Ec98D7ca870cF1Dd0b00EBbb7c4bF60A8e74d",
+        "name": "Biconomy",
+        "symbol": "BICO",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/21061/thumb/biconomy_logo.jpg?1638269749",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0xF17e65822b568B3903685a7c9F496CF7656Cc6C2"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 42161,
+        "address": "0x406C8dB506653D882295875F633bEC0bEb921C2A",
+        "name": "BitDAO",
+        "symbol": "BIT",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/17627/thumb/rI_YptK8.png?1653983088",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x1A4b46696b2bB4794Eb3D4c26f1c55F9170fa4C5"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 42161,
+        "address": "0x0D81E50bC677fa67341c44D7eaA9228DEE64A4e1",
+        "name": "BarnBridge",
+        "symbol": "BOND",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/12811/thumb/barnbridge.jpg?1602728853",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x0391D2021f89DC339F60Fff84546EA23E337750f"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 42161,
+        "address": "0x31190254504622cEFdFA55a7d3d272e6462629a2",
+        "name": "Binance USD",
+        "symbol": "BUSD",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/9576/thumb/BUSD.png?1568947766",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x4Fabb145d64652a948d72533023f6E7A623C7C53"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 42161,
+        "address": "0x3a8B787f78D775AECFEEa15706D4221B40F345AB",
+        "name": "Celer Network",
+        "symbol": "CELR",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/4379/thumb/Celr.png?1554705437",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x4F9254C83EB525f9FCf346490bbb3ed28a81C667"
+            }
+          }
+        }
+      },
+      {
+        "name": "Compound",
+        "address": "0x354A6dA3fcde098F8389cad84b0182725c6C91dE",
+        "symbol": "COMP",
+        "decimals": 18,
+        "chainId": 42161,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xc00e94Cb662C3520282E6f5717214004A7f26888/logo.png",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0xc00e94Cb662C3520282E6f5717214004A7f26888"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 42161,
+        "address": "0x6FE14d3CC2f7bDdffBa5CdB3BBE7467dd81ea101",
+        "name": "COTI",
+        "symbol": "COTI",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/2962/thumb/Coti.png?1559653863",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0xDDB3422497E61e13543BeA06989C0789117555c5"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 42161,
+        "address": "0x8ea3156f834A0dfC78F1A5304fAC2CdA676F354C",
+        "name": "Cronos",
+        "symbol": "CRO",
+        "decimals": 8,
+        "logoURI": "https://assets.coingecko.com/coins/images/7310/thumb/oCw2s3GI_400x400.jpeg?1645172042",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0xA0b73E1Ff0B80914AB6fe0444E65848C4C34450b"
+            }
+          }
+        }
+      },
+      {
+        "name": "Curve DAO Token",
+        "address": "0x11cDb42B0EB46D95f990BeDD4695A6e3fA034978",
+        "symbol": "CRV",
+        "decimals": 18,
+        "chainId": 42161,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xD533a949740bb3306d119CC777fa900bA034cd52/logo.png",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0xD533a949740bb3306d119CC777fa900bA034cd52"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 42161,
+        "address": "0x319f865b287fCC10b30d8cE6144e8b6D1b476999",
+        "name": "Cartesi",
+        "symbol": "CTSI",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/11038/thumb/cartesi.png?1592288021",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x491604c0FDF08347Dd1fa4Ee062a822A5DD06B5D"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 42161,
+        "address": "0x9DfFB23CAd3322440bCcFF7aB1C58E781dDBF144",
+        "name": "Civic",
+        "symbol": "CVC",
+        "decimals": 8,
+        "logoURI": "https://assets.coingecko.com/coins/images/788/thumb/civic.png?1547034556",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x41e5560054824eA6B0732E656E3Ad64E20e94E45"
+            }
+          }
+        }
+      },
+      {
+        "name": "Dai Stablecoin",
+        "address": "0xDA10009cBd5D07dd0CeCc66161FC93D7c9000da1",
+        "symbol": "DAI",
+        "decimals": 18,
+        "chainId": 42161,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x6B175474E89094C44Da98b954EedeAC495271d0F/logo.png",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x6B175474E89094C44Da98b954EedeAC495271d0F"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 42161,
+        "address": "0xca642467C6Ebe58c13cB4A7091317f34E17ac05e",
+        "name": "DIA",
+        "symbol": "DIA",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/11955/thumb/image.png?1646041751",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x84cA8bc7997272c7CfB4D0Cd3D55cd942B3c9419"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 42161,
+        "address": "0x51863cB90Ce5d6dA9663106F292fA27c8CC90c5a",
+        "name": "dYdX",
+        "symbol": "DYDX",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/17500/thumb/hjnIm9bV.jpg?1628009360",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x92D6C1e31e14520e676a687F0a93788B716BEff5"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 42161,
+        "address": "0x3e4Cff6E50F37F731284A92d44AE943e17077fD4",
+        "name": "Dogelon Mars",
+        "symbol": "ELON",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/14962/thumb/6GxcPRo3_400x400.jpg?1619157413",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x761D38e5ddf6ccf6Cf7c55759d5210750B5D60F3"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 42161,
+        "address": "0x7fa9549791EFc9030e1Ed3F25D18014163806758",
+        "name": "Enjin Coin",
+        "symbol": "ENJ",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/1102/thumb/enjin-coin-logo.png?1547035078",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0xF629cBd94d3791C9250152BD8dfBDF380E2a3B9c"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 42161,
+        "address": "0xfeA31d704DEb0975dA8e77Bf13E04239e70d7c28",
+        "name": "Ethereum Name Service",
+        "symbol": "ENS",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/19785/thumb/acatxTm8_400x400.jpg?1635850140",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0xC18360217D8F7Ab5e7c516566761Ea12Ce7F9D72"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 42161,
+        "address": "0x3A1429d50E0cBBc45c997aF600541Fe1cc3D2923",
+        "name": "Forta",
+        "symbol": "FORT",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/25060/thumb/Forta_lgo_%281%29.png?1655353696",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x41545f8b9472D758bB669ed8EaEEEcD7a9C4Ec29"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 42161,
+        "address": "0x7468a5d8E02245B00E8C0217fCE021C70Bc51305",
+        "name": "Frax",
+        "symbol": "FRAX",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/13422/thumb/frax_logo.png?1608476506",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x853d955aCEf822Db058eb8505911ED77F175b99e"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 42161,
+        "address": "0xd42785D323e608B9E99fa542bd8b1000D4c2Df37",
+        "name": "Fantom",
+        "symbol": "FTM",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/4001/thumb/Fantom.png?1558015016",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x4E15361FD6b4BB609Fa63C81A2be19d873717870"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 42161,
+        "address": "0xd9f9d2Ee2d3EFE420699079f16D9e924affFdEA4",
+        "name": "Frax Share",
+        "symbol": "FXS",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/13423/thumb/frax_share.png?1608478989",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x3432B6A60D23Ca0dFCa7761B7ab56459D9C964D0"
+            }
+          }
+        }
+      },
+      {
+        "name": "Gnosis Token",
+        "address": "0xa0b862F60edEf4452F25B4160F177db44DeB6Cf1",
+        "symbol": "GNO",
+        "decimals": 18,
+        "chainId": 42161,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x6810e776880C02933D47DB1b9fc05908e5386b96/logo.png",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x6810e776880C02933D47DB1b9fc05908e5386b96"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 42161,
+        "address": "0x23A941036Ae778Ac51Ab04CEa08Ed6e2FE103614",
+        "name": "The Graph",
+        "symbol": "GRT",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/13397/thumb/Graph_Token.png?1608145566",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0xc944E90C64B2c07662A292be6244BDf05Cda44a7"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 42161,
+        "address": "0x7f9a7DB853Ca816B9A138AEe3380Ef34c437dEe0",
+        "name": "Gitcoin",
+        "symbol": "GTC",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/15810/thumb/gitcoin.png?1621992929",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0xDe30da39c46104798bB5aA3fe8B9e0e1F348163F"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 42161,
+        "address": "0x3fEcB65993e4835884baF6452d1ebfdBC3A78480",
+        "name": "GYEN",
+        "symbol": "GYEN",
+        "decimals": 6,
+        "logoURI": "https://assets.coingecko.com/coins/images/14191/thumb/icon_gyen_200_200.png?1614843343",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0xC08512927D12348F6620a698105e1BAac6EcD911"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 42161,
+        "address": "0x13Ad51ed4F1B7e9Dc168d8a00cB3f4dDD85EfA60",
+        "name": "Lido DAO",
+        "symbol": "LDO",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/13573/thumb/Lido_DAO.png?1609873644",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x5A98FcBEA516Cf06857215779Fd812CA3beF1B32"
+            }
+          }
+        }
+      },
+      {
+        "name": "ChainLink Token",
+        "address": "0xf97f4df75117a78c1A5a0DBb814Af92458539FB4",
+        "symbol": "LINK",
+        "decimals": 18,
+        "chainId": 42161,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x514910771AF9Ca656af840dff83E8264EcF986CA/logo.png",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x514910771AF9Ca656af840dff83E8264EcF986CA"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 42161,
+        "address": "0x289ba1701C2F088cf0faf8B3705246331cB8A839",
+        "name": "Livepeer",
+        "symbol": "LPT",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/7137/thumb/logo-circle-green.png?1619593365",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x58b6A8A3302369DAEc383334672404Ee733aB239"
+            }
+          }
+        }
+      },
+      {
+        "name": "LoopringCoin V2",
+        "address": "0x46d0cE7de6247b0A95f67b43B589b4041BaE7fbE",
+        "symbol": "LRC",
+        "decimals": 18,
+        "chainId": 42161,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xBBbbCA6A901c926F240b89EacB641d8Aec7AEafD/logo.png",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0xBBbbCA6A901c926F240b89EacB641d8Aec7AEafD"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 42161,
+        "name": "Liquity USD",
+        "symbol": "LUSD",
+        "logoURI": "https://assets.coingecko.com/coins/images/14666/thumb/Group_3.png?1617631327",
+        "address": "0x93b346b6BC2548dA6A1E7d98E9a421B42541425b",
+        "decimals": 18,
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x5f98805A4E8be255a32880FDeC7F6728C6568bA0"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 42161,
+        "address": "0x442d24578A564EF628A65e6a7E3e7be2a165E231",
+        "name": "Decentraland",
+        "symbol": "MANA",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/878/thumb/decentraland-mana.png?1550108745",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x0F5D2fB29fb7d3CFeE444a200298f468908cC942"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 42161,
+        "address": "0x533A7B414CD1236815a5e09F1E97FC7d5c313739",
+        "name": "Mask Network",
+        "symbol": "MASK",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/14051/thumb/Mask_Network.jpg?1614050316",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x69af81e73A73B40adF4f3d4223Cd9b1ECE623074"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 42161,
+        "name": "MATH",
+        "symbol": "MATH",
+        "logoURI": "https://assets.coingecko.com/coins/images/11335/thumb/2020-05-19-token-200.png?1589940590",
+        "address": "0x99F40b01BA9C469193B360f72740E416B17Ac332",
+        "decimals": 18,
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x08d967bb0134F2d07f7cfb6E246680c53927DD30"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 42161,
+        "address": "0x561877b6b3DD7651313794e5F2894B2F18bE0766",
+        "name": "Polygon",
+        "symbol": "MATIC",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/4713/thumb/matic-token-icon.png?1624446912",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x7D1AfA7B718fb893dB30A3aBc0Cfc608AaCfeBB0"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 42161,
+        "name": "Metis",
+        "symbol": "METIS",
+        "logoURI": "https://assets.coingecko.com/coins/images/15595/thumb/metis.jpeg?1660285312",
+        "address": "0x7F728F3595db17B0B359f4FC47aE80FAd2e33769",
+        "decimals": 18,
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x9E32b13ce7f2E80A01932B42553652E053D6ed8e"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 42161,
+        "address": "0xB20A02dfFb172C474BC4bDa3fD6f4eE70C04daf2",
+        "name": "Magic Internet Money",
+        "symbol": "MIM",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/16786/thumb/mimlogopng.png?1624979612",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x99D8a9C45b2ecA8864373A26D1459e3Dff1e17F3"
+            }
+          }
+        }
+      },
+      {
+        "name": "Maker",
+        "address": "0x2e9a6Df78E42a30712c10a9Dc4b1C8656f8F2879",
+        "symbol": "MKR",
+        "decimals": 18,
+        "chainId": 42161,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x9f8F72aA9304c8B593d555F12eF6589cC3A579A2/logo.png",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x9f8F72aA9304c8B593d555F12eF6589cC3A579A2"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 42161,
+        "address": "0x8f5c1A99b1df736Ad685006Cb6ADCA7B7Ae4b514",
+        "name": "Melon",
+        "symbol": "MLN",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/605/thumb/melon.png?1547034295",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0xec67005c4E498Ec7f55E092bd1d35cbC47C91892"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 42161,
+        "address": "0x53236015A675fcB937485F1AE58040e4Fb920d5b",
+        "name": "PolySwarm",
+        "symbol": "NCT",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/2843/thumb/ImcYCVfX_400x400.jpg?1628519767",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x9E46A38F5DaaBe8683E10793b06749EEF7D733d1"
+            }
+          }
+        }
+      },
+      {
+        "name": "Numeraire",
+        "address": "0x597701b32553b9fa473e21362D480b3a6B569711",
+        "symbol": "NMR",
+        "decimals": 18,
+        "chainId": 42161,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x1776e1F26f98b1A5dF9cD347953a26dd3Cb46671/logo.png",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x1776e1F26f98b1A5dF9cD347953a26dd3Cb46671"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 42161,
+        "address": "0x933d31561e470478079FEB9A6Dd2691fAD8234DF",
+        "name": "Ocean Protocol",
+        "symbol": "OCEAN",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/3687/thumb/ocean-protocol-logo.jpg?1547038686",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x967da4048cD07aB37855c090aAF366e4ce1b9F48"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 42161,
+        "address": "0xfEb4DfC8C4Cf7Ed305bb08065D08eC6ee6728429",
+        "name": "PAX Gold",
+        "symbol": "PAXG",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/9519/thumb/paxg.PNG?1568542565",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x45804880De22913dAFE09f4980848ECE6EcbAf78"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 42161,
+        "address": "0x753D224bCf9AAFaCD81558c32341416df61D3DAC",
+        "name": "Perpetual Protocol",
+        "symbol": "PERP",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/12381/thumb/60d18e06844a844ad75901a9_mark_only_03.png?1628674771",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0xbC396689893D065F41bc2C6EcbeE5e0085233447"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 42161,
+        "name": "Marlin",
+        "symbol": "POND",
+        "logoURI": "https://assets.coingecko.com/coins/images/8903/thumb/POND_200x200.png?1622515451",
+        "address": "0xdA0a57B710768ae17941a9Fa33f8B720c8bD9ddD",
+        "decimals": 18,
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x57B946008913B82E4dF85f501cbAeD910e58D26C"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 42161,
+        "address": "0x4e91F2AF1ee0F84B529478f19794F5AFD423e4A6",
+        "name": "Power Ledger",
+        "symbol": "POWR",
+        "decimals": 6,
+        "logoURI": "https://assets.coingecko.com/coins/images/1104/thumb/power-ledger.png?1547035082",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x595832F8FC6BF59c85C527fEC3740A1b7a361269"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 42161,
+        "name": "PARSIQ",
+        "symbol": "PRQ",
+        "logoURI": "https://assets.coingecko.com/coins/images/11973/thumb/DsNgK0O.png?1596590280",
+        "address": "0x82164a8B646401a8776F9dC5c8Cba35DcAf60Cd2",
+        "decimals": 18,
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x362bc847A3a9637d3af6624EeC853618a43ed7D2"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 42161,
+        "address": "0xaeF5bbcbFa438519a5ea80B4c7181B4E78d419f2",
+        "name": "Rai Reflex Index",
+        "symbol": "RAI",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/14004/thumb/RAI-logo-coin.png?1613592334",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x03ab458634910AaD20eF5f1C8ee96F1D6ac54919"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 42161,
+        "address": "0xCF8600347Dc375C5f2FdD6Dab9BB66e0b6773cd7",
+        "name": "Rarible",
+        "symbol": "RARI",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/11845/thumb/Rari.png?1594946953",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0xFca59Cd816aB1eaD66534D82bc21E7515cE441CF"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 42161,
+        "address": "0x2E9AE8f178d5Ea81970C7799A377B3985cbC335F",
+        "name": "Rubic",
+        "symbol": "RBC",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/12629/thumb/200x200.png?1607952509",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0xA4EED63db85311E22dF4473f87CcfC3DaDCFA3E3"
+            }
+          }
+        }
+      },
+      {
+        "name": "Republic Token",
+        "address": "0x9fA891e1dB0a6D1eEAC4B929b5AAE1011C79a204",
+        "symbol": "REN",
+        "decimals": 18,
+        "chainId": 42161,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x408e41876cCCDC0F92210600ef50372656052a38/logo.png",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x408e41876cCCDC0F92210600ef50372656052a38"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 42161,
+        "address": "0xef888bcA6AB6B1d26dbeC977C455388ecd794794",
+        "name": "Rari Governance Token",
+        "symbol": "RGT",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/12900/thumb/Rari_Logo_Transparent.png?1613978014",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0xD291E7a03283640FDc51b121aC401383A46cC623"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 42161,
+        "address": "0xd1318eb19DBF2647743c720ed35174efd64e3DAC",
+        "name": "The Sandbox",
+        "symbol": "SAND",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/12129/thumb/sandbox_logo.jpg?1597397942",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x3845badAde8e6dFF049820680d1F14bD3903a5d0"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 42161,
+        "address": "0x5033833c9fe8B9d3E09EEd2f73d2aaF7E3872fd1",
+        "name": "Shiba Inu",
+        "symbol": "SHIB",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/11939/thumb/shiba.png?1622619446",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x95aD61b0a150d79219dCF64E1E6Cc01f0B64C4cE"
+            }
+          }
+        }
+      },
+      {
+        "name": "Synthetix Network Token",
+        "address": "0xcBA56Cd8216FCBBF3fA6DF6137F3147cBcA37D60",
+        "symbol": "SNX",
+        "decimals": 18,
+        "chainId": 42161,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xC011a73ee8576Fb46F5E1c5751cA3B9Fe0af2a6F/logo.png",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0xC011a73ee8576Fb46F5E1c5751cA3B9Fe0af2a6F"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 42161,
+        "address": "0xb2BE52744a804Cc732d606817C2572C5A3B264e7",
+        "name": "Unisocks",
+        "symbol": "SOCKS",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/10717/thumb/qFrcoiM.png?1582525244",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x23B608675a2B2fB1890d3ABBd85c5775c51691d5"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 42161,
+        "address": "0xb74Da9FE2F96B9E0a5f4A3cf0b92dd2bEC617124",
+        "name": "SOL Wormhole ",
+        "symbol": "SOL",
+        "decimals": 9,
+        "logoURI": "https://assets.coingecko.com/coins/images/22876/thumb/SOL_wh_small.png?1644224316",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0xD31a59c85aE9D8edEFeC411D448f90841571b89c"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 42161,
+        "address": "0x3E6648C5a70A150A88bCE65F4aD4d506Fe15d2AF",
+        "name": "Spell Token",
+        "symbol": "SPELL",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/15861/thumb/abracadabra-3.png?1622544862",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x090185f2135308BaD17527004364eBcC2D37e5F6"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 42161,
+        "name": "Stargate Finance",
+        "symbol": "STG",
+        "logoURI": "https://assets.coingecko.com/coins/images/24413/thumb/STG_LOGO.png?1647654518",
+        "address": "0xe018C7a3d175Fb0fE15D70Da2c874d3CA16313EC",
+        "decimals": 18,
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0xAf5191B0De278C7286d6C7CC6ab6BB8A73bA2Cd6"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 42161,
+        "address": "0x7f9cf5a2630a0d58567122217dF7609c26498956",
+        "name": "SuperFarm",
+        "symbol": "SUPER",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/14040/thumb/6YPdWn6.png?1613975899",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0xe53EC727dbDEB9E2d5456c3be40cFF031AB40A55"
+            }
+          }
+        }
+      },
+      {
+        "name": "Synth sUSD",
+        "address": "0xA970AF1a584579B618be4d69aD6F73459D112F95",
+        "symbol": "sUSD",
+        "decimals": 18,
+        "chainId": 42161,
+        "logoURI": "https://assets.coingecko.com/coins/images/5013/thumb/sUSD.png?1616150765",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x57Ab1ec28D129707052df4dF418D58a2D46d5f51"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 42161,
+        "address": "0xd4d42F0b6DEF4CE0383636770eF773390d85c61A",
+        "name": "Sushi",
+        "symbol": "SUSHI",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/12271/thumb/512x512_Logo_no_chop.png?1606986688",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x6B3595068778DD592e39A122f4f5a5cF09C90fE2"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 42161,
+        "address": "0x1bCfc0B4eE1471674cd6A9F6B363A034375eAD84",
+        "name": "Synapse",
+        "symbol": "SYN",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/18024/thumb/syn.png?1635002049",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x0f2D719407FdBeFF09D87557AbB7232601FD9F29"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 42161,
+        "address": "0xd58D345Fd9c82262E087d2D0607624B410D88242",
+        "name": "Tellor",
+        "symbol": "TRB",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/9644/thumb/Blk_icon_current.png?1584980686",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x88dF592F8eb5D7Bd38bFeF7dEb0fBc02cf3778a0"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 42161,
+        "address": "0xBfAE6fecD8124ba33cbB2180aAb0Fe4c03914A5A",
+        "name": "Tribe",
+        "symbol": "TRIBE",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/14575/thumb/tribe.PNG?1617487954",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0xc7283b66Eb1EB5FB86327f08e1B5816b0720212B"
+            }
+          }
+        }
+      },
+      {
+        "name": "UMA Voting Token v1",
+        "address": "0xd693Ec944A85eeca4247eC1c3b130DCa9B0C3b22",
+        "symbol": "UMA",
+        "decimals": 18,
+        "chainId": 42161,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x04Fa0d235C4abf4BcF4787aF4CF447DE572eF828/logo.png",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x04Fa0d235C4abf4BcF4787aF4CF447DE572eF828"
+            }
+          }
+        }
+      },
+      {
+        "name": "Uniswap",
+        "address": "0xFa7F8980b0f1E64A2062791cc3b0871572f1F7f0",
+        "symbol": "UNI",
+        "decimals": 18,
+        "chainId": 42161,
+        "logoURI": "ipfs://QmXttGpZrECX5qCyXbBQiqgQNytVGeZW5Anewvh2jc4psg",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x1f9840a85d5aF5bf1D1762F925BDADdC4201F984"
+            }
+          }
+        }
+      },
+      {
+        "name": "USDCoin",
+        "address": "0xFF970A61A04b1cA14834A43f5dE4533eBDDB5CC8",
+        "symbol": "USDC",
+        "decimals": 6,
+        "chainId": 42161,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/logo.png",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"
+            }
+          }
+        }
+      },
+      {
+        "name": "Tether USD",
+        "address": "0xFd086bC7CD5C481DCC9C85ebE478A1C0b69FCbb9",
+        "symbol": "USDT",
+        "decimals": 6,
+        "chainId": 42161,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xdAC17F958D2ee523a2206206994597C13D831ec7/logo.png",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0xdAC17F958D2ee523a2206206994597C13D831ec7"
+            }
+          }
+        }
+      },
+      {
+        "name": "Wrapped BTC",
+        "address": "0x2f2a2543B76A4166549F7aaB2e75Bef0aefC5B0f",
+        "symbol": "WBTC",
+        "decimals": 8,
+        "chainId": 42161,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599/logo.png",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599"
+            }
+          }
+        }
+      },
+      {
+        "name": "Wrapped Ether",
+        "address": "0x82aF49447D8a07e3bd95BD0d56f35241523fBab1",
+        "symbol": "WETH",
+        "decimals": 18,
+        "chainId": 42161,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2/logo.png",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 42161,
+        "name": "WOO Network",
+        "symbol": "WOO",
+        "logoURI": "https://assets.coingecko.com/coins/images/12921/thumb/w2UiemF__400x400.jpg?1603670367",
+        "address": "0xcAFcD85D8ca7Ad1e1C6F82F651fA15E33AEfD07b",
+        "decimals": 18,
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x4691937a7508860F876c9c0a2a617E7d9E945D4B"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 42161,
+        "address": "0x82e3A8F066a6989666b031d916c43672085b1582",
+        "name": "yearn finance",
+        "symbol": "YFI",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/11849/thumb/yfi-192x192.png?1598325330",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x0bc529c00C6401aEF6D220BE8C6Ea1667F6Ad93e"
+            }
+          }
+        }
+      },
+      {
+        "name": "0x Protocol Token",
+        "address": "0xBD591Bd4DdB64b77B5f76Eab8f03d02519235Ae2",
+        "symbol": "ZRX",
+        "decimals": 18,
+        "chainId": 42161,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xE41d2489571d322189246DaFA5ebDe1F4699F498/logo.png",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0xE41d2489571d322189246DaFA5ebDe1F4699F498"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 42220,
+        "address": "0x471EcE3750Da237f93B8E339c536989b8978a438",
+        "name": "Celo",
+        "symbol": "CELO",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/ubeswap/default-token-list/master/assets/asset_CELO.png"
+      },
+      {
+        "name": "Wrapped Ether",
+        "address": "0x2DEf4285787d58a2f811AF24755A8150622f4361",
+        "symbol": "WETH",
+        "decimals": 18,
+        "chainId": 42220,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2/logo.png",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2"
+            }
+          }
+        }
+      },
+      {
+        "name": "Wrapped Ether",
+        "address": "0xA6FA4fB5f76172d178d61B04b0ecd319C5d1C0aa",
+        "symbol": "WETH",
+        "decimals": 18,
+        "chainId": 80001,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2/logo.png"
+      },
+      {
+        "name": "Wrapped Matic",
+        "address": "0x9c3C9283D3e44854697Cd22D3Faa240Cfb032889",
+        "symbol": "WMATIC",
+        "decimals": 18,
+        "chainId": 80001,
+        "logoURI": "https://assets.coingecko.com/coins/images/4713/thumb/matic-token-icon.png?1624446912"
+      }
+    ]
+  },
+  "https://www.gemini.com/uniswap/manifest.json": {
+    "name": "Gemini Token List",
+    "version": { "major": 0, "minor": 2, "patch": 0 },
+    "keywords": ["gemini", "tokens", "trusted"],
+    "logoURI": "https://gemini.com/static/images/loader.png",
+    "timestamp": "2022-06-22T14:15:22+0000",
+    "tokens": [
+      {
+        "name": "1Inch",
+        "chainId": 1,
+        "symbol": "1INCH",
+        "decimals": 18,
+        "address": "0x111111111117dc0aa78b770fa6a738034120c302",
+        "logoURI": "https://gemini.com/images/currencies/icons/default/1inch.svg"
+      },
+      {
+        "name": "AaveToken",
+        "chainId": 1,
+        "symbol": "AAVE",
+        "decimals": 18,
+        "address": "0x7Fc66500c84A76Ad7e9c93437bFc5Ac33E2DDaE9",
+        "logoURI": "https://gemini.com/images/currencies/icons/default/aave.svg"
+      },
+      {
+        "name": "Amp",
+        "chainId": 1,
+        "symbol": "AMP",
+        "decimals": 18,
+        "address": "0xfF20817765cB7f73d4bde2e66e067E58D11095C2",
+        "logoURI": "https://gemini.com/images/currencies/icons/default/amp.svg"
+      },
+      {
+        "name": "Balancer",
+        "chainId": 1,
+        "symbol": "BAL",
+        "decimals": 18,
+        "address": "0xba100000625a3754423978a60c9317c58a424e3D",
+        "logoURI": "https://gemini.com/images/currencies/icons/default/bal.svg"
+      },
+      {
+        "name": "BasicAttentionToken",
+        "chainId": 1,
+        "symbol": "BAT",
+        "decimals": 18,
+        "address": "0x0D8775F648430679A709E98d2b0Cb6250d2887EF",
+        "logoURI": "https://gemini.com/images/currencies/icons/default/bat.svg"
+      },
+      {
+        "name": "Bancor",
+        "chainId": 1,
+        "symbol": "BNT",
+        "decimals": 18,
+        "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
+        "logoURI": "https://gemini.com/images/currencies/icons/default/bnt.svg"
+      },
+      {
+        "name": "Compound",
+        "chainId": 1,
+        "symbol": "COMP",
+        "decimals": 18,
+        "address": "0xc00e94Cb662C3520282E6f5717214004A7f26888",
+        "logoURI": "https://gemini.com/images/currencies/icons/default/comp.svg"
+      },
+      {
+        "name": "CurveDAOToken",
+        "chainId": 1,
+        "symbol": "CRV",
+        "decimals": 18,
+        "address": "0xD533a949740bb3306d119CC777fa900bA034cd52",
+        "logoURI": "https://gemini.com/images/currencies/icons/default/crv.svg"
+      },
+      {
+        "name": "DaiStablecoin",
+        "chainId": 1,
+        "symbol": "DAI",
+        "decimals": 18,
+        "address": "0x6B175474E89094C44Da98b954EedeAC495271d0F",
+        "logoURI": "https://gemini.com/images/currencies/icons/default/dai.svg"
+      },
+      {
+        "name": "Enjin",
+        "chainId": 1,
+        "symbol": "ENJ",
+        "decimals": 18,
+        "address": "0xf629cbd94d3791c9250152bd8dfbdf380e2a3b9c",
+        "logoURI": "https://gemini.com/images/currencies/icons/default/enj.svg"
+      },
+      {
+        "name": "The Graph",
+        "chainId": 1,
+        "symbol": "GRT",
+        "decimals": 18,
+        "address": "0xc944e90c64b2c07662a292be6244bdf05cda44a7",
+        "logoURI": "https://gemini.com/images/currencies/icons/default/grt.svg"
+      },
+      {
+        "name": "GeminiDollar",
+        "chainId": 1,
+        "symbol": "GUSD",
+        "decimals": 2,
+        "address": "0x056fd409e1d7a124bd7017459dfea2f387b6d5cd",
+        "logoURI": "https://gemini.com/images/currencies/icons/default/gusd.svg"
+      },
+      {
+        "name": "KyberNetwork",
+        "chainId": 1,
+        "symbol": "KNC",
+        "decimals": 18,
+        "address": "0xdd974D5C2e2928deA5F71b9825b8b646686BD200",
+        "logoURI": "https://gemini.com/images/currencies/icons/default/knc.svg"
+      },
+      {
+        "name": "Chainlink",
+        "chainId": 1,
+        "symbol": "LINK",
+        "decimals": 18,
+        "address": "0x514910771AF9Ca656af840dff83E8264EcF986CA",
+        "logoURI": "https://gemini.com/images/currencies/icons/default/link.svg"
+      },
+      {
+        "name": "Loopring",
+        "chainId": 1,
+        "symbol": "LRC",
+        "decimals": 18,
+        "address": "0xbbbbca6a901c926f240b89eacb641d8aec7aeafd",
+        "logoURI": "https://gemini.com/images/currencies/icons/default/lrc.svg"
+      },
+      {
+        "name": "Decentraland",
+        "chainId": 1,
+        "symbol": "MANA",
+        "decimals": 18,
+        "address": "0x0F5D2fB29fb7d3CFeE444a200298f468908cC942",
+        "logoURI": "https://gemini.com/images/currencies/icons/default/mana.svg"
+      },
+      {
+        "name": "Maker",
+        "chainId": 1,
+        "symbol": "MKR",
+        "decimals": 18,
+        "address": "0x9f8F72aA9304c8B593d555F12eF6589cC3A579A2",
+        "logoURI": "https://gemini.com/images/currencies/icons/default/mkr.svg"
+      },
+      {
+        "name": "Orchid",
+        "chainId": 1,
+        "symbol": "OXT",
+        "decimals": 18,
+        "address": "0x4575f41308EC1483f3d399aa9a2826d74Da13Deb",
+        "logoURI": "https://gemini.com/images/currencies/icons/default/oxt.svg"
+      },
+      {
+        "name": "PaxosGold",
+        "chainId": 1,
+        "symbol": "PAXG",
+        "decimals": 18,
+        "address": "0x45804880De22913dAFE09f4980848ECE6EcbAf78",
+        "logoURI": "https://gemini.com/images/currencies/icons/default/paxg.svg"
+      },
+      {
+        "name": "Republic",
+        "chainId": 1,
+        "symbol": "REN",
+        "decimals": 18,
+        "address": "0x408e41876cCCDC0F92210600ef50372656052a38",
+        "logoURI": "https://gemini.com/images/currencies/icons/default/ren.svg"
+      },
+      {
+        "name": "Sandbox",
+        "chainId": 1,
+        "symbol": "SAND",
+        "decimals": 18,
+        "address": "0x3845badAde8e6dFF049820680d1F14bD3903a5d0",
+        "logoURI": "https://gemini.com/images/currencies/icons/default/sand.svg"
+      },
+      {
+        "name": "Skale",
+        "chainId": 1,
+        "symbol": "SKL",
+        "decimals": 18,
+        "address": "0x00c83aecc790e8a4453e5dd3b0b4b3680501a7a7",
+        "logoURI": "https://gemini.com/images/currencies/icons/default/skl.svg"
+      },
+      {
+        "name": "Synthetix",
+        "chainId": 1,
+        "symbol": "SNX",
+        "decimals": 18,
+        "address": "0xC011a73ee8576Fb46F5E1c5751cA3B9Fe0af2a6F",
+        "logoURI": "https://gemini.com/images/currencies/icons/default/snx.svg"
+      },
+      {
+        "name": "Storj",
+        "chainId": 1,
+        "symbol": "STORJ",
+        "decimals": 8,
+        "address": "0xB64ef51C888972c908CFacf59B47C1AfBC0Ab8aC",
+        "logoURI": "https://gemini.com/images/currencies/icons/default/storj.svg"
+      },
+      {
+        "name": "UMAVotingTokenv1",
+        "chainId": 1,
+        "symbol": "UMA",
+        "decimals": 18,
+        "address": "0x04Fa0d235C4abf4BcF4787aF4CF447DE572eF828",
+        "logoURI": "https://gemini.com/images/currencies/icons/default/uma.svg"
+      },
+      {
+        "name": "Uniswap",
+        "chainId": 1,
+        "symbol": "UNI",
+        "decimals": 18,
+        "address": "0x1f9840a85d5aF5bf1D1762F925BDADdC4201F984",
+        "logoURI": "https://gemini.com/images/currencies/icons/default/uni.svg"
+      },
+      {
+        "name": "yearn.finance",
+        "chainId": 1,
+        "symbol": "YFI",
+        "decimals": 18,
+        "address": "0x0bc529c00C6401aEF6D220BE8C6Ea1667F6Ad93e",
+        "logoURI": "https://gemini.com/images/currencies/icons/default/yfi.svg"
+      },
+      {
+        "name": "0xProtocol",
+        "chainId": 1,
+        "symbol": "ZRX",
+        "decimals": 18,
+        "address": "0xE41d2489571d322189246DaFA5ebDe1F4699F498",
+        "logoURI": "https://gemini.com/images/currencies/icons/default/zrx.svg"
+      },
+      {
+        "name": "BarnBridge",
+        "chainId": 1,
+        "symbol": "BOND",
+        "decimals": 18,
+        "address": "0x0391D2021f89DC339F60Fff84546EA23E337750f",
+        "logoURI": "https://gemini.com/images/currencies/icons/default/bond.svg"
+      },
+      {
+        "name": "Somnium Space",
+        "chainId": 1,
+        "symbol": "CUBE",
+        "decimals": 8,
+        "address": "0xDf801468a808a32656D2eD2D2d80B72A129739f4",
+        "logoURI": "https://gemini.com/images/currencies/icons/default/cube.svg"
+      },
+      {
+        "name": "Injective",
+        "chainId": 1,
+        "symbol": "INJ",
+        "decimals": 18,
+        "address": "0xe28b3B32B6c345A34Ff64674606124Dd5Aceca30",
+        "logoURI": "https://gemini.com/images/currencies/icons/default/inj.svg"
+      },
+      {
+        "name": "Livepeer",
+        "chainId": 1,
+        "symbol": "LPT",
+        "decimals": 18,
+        "address": "0x58b6A8A3302369DAEc383334672404Ee733aB239",
+        "logoURI": "https://gemini.com/images/currencies/icons/default/lpt.svg"
+      },
+      {
+        "name": "Polygon",
+        "chainId": 1,
+        "symbol": "MATIC",
+        "decimals": 18,
+        "address": "0x7D1AfA7B718fb893dB30A3aBc0Cfc608AaCfeBB0",
+        "logoURI": "https://gemini.com/images/currencies/icons/default/matic.svg"
+      },
+      {
+        "name": "Sushiswap",
+        "chainId": 1,
+        "symbol": "SUSHI",
+        "decimals": 18,
+        "address": "0x6B3595068778DD592e39A122f4f5a5cF09C90fE2",
+        "logoURI": "https://gemini.com/images/currencies/icons/default/sushi.svg"
+      },
+      {
+        "name": "Ankr Network",
+        "chainId": 1,
+        "symbol": "ANKR",
+        "decimals": 18,
+        "address": "0x8290333ceF9e6D528dD5618Fb97a76f268f3EDD4",
+        "logoURI": "https://gemini.com/images/currencies/icons/default/ankr.svg"
+      },
+      {
+        "name": "Fantom",
+        "chainId": 1,
+        "symbol": "FTM",
+        "decimals": 18,
+        "address": "0x4E15361FD6b4BB609Fa63C81A2be19d873717870",
+        "logoURI": "https://gemini.com/images/currencies/icons/default/ftm.svg"
+      },
+      {
+        "name": "Alchemix",
+        "chainId": 1,
+        "symbol": "ALCX",
+        "decimals": 18,
+        "address": "0xdBdb4d16EdA451D0503b854CF79D55697F90c8DF",
+        "logoURI": "https://gemini.com/images/currencies/icons/default/alcx.svg"
+      },
+      {
+        "name": "Cryptex Finance",
+        "chainId": 1,
+        "symbol": "CTX",
+        "decimals": 18,
+        "address": "0x321C2fE4446C7c963dc41Dd58879AF648838f98D",
+        "logoURI": "https://gemini.com/images/currencies/icons/default/ctx.svg"
+      },
+      {
+        "name": "API3",
+        "chainId": 1,
+        "symbol": "API3",
+        "decimals": 18,
+        "address": "0x0b38210ea11411557c13457D4dA7dC6ea731B88a",
+        "logoURI": "https://gemini.com/images/currencies/icons/default/api3.svg"
+      },
+      {
+        "name": "Wrapped Filecoin",
+        "chainId": 1,
+        "symbol": "EFIL",
+        "decimals": 18,
+        "address": "0x4B7ee45f30767F36f06F79B32BF1FCa6f726DEda",
+        "logoURI": "https://gemini.com/images/currencies/icons/default/efil.svg"
+      },
+      {
+        "name": "Smooth Love Potion",
+        "chainId": 1,
+        "symbol": "SLP",
+        "decimals": 0,
+        "address": "0xCC8Fa225D80b9c7D42F96e9570156c65D6cAAa25",
+        "logoURI": "https://gemini.com/images/currencies/icons/default/slp.svg"
+      },
+      {
+        "name": "Axie Infinity",
+        "chainId": 1,
+        "symbol": "AXS",
+        "decimals": 0,
+        "address": "0xBB0E17EF65F82Ab018d8EDd776e8DD940327B28b",
+        "logoURI": "https://gemini.com/images/currencies/icons/default/axs.svg"
+      },
+      {
+        "name": "Moss Carbon Credit",
+        "chainId": 1,
+        "symbol": "MCO2",
+        "decimals": 18,
+        "address": "0xfC98e825A2264D890F9a1e68ed50E1526abCcacD",
+        "logoURI": "https://gemini.com/images/currencies/icons/default/mco2.svg"
+      },
+      {
+        "name": "Wrapped Centrifuge",
+        "chainId": 1,
+        "symbol": "wCFG",
+        "decimals": 18,
+        "address": "0xc221b7E65FfC80DE234bbB6667aBDd46593D34F0",
+        "logoURI": "https://gemini.com/images/currencies/icons/default/wcfg.svg"
+      },
+      {
+        "name": "Audius",
+        "chainId": 1,
+        "symbol": "AUDIO",
+        "decimals": 0,
+        "address": "0x18aAA7115705e8be94bfFEBDE57Af9BFc265B998",
+        "logoURI": "https://gemini.com/images/currencies/icons/default/audio.svg"
+      },
+      {
+        "name": "Quant",
+        "chainId": 1,
+        "symbol": "QNT",
+        "decimals": 18,
+        "address": "0x4a220E6096B25EADb88358cb44068A3248254675",
+        "logoURI": "https://gemini.com/images/currencies/icons/default/qnt.svg"
+      },
+      {
+        "name": "Mask Network",
+        "chainId": 1,
+        "symbol": "MASK",
+        "decimals": 18,
+        "address": "0x69af81e73A73B40adF4f3d4223Cd9b1ECE623074",
+        "logoURI": "https://gemini.com/images/currencies/icons/default/mask.svg"
+      },
+      {
+        "name": "Radicle",
+        "chainId": 1,
+        "symbol": "RAD",
+        "decimals": 18,
+        "address": "0x31c8EAcBFFdD875c74b94b077895Bd78CF1E64A3",
+        "logoURI": "https://gemini.com/images/currencies/icons/default/rad.svg"
+      },
+      {
+        "name": "Fetch.ai",
+        "chainId": 1,
+        "symbol": "FET",
+        "decimals": 18,
+        "address": "0xaea46A60368A7bD060eec7DF8CBa43b7EF41Ad85",
+        "logoURI": "https://gemini.com/images/currencies/icons/default/fet.svg"
+      },
+      {
+        "name": "Shiba Inu",
+        "chainId": 1,
+        "symbol": "SHIB",
+        "decimals": 18,
+        "address": "0x95aD61b0a150d79219dCF64E1E6Cc01f0B64C4cE",
+        "logoURI": "https://gemini.com/images/currencies/icons/default/shib.svg"
+      },
+      {
+        "name": "Numeraire",
+        "chainId": 1,
+        "symbol": "NMR",
+        "decimals": 18,
+        "address": "0x1776e1F26f98b1A5dF9cD347953a26dd3Cb46671",
+        "logoURI": "https://gemini.com/images/currencies/icons/default/nmr.svg"
+      },
+      {
+        "name": "Spell Token",
+        "chainId": 1,
+        "symbol": "SPELL",
+        "decimals": 18,
+        "address": "0x090185f2135308BaD17527004364eBcC2D37e5F6",
+        "logoURI": "https://gemini.com/images/currencies/icons/default/spell.svg"
+      },
+      {
+        "name": "Magic Internet Money",
+        "chainId": 1,
+        "symbol": "MIM",
+        "decimals": 18,
+        "address": "0x99D8a9C45b2ecA8864373A26D1459e3Dff1e17F3",
+        "logoURI": "https://gemini.com/images/currencies/icons/default/mim.svg"
+      },
+      {
+        "name": "Render Token",
+        "chainId": 1,
+        "symbol": "RNDR",
+        "decimals": 18,
+        "address": "0x6De037ef9aD2725EB40118Bb1702EBb27e4Aeb24",
+        "logoURI": "https://gemini.com/images/currencies/icons/default/rndr.svg"
+      },
+      {
+        "name": "Gala",
+        "chainId": 1,
+        "symbol": "GALA",
+        "decimals": 8,
+        "address": "0x15D4c048F83bd7e37d49eA4C83a07267Ec4203dA",
+        "logoURI": "https://gemini.com/images/currencies/icons/default/gala.svg"
+      },
+      {
+        "name": "Merit Circle",
+        "chainId": 1,
+        "symbol": "MC",
+        "decimals": 18,
+        "address": "0x949D48EcA67b17269629c7194F4b727d4Ef9E5d6",
+        "logoURI": "https://gemini.com/images/currencies/icons/default/mc.svg"
+      },
+      {
+        "name": "Ethereum Name Service",
+        "chainId": 1,
+        "symbol": "ENS",
+        "decimals": 18,
+        "address": "0xC18360217D8F7Ab5e7c516566761Ea12Ce7F9D72",
+        "logoURI": "https://gemini.com/images/currencies/icons/default/ens.svg"
+      },
+      {
+        "name": "Keep3rV1",
+        "chainId": 1,
+        "symbol": "KP3R",
+        "decimals": 18,
+        "address": "0x1cEB5cB57C4D4E2b2433641b95Dd330A33185A44",
+        "logoURI": "https://gemini.com/images/currencies/icons/default/kp3r.svg"
+      },
+      {
+        "name": "Dogelon Mars",
+        "chainId": 1,
+        "symbol": "ELON",
+        "decimals": 18,
+        "address": "0x761D38e5ddf6ccf6Cf7c55759d5210750B5D60F3",
+        "logoURI": "https://gemini.com/images/currencies/icons/default/elon.svg"
+      },
+      {
+        "name": "Civic",
+        "chainId": 1,
+        "symbol": "CVC",
+        "decimals": 8,
+        "address": "0x41e5560054824eA6B0732E656E3Ad64E20e94E45",
+        "logoURI": "https://gemini.com/images/currencies/icons/default/cvc.svg"
+      },
+      {
+        "name": "Tokemak",
+        "chainId": 1,
+        "symbol": "TOKE",
+        "decimals": 18,
+        "address": "0x2e9d63788249371f1DFC918a52f8d799F4a38C94",
+        "logoURI": "https://gemini.com/images/currencies/icons/default/toke.svg"
+      },
+      {
+        "name": "Lido DAO",
+        "chainId": 1,
+        "symbol": "LDO",
+        "decimals": 18,
+        "address": "0x5A98FcBEA516Cf06857215779Fd812CA3beF1B32",
+        "logoURI": "https://gemini.com/images/currencies/icons/default/ldo.svg"
+      },
+      {
+        "name": "Rally",
+        "chainId": 1,
+        "symbol": "RLY",
+        "decimals": 18,
+        "address": "0xf1f955016EcbCd7321c7266BccFB96c68ea5E49b",
+        "logoURI": "https://gemini.com/images/currencies/icons/default/rly.svg"
+      },
+      {
+        "name": "ApeCoin",
+        "chainId": 1,
+        "symbol": "APE",
+        "decimals": 18,
+        "address": "0x4d224452801ACEd8B2F0aebE155379bb5D594381",
+        "logoURI": "https://gemini.com/images/currencies/icons/default/ape.svg"
+      },
+      {
+        "name": "Liquity",
+        "chainId": 1,
+        "symbol": "LQTY",
+        "decimals": 18,
+        "address": "0x6DEA81C8171D0bA574754EF6F8b412F2Ed88c54D",
+        "logoURI": "https://gemini.com/images/currencies/icons/default/lqty.svg"
+      },
+      {
+        "name": "Liquity USD",
+        "chainId": 1,
+        "symbol": "LUSD",
+        "decimals": 18,
+        "address": "0x5f98805A4E8be255a32880FDeC7F6728C6568bA0",
+        "logoURI": "https://gemini.com/images/currencies/icons/default/lusd.svg"
+      },
+      {
+        "name": "Maple Finance",
+        "chainId": 1,
+        "symbol": "MPL",
+        "decimals": 18,
+        "address": "0x33349B282065b0284d756F0577FB39c158F935e6",
+        "logoURI": "https://gemini.com/images/currencies/icons/default/mpl.svg"
+      },
+      {
+        "name": "Ribbon Finance",
+        "chainId": 1,
+        "symbol": "RBN",
+        "decimals": 18,
+        "address": "0x6123B0049F904d730dB3C36a31167D9d4121fA6B",
+        "logoURI": "https://gemini.com/images/currencies/icons/default/rbn.svg"
+      },
+      {
+        "name": "DeFi Pulse Index",
+        "chainId": 1,
+        "symbol": "DPI",
+        "decimals": 18,
+        "address": "0x1494CA1F11D487c2bBe4543E90080AeBa4BA3C2b",
+        "logoURI": "https://gemini.com/images/currencies/icons/default/dpi.svg"
+      },
+      {
+        "name": "Index Cooperative",
+        "chainId": 1,
+        "symbol": "INDEX",
+        "decimals": 18,
+        "address": "0x0954906da0Bf32d5479e25f46056d22f08464cab",
+        "logoURI": "https://gemini.com/images/currencies/icons/default/index.svg"
+      },
+      {
+        "name": "Chiliz",
+        "chainId": 1,
+        "symbol": "CHZ",
+        "decimals": 18,
+        "address": "0x3506424F91fD33084466F402d5D97f05F8e3b4AF",
+        "logoURI": "https://gemini.com/images/currencies/icons/default/chz.svg"
+      },
+      {
+        "name": "Metis",
+        "chainId": 1,
+        "symbol": "METIS",
+        "decimals": 18,
+        "address": "0x9E32b13ce7f2E80A01932B42553652E053D6ed8e",
+        "logoURI": "https://gemini.com/images/currencies/icons/default/metis.svg"
+      },
+      {
+        "name": "Qredo",
+        "chainId": 1,
+        "symbol": "QRDO",
+        "decimals": 8,
+        "address": "0x4123a133ae3c521FD134D7b13A2dEC35b56c2463",
+        "logoURI": "https://gemini.com/images/currencies/icons/default/qrdo.svg"
+      },
+      {
+        "name": "Revv",
+        "chainId": 1,
+        "symbol": "REVV",
+        "decimals": 18,
+        "address": "0x557B933a7C2c45672B610F8954A3deB39a51A8Ca",
+        "logoURI": "https://gemini.com/images/currencies/icons/default/revv.svg"
+      },
+      {
+        "name": "Geojam",
+        "chainId": 1,
+        "symbol": "JAM",
+        "decimals": 18,
+        "address": "0x23894DC9da6c94ECb439911cAF7d337746575A72",
+        "logoURI": "https://gemini.com/images/currencies/icons/default/jam.svg"
+      },
+      {
+        "name": "Goldfinch",
+        "chainId": 1,
+        "symbol": "GFI",
+        "decimals": 18,
+        "address": "0xdab396cCF3d84Cf2D07C4454e10C8A6F5b008D2b",
+        "logoURI": "https://gemini.com/images/currencies/icons/default/gfi.svg"
+      },
+      {
+        "name": "TrueFi",
+        "chainId": 1,
+        "symbol": "TRU",
+        "decimals": 8,
+        "address": "0x4C19596f5aAfF459fA38B0f7eD92F11AE6543784",
+        "logoURI": "https://gemini.com/images/currencies/icons/default/tru.svg"
+      },
+      {
+        "name": "Alethea Artificial Liquid Intelligence",
+        "chainId": 1,
+        "symbol": "ALI",
+        "decimals": 8,
+        "address": "0x6B0b3a982b4634aC68dD83a4DBF02311cE324181",
+        "logoURI": "https://gemini.com/images/currencies/icons/default/ali.svg"
+      },
+      {
+        "name": "Ethernity",
+        "chainId": 1,
+        "symbol": "ERN",
+        "decimals": 18,
+        "address": "0xBBc2AE13b23d715c30720F079fcd9B4a74093505",
+        "logoURI": "https://gemini.com/images/currencies/icons/default/ern.svg"
+      },
+      {
+        "name": "Euler Finance",
+        "chainId": 1,
+        "symbol": "EUL",
+        "decimals": 18,
+        "address": "0xd9Fcd98c322942075A5C3860693e9f4f03AAE07b",
+        "logoURI": "https://gemini.com/images/currencies/icons/default/eul.svg"
+      },
+      {
+        "name": "Project Galaxy",
+        "chainId": 1,
+        "symbol": "GAL",
+        "decimals": 18,
+        "address": "0x5fAa989Af96Af85384b8a938c2EdE4A7378D9875",
+        "logoURI": "https://gemini.com/images/currencies/icons/default/gal.svg"
+      },
+      {
+        "name": "Biconomy",
+        "chainId": 1,
+        "symbol": "BICO",
+        "decimals": 18,
+        "address": "0xF17e65822b568B3903685a7c9F496CF7656Cc6C2",
+        "logoURI": "https://gemini.com/images/currencies/icons/default/bico.svg"
+      },
+      {
+        "name": "Immutable X",
+        "chainId": 1,
+        "symbol": "IMX",
+        "decimals": 18,
+        "address": "0xF57e7e7C23978C3cAEC3C3548E3D615c346e79fF",
+        "logoURI": "https://gemini.com/images/currencies/icons/default/imx.svg"
+      },
+      {
+        "name": "IoTeX",
+        "chainId": 1,
+        "symbol": "IOTX",
+        "decimals": 18,
+        "address": "0x6fB3e0A217407EFFf7Ca062D46c26E5d60a14d69",
+        "logoURI": "https://gemini.com/images/currencies/icons/default/iotx.svg"
+      },
+      {
+        "name": "PlayDapp",
+        "chainId": 1,
+        "symbol": "PLA",
+        "decimals": 18,
+        "address": "0x3a4f40631a4f906c2BaD353Ed06De7A5D3fCb430",
+        "logoURI": "https://gemini.com/images/currencies/icons/default/pla.svg"
+      }
+    ]
+  }
+}

--- a/public/data/tokenlists/tokens-137.json
+++ b/public/data/tokenlists/tokens-137.json
@@ -1,0 +1,2174 @@
+{
+  "https://raw.githubusercontent.com/balancer-labs/assets/refactor-for-multichain/generated/polygon.listed.tokenlist.json": {
+    "name": "Balancer",
+    "timestamp": "2022-09-23T00:00:00.000Z",
+    "logoURI": "https://raw.githubusercontent.com/balancer-labs/pebbles/master/images/pebbles-pad.256w.png",
+    "keywords": ["balancer", "listed"],
+    "version": { "major": 1, "minor": 17, "patch": 0 },
+    "tokens": [
+      {
+        "address": "0x3d468AB2329F296e1b9d8476Bb54Dd77D8c2320f",
+        "chainId": 137,
+        "name": "20WETH-80BAL",
+        "symbol": "20WETH-80BAL",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/balancer-labs/assets/refactor-for-multichain/assets/0x3d468ab2329f296e1b9d8476bb54dd77d8c2320f.png"
+      },
+      {
+        "address": "0xD6DF932A45C0f255f85145f286eA0b292B21C90B",
+        "chainId": 137,
+        "name": "Aave",
+        "symbol": "AAVE",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x7Fc66500c84A76Ad7e9c93437bFc5Ac33E2DDaE9/logo.png"
+      },
+      {
+        "address": "0x385Eeac5cB85A38A9a07A70c73e0a3271CfB54A7",
+        "chainId": 137,
+        "name": "Aavegotchi",
+        "symbol": "GHST",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/12467/large/ghst_200.png?1600750321"
+      },
+      {
+        "address": "0xc3FdbadC7c795EF1D6Ba111e06fF8F16A20Ea539",
+        "chainId": 137,
+        "name": "Adamant",
+        "symbol": "ADDY",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/15225/large/adamant.png?1620136256"
+      },
+      {
+        "address": "0xB7b31a6BC18e48888545CE79e83E06003bE70930",
+        "chainId": 137,
+        "name": "ApeCoin (PoS)",
+        "symbol": "APE",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/balancer-labs/assets/refactor-for-multichain/assets/0xb7b31a6bc18e48888545ce79e83e06003be70930.png"
+      },
+      {
+        "address": "0x2C89bbc92BD86F8075d1DEcc58C7F4E0107f286b",
+        "chainId": 137,
+        "name": "Avalanche",
+        "symbol": "AVAX",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/2563ac9dc5369d8e3255cde663cf7f08e3c58914/blockchains/avalanchec/info/logo.png"
+      },
+      {
+        "address": "0x61BDD9C7d4dF4Bf47A4508c0c8245505F2Af5b7b",
+        "chainId": 137,
+        "name": "Axie Infinity Shard (PoS)",
+        "symbol": "AXS",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/balancer-labs/assets/refactor-for-multichain/assets/0x61bdd9c7d4df4bf47a4508c0c8245505f2af5b7b.png"
+      },
+      {
+        "address": "0xd6cA869a4EC9eD2C7E618062Cdc45306d8dBBc14",
+        "chainId": 137,
+        "name": "BTC 2x Flexible Leverage Index (Polygon)",
+        "symbol": "BTC2x-FLI-P",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/balancer-labs/assets/refactor-for-multichain/assets/0xd6ca869a4ec9ed2c7e618062cdc45306d8dbbc14.png"
+      },
+      {
+        "address": "0x9C9e5fD8bbc25984B178FdCE6117Defa39d2db39",
+        "chainId": 137,
+        "name": "BUSD Token",
+        "symbol": "BUSD",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/balancer-labs/assets/refactor-for-multichain/assets/0x9c9e5fd8bbc25984b178fdce6117defa39d2db39.png"
+      },
+      {
+        "address": "0x9a71012B13CA4d3D0Cdc72A177DF3ef03b0E76A3",
+        "chainId": 137,
+        "name": "Balancer",
+        "symbol": "BAL",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xba100000625a3754423978a60c9317c58a424e3D/logo.png"
+      },
+      {
+        "address": "0x178E029173417b1F9C8bC16DCeC6f697bC323746",
+        "chainId": 137,
+        "name": "Balancer Aave Boosted Pool (DAI)",
+        "symbol": "bb-am-DAI",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/balancer-labs/assets/refactor-for-multichain/assets/0x178e029173417b1f9c8bc16dcec6f697bc323746.png"
+      },
+      {
+        "address": "0xF93579002DBE8046c43FEfE86ec78b1112247BB8",
+        "chainId": 137,
+        "name": "Balancer Aave Boosted Pool (USDC)",
+        "symbol": "bb-am-USDC",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/balancer-labs/assets/refactor-for-multichain/assets/0xf93579002dbe8046c43fefe86ec78b1112247bb8.png"
+      },
+      {
+        "address": "0xFf4ce5AAAb5a627bf82f4A571AB1cE94Aa365eA6",
+        "chainId": 137,
+        "name": "Balancer Aave Boosted Pool (USDT)",
+        "symbol": "bb-am-USDT",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/balancer-labs/assets/refactor-for-multichain/assets/0xff4ce5aaab5a627bf82f4a571ab1ce94aa365ea6.png"
+      },
+      {
+        "address": "0x48e6B98ef6329f8f0A30eBB8c7C960330d648085",
+        "chainId": 137,
+        "name": "Balancer Aave Boosted StablePool",
+        "symbol": "bb-am-usd",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/balancer-labs/assets/refactor-for-multichain/assets/0x48e6b98ef6329f8f0a30ebb8c7c960330d648085.png"
+      },
+      {
+        "address": "0xDB7Cb471dd0b49b29CAB4a1C14d070f27216a0Ab",
+        "chainId": 137,
+        "name": "Bankless DAO",
+        "symbol": "BANK",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x2d94AA3e47d9D5024503Ca8491fcE9A2fB4DA198/logo.png"
+      },
+      {
+        "address": "0x53E0bca35eC356BD5ddDFebbD1Fc0fD03FaBad39",
+        "chainId": 137,
+        "name": "Chainlink",
+        "symbol": "LINK",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x514910771AF9Ca656af840dff83E8264EcF986CA/logo.png"
+      },
+      {
+        "address": "0x8505b9d2254A7Ae468c0E9dd10Ccea3A837aef5c",
+        "chainId": 137,
+        "name": "Compound",
+        "symbol": "COMP",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xc00e94Cb662C3520282E6f5717214004A7f26888/logo.png"
+      },
+      {
+        "address": "0x172370d5Cd63279eFa6d502DAB29171933a610AF",
+        "chainId": 137,
+        "name": "Curve DAO Token",
+        "symbol": "CRV",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xD533a949740bb3306d119CC777fa900bA034cd52/logo.png"
+      },
+      {
+        "address": "0xE7804D91dfCDE7F776c90043E03eAa6Df87E6395",
+        "chainId": 137,
+        "name": "DFX Token",
+        "symbol": "DFX",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/dfx-finance/assets/add-dfx-logov3/blockchains/ethereum/assets/0x888888435FDe8e7d4c54cAb67f206e4199454c60/logo.png"
+      },
+      {
+        "address": "0x8f3Cf7ad23Cd3CaDbD9735AFf958023239c6A063",
+        "chainId": 137,
+        "name": "Dai",
+        "symbol": "DAI",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x6B175474E89094C44Da98b954EedeAC495271d0F/logo.png"
+      },
+      {
+        "address": "0x1D607Faa0A51518a7728580C238d912747e71F7a",
+        "chainId": 137,
+        "name": "Data Economy Index",
+        "symbol": "DATA",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x33d63Ba1E57E54779F7dDAeaA7109349344cf5F1/logo.png"
+      },
+      {
+        "address": "0x85955046DF4668e1DD369D2DE9f3AEB98DD2A369",
+        "chainId": 137,
+        "name": "DeFiPulse Index",
+        "symbol": "DPI",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x1494CA1F11D487c2bBe4543E90080AeBa4BA3C2b/logo.png"
+      },
+      {
+        "address": "0x2a93172c8DCCbfBC60a39d56183B7279a2F647b4",
+        "chainId": 137,
+        "name": "Decentral Games",
+        "symbol": "$DG",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/13267/large/Decentral_Games_Logo-1.png?1621652581"
+      },
+      {
+        "address": "0xbD7A5Cf51d22930B8B3Df6d834F9BCEf90EE7c4f",
+        "chainId": 137,
+        "name": "Ethereum Name Service",
+        "symbol": "ENS",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xC18360217D8F7Ab5e7c516566761Ea12Ce7F9D72/logo.png"
+      },
+      {
+        "address": "0x656Bf6767Fa8863aC0dD0b7d2a26602B838A2E70",
+        "chainId": 137,
+        "name": "Fitmint Token",
+        "symbol": "FITT",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/balancer-labs/assets/refactor-for-multichain/assets/0x656bf6767fa8863ac0dd0b7d2a26602b838a2e70.png"
+      },
+      {
+        "address": "0x45c32fA6DF82ead1e2EF74d17b76547EDdFaFF89",
+        "chainId": 137,
+        "name": "Frax",
+        "symbol": "FRAX",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/balancer-labs/assets/refactor-for-multichain/assets/0x45c32fa6df82ead1e2ef74d17b76547eddfaff89.png"
+      },
+      {
+        "address": "0xC8A94a3d3D2dabC3C1CaffFFDcA6A7543c3e3e65",
+        "chainId": 137,
+        "name": "Gemini Dollar",
+        "symbol": "GUSD",
+        "decimals": 2,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x056Fd409E1d7A124BD7017459dFEa2F387b6d5Cd/logo.png"
+      },
+      {
+        "address": "0xdb95f9188479575F3F718a245EcA1B3BF74567EC",
+        "chainId": 137,
+        "name": "Gitcoin",
+        "symbol": "GTC",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/balancer-labs/assets/master/assets/0xde30da39c46104798bb5aa3fe8b9e0e1f348163f.png"
+      },
+      {
+        "address": "0x5FFD62D3C3eE2E81C00A7b9079FB248e7dF024A8",
+        "chainId": 137,
+        "name": "Gnosis",
+        "symbol": "GNO",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x6810e776880C02933D47DB1b9fc05908e5386b96/logo.png"
+      },
+      {
+        "address": "0xfBd8A3b908e764dBcD51e27992464B4432A1132b",
+        "chainId": 137,
+        "name": "Index",
+        "symbol": "INDEX",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x0954906da0Bf32d5479e25f46056d22f08464cab/logo.png"
+      },
+      {
+        "address": "0x3Ad707dA309f3845cd602059901E39C4dcd66473",
+        "chainId": 137,
+        "name": "Index Coop - ETH 2x Flexible Leverage Index (Polygon)",
+        "symbol": "ETH2x-FLI-P",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/balancer-labs/assets/refactor-for-multichain/assets/0x3ad707da309f3845cd602059901e39c4dcd66473.png"
+      },
+      {
+        "address": "0x4f025829C4B13dF652f38Abd2AB901185fF1e609",
+        "chainId": 137,
+        "name": "Index Coop - Inverse ETH Flexible Leverage Index",
+        "symbol": "iETH-FLI-P",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/balancer-labs/assets/refactor-for-multichain/assets/0x4f025829c4b13df652f38abd2ab901185ff1e609.png"
+      },
+      {
+        "address": "0x340f412860dA7b7823df372a2b59Ff78b7ae6abc",
+        "chainId": 137,
+        "name": "Index Coop - Inverse MATIC Flexible Leverage Index",
+        "symbol": "iMATIC-FLI-P",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/balancer-labs/assets/refactor-for-multichain/assets/0x340f412860da7b7823df372a2b59ff78b7ae6abc.png"
+      },
+      {
+        "address": "0xf287D97B6345bad3D88856b26Fb7c0ab3F2C7976",
+        "chainId": 137,
+        "name": "Index Coop - MATIC 2x Flexible Leverage Index",
+        "symbol": "MATIC2x-FLI-P",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/balancer-labs/assets/refactor-for-multichain/assets/0xf287d97b6345bad3d88856b26fb7c0ab3f2c7976.png"
+      },
+      {
+        "address": "0x130cE4E4F76c2265f94a961D70618562de0bb8d2",
+        "chainId": 137,
+        "name": "Inverse BTC Flexible Leverage Index",
+        "symbol": "iBTC-FLI-P",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/balancer-labs/assets/refactor-for-multichain/assets/0x130ce4e4f76c2265f94a961d70618562de0bb8d2.png"
+      },
+      {
+        "address": "0x596ebe76e2db4470966ea395b0d063ac6197a8c5",
+        "chainId": 137,
+        "name": "Jarvis Reward Token",
+        "symbol": "JRT",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/10390/large/cfeii0y.png?1578868949"
+      },
+      {
+        "address": "0x4e3Decbb3645551B8A19f0eA1678079FCB33fB4c",
+        "chainId": 137,
+        "name": "Jarvis Synthetic Euro",
+        "symbol": "jEUR",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/15725/large/jEUR.png?1634046044"
+      },
+      {
+        "address": "0x6749441fdc8650b5b5a854ed255c82ef361f1596",
+        "chainId": 137,
+        "name": "LUCHA Token",
+        "symbol": "LUCHA",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/balancer-labs/assets/refactor-for-multichain/assets/0x6749441fdc8650b5b5a854ed255c82ef361f1596.png"
+      },
+      {
+        "address": "0xfa68FB4628DFF1028CFEc22b4162FCcd0d45efb6",
+        "chainId": 137,
+        "name": "Liquid Staking Matic (PoS)",
+        "symbol": "MaticX",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/balancer-labs/assets/refactor-for-multichain/assets/0xfa68fb4628dff1028cfec22b4162fccd0d45efb6.png"
+      },
+      {
+        "address": "0xa3Fa99A148fA48D14Ed51d610c367C61876997F1",
+        "chainId": 137,
+        "name": "MAI",
+        "symbol": "miMATIC",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/15264/large/mimatic-red.png?1620281018"
+      },
+      {
+        "address": "0x6f7C932e7684666C9fd1d44527765433e01fF61d",
+        "chainId": 137,
+        "name": "MAKER (PoS)",
+        "symbol": "MKR",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/balancer-labs/assets/refactor-for-multichain/assets/0x6f7c932e7684666c9fd1d44527765433e01ff61d.png"
+      },
+      {
+        "address": "0xF501dd45a1198C2E1b5aEF5314A68B9006D842E0",
+        "chainId": 137,
+        "name": "Meta",
+        "symbol": "MTA",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xa3BeD4E1c75D00fa6f4E5E6922DB7261B5E9AcD2/logo.png"
+      },
+      {
+        "address": "0xfe712251173A2cd5F5bE2B46Bb528328EA3565E1",
+        "chainId": 137,
+        "name": "Metaverse Index",
+        "symbol": "MVI",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x72e364F2ABdC788b7E918bc238B21f109Cd634D7/logo.png"
+      },
+      {
+        "address": "0x282d8efCe846A88B159800bd4130ad77443Fa1A1",
+        "chainId": 137,
+        "name": "Ocean Protocol",
+        "symbol": "mOCEAN",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x967da4048cD07aB37855c090aAF366e4ce1b9F48/logo.png"
+      },
+      {
+        "address": "0xE2Aa7db6dA1dAE97C5f5C6914d285fBfCC32A128",
+        "chainId": 137,
+        "name": "Parallel",
+        "symbol": "PAR",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/14153/large/par_round_200.png?1614670422"
+      },
+      {
+        "address": "0x263534a4Fe3cb249dF46810718B7B612a30ebbff",
+        "chainId": 137,
+        "name": "Perpetual Protocol",
+        "symbol": "PERP",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xbC396689893D065F41bc2C6EcbeE5e0085233447/logo.png"
+      },
+      {
+        "address": "0x580A84C73811E1839F75d86d75d88cCa0c241fF4",
+        "chainId": 137,
+        "name": "Qi Dao",
+        "symbol": "QI",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/15329/large/qi.png?1620540969"
+      },
+      {
+        "address": "0x831753DD7087CaC61aB5644b308642cc1c33Dc13",
+        "chainId": 137,
+        "name": "Quickswap",
+        "symbol": "QUICK",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/13970/large/1_pOU6pBMEmiL-ZJVb0CYRjQ.png?1613386659"
+      },
+      {
+        "address": "0x00e5646f60AC6Fb446f621d146B6E1886f002905",
+        "chainId": 137,
+        "name": "Rai Reflex Index",
+        "symbol": "RAI",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/14004/large/RAI-logo-coin.png?1613592334"
+      },
+      {
+        "address": "0x431CD3C9AC9Fc73644BF68bF5691f4B83F9E104f",
+        "chainId": 137,
+        "name": "Rainbow Token",
+        "symbol": "RBW",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/balancer-labs/assets/refactor-for-multichain/assets/0x431cd3c9ac9fc73644bf68bf5691f4b83f9e104f.png"
+      },
+      {
+        "address": "0xE111178A87A3BFf0c8d18DECBa5798827539Ae99",
+        "chainId": 137,
+        "name": "STASIS EURO",
+        "symbol": "EURS",
+        "decimals": 2,
+        "logoURI": "https://assets.coingecko.com/coins/images/5164/large/EURS_300x300.png?1550571779"
+      },
+      {
+        "address": "0x7DfF46370e9eA5f0Bad3C4E29711aD50062EA7A4",
+        "chainId": 137,
+        "name": "Solana",
+        "symbol": "SOL",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/2563ac9dc5369d8e3255cde663cf7f08e3c58914/blockchains/solana/info/logo.png"
+      },
+      {
+        "address": "0x1d734A02eF1e1f5886e66b0673b71Af5B53ffA94",
+        "chainId": 137,
+        "name": "Stader",
+        "symbol": "SD",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/balancer-labs/assets/refactor-for-multichain/assets/0x1d734a02ef1e1f5886e66b0673b71af5b53ffa94.png"
+      },
+      {
+        "address": "0x0b3F868E0BE5597D5DB7fEB59E1CADBb0fdDa50a",
+        "chainId": 137,
+        "name": "Sushi",
+        "symbol": "SUSHI",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x6B3595068778DD592e39A122f4f5a5cF09C90fE2/logo.png"
+      },
+      {
+        "address": "0x50B728D8D964fd00C2d0AAD81718b71311feF68a",
+        "chainId": 137,
+        "name": "Synthetix Network Token",
+        "symbol": "SNX",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xC011a73ee8576Fb46F5E1c5751cA3B9Fe0af2a6F/logo.png"
+      },
+      {
+        "address": "0x7fC9E0Aa043787BFad28e29632AdA302C790Ce33",
+        "chainId": 137,
+        "name": "TETU_ST_BAL",
+        "symbol": "tetuBAL",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/balancer-labs/assets/refactor-for-multichain/assets/0x7fc9e0aa043787bfad28e29632ada302c790ce33.png"
+      },
+      {
+        "address": "0x2934b36ca9A4B31E633C5BE670C8C8b28b6aA015",
+        "chainId": 137,
+        "name": "THX Network",
+        "symbol": "THX",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/balancer-labs/assets/refactor-for-multichain/assets/0x2934b36ca9a4b31e633c5be670c8c8b28b6aa015.png"
+      },
+      {
+        "address": "0xdF7837DE1F2Fa4631D716CF2502f8b230F1dcc32",
+        "chainId": 137,
+        "name": "Telcoin",
+        "symbol": "TEL",
+        "decimals": 2,
+        "logoURI": "https://assets.coingecko.com/coins/images/1899/large/tel.png?1547036203"
+      },
+      {
+        "address": "0xE6469Ba6D2fD6130788E0eA9C0a0515900563b59",
+        "chainId": 137,
+        "name": "TerraUSD (Wormhole)",
+        "symbol": "UST",
+        "decimals": 6,
+        "logoURI": "https://raw.githubusercontent.com/balancer-labs/assets/refactor-for-multichain/assets/0xe6469ba6d2fd6130788e0ea9c0a0515900563b59.png"
+      },
+      {
+        "address": "0xc2132D05D31c914a87C6611C10748AEb04B58e8F",
+        "chainId": 137,
+        "name": "Tether",
+        "symbol": "USDT",
+        "decimals": 6,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xdAC17F958D2ee523a2206206994597C13D831ec7/logo.png"
+      },
+      {
+        "address": "0x5fe2B58c013d7601147DcdD68C143A77499f5531",
+        "chainId": 137,
+        "name": "The Graph",
+        "symbol": "GRT",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xc944E90C64B2c07662A292be6244BDf05Cda44a7/logo.png"
+      },
+      {
+        "address": "0xBbba073C31bF03b8ACf7c28EF0738DeCF3695683",
+        "chainId": 137,
+        "name": "The Sandbox",
+        "symbol": "SAND",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/balancer-labs/assets/refactor-for-multichain/assets/0xbbba073c31bf03b8acf7c28ef0738decf3695683.png"
+      },
+      {
+        "address": "0x2e1AD108fF1D8C782fcBbB89AAd783aC49586756",
+        "chainId": 137,
+        "name": "TrueUSD",
+        "symbol": "TUSD",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x0000000000085d4780B73119b644AE5ecd22b376/logo.png"
+      },
+      {
+        "address": "0x3066818837c5e6eD6601bd5a91B0762877A6B731",
+        "chainId": 137,
+        "name": "UMA Protocol",
+        "symbol": "UMA",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x04Fa0d235C4abf4BcF4787aF4CF447DE572eF828/logo.png"
+      },
+      {
+        "address": "0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174",
+        "chainId": 137,
+        "name": "USD Coin",
+        "symbol": "USDC",
+        "decimals": 6,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/logo.png"
+      },
+      {
+        "address": "0x64060aB139Feaae7f06Ca4E63189D86aDEb51691",
+        "chainId": 137,
+        "name": "Unicorn Milk",
+        "symbol": "UNIM",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/balancer-labs/assets/refactor-for-multichain/assets/0x64060ab139feaae7f06ca4e63189d86adeb51691.png"
+      },
+      {
+        "address": "0xb33EaAd8d922B1083446DC23f610c2567fB5180f",
+        "chainId": 137,
+        "name": "Uniswap",
+        "symbol": "UNI",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x1f9840a85d5aF5bf1D1762F925BDADdC4201F984/logo.png"
+      },
+      {
+        "address": "0x87ff96aba480f1813aF5c780387d8De7cf7D8261",
+        "chainId": 137,
+        "name": "Wrapped BUSD",
+        "symbol": "WBUSD",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x4Fabb145d64652a948d72533023f6E7A623C7C53/logo.png"
+      },
+      {
+        "address": "0x1BFD67037B42Cf73acF2047067bd4F2C47D9BfD6",
+        "chainId": 137,
+        "name": "Wrapped Bitcoin",
+        "symbol": "WBTC",
+        "decimals": 8,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599/logo.png"
+      },
+      {
+        "address": "0x7ceB23fD6bC0adD59E62ac25578270cFf1b9f619",
+        "chainId": 137,
+        "name": "Wrapped Ether",
+        "symbol": "WETH",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2/logo.png"
+      },
+      {
+        "address": "0x0d500B1d8E8eF31E21C99d1Db9A6444d3ADf1270",
+        "chainId": 137,
+        "name": "Wrapped Matic",
+        "symbol": "WMATIC",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/14073/large/matic.png?1628852392"
+      },
+      {
+        "address": "0xEE029120c72b0607344f35B17cdD90025e647B00",
+        "chainId": 137,
+        "name": "Wrapped amDAI",
+        "symbol": "amDAI",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/balancer-labs/assets/refactor-for-multichain/assets/0xee029120c72b0607344f35b17cdd90025e647b00.png"
+      },
+      {
+        "address": "0x221836a597948Dce8F3568E044fF123108aCc42A",
+        "chainId": 137,
+        "name": "Wrapped amUSDC",
+        "symbol": "amUSDC",
+        "decimals": 6,
+        "logoURI": "https://raw.githubusercontent.com/balancer-labs/assets/refactor-for-multichain/assets/0x221836a597948dce8f3568e044ff123108acc42a.png"
+      },
+      {
+        "address": "0x19C60a251e525fa88Cd6f3768416a8024e98fC19",
+        "chainId": 137,
+        "name": "Wrapped amUSDT",
+        "symbol": "amUSDT",
+        "decimals": 6,
+        "logoURI": "https://raw.githubusercontent.com/balancer-labs/assets/refactor-for-multichain/assets/0x19c60a251e525fa88cd6f3768416a8024e98fc19.png"
+      },
+      {
+        "address": "0xbAe28251B2a4E621aA7e20538c06DEe010Bc06DE",
+        "chainId": 137,
+        "name": "dHEDGE Stablecoin Yield",
+        "symbol": "dUSD",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/20765/large/dUSD-200px.png?1637653645"
+      },
+      {
+        "address": "0xDBf31dF14B66535aF65AaC99C32e9eA844e14501",
+        "chainId": 137,
+        "name": "renBTC",
+        "symbol": "renBTC",
+        "decimals": 8,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xEB4C2781e4ebA804CE9a9803C67d0893436bB27D/logo.png"
+      },
+      {
+        "address": "0xDA537104D6A5edd53c6fBba9A898708E465260b6",
+        "chainId": 137,
+        "name": "yearn.finance",
+        "symbol": "YFI",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x0bc529c00C6401aEF6D220BE8C6Ea1667F6Ad93e/logo.png"
+      }
+    ]
+  },
+  "https://raw.githubusercontent.com/balancer-labs/assets/refactor-for-multichain/generated/polygon.vetted.tokenlist.json": {
+    "name": "Balancer",
+    "timestamp": "2022-09-23T00:00:00.000Z",
+    "logoURI": "https://raw.githubusercontent.com/balancer-labs/pebbles/master/images/pebbles-pad.256w.png",
+    "keywords": ["balancer", "vetted"],
+    "version": { "major": 1, "minor": 19, "patch": 0 },
+    "tokens": [
+      {
+        "address": "0x3d468AB2329F296e1b9d8476Bb54Dd77D8c2320f",
+        "chainId": 137,
+        "name": "20WETH-80BAL",
+        "symbol": "20WETH-80BAL",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/balancer-labs/assets/refactor-for-multichain/assets/0x3d468ab2329f296e1b9d8476bb54dd77d8c2320f.png"
+      },
+      {
+        "address": "0xD6DF932A45C0f255f85145f286eA0b292B21C90B",
+        "chainId": 137,
+        "name": "Aave",
+        "symbol": "AAVE",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x7Fc66500c84A76Ad7e9c93437bFc5Ac33E2DDaE9/logo.png"
+      },
+      {
+        "address": "0x385Eeac5cB85A38A9a07A70c73e0a3271CfB54A7",
+        "chainId": 137,
+        "name": "Aavegotchi",
+        "symbol": "GHST",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/12467/large/ghst_200.png?1600750321"
+      },
+      {
+        "address": "0xc3FdbadC7c795EF1D6Ba111e06fF8F16A20Ea539",
+        "chainId": 137,
+        "name": "Adamant",
+        "symbol": "ADDY",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/15225/large/adamant.png?1620136256"
+      },
+      {
+        "address": "0xB7b31a6BC18e48888545CE79e83E06003bE70930",
+        "chainId": 137,
+        "name": "ApeCoin (PoS)",
+        "symbol": "APE",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/balancer-labs/assets/refactor-for-multichain/assets/0xb7b31a6bc18e48888545ce79e83e06003be70930.png"
+      },
+      {
+        "address": "0x2C89bbc92BD86F8075d1DEcc58C7F4E0107f286b",
+        "chainId": 137,
+        "name": "Avalanche",
+        "symbol": "AVAX",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/2563ac9dc5369d8e3255cde663cf7f08e3c58914/blockchains/avalanchec/info/logo.png"
+      },
+      {
+        "address": "0x61BDD9C7d4dF4Bf47A4508c0c8245505F2Af5b7b",
+        "chainId": 137,
+        "name": "Axie Infinity Shard (PoS)",
+        "symbol": "AXS",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/balancer-labs/assets/refactor-for-multichain/assets/0x61bdd9c7d4df4bf47a4508c0c8245505f2af5b7b.png"
+      },
+      {
+        "address": "0xd6cA869a4EC9eD2C7E618062Cdc45306d8dBBc14",
+        "chainId": 137,
+        "name": "BTC 2x Flexible Leverage Index (Polygon)",
+        "symbol": "BTC2x-FLI-P",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/balancer-labs/assets/refactor-for-multichain/assets/0xd6ca869a4ec9ed2c7e618062cdc45306d8dbbc14.png"
+      },
+      {
+        "address": "0x9C9e5fD8bbc25984B178FdCE6117Defa39d2db39",
+        "chainId": 137,
+        "name": "BUSD Token",
+        "symbol": "BUSD",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/balancer-labs/assets/refactor-for-multichain/assets/0x9c9e5fd8bbc25984b178fdce6117defa39d2db39.png"
+      },
+      {
+        "address": "0x9a71012B13CA4d3D0Cdc72A177DF3ef03b0E76A3",
+        "chainId": 137,
+        "name": "Balancer",
+        "symbol": "BAL",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xba100000625a3754423978a60c9317c58a424e3D/logo.png"
+      },
+      {
+        "address": "0x178E029173417b1F9C8bC16DCeC6f697bC323746",
+        "chainId": 137,
+        "name": "Balancer Aave Boosted Pool (DAI)",
+        "symbol": "bb-am-DAI",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/balancer-labs/assets/refactor-for-multichain/assets/0x178e029173417b1f9c8bc16dcec6f697bc323746.png"
+      },
+      {
+        "address": "0xF93579002DBE8046c43FEfE86ec78b1112247BB8",
+        "chainId": 137,
+        "name": "Balancer Aave Boosted Pool (USDC)",
+        "symbol": "bb-am-USDC",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/balancer-labs/assets/refactor-for-multichain/assets/0xf93579002dbe8046c43fefe86ec78b1112247bb8.png"
+      },
+      {
+        "address": "0xFf4ce5AAAb5a627bf82f4A571AB1cE94Aa365eA6",
+        "chainId": 137,
+        "name": "Balancer Aave Boosted Pool (USDT)",
+        "symbol": "bb-am-USDT",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/balancer-labs/assets/refactor-for-multichain/assets/0xff4ce5aaab5a627bf82f4a571ab1ce94aa365ea6.png"
+      },
+      {
+        "address": "0x48e6B98ef6329f8f0A30eBB8c7C960330d648085",
+        "chainId": 137,
+        "name": "Balancer Aave Boosted StablePool",
+        "symbol": "bb-am-usd",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/balancer-labs/assets/refactor-for-multichain/assets/0x48e6b98ef6329f8f0a30ebb8c7c960330d648085.png"
+      },
+      {
+        "address": "0xDB7Cb471dd0b49b29CAB4a1C14d070f27216a0Ab",
+        "chainId": 137,
+        "name": "Bankless DAO",
+        "symbol": "BANK",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x2d94AA3e47d9D5024503Ca8491fcE9A2fB4DA198/logo.png"
+      },
+      {
+        "address": "0xFbdd194376de19a88118e84E279b977f165d01b8",
+        "chainId": 137,
+        "name": "Beefy.Finance",
+        "symbol": "BIFI",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/12704/large/token.png?1601876182"
+      },
+      {
+        "address": "0x53E0bca35eC356BD5ddDFebbD1Fc0fD03FaBad39",
+        "chainId": 137,
+        "name": "Chainlink",
+        "symbol": "LINK",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x514910771AF9Ca656af840dff83E8264EcF986CA/logo.png"
+      },
+      {
+        "address": "0x8505b9d2254A7Ae468c0E9dd10Ccea3A837aef5c",
+        "chainId": 137,
+        "name": "Compound",
+        "symbol": "COMP",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xc00e94Cb662C3520282E6f5717214004A7f26888/logo.png"
+      },
+      {
+        "address": "0x172370d5Cd63279eFa6d502DAB29171933a610AF",
+        "chainId": 137,
+        "name": "Curve DAO Token",
+        "symbol": "CRV",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xD533a949740bb3306d119CC777fa900bA034cd52/logo.png"
+      },
+      {
+        "address": "0xE7804D91dfCDE7F776c90043E03eAa6Df87E6395",
+        "chainId": 137,
+        "name": "DFX Token",
+        "symbol": "DFX",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/dfx-finance/assets/add-dfx-logov3/blockchains/ethereum/assets/0x888888435FDe8e7d4c54cAb67f206e4199454c60/logo.png"
+      },
+      {
+        "address": "0x8f3Cf7ad23Cd3CaDbD9735AFf958023239c6A063",
+        "chainId": 137,
+        "name": "Dai",
+        "symbol": "DAI",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x6B175474E89094C44Da98b954EedeAC495271d0F/logo.png"
+      },
+      {
+        "address": "0x1D607Faa0A51518a7728580C238d912747e71F7a",
+        "chainId": 137,
+        "name": "Data Economy Index",
+        "symbol": "DATA",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x33d63Ba1E57E54779F7dDAeaA7109349344cf5F1/logo.png"
+      },
+      {
+        "address": "0x85955046DF4668e1DD369D2DE9f3AEB98DD2A369",
+        "chainId": 137,
+        "name": "DeFiPulse Index",
+        "symbol": "DPI",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x1494CA1F11D487c2bBe4543E90080AeBa4BA3C2b/logo.png"
+      },
+      {
+        "address": "0x2a93172c8DCCbfBC60a39d56183B7279a2F647b4",
+        "chainId": 137,
+        "name": "Decentral Games",
+        "symbol": "$DG",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/13267/large/Decentral_Games_Logo-1.png?1621652581"
+      },
+      {
+        "address": "0xbD7A5Cf51d22930B8B3Df6d834F9BCEf90EE7c4f",
+        "chainId": 137,
+        "name": "Ethereum Name Service",
+        "symbol": "ENS",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xC18360217D8F7Ab5e7c516566761Ea12Ce7F9D72/logo.png"
+      },
+      {
+        "address": "0x656Bf6767Fa8863aC0dD0b7d2a26602B838A2E70",
+        "chainId": 137,
+        "name": "Fitmint Token",
+        "symbol": "FITT",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/balancer-labs/assets/refactor-for-multichain/assets/0x656bf6767fa8863ac0dd0b7d2a26602b838a2e70.png"
+      },
+      {
+        "address": "0x45c32fA6DF82ead1e2EF74d17b76547EDdFaFF89",
+        "chainId": 137,
+        "name": "Frax",
+        "symbol": "FRAX",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/balancer-labs/assets/refactor-for-multichain/assets/0x45c32fa6df82ead1e2ef74d17b76547eddfaff89.png"
+      },
+      {
+        "address": "0xC8A94a3d3D2dabC3C1CaffFFDcA6A7543c3e3e65",
+        "chainId": 137,
+        "name": "Gemini Dollar",
+        "symbol": "GUSD",
+        "decimals": 2,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x056Fd409E1d7A124BD7017459dFEa2F387b6d5Cd/logo.png"
+      },
+      {
+        "address": "0xdb95f9188479575F3F718a245EcA1B3BF74567EC",
+        "chainId": 137,
+        "name": "Gitcoin",
+        "symbol": "GTC",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/balancer-labs/assets/master/assets/0xde30da39c46104798bb5aa3fe8b9e0e1f348163f.png"
+      },
+      {
+        "address": "0x5FFD62D3C3eE2E81C00A7b9079FB248e7dF024A8",
+        "chainId": 137,
+        "name": "Gnosis",
+        "symbol": "GNO",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x6810e776880C02933D47DB1b9fc05908e5386b96/logo.png"
+      },
+      {
+        "address": "0xfBd8A3b908e764dBcD51e27992464B4432A1132b",
+        "chainId": 137,
+        "name": "Index",
+        "symbol": "INDEX",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x0954906da0Bf32d5479e25f46056d22f08464cab/logo.png"
+      },
+      {
+        "address": "0x3Ad707dA309f3845cd602059901E39C4dcd66473",
+        "chainId": 137,
+        "name": "Index Coop - ETH 2x Flexible Leverage Index (Polygon)",
+        "symbol": "ETH2x-FLI-P",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/balancer-labs/assets/refactor-for-multichain/assets/0x3ad707da309f3845cd602059901e39c4dcd66473.png"
+      },
+      {
+        "address": "0x4f025829C4B13dF652f38Abd2AB901185fF1e609",
+        "chainId": 137,
+        "name": "Index Coop - Inverse ETH Flexible Leverage Index",
+        "symbol": "iETH-FLI-P",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/balancer-labs/assets/refactor-for-multichain/assets/0x4f025829c4b13df652f38abd2ab901185ff1e609.png"
+      },
+      {
+        "address": "0x340f412860dA7b7823df372a2b59Ff78b7ae6abc",
+        "chainId": 137,
+        "name": "Index Coop - Inverse MATIC Flexible Leverage Index",
+        "symbol": "iMATIC-FLI-P",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/balancer-labs/assets/refactor-for-multichain/assets/0x340f412860da7b7823df372a2b59ff78b7ae6abc.png"
+      },
+      {
+        "address": "0xf287D97B6345bad3D88856b26Fb7c0ab3F2C7976",
+        "chainId": 137,
+        "name": "Index Coop - MATIC 2x Flexible Leverage Index",
+        "symbol": "MATIC2x-FLI-P",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/balancer-labs/assets/refactor-for-multichain/assets/0xf287d97b6345bad3d88856b26fb7c0ab3f2c7976.png"
+      },
+      {
+        "address": "0x130cE4E4F76c2265f94a961D70618562de0bb8d2",
+        "chainId": 137,
+        "name": "Inverse BTC Flexible Leverage Index",
+        "symbol": "iBTC-FLI-P",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/balancer-labs/assets/refactor-for-multichain/assets/0x130ce4e4f76c2265f94a961d70618562de0bb8d2.png"
+      },
+      {
+        "address": "0x596ebe76e2db4470966ea395b0d063ac6197a8c5",
+        "chainId": 137,
+        "name": "Jarvis Reward Token",
+        "symbol": "JRT",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/10390/large/cfeii0y.png?1578868949"
+      },
+      {
+        "address": "0x4e3Decbb3645551B8A19f0eA1678079FCB33fB4c",
+        "chainId": 137,
+        "name": "Jarvis Synthetic Euro",
+        "symbol": "jEUR",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/15725/large/jEUR.png?1634046044"
+      },
+      {
+        "address": "0x6749441fdc8650b5b5a854ed255c82ef361f1596",
+        "chainId": 137,
+        "name": "LUCHA Token",
+        "symbol": "LUCHA",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/balancer-labs/assets/refactor-for-multichain/assets/0x6749441fdc8650b5b5a854ed255c82ef361f1596.png"
+      },
+      {
+        "address": "0xfa68FB4628DFF1028CFEc22b4162FCcd0d45efb6",
+        "chainId": 137,
+        "name": "Liquid Staking Matic (PoS)",
+        "symbol": "MaticX",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/balancer-labs/assets/refactor-for-multichain/assets/0xfa68fb4628dff1028cfec22b4162fccd0d45efb6.png"
+      },
+      {
+        "address": "0xa3Fa99A148fA48D14Ed51d610c367C61876997F1",
+        "chainId": 137,
+        "name": "MAI",
+        "symbol": "miMATIC",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/15264/large/mimatic-red.png?1620281018"
+      },
+      {
+        "address": "0x6f7C932e7684666C9fd1d44527765433e01fF61d",
+        "chainId": 137,
+        "name": "MAKER (PoS)",
+        "symbol": "MKR",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/balancer-labs/assets/refactor-for-multichain/assets/0x6f7c932e7684666c9fd1d44527765433e01ff61d.png"
+      },
+      {
+        "address": "0xF501dd45a1198C2E1b5aEF5314A68B9006D842E0",
+        "chainId": 137,
+        "name": "Meta",
+        "symbol": "MTA",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xa3BeD4E1c75D00fa6f4E5E6922DB7261B5E9AcD2/logo.png"
+      },
+      {
+        "address": "0xEAeCC18198a475c921B24b8A6c1C1f0f5F3F7EA0",
+        "chainId": 137,
+        "name": "MetaGame",
+        "symbol": "SEED",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/13099/large/V8phEz8V.png?1612854078"
+      },
+      {
+        "address": "0xfe712251173A2cd5F5bE2B46Bb528328EA3565E1",
+        "chainId": 137,
+        "name": "Metaverse Index",
+        "symbol": "MVI",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x72e364F2ABdC788b7E918bc238B21f109Cd634D7/logo.png"
+      },
+      {
+        "address": "0x282d8efCe846A88B159800bd4130ad77443Fa1A1",
+        "chainId": 137,
+        "name": "Ocean Protocol",
+        "symbol": "mOCEAN",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x967da4048cD07aB37855c090aAF366e4ce1b9F48/logo.png"
+      },
+      {
+        "address": "0xE2Aa7db6dA1dAE97C5f5C6914d285fBfCC32A128",
+        "chainId": 137,
+        "name": "Parallel",
+        "symbol": "PAR",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/14153/large/par_round_200.png?1614670422"
+      },
+      {
+        "address": "0x263534a4Fe3cb249dF46810718B7B612a30ebbff",
+        "chainId": 137,
+        "name": "Perpetual Protocol",
+        "symbol": "PERP",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xbC396689893D065F41bc2C6EcbeE5e0085233447/logo.png"
+      },
+      {
+        "address": "0x580A84C73811E1839F75d86d75d88cCa0c241fF4",
+        "chainId": 137,
+        "name": "Qi Dao",
+        "symbol": "QI",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/15329/large/qi.png?1620540969"
+      },
+      {
+        "address": "0x831753DD7087CaC61aB5644b308642cc1c33Dc13",
+        "chainId": 137,
+        "name": "Quickswap",
+        "symbol": "QUICK",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/13970/large/1_pOU6pBMEmiL-ZJVb0CYRjQ.png?1613386659"
+      },
+      {
+        "address": "0x00e5646f60AC6Fb446f621d146B6E1886f002905",
+        "chainId": 137,
+        "name": "Rai Reflex Index",
+        "symbol": "RAI",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/14004/large/RAI-logo-coin.png?1613592334"
+      },
+      {
+        "address": "0x431CD3C9AC9Fc73644BF68bF5691f4B83F9E104f",
+        "chainId": 137,
+        "name": "Rainbow Token",
+        "symbol": "RBW",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/balancer-labs/assets/refactor-for-multichain/assets/0x431cd3c9ac9fc73644bf68bf5691f4b83f9e104f.png"
+      },
+      {
+        "address": "0xE111178A87A3BFf0c8d18DECBa5798827539Ae99",
+        "chainId": 137,
+        "name": "STASIS EURO",
+        "symbol": "EURS",
+        "decimals": 2,
+        "logoURI": "https://assets.coingecko.com/coins/images/5164/large/EURS_300x300.png?1550571779"
+      },
+      {
+        "address": "0x7DfF46370e9eA5f0Bad3C4E29711aD50062EA7A4",
+        "chainId": 137,
+        "name": "Solana",
+        "symbol": "SOL",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/2563ac9dc5369d8e3255cde663cf7f08e3c58914/blockchains/solana/info/logo.png"
+      },
+      {
+        "address": "0x1d734A02eF1e1f5886e66b0673b71Af5B53ffA94",
+        "chainId": 137,
+        "name": "Stader",
+        "symbol": "SD",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/balancer-labs/assets/refactor-for-multichain/assets/0x1d734a02ef1e1f5886e66b0673b71af5b53ffa94.png"
+      },
+      {
+        "address": "0x3A58a54C066FdC0f2D55FC9C89F0415C92eBf3C4",
+        "chainId": 137,
+        "name": "Staked MATIC",
+        "symbol": "stMATIC",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/balancer-labs/assets/refactor-for-multichain/assets/0x3a58a54c066fdc0f2d55fc9c89f0415c92ebf3c4.png"
+      },
+      {
+        "address": "0x0b3F868E0BE5597D5DB7fEB59E1CADBb0fdDa50a",
+        "chainId": 137,
+        "name": "Sushi",
+        "symbol": "SUSHI",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x6B3595068778DD592e39A122f4f5a5cF09C90fE2/logo.png"
+      },
+      {
+        "address": "0x50B728D8D964fd00C2d0AAD81718b71311feF68a",
+        "chainId": 137,
+        "name": "Synthetix Network Token",
+        "symbol": "SNX",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xC011a73ee8576Fb46F5E1c5751cA3B9Fe0af2a6F/logo.png"
+      },
+      {
+        "address": "0x7fC9E0Aa043787BFad28e29632AdA302C790Ce33",
+        "chainId": 137,
+        "name": "TETU_ST_BAL",
+        "symbol": "tetuBAL",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/balancer-labs/assets/refactor-for-multichain/assets/0x7fc9e0aa043787bfad28e29632ada302c790ce33.png"
+      },
+      {
+        "address": "0x2934b36ca9A4B31E633C5BE670C8C8b28b6aA015",
+        "chainId": 137,
+        "name": "THX Network",
+        "symbol": "THX",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/balancer-labs/assets/refactor-for-multichain/assets/0x2934b36ca9a4b31e633c5be670c8c8b28b6aa015.png"
+      },
+      {
+        "address": "0xdF7837DE1F2Fa4631D716CF2502f8b230F1dcc32",
+        "chainId": 137,
+        "name": "Telcoin",
+        "symbol": "TEL",
+        "decimals": 2,
+        "logoURI": "https://assets.coingecko.com/coins/images/1899/large/tel.png?1547036203"
+      },
+      {
+        "address": "0xE6469Ba6D2fD6130788E0eA9C0a0515900563b59",
+        "chainId": 137,
+        "name": "TerraUSD (Wormhole)",
+        "symbol": "UST",
+        "decimals": 6,
+        "logoURI": "https://raw.githubusercontent.com/balancer-labs/assets/refactor-for-multichain/assets/0xe6469ba6d2fd6130788e0ea9c0a0515900563b59.png"
+      },
+      {
+        "address": "0xc2132D05D31c914a87C6611C10748AEb04B58e8F",
+        "chainId": 137,
+        "name": "Tether",
+        "symbol": "USDT",
+        "decimals": 6,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xdAC17F958D2ee523a2206206994597C13D831ec7/logo.png"
+      },
+      {
+        "address": "0x5fe2B58c013d7601147DcdD68C143A77499f5531",
+        "chainId": 137,
+        "name": "The Graph",
+        "symbol": "GRT",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xc944E90C64B2c07662A292be6244BDf05Cda44a7/logo.png"
+      },
+      {
+        "address": "0xBbba073C31bF03b8ACf7c28EF0738DeCF3695683",
+        "chainId": 137,
+        "name": "The Sandbox",
+        "symbol": "SAND",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/balancer-labs/assets/refactor-for-multichain/assets/0xbbba073c31bf03b8acf7c28ef0738decf3695683.png"
+      },
+      {
+        "address": "0x2e1AD108fF1D8C782fcBbB89AAd783aC49586756",
+        "chainId": 137,
+        "name": "TrueUSD",
+        "symbol": "TUSD",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x0000000000085d4780B73119b644AE5ecd22b376/logo.png"
+      },
+      {
+        "address": "0x3066818837c5e6eD6601bd5a91B0762877A6B731",
+        "chainId": 137,
+        "name": "UMA Protocol",
+        "symbol": "UMA",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x04Fa0d235C4abf4BcF4787aF4CF447DE572eF828/logo.png"
+      },
+      {
+        "address": "0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174",
+        "chainId": 137,
+        "name": "USD Coin",
+        "symbol": "USDC",
+        "decimals": 6,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/logo.png"
+      },
+      {
+        "address": "0x64060aB139Feaae7f06Ca4E63189D86aDEb51691",
+        "chainId": 137,
+        "name": "Unicorn Milk",
+        "symbol": "UNIM",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/balancer-labs/assets/refactor-for-multichain/assets/0x64060ab139feaae7f06ca4e63189d86adeb51691.png"
+      },
+      {
+        "address": "0xb33EaAd8d922B1083446DC23f610c2567fB5180f",
+        "chainId": 137,
+        "name": "Uniswap",
+        "symbol": "UNI",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x1f9840a85d5aF5bf1D1762F925BDADdC4201F984/logo.png"
+      },
+      {
+        "address": "0x87ff96aba480f1813aF5c780387d8De7cf7D8261",
+        "chainId": 137,
+        "name": "Wrapped BUSD",
+        "symbol": "WBUSD",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x4Fabb145d64652a948d72533023f6E7A623C7C53/logo.png"
+      },
+      {
+        "address": "0x1BFD67037B42Cf73acF2047067bd4F2C47D9BfD6",
+        "chainId": 137,
+        "name": "Wrapped Bitcoin",
+        "symbol": "WBTC",
+        "decimals": 8,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599/logo.png"
+      },
+      {
+        "address": "0x7ceB23fD6bC0adD59E62ac25578270cFf1b9f619",
+        "chainId": 137,
+        "name": "Wrapped Ether",
+        "symbol": "WETH",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2/logo.png"
+      },
+      {
+        "address": "0x0d500B1d8E8eF31E21C99d1Db9A6444d3ADf1270",
+        "chainId": 137,
+        "name": "Wrapped Matic",
+        "symbol": "WMATIC",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/14073/large/matic.png?1628852392"
+      },
+      {
+        "address": "0xEE029120c72b0607344f35B17cdD90025e647B00",
+        "chainId": 137,
+        "name": "Wrapped amDAI",
+        "symbol": "amDAI",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/balancer-labs/assets/refactor-for-multichain/assets/0xee029120c72b0607344f35b17cdd90025e647b00.png"
+      },
+      {
+        "address": "0x221836a597948Dce8F3568E044fF123108aCc42A",
+        "chainId": 137,
+        "name": "Wrapped amUSDC",
+        "symbol": "amUSDC",
+        "decimals": 6,
+        "logoURI": "https://raw.githubusercontent.com/balancer-labs/assets/refactor-for-multichain/assets/0x221836a597948dce8f3568e044ff123108acc42a.png"
+      },
+      {
+        "address": "0x19C60a251e525fa88Cd6f3768416a8024e98fC19",
+        "chainId": 137,
+        "name": "Wrapped amUSDT",
+        "symbol": "amUSDT",
+        "decimals": 6,
+        "logoURI": "https://raw.githubusercontent.com/balancer-labs/assets/refactor-for-multichain/assets/0x19c60a251e525fa88cd6f3768416a8024e98fc19.png"
+      },
+      {
+        "address": "0xbAe28251B2a4E621aA7e20538c06DEe010Bc06DE",
+        "chainId": 137,
+        "name": "dHEDGE Stablecoin Yield",
+        "symbol": "dUSD",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/20765/large/dUSD-200px.png?1637653645"
+      },
+      {
+        "address": "0xDBf31dF14B66535aF65AaC99C32e9eA844e14501",
+        "chainId": 137,
+        "name": "renBTC",
+        "symbol": "renBTC",
+        "decimals": 8,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xEB4C2781e4ebA804CE9a9803C67d0893436bB27D/logo.png"
+      },
+      {
+        "address": "0xDA537104D6A5edd53c6fBba9A898708E465260b6",
+        "chainId": 137,
+        "name": "yearn.finance",
+        "symbol": "YFI",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x0bc529c00C6401aEF6D220BE8C6Ea1667F6Ad93e/logo.png"
+      }
+    ]
+  },
+  "https://unpkg.com/quickswap-default-token-list@1.0.67/build/quickswap-default.tokenlist.json": {
+    "name": "Quickswap Token List",
+    "timestamp": "2021-06-16T19:27:15.683Z",
+    "version": { "major": 1, "minor": 0, "patch": 67 },
+    "tags": {},
+    "logoURI": "ipfs://QmQ9GCVmLQkbPohxKeCYkbpmwfTvHXrY64TmBsPQAZdbqZ",
+    "keywords": ["uniswap", "default"],
+    "tokens": [
+      {
+        "name": "decentral.games",
+        "address": "0x2a93172c8DCCbfBC60a39d56183B7279a2F647b4",
+        "symbol": "$DG",
+        "decimals": 18,
+        "chainId": 137,
+        "logoURI": "https://raw.githubusercontent.com/sameepsi/quickswap-default-token-list/master/assets/dg.jpg"
+      },
+      {
+        "name": "0xBitcoin Token",
+        "address": "0x71B821aa52a49F32EEd535fCA6Eb5aa130085978",
+        "symbol": "0xBTC",
+        "decimals": 8,
+        "chainId": 137,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xB6eD7644C69416d67B522e20bC294A9a9B405B31/logo.png"
+      },
+      {
+        "name": "Aave",
+        "address": "0xD6DF932A45C0f255f85145f286eA0b292B21C90B",
+        "symbol": "AAVE",
+        "decimals": 18,
+        "chainId": 137,
+        "logoURI": "https://etherscan.io/token/images/aave_32.png"
+      },
+      {
+        "name": "Adamant",
+        "address": "0xc3FdbadC7c795EF1D6Ba111e06fF8F16A20Ea539",
+        "symbol": "ADDY",
+        "decimals": 18,
+        "chainId": 137,
+        "logoURI": "https://adamant.finance/img/adamant.png"
+      },
+      {
+        "name": "AGA Token",
+        "address": "0x033d942A6b495C4071083f4CDe1f17e986FE856c",
+        "symbol": "AGA",
+        "decimals": 4,
+        "chainId": 137,
+        "logoURI": "https://i.imgur.com/R0aQlym.png"
+      },
+      {
+        "name": "AGA Rewards",
+        "address": "0xF84BD51eab957c2e7B7D646A3427C5A50848281D",
+        "symbol": "AGAr",
+        "decimals": 8,
+        "chainId": 137,
+        "logoURI": "https://i.imgur.com/06BkcTT.png"
+      },
+      {
+        "name": "Anyswap",
+        "address": "0x6aB6d61428fde76768D7b45D8BFeec19c6eF91A8",
+        "symbol": "ANY",
+        "decimals": 18,
+        "chainId": 137,
+        "logoURI": "https://raw.githubusercontent.com/anyswap/Brand-assets/master/logo/c-128-white.svg"
+      },
+      {
+        "name": "ARIANEE",
+        "address": "0x46F48FbdedAa6F5500993BEDE9539ef85F4BeE8e",
+        "symbol": "ARIA20",
+        "decimals": 18,
+        "chainId": 137,
+        "logoURI": "https://aria.fyi/images/Aria_Logo_256.png"
+      },
+      {
+        "name": "DokiDokiAzuki",
+        "address": "0x7CdC0421469398e0F3aA8890693d86c840Ac8931",
+        "symbol": "AZUKI",
+        "decimals": 18,
+        "chainId": 137,
+        "logoURI": "https://raw.githubusercontent.com/sameepsi/quickswap-default-token-list/master/assets/azuki.png"
+      },
+      {
+        "name": "beefy.finance",
+        "address": "0xFbdd194376de19a88118e84E279b977f165d01b8",
+        "symbol": "BIFI",
+        "decimals": 18,
+        "chainId": 137,
+        "logoURI": "https://raw.githubusercontent.com/beefyfinance/beefy-app/prod/src/images/single-assets/BIFI.png"
+      },
+      {
+        "name": "BoringDAO",
+        "address": "0xff88434E29d1E2333aD6baa08D358b436196da6b",
+        "symbol": "BORING",
+        "decimals": 18,
+        "chainId": 137,
+        "logoURI": "https://i.imgur.com/Jo6QWz7.png"
+      },
+      {
+        "name": "BTU Protocol",
+        "address": "0xFdc26CDA2d2440d0E83CD1DeE8E8bE48405806DC",
+        "symbol": "BTU",
+        "decimals": 18,
+        "chainId": 137,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xb683D83a532e2Cb7DFa5275eED3698436371cc9f/logo.png"
+      },
+      {
+        "name": "Cryptocurrency Top Tokens Index",
+        "address": "0x9c49BA0212Bb5Db371e66b59D1565b7c06E4894e",
+        "symbol": "CC10",
+        "decimals": 18,
+        "chainId": 137,
+        "logoURI": "https://etherscan.io/token/images/indexed-cc10_32.png"
+      },
+      {
+        "name": "Celsius",
+        "address": "0xD85d1e945766Fea5Eda9103F918Bd915FbCa63E6",
+        "symbol": "CEL",
+        "decimals": 4,
+        "chainId": 137,
+        "logoURI": "https://assets.coingecko.com/coins/images/3263/small/CEL_logo.png?1609598753"
+      },
+      {
+        "name": "CyberFi Token",
+        "address": "0xeCf8f2FA183b1C4d2A269BF98A54fCe86C812d3e",
+        "symbol": "CFI",
+        "decimals": 18,
+        "chainId": 137,
+        "logoURI": "https://i.imgur.com/Z8V1O7H.png"
+      },
+      {
+        "name": "ChumHum",
+        "address": "0x2e2DDe47952b9c7deFDE7424d00dD2341AD927Ca",
+        "symbol": "CHUM",
+        "decimals": 18,
+        "chainId": 137,
+        "logoURI": "https://i.imgur.com/66lM7Rx.png"
+      },
+      {
+        "name": "Compound",
+        "address": "0x8505b9d2254A7Ae468c0E9dd10Ccea3A837aef5c",
+        "symbol": "COMP",
+        "decimals": 18,
+        "chainId": 137,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xc00e94Cb662C3520282E6f5717214004A7f26888/logo.png"
+      },
+      {
+        "name": "CRV",
+        "address": "0x172370d5Cd63279eFa6d502DAB29171933a610AF",
+        "symbol": "CRV",
+        "decimals": 18,
+        "chainId": 137,
+        "logoURI": "https://assets.coingecko.com/coins/images/12124/small/Curve.png?1597369484"
+      },
+      {
+        "name": "Cartesi Token",
+        "address": "0x2727Ab1c2D22170ABc9b595177B2D5C6E1Ab7B7B",
+        "symbol": "CTSI",
+        "decimals": 18,
+        "chainId": 137,
+        "logoURI": "https://i.imgur.com/q3SnElh.png"
+      },
+      {
+        "name": "Dai Stablecoin",
+        "address": "0x8f3Cf7ad23Cd3CaDbD9735AFf958023239c6A063",
+        "symbol": "DAI",
+        "decimals": 18,
+        "chainId": 137,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x6B175474E89094C44Da98b954EedeAC495271d0F/logo.png"
+      },
+      {
+        "name": "Dark.Build",
+        "address": "0x0e59D50adD2d90f5111aca875baE0a72D95B4762",
+        "symbol": "DB",
+        "decimals": 18,
+        "chainId": 137,
+        "logoURI": "https://dark-build.app/logo192.png"
+      },
+      {
+        "name": "DEFI Top 5 Tokens Index",
+        "address": "0x42435F467D33e5C4146a4E8893976ef12BBCE762",
+        "symbol": "DEFI5",
+        "decimals": 18,
+        "chainId": 137,
+        "logoURI": "https://i.imgur.com/uVGtugL.png"
+      },
+      {
+        "name": "DEGEN Index",
+        "address": "0x8a2870fb69A90000D6439b7aDfB01d4bA383A415",
+        "symbol": "DEGEN",
+        "decimals": 18,
+        "chainId": 137,
+        "logoURI": "https://raw.githubusercontent.com/sameepsi/quickswap-default-token-list/master/assets/DEGEN_LOGO.png"
+      },
+      {
+        "name": "Dark Matter Token",
+        "address": "0xd28449BB9bB659725aCcAd52947677ccE3719fD7",
+        "symbol": "DMT",
+        "decimals": 18,
+        "chainId": 137,
+        "logoURI": "https://darkmatter.finance/i/favicon/512x512.png"
+      },
+      {
+        "name": "Digital Reserve Currency",
+        "address": "0xFeD16c746CB5BFeD009730f9E3e6A673006105c7",
+        "symbol": "DRC",
+        "decimals": 0,
+        "chainId": 137,
+        "logoURI": "https://pbs.twimg.com/profile_images/1318783238291292160/R4DxXdRA_400x400.jpg"
+      },
+      {
+        "name": "DSLA",
+        "address": "0xa0E390e9ceA0D0e8cd40048ced9fA9EA10D71639",
+        "symbol": "DSLA",
+        "decimals": 18,
+        "chainId": 137,
+        "logoURI": "https://storage.googleapis.com/stacktical-public/dsla.png"
+      },
+      {
+        "name": "Eleven.finance",
+        "address": "0xAcD7B3D9c10e97d0efA418903C0c7669E702E4C0",
+        "symbol": "ELE",
+        "decimals": 18,
+        "chainId": 137,
+        "logoURI": "https://assets.coingecko.com/coins/images/14541/small/eleven_finance_logo.png?1616895791"
+      },
+      {
+        "name": "Elementeum",
+        "address": "0x07738Eb4ce8932CA961c815Cb12C9d4ab5Bd0Da4",
+        "symbol": "ELET",
+        "decimals": 18,
+        "chainId": 137,
+        "logoURI": "https://etherlegends.com/ELET.png"
+      },
+      {
+        "name": "EthermonToken",
+        "address": "0xd6A5aB46ead26f49b03bBB1F9EB1Ad5c1767974a",
+        "symbol": "EMON",
+        "decimals": 18,
+        "chainId": 137,
+        "logoURI": "https://s2.coinmarketcap.com/static/img/coins/64x64/9651.png"
+      },
+      {
+        "name": "Ethernity Chain",
+        "address": "0x0E50BEA95Fe001A370A4F1C220C49AEdCB982DeC",
+        "symbol": "ERN",
+        "decimals": 18,
+        "chainId": 137,
+        "logoURI": "https://assets.coingecko.com/coins/images/14238/small/ethernity_logo.png?1615189750"
+      },
+      {
+        "name": "Ether",
+        "address": "0x7ceB23fD6bC0adD59E62ac25578270cFf1b9f619",
+        "symbol": "ETH",
+        "decimals": 18,
+        "chainId": 137,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2/logo.png"
+      },
+      {
+        "name": "Future of Finance Fund",
+        "address": "0x9aCeB6f749396d1930aBc9e263eFc449E5e82c13",
+        "symbol": "FFF",
+        "decimals": 18,
+        "chainId": 137,
+        "logoURI": "https://assets.coingecko.com/coins/images/15761/small/xg1NFl0.png?1621825451"
+      },
+      {
+        "name": "Fish",
+        "address": "0x3a3Df212b7AA91Aa0402B9035b098891d276572B",
+        "symbol": "FISH",
+        "decimals": 18,
+        "chainId": 137,
+        "logoURI": "https://i.imgur.com/ncleoTN.png"
+      },
+      {
+        "name": "Frax",
+        "address": "0x104592a158490a9228070E0A8e5343B499e125D0",
+        "symbol": "FRAX",
+        "decimals": 18,
+        "chainId": 137,
+        "logoURI": "https://avatars.githubusercontent.com/u/56005256?s=200&v=4"
+      },
+      {
+        "name": "Fusion",
+        "address": "0x2bF9b864cdc97b08B6D79ad4663e71B8aB65c45c",
+        "symbol": "FSN",
+        "decimals": 18,
+        "chainId": 137,
+        "logoURI": "https://cryptologos.cc/logos/fusion-fsn-logo.png?v=010"
+      },
+      {
+        "name": "Frax Share",
+        "address": "0x3e121107F6F22DA4911079845a470757aF4e1A1b",
+        "symbol": "FXS",
+        "decimals": 18,
+        "chainId": 137,
+        "logoURI": "https://avatars.githubusercontent.com/u/56005256?s=200&v=4"
+      },
+      {
+        "name": "GAME Credits",
+        "address": "0x8d1566569d5b695d44a9a234540f68D393cDC40D",
+        "symbol": "GAME",
+        "decimals": 18,
+        "chainId": 137,
+        "logoURI": "https://i.imgur.com/IIUglm9.png?1"
+      },
+      {
+        "name": "Gains V2",
+        "address": "0x7075cAB6bCCA06613e2d071bd918D1a0241379E2",
+        "symbol": "GFARM2",
+        "decimals": 18,
+        "chainId": 137,
+        "logoURI": "https://gains.farm/images/logo256.png"
+      },
+      {
+        "name": "Gravity Finance",
+        "address": "0x874e178A2f3f3F9d34db862453Cd756E7eAb0381",
+        "symbol": "GFI",
+        "decimals": 18,
+        "chainId": 137,
+        "logoURI": "https://assets.coingecko.com/coins/images/15871/small/GFI-Icon.png?1622178588"
+      },
+      {
+        "name": "Aavegotchi GHST Token",
+        "address": "0x385Eeac5cB85A38A9a07A70c73e0a3271CfB54A7",
+        "symbol": "GHST",
+        "decimals": 18,
+        "chainId": 137,
+        "logoURI": "https://aavegotchi.com/images/ghsttoken.svg"
+      },
+      {
+        "name": "HEXX",
+        "address": "0x23D29D30e35C5e8D321e1dc9A8a61BFD846D4C5C",
+        "symbol": "HEX",
+        "decimals": 8,
+        "chainId": 137,
+        "logoURI": "https://hex.com/favicon.png"
+      },
+      {
+        "name": "Holyheld",
+        "address": "0x521CddC0CBa84F14c69C1E99249F781AA73Ee0BC",
+        "symbol": "HH",
+        "decimals": 18,
+        "chainId": 137,
+        "logoURI": "https://assets.coingecko.com/coins/images/13719/small/hh.png?1611137626"
+      },
+      {
+        "name": "iFARM",
+        "address": "0xab0b2ddB9C7e440fAc8E140A89c0dbCBf2d7Bbff",
+        "symbol": "iFARM",
+        "decimals": 18,
+        "chainId": 137,
+        "logoURI": "https://raw.githubusercontent.com/harvestfi/assets/main/farm-logo.png"
+      },
+      {
+        "name": "IG Gold",
+        "address": "0xe6FC6C7CB6d2c31b359A49A33eF08aB87F4dE7CE",
+        "symbol": "IGG",
+        "decimals": 6,
+        "chainId": 137,
+        "logoURI": "https://assets.coingecko.com/coins/images/7697/small/N7aEdYrY_400x400.png?1561587437"
+      },
+      {
+        "name": "Rupeeto",
+        "address": "0xde485931674F4EdD3Ed3bf22e86E7d3C7D5347a1",
+        "symbol": "INRP",
+        "decimals": 18,
+        "chainId": 137,
+        "logoURI": "https://cdn.rupeeto.com/images/rupeeto-symbol.jpeg"
+      },
+      {
+        "name": "IOI Token",
+        "address": "0xAF24765F631C8830B5528B57002241eE7eef1C14",
+        "symbol": "IOI",
+        "decimals": 6,
+        "chainId": 137,
+        "logoURI": "https://assets.coingecko.com/coins/images/15952/small/IOI.jpg?1622514420"
+      },
+      {
+        "name": "Everipedia IQ",
+        "address": "0xB9638272aD6998708de56BBC0A290a1dE534a578",
+        "symbol": "IQ",
+        "decimals": 18,
+        "chainId": 137,
+        "logoURI": "https://i.imgur.com/2Tocoq5.png"
+      },
+      {
+        "name": "IRON Stablecoin",
+        "address": "0xD86b5923F3AD7b585eD81B448170ae026c65ae9a",
+        "symbol": "IRON",
+        "decimals": 18,
+        "chainId": 137,
+        "logoURI": "https://ironfi.s3.amazonaws.com/images/IRON.png"
+      },
+      {
+        "name": "Krill",
+        "address": "0x05089C9EBFFa4F0AcA269e32056b1b36B37ED71b",
+        "symbol": "Krill",
+        "decimals": 18,
+        "chainId": 137,
+        "logoURI": "https://i.imgur.com/REyP9yh.jpg"
+      },
+      {
+        "name": "EthLend Token",
+        "address": "0x313d009888329C9d1cf4f75CA3f32566335bd604",
+        "symbol": "LEND",
+        "decimals": 18,
+        "chainId": 137,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x80fB784B7eD66730e8b1DBd9820aFD29931aab03/logo.png"
+      },
+      {
+        "name": "ChainLink Token",
+        "address": "0x53E0bca35eC356BD5ddDFebbD1Fc0fD03FaBad39",
+        "symbol": "LINK",
+        "decimals": 18,
+        "chainId": 137,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x514910771AF9Ca656af840dff83E8264EcF986CA/logo.png"
+      },
+      {
+        "name": "Matic Aave interest bearing AAVE",
+        "address": "0x823CD4264C1b951C9209aD0DeAea9988fE8429bF",
+        "symbol": "maAAVE",
+        "decimals": 18,
+        "chainId": 137,
+        "logoURI": "https://aavegotchi.com/images/matokens/maAAVE.svg"
+      },
+      {
+        "name": "Matic Aave interest bearing DAI",
+        "address": "0xE0b22E0037B130A9F56bBb537684E6fA18192341",
+        "symbol": "maDAI",
+        "decimals": 18,
+        "chainId": 137,
+        "logoURI": "https://aavegotchi.com/images/matokens/maDAI.svg"
+      },
+      {
+        "name": "Matic Aave interest bearing LINK",
+        "address": "0x98ea609569bD25119707451eF982b90E3eb719cD",
+        "symbol": "maLINK",
+        "decimals": 18,
+        "chainId": 137,
+        "logoURI": "https://aavegotchi.com/images/matokens/maLINK.svg"
+      },
+      {
+        "name": "Decentraland MANA",
+        "address": "0xA1c57f48F0Deb89f569dFbE6E2B7f46D33606fD4",
+        "symbol": "MANA",
+        "decimals": 18,
+        "chainId": 137,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x0F5D2fB29fb7d3CFeE444a200298f468908cC942/logo.png"
+      },
+      {
+        "name": "Matic Aave interest bearing TUSD",
+        "address": "0xF4b8888427b00d7caf21654408B7CBA2eCf4EbD9",
+        "symbol": "maTUSD",
+        "decimals": 18,
+        "chainId": 137,
+        "logoURI": "https://aavegotchi.com/images/matokens/maTUSD.svg"
+      },
+      {
+        "name": "Matic Aave interest bearing UNI",
+        "address": "0x8c8bdBe9CeE455732525086264a4Bf9Cf821C498",
+        "symbol": "maUNI",
+        "decimals": 18,
+        "chainId": 137,
+        "logoURI": "https://aavegotchi.com/images/matokens/maUNI.svg"
+      },
+      {
+        "name": "Matic Aave interest bearing USDC",
+        "address": "0x9719d867A500Ef117cC201206B8ab51e794d3F82",
+        "symbol": "maUSDC",
+        "decimals": 6,
+        "chainId": 137,
+        "logoURI": "https://aavegotchi.com/images/matokens/maUSDC.svg"
+      },
+      {
+        "name": "Matic Aave interest bearing USDT",
+        "address": "0xDAE5F1590db13E3B40423B5b5c5fbf175515910b",
+        "symbol": "maUSDT",
+        "decimals": 6,
+        "chainId": 137,
+        "logoURI": "https://aavegotchi.com/images/matokens/maUSDT.svg"
+      },
+      {
+        "name": "Matic Aave interest bearing WETH",
+        "address": "0x20D3922b4a1A8560E1aC99FBA4faDe0c849e2142",
+        "symbol": "maWETH",
+        "decimals": 18,
+        "chainId": 137,
+        "logoURI": "https://aavegotchi.com/images/matokens/maWETH.svg"
+      },
+      {
+        "name": "Matic Aave interest bearing YFI",
+        "address": "0xe20f7d1f0eC39C4d5DB01f53554F2EF54c71f613",
+        "symbol": "maYFI",
+        "decimals": 18,
+        "chainId": 137,
+        "logoURI": "https://aavegotchi.com/images/matokens/maYFI.svg"
+      },
+      {
+        "name": "Matic Deflect Protocol",
+        "address": "0x82B6205002ecd05e97642D38D61e2cFeaC0E18cE",
+        "symbol": "mDEF",
+        "decimals": 9,
+        "chainId": 137,
+        "logoURI": "https://etherscan.io/token/images/deflect_32.png?=v1"
+      },
+      {
+        "name": "Memecoin",
+        "address": "0x42dbBd5ae373FEA2FC320F62d44C058522Bb3758",
+        "symbol": "MEM",
+        "decimals": 18,
+        "chainId": 137,
+        "logoURI": "https://media.discordapp.net/attachments/846293892785242143/852874003928449054/mem_gold_with_white_5.png"
+      },
+      {
+        "name": "miMATIC",
+        "address": "0xa3Fa99A148fA48D14Ed51d610c367C61876997F1",
+        "symbol": "miMATIC",
+        "decimals": 18,
+        "chainId": 137,
+        "logoURI": "https://raw.githubusercontent.com/0xlaozi/qidao/main/images/mimatic-red.png"
+      },
+      {
+        "name": "Ocean Token",
+        "address": "0x282d8efCe846A88B159800bd4130ad77443Fa1A1",
+        "symbol": "mOCEAN",
+        "decimals": 18,
+        "chainId": 137,
+        "logoURI": "https://oceanprotocol.com/static/4ad704a150d436a1f32d495413fc47cd/favicon-white.png"
+      },
+      {
+        "name": "Monavale",
+        "address": "0x6968105460f67c3BF751bE7C15f92F5286Fd0CE5",
+        "symbol": "MONA",
+        "decimals": 18,
+        "chainId": 137,
+        "logoURI": "https://i.imgur.com/FR12tmm.jpg"
+      },
+      {
+        "name": "Polywolf",
+        "address": "0xc56d17dD519e5eB43a19C9759b5D5372115220BD",
+        "symbol": "MOON",
+        "decimals": 18,
+        "chainId": 137,
+        "logoURI": "https://i.postimg.cc/CxvzF5bJ/moon-black.png"
+      },
+      {
+        "name": "Matic Rebalance Token",
+        "address": "0x66768ad00746aC4d68ded9f64886d55d5243f5Ec",
+        "symbol": "mRBAL",
+        "decimals": 18,
+        "chainId": 137,
+        "logoURI": "https://rebalancetoken.io/images/logo/logo.png"
+      },
+      {
+        "name": "Must",
+        "address": "0x9C78EE466D6Cb57A4d01Fd887D2b5dFb2D46288f",
+        "symbol": "MUST",
+        "decimals": 18,
+        "chainId": 137,
+        "logoURI": "https://etherscan.io/token/images/cometh_32.png"
+      },
+      {
+        "name": "NFT Platform Index",
+        "address": "0xf7d9e281c5Cb4C6796284C5b663b3593D2037aF2",
+        "symbol": "NFTP",
+        "decimals": 18,
+        "chainId": 137,
+        "logoURI": "https://raw.githubusercontent.com/sameepsi/quickswap-default-token-list/master/assets/NFTP.png"
+      },
+      {
+        "name": "OM",
+        "address": "0xC3Ec80343D2bae2F8E680FDADDe7C17E71E114ea",
+        "symbol": "OM",
+        "decimals": 18,
+        "chainId": 137,
+        "logoURI": "https://etherscan.io/token/images/mantradao_32.png"
+      },
+      {
+        "name": "Opu Coin",
+        "address": "0x7ff2FC33E161E3b1C6511B934F0209D304267857",
+        "symbol": "OPU",
+        "decimals": 18,
+        "chainId": 137,
+        "logoURI": "https://www.opucoin.io/wp-content/uploads/2021/04/opu-coiin-icon-border.svg"
+      },
+      {
+        "name": "Orbit Bridge Polygon AUTOv2",
+        "address": "0x7f426F6Dc648e50464a0392E60E1BB465a67E9cf",
+        "symbol": "PAUTO",
+        "decimals": 18,
+        "chainId": 137,
+        "logoURI": "https://assets.coingecko.com/coins/images/13751/small/autofarm_icon_200x200.png?1611494288"
+      },
+      {
+        "name": "Orbit Bridge Polygon Binance Coin",
+        "address": "0x7e9928aFe96FefB820b85B4CE6597B8F660Fe4F4",
+        "symbol": "PBNB",
+        "decimals": 18,
+        "chainId": 137,
+        "logoURI": "https://assets.coingecko.com/coins/images/825/small/binance-coin-logo.png?1547034615"
+      },
+      {
+        "name": "PLOT",
+        "address": "0xe82808eaA78339b06a691fd92E1Be79671cAd8D3",
+        "symbol": "PLOT",
+        "decimals": 18,
+        "chainId": 137,
+        "logoURI": "https://i.imgur.com/nQDG9AQ.png"
+      },
+      {
+        "name": "PolyDoge",
+        "address": "0x8A953CfE442c5E8855cc6c61b1293FA648BAE472",
+        "symbol": "PolyDoge",
+        "decimals": 18,
+        "chainId": 137,
+        "logoURI": "https://polydoge.com/doge-webpage_files/doge.png"
+      },
+      {
+        "name": "Pepedex",
+        "address": "0x127984b5E6d5c59f81DACc9F1C8b3Bdc8494572e",
+        "symbol": "PPDEX",
+        "decimals": 18,
+        "chainId": 137,
+        "logoURI": "https://etherscan.io/token/images/pepedex_32.png?v=2"
+      },
+      {
+        "name": "Qi Dao",
+        "address": "0x580A84C73811E1839F75d86d75d88cCa0c241fF4",
+        "symbol": "QI",
+        "decimals": 18,
+        "chainId": 137,
+        "logoURI": "https://raw.githubusercontent.com/0xlaozi/qidao/main/images/qi.png"
+      },
+      {
+        "name": "Quickswap",
+        "address": "0x831753DD7087CaC61aB5644b308642cc1c33Dc13",
+        "symbol": "QUICK",
+        "decimals": 18,
+        "chainId": 137,
+        "logoURI": "https://raw.githubusercontent.com/sameepsi/quickswap-interface/master/public/favicon.jpeg"
+      },
+      {
+        "name": "QuickChart",
+        "address": "0x99dA82C5464C49962Cdda44fe30d352Bc5Da0580",
+        "symbol": "QuickChart",
+        "decimals": 9,
+        "chainId": 137,
+        "logoURI": "https://i.imgur.com/jv5A0eX.png"
+      },
+      {
+        "name": "RAMP",
+        "address": "0xaECeBfcF604AD245Eaf0D5BD68459C3a7A6399c2",
+        "symbol": "RAMP",
+        "decimals": 18,
+        "chainId": 137,
+        "logoURI": "https://rampdefi.com/assets/RAMP_LOGO_V4_256.png"
+      },
+      {
+        "name": "Rebalance Token",
+        "address": "0x03247a4368A280bEc8133300cD930A3a61d604f6",
+        "symbol": "RBAL",
+        "decimals": 18,
+        "chainId": 137,
+        "logoURI": "http://rebalancetoken.io/images/logo/RBAL_ERC20_small_001_256.png"
+      },
+      {
+        "name": "rUSD",
+        "address": "0xfC40a4F89b410a1b855b5e205064a38fC29F5eb5",
+        "symbol": "rUSD",
+        "decimals": 18,
+        "chainId": 137,
+        "logoURI": "https://rampdefi.com/assets/rUSD-Logo-200.png"
+      },
+      {
+        "name": "Sentinel",
+        "address": "0x48e3883233461C2eF4cB3FcF419D6db07fb86CeA",
+        "symbol": "SENT",
+        "decimals": 8,
+        "chainId": 137,
+        "logoURI": "https://cdn-images-1.medium.com/max/1200/1*mK1oPGsQWh4Nfupg-e0S-g.png"
+      },
+      {
+        "name": "SuperFarm",
+        "address": "0xa1428174F516F527fafdD146b883bB4428682737",
+        "symbol": "SUPER",
+        "decimals": 18,
+        "chainId": 137,
+        "logoURI": "https://assets.coingecko.com/coins/images/14040/small/6YPdWn6.png?1613975899"
+      },
+      {
+        "name": "TrustSwap Token",
+        "address": "0x3809dcDd5dDe24B37AbE64A5a339784c3323c44F",
+        "symbol": "SWAP",
+        "decimals": 18,
+        "chainId": 137,
+        "logoURI": "https://i.imgur.com/vZnU36G.png"
+      },
+      {
+        "name": "Swirge",
+        "address": "0x043A3Aa319B563aC25D4E342d32bFfb51298DB7b",
+        "symbol": "SWG",
+        "decimals": 18,
+        "chainId": 137,
+        "logoURI": "https://etherscan.io/token/images/swirge_32.png"
+      },
+      {
+        "name": "SportX",
+        "address": "0x840195888Db4D6A99ED9F73FcD3B225Bb3cB1A79",
+        "symbol": "SX",
+        "decimals": 18,
+        "chainId": 137,
+        "logoURI": "https://raw.githubusercontent.com/sameepsi/quickswap-default-token-list/master/assets/sx.jpg"
+      },
+      {
+        "name": "Telcoin",
+        "address": "0xdF7837DE1F2Fa4631D716CF2502f8b230F1dcc32",
+        "symbol": "TEL",
+        "decimals": 2,
+        "chainId": 137,
+        "logoURI": "https://pbs.twimg.com/profile_images/933388441475194881/57fOk40N_400x400.jpg"
+      },
+      {
+        "name": "IRON Titanium Token",
+        "address": "0xaAa5B9e6c589642f98a1cDA99B9D024B8407285A",
+        "symbol": "TITAN",
+        "decimals": 18,
+        "chainId": 137,
+        "logoURI": "https://ironfi.s3.amazonaws.com/images/TITAN.png"
+      },
+      {
+        "name": "Unibright",
+        "address": "0x7FBc10850caE055B27039aF31bD258430e714c62",
+        "symbol": "UBT",
+        "decimals": 8,
+        "chainId": 137,
+        "logoURI": "https://assets.coingecko.com/coins/images/2707/small/UnibrightLogo_colorful_500x500_preview.png?1547036916"
+      },
+      {
+        "name": "UniLend Finance Token",
+        "address": "0x5B4CF2C120A9702225814E18543ee658c5f8631e",
+        "symbol": "UFT",
+        "decimals": 18,
+        "chainId": 137,
+        "logoURI": "https://assets.coingecko.com/coins/images/12819/small/UniLend_Finance_logo_PNG.png?1602748658"
+      },
+      {
+        "name": "Uniswap",
+        "address": "0xb33EaAd8d922B1083446DC23f610c2567fB5180f",
+        "symbol": "UNI",
+        "decimals": 18,
+        "chainId": 137,
+        "logoURI": "https://raw.githubusercontent.com/sameepsi/quickswap-interface/master/public/favicon1.png"
+      },
+      {
+        "name": "USD Coin",
+        "address": "0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174",
+        "symbol": "USDC",
+        "decimals": 6,
+        "chainId": 137,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/logo.png"
+      },
+      {
+        "name": "Tether USD",
+        "address": "0xc2132D05D31c914a87C6611C10748AEb04B58e8F",
+        "symbol": "USDT",
+        "decimals": 6,
+        "chainId": 137,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xdAC17F958D2ee523a2206206994597C13D831ec7/logo.png"
+      },
+      {
+        "name": "Vision Token",
+        "address": "0x034b2090b579228482520c589dbD397c53Fc51cC",
+        "symbol": "VISION",
+        "decimals": 18,
+        "chainId": 137,
+        "logoURI": "https://s3-us-west-2.amazonaws.com/acf-uploads/apyvisionlogo200circle.png"
+      },
+      {
+        "name": "Wrapped BTC",
+        "address": "0x1BFD67037B42Cf73acF2047067bd4F2C47D9BfD6",
+        "symbol": "WBTC",
+        "decimals": 8,
+        "chainId": 137,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599/logo.png"
+      },
+      {
+        "name": "Wrapped BUSD",
+        "address": "0x87ff96aba480f1813aF5c780387d8De7cf7D8261",
+        "symbol": "WBUSD",
+        "decimals": 18,
+        "chainId": 137,
+        "logoURI": "https://assets.coingecko.com/coins/images/9576/small/BUSD.png?1568947766"
+      },
+      {
+        "name": "Wise Token",
+        "address": "0xB77e62709e39aD1cbeEBE77cF493745AeC0F453a",
+        "symbol": "WISE",
+        "decimals": 18,
+        "chainId": 137,
+        "logoURI": "https://etherscan.io/token/images/wisetoken_32.png"
+      },
+      {
+        "name": "Wrapped Matic",
+        "address": "0x0d500B1d8E8eF31E21C99d1Db9A6444d3ADf1270",
+        "symbol": "WMATIC",
+        "decimals": 18,
+        "chainId": 137,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x7D1AfA7B718fb893dB30A3aBc0Cfc608AaCfeBB0/logo.png"
+      },
+      {
+        "name": "moonwolf.io",
+        "address": "0x8f18dC399594b451EdA8c5da02d0563c0b2d0f16",
+        "symbol": "WOLF",
+        "decimals": 9,
+        "chainId": 137,
+        "logoURI": "https://i.postimg.cc/PfLb0ssB/wolf-black.png"
+      },
+      {
+        "name": "WazirX",
+        "address": "0x72d6066F486bd0052eefB9114B66ae40e0A6031a",
+        "symbol": "WRX",
+        "decimals": 8,
+        "chainId": 137,
+        "logoURI": "https://etherscan.io/token/images/binance-wrx_32.png"
+      },
+      {
+        "name": "Standard",
+        "address": "0xf153EfF70DC0bf3b085134928daeEA248d9B30d0",
+        "symbol": "xMARK",
+        "decimals": 9,
+        "chainId": 137,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/8cb78aca77b340510958ed98a3cd260d2d7f0420/blockchains/ethereum/assets/0x36b679bd64Ed73DBfd88909cDCB892cB66Bd4CBb/logo.png"
+      },
+      {
+        "name": "yearn.finance",
+        "address": "0xDA537104D6A5edd53c6fBba9A898708E465260b6",
+        "symbol": "YFI",
+        "decimals": 18,
+        "chainId": 137,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x0bc529c00C6401aEF6D220BE8C6Ea1667F6Ad93e/logo.png"
+      },
+      {
+        "name": "ZeroSwapToken",
+        "address": "0xfd4959c06FbCc02250952DAEbf8e0Fb38cF9FD8C",
+        "symbol": "ZEE",
+        "decimals": 18,
+        "chainId": 137,
+        "logoURI": "https://pbs.twimg.com/profile_images/1366339230683652096/sit30Uuo_400x400.png"
+      },
+      {
+        "name": "ZeroUtility",
+        "address": "0xe86E8beb7340659DDDCE61727E500e3A5aD75a90",
+        "symbol": "ZUT",
+        "decimals": 18,
+        "chainId": 137,
+        "logoURI": "https://s2.gifyu.com/images/zutlogo.jpg"
+      },
+      {
+        "name": "Zeus",
+        "address": "0x232eaB56c4fB3f84c6Fb0a50c087c74b7B43c6Ad",
+        "symbol": "ZUZ",
+        "decimals": 18,
+        "chainId": 137,
+        "logoURI": "https://etherscan.io/token/images/zuzprotocol_32.png"
+      },
+      {
+        "name": "Dai Stablecoin",
+        "address": "0xcB1e72786A6eb3b44C2a2429e317c8a2462CFeb1",
+        "symbol": "DAI",
+        "decimals": 18,
+        "chainId": 80001,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x6B175474E89094C44Da98b954EedeAC495271d0F/logo.png"
+      },
+      {
+        "name": "Ether",
+        "address": "0x714550C2C1Ea08688607D86ed8EeF4f5E4F22323",
+        "symbol": "ETH",
+        "decimals": 18,
+        "chainId": 80001,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2/logo.png"
+      },
+      {
+        "name": "Tether USD",
+        "address": "0x3813e82e6f7098b9583FC0F33a962D02018B6803",
+        "symbol": "USDT",
+        "decimals": 6,
+        "chainId": 80001,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xdAC17F958D2ee523a2206206994597C13D831ec7/logo.png"
+      },
+      {
+        "name": "Wrapped Matic",
+        "address": "0xd0A1E359811322d97991E03f863a0C30C2cF029C",
+        "symbol": "WMATIC",
+        "decimals": 18,
+        "chainId": 80001,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x7D1AfA7B718fb893dB30A3aBc0Cfc608AaCfeBB0/logo.png"
+      }
+    ]
+  }
+}

--- a/public/data/tokenlists/tokens-42.json
+++ b/public/data/tokenlists/tokens-42.json
@@ -1,0 +1,7901 @@
+{
+  "https://raw.githubusercontent.com/balancer-labs/assets/refactor-for-multichain/generated/kovan.listed.tokenlist.json": {
+    "name": "Balancer",
+    "timestamp": "2022-05-13T00:00:00.000Z",
+    "logoURI": "https://raw.githubusercontent.com/balancer-labs/pebbles/master/images/pebbles-pad.256w.png",
+    "keywords": ["balancer", "listed"],
+    "version": { "major": 1, "minor": 0, "patch": 2 },
+    "tokens": [
+      {
+        "address": "0x41286Bb1D3E870f3F750eB7E1C25d7E48c8A1Ac7",
+        "chainId": 42,
+        "name": "Balancer",
+        "symbol": "BAL",
+        "decimals": 18,
+        "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0xba100000625a3754423978a60c9317c58a424e3D/logo.png"
+      },
+      {
+        "address": "0x04DF6e4121c27713ED22341E7c7Df330F56f289B",
+        "chainId": 42,
+        "name": "Dai",
+        "symbol": "DAI",
+        "decimals": 18,
+        "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0x6B175474E89094C44Da98b954EedeAC495271d0F/logo.png"
+      },
+      {
+        "address": "0xAf9ac3235be96eD496db7969f60D354fe5e426B0",
+        "chainId": 42,
+        "name": "Maker",
+        "symbol": "MKR",
+        "decimals": 18,
+        "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0x9f8F72aA9304c8B593d555F12eF6589cC3A579A2/logo.png"
+      },
+      {
+        "address": "0x8F4beBF498cc624a0797Fe64114A6Ff169EEe078",
+        "chainId": 42,
+        "name": "Perpetual",
+        "symbol": "PERP",
+        "decimals": 18,
+        "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0xbC396689893D065F41bc2C6EcbeE5e0085233447/logo.png"
+      },
+      {
+        "address": "0xc2569dd7d0fd715B054fBf16E75B001E5c0C1115",
+        "chainId": 42,
+        "name": "USD Coin",
+        "symbol": "USDC",
+        "decimals": 6,
+        "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/logo.png"
+      },
+      {
+        "address": "0xdFCeA9088c8A88A76FF74892C1457C17dfeef9C1",
+        "chainId": 42,
+        "name": "WETH",
+        "symbol": "WETH",
+        "decimals": 18,
+        "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2/logo.png"
+      },
+      {
+        "address": "0x1C8E3Bcb3378a443CC591f154c5CE0EBb4dA9648",
+        "chainId": 42,
+        "name": "Wrapped Bitcoin",
+        "symbol": "WBTC",
+        "decimals": 8,
+        "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599/logo.png"
+      }
+    ]
+  },
+  "https://raw.githubusercontent.com/balancer-labs/assets/refactor-for-multichain/generated/kovan.vetted.tokenlist.json": {
+    "name": "Balancer",
+    "timestamp": "2022-05-13T00:00:00.000Z",
+    "logoURI": "https://raw.githubusercontent.com/balancer-labs/pebbles/master/images/pebbles-pad.256w.png",
+    "keywords": ["balancer", "vetted"],
+    "version": { "major": 1, "minor": 0, "patch": 2 },
+    "tokens": [
+      {
+        "address": "0x41286Bb1D3E870f3F750eB7E1C25d7E48c8A1Ac7",
+        "chainId": 42,
+        "name": "Balancer",
+        "symbol": "BAL",
+        "decimals": 18,
+        "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0xba100000625a3754423978a60c9317c58a424e3D/logo.png"
+      },
+      {
+        "address": "0x04DF6e4121c27713ED22341E7c7Df330F56f289B",
+        "chainId": 42,
+        "name": "Dai",
+        "symbol": "DAI",
+        "decimals": 18,
+        "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0x6B175474E89094C44Da98b954EedeAC495271d0F/logo.png"
+      },
+      {
+        "address": "0xAf9ac3235be96eD496db7969f60D354fe5e426B0",
+        "chainId": 42,
+        "name": "Maker",
+        "symbol": "MKR",
+        "decimals": 18,
+        "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0x9f8F72aA9304c8B593d555F12eF6589cC3A579A2/logo.png"
+      },
+      {
+        "address": "0x8F4beBF498cc624a0797Fe64114A6Ff169EEe078",
+        "chainId": 42,
+        "name": "Perpetual",
+        "symbol": "PERP",
+        "decimals": 18,
+        "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0xbC396689893D065F41bc2C6EcbeE5e0085233447/logo.png"
+      },
+      {
+        "address": "0xc2569dd7d0fd715B054fBf16E75B001E5c0C1115",
+        "chainId": 42,
+        "name": "USD Coin",
+        "symbol": "USDC",
+        "decimals": 6,
+        "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/logo.png"
+      },
+      {
+        "address": "0xdFCeA9088c8A88A76FF74892C1457C17dfeef9C1",
+        "chainId": 42,
+        "name": "WETH",
+        "symbol": "WETH",
+        "decimals": 18,
+        "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2/logo.png"
+      },
+      {
+        "address": "0x1C8E3Bcb3378a443CC591f154c5CE0EBb4dA9648",
+        "chainId": 42,
+        "name": "Wrapped Bitcoin",
+        "symbol": "WBTC",
+        "decimals": 8,
+        "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599/logo.png"
+      }
+    ]
+  },
+  "ipns://tokens.uniswap.org": {
+    "name": "Uniswap Labs Default",
+    "timestamp": "2022-10-20T17:29:34.056Z",
+    "version": { "major": 5, "minor": 2, "patch": 0 },
+    "tags": {},
+    "logoURI": "ipfs://QmNa8mQkrNKp1WEEeGjFezDmDeodkWRevGFN8JCV7b4Xir",
+    "keywords": ["uniswap", "default"],
+    "tokens": [
+      {
+        "chainId": 1,
+        "address": "0x111111111117dC0aa78b770fA6A738034120C302",
+        "name": "1inch",
+        "symbol": "1INCH",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/13469/thumb/1inch-token.png?1608803028",
+        "extensions": {
+          "bridgeInfo": {
+            "137": {
+              "tokenAddress": "0x9c2C5fd7b07E95EE044DDeba0E97a665F142394f"
+            },
+            "42161": {
+              "tokenAddress": "0x6314C31A7a1652cE482cffe247E9CB7c3f4BB9aF"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "address": "0x7Fc66500c84A76Ad7e9c93437bFc5Ac33E2DDaE9",
+        "name": "Aave",
+        "symbol": "AAVE",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/12645/thumb/AAVE.png?1601374110",
+        "extensions": {
+          "bridgeInfo": {
+            "10": {
+              "tokenAddress": "0x76FB31fb4af56892A25e32cFC43De717950c9278"
+            },
+            "137": {
+              "tokenAddress": "0xD6DF932A45C0f255f85145f286eA0b292B21C90B"
+            },
+            "42161": {
+              "tokenAddress": "0xba5DdD1f9d7F570dc94a51479a000E3BCE967196"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "address": "0xB98d4C97425d9908E66E53A6fDf673ACcA0BE986",
+        "name": "Arcblock",
+        "symbol": "ABT",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/2341/thumb/arcblock.png?1547036543"
+      },
+      {
+        "chainId": 1,
+        "address": "0xEd04915c23f00A313a544955524EB7DBD823143d",
+        "name": "Alchemy Pay",
+        "symbol": "ACH",
+        "decimals": 8,
+        "logoURI": "https://assets.coingecko.com/coins/images/12390/thumb/ACH_%281%29.png?1599691266"
+      },
+      {
+        "chainId": 1,
+        "address": "0xADE00C28244d5CE17D72E40330B1c318cD12B7c3",
+        "name": "Ambire AdEx",
+        "symbol": "ADX",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/847/thumb/Ambire_AdEx_Symbol_color.png?1655432540",
+        "extensions": {
+          "bridgeInfo": {
+            "137": {
+              "tokenAddress": "0xdDa7b23D2D72746663E7939743f929a3d85FC975"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "address": "0x91Af0fBB28ABA7E31403Cb457106Ce79397FD4E6",
+        "name": "Aergo",
+        "symbol": "AERGO",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/4490/thumb/aergo.png?1647696770"
+      },
+      {
+        "chainId": 1,
+        "address": "0x32353A6C91143bfd6C7d363B546e62a9A2489A20",
+        "name": "Adventure Gold",
+        "symbol": "AGLD",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/18125/thumb/lpgblc4h_400x400.jpg?1630570955",
+        "extensions": {
+          "bridgeInfo": {
+            "137": {
+              "tokenAddress": "0x6a6bD53d677F8632631662C48bD47b1D4D6524ee"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "address": "0x626E8036dEB333b408Be468F951bdB42433cBF18",
+        "name": "AIOZ Network",
+        "symbol": "AIOZ",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/14631/thumb/aioz_logo.png?1617413126",
+        "extensions": {
+          "bridgeInfo": {
+            "137": {
+              "tokenAddress": "0xe2341718c6C0CbFa8e6686102DD8FbF4047a9e9B"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "address": "0xdBdb4d16EdA451D0503b854CF79D55697F90c8DF",
+        "name": "Alchemix",
+        "symbol": "ALCX",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/14113/thumb/Alchemix.png?1614409874",
+        "extensions": {
+          "bridgeInfo": {
+            "137": {
+              "tokenAddress": "0x95c300e7740D2A88a44124B424bFC1cB2F9c3b89"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "address": "0x27702a26126e0B3702af63Ee09aC4d1A084EF628",
+        "name": "Aleph im",
+        "symbol": "ALEPH",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/11676/thumb/Monochram-aleph.png?1608483725",
+        "extensions": {
+          "bridgeInfo": {
+            "137": {
+              "tokenAddress": "0x82dCf1Df86AdA26b2dCd9ba6334CeDb8c2448e9e"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "address": "0x6B0b3a982b4634aC68dD83a4DBF02311cE324181",
+        "name": "Alethea Artificial Liquid Intelligence",
+        "symbol": "ALI",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/22062/thumb/alethea-logo-transparent-colored.png?1642748848"
+      },
+      {
+        "chainId": 1,
+        "address": "0xAC51066d7bEC65Dc4589368da368b212745d63E8",
+        "name": "My Neighbor Alice",
+        "symbol": "ALICE",
+        "decimals": 6,
+        "logoURI": "https://assets.coingecko.com/coins/images/14375/thumb/alice_logo.jpg?1615782968",
+        "extensions": {
+          "bridgeInfo": {
+            "137": {
+              "tokenAddress": "0x50858d870FAF55da2fD90FB6DF7c34b5648305C6"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "address": "0xa1faa113cbE53436Df28FF0aEe54275c13B40975",
+        "name": "Alpha Venture DAO",
+        "symbol": "ALPHA",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/12738/thumb/AlphaToken_256x256.png?1617160876",
+        "extensions": {
+          "bridgeInfo": {
+            "137": {
+              "tokenAddress": "0x3AE490db48d74B1bC626400135d4616377D0109f"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "address": "0xfF20817765cB7f73d4bde2e66e067E58D11095C2",
+        "name": "Amp",
+        "symbol": "AMP",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/12409/thumb/amp-200x200.png?1599625397",
+        "extensions": {
+          "bridgeInfo": {
+            "137": {
+              "tokenAddress": "0x0621d647cecbFb64b79E44302c1933cB4f27054d"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "address": "0x8290333ceF9e6D528dD5618Fb97a76f268f3EDD4",
+        "name": "Ankr",
+        "symbol": "ANKR",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/4324/thumb/U85xTl2.png?1608111978",
+        "extensions": {
+          "bridgeInfo": {
+            "137": {
+              "tokenAddress": "0x101A023270368c0D50BFfb62780F4aFd4ea79C35"
+            }
+          }
+        }
+      },
+      {
+        "name": "Aragon",
+        "address": "0xa117000000f279D81A1D3cc75430fAA017FA5A2e",
+        "symbol": "ANT",
+        "decimals": 18,
+        "chainId": 1,
+        "logoURI": "https://assets.coingecko.com/coins/images/681/thumb/JelZ58cv_400x400.png?1601449653",
+        "extensions": {
+          "bridgeInfo": {
+            "137": {
+              "tokenAddress": "0x2b8504ab5eFc246d0eC5Ec7E74565683227497de"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "address": "0x4d224452801ACEd8B2F0aebE155379bb5D594381",
+        "name": "ApeCoin",
+        "symbol": "APE",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/24383/small/apecoin.jpg?1647476455",
+        "extensions": {
+          "bridgeInfo": {
+            "137": {
+              "tokenAddress": "0xB7b31a6BC18e48888545CE79e83E06003bE70930"
+            },
+            "42161": {
+              "tokenAddress": "0x74885b4D524d497261259B38900f54e6dbAd2210"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "address": "0x0b38210ea11411557c13457D4dA7dC6ea731B88a",
+        "name": "API3",
+        "symbol": "API3",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/13256/thumb/api3.jpg?1606751424",
+        "extensions": {
+          "bridgeInfo": {
+            "137": {
+              "tokenAddress": "0x45C27821E80F8789b60Fd8B600C73815d34DDa6C"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "address": "0xBA50933C268F567BDC86E1aC131BE072C6B0b71a",
+        "name": "ARPA Chain",
+        "symbol": "ARPA",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/8506/thumb/9u0a23XY_400x400.jpg?1559027357",
+        "extensions": {
+          "bridgeInfo": {
+            "137": {
+              "tokenAddress": "0xEE800B277A96B0f490a1A732e1D6395FAD960A26"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "address": "0x64D91f12Ece7362F91A6f8E7940Cd55F05060b92",
+        "name": "ASH",
+        "symbol": "ASH",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/15714/thumb/omnPqaTY.png?1622820503"
+      },
+      {
+        "chainId": 1,
+        "address": "0x2565ae0385659badCada1031DB704442E1b69982",
+        "name": "Assemble Protocol",
+        "symbol": "ASM",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/11605/thumb/gpvrlkSq_400x400_%281%29.jpg?1591775789"
+      },
+      {
+        "chainId": 1,
+        "address": "0x27054b13b1B798B345b591a4d22e6562d47eA75a",
+        "name": "AirSwap",
+        "symbol": "AST",
+        "decimals": 4,
+        "logoURI": "https://assets.coingecko.com/coins/images/1019/thumb/Airswap.png?1630903484",
+        "extensions": {
+          "bridgeInfo": {
+            "137": {
+              "tokenAddress": "0x04bEa9FCE76943E90520489cCAb84E84C0198E29"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "address": "0xA2120b9e674d3fC3875f415A7DF52e382F141225",
+        "name": "Automata",
+        "symbol": "ATA",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/15985/thumb/ATA.jpg?1622535745",
+        "extensions": {
+          "bridgeInfo": {
+            "137": {
+              "tokenAddress": "0x0df0f72EE0e5c9B7ca761ECec42754992B2Da5BF"
+            },
+            "42161": {
+              "tokenAddress": "0xAC9Ac2C17cdFED4AbC80A53c5553388575714d03"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "address": "0xA9B1Eb5908CfC3cdf91F9B8B3a74108598009096",
+        "name": "Bounce",
+        "symbol": "AUCTION",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/13860/thumb/1_KtgpRIJzuwfHe0Rl0avP_g.jpeg?1612412025"
+      },
+      {
+        "chainId": 1,
+        "address": "0x18aAA7115705e8be94bfFEBDE57Af9BFc265B998",
+        "name": "Audius",
+        "symbol": "AUDIO",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/12913/thumb/AudiusCoinLogo_2x.png?1603425727",
+        "extensions": {
+          "bridgeInfo": {
+            "137": {
+              "tokenAddress": "0x5eB8D998371971D01954205c7AFE90A7AF6a95AC"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "address": "0x845576c64f9754CF09d87e45B720E82F3EeF522C",
+        "name": "Artverse Token",
+        "symbol": "AVT",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/19727/thumb/ewnektoB_400x400.png?1635767094"
+      },
+      {
+        "chainId": 1,
+        "address": "0xBB0E17EF65F82Ab018d8EDd776e8DD940327B28b",
+        "name": "Axie Infinity",
+        "symbol": "AXS",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/13029/thumb/axie_infinity_logo.png?1604471082",
+        "extensions": {
+          "bridgeInfo": {
+            "137": {
+              "tokenAddress": "0x61BDD9C7d4dF4Bf47A4508c0c8245505F2Af5b7b"
+            },
+            "42161": {
+              "tokenAddress": "0xe88998Fb579266628aF6a03e3821d5983e5D0089"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "address": "0x3472A5A71965499acd81997a54BBA8D852C6E53d",
+        "name": "Badger DAO",
+        "symbol": "BADGER",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/13287/thumb/badger_dao_logo.jpg?1607054976",
+        "extensions": {
+          "bridgeInfo": {
+            "137": {
+              "tokenAddress": "0x1FcbE5937B0cc2adf69772D228fA4205aCF4D9b2"
+            },
+            "42161": {
+              "tokenAddress": "0xBfa641051Ba0a0Ad1b0AcF549a89536A0D76472E"
+            }
+          }
+        }
+      },
+      {
+        "name": "Balancer",
+        "address": "0xba100000625a3754423978a60c9317c58a424e3D",
+        "symbol": "BAL",
+        "decimals": 18,
+        "chainId": 1,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xba100000625a3754423978a60c9317c58a424e3D/logo.png",
+        "extensions": {
+          "bridgeInfo": {
+            "137": {
+              "tokenAddress": "0x9a71012B13CA4d3D0Cdc72A177DF3ef03b0E76A3"
+            },
+            "42161": {
+              "tokenAddress": "0x040d1EdC9569d4Bab2D15287Dc5A4F10F56a56B8"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "address": "0xBA11D00c5f74255f56a5E366F4F77f5A186d7f55",
+        "name": "Band Protocol",
+        "symbol": "BAND",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/9545/thumb/band-protocol.png?1568730326",
+        "extensions": {
+          "bridgeInfo": {
+            "137": {
+              "tokenAddress": "0xA8b1E0764f85f53dfe21760e8AfE5446D82606ac"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "address": "0x0D8775F648430679A709E98d2b0Cb6250d2887EF",
+        "name": "Basic Attention Token",
+        "symbol": "BAT",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/677/thumb/basic-attention-token.png?1547034427",
+        "extensions": {
+          "bridgeInfo": {
+            "137": {
+              "tokenAddress": "0x3Cef98bb43d732E2F285eE605a8158cDE967D219"
+            },
+            "42161": {
+              "tokenAddress": "0x3450687EF141dCd6110b77c2DC44B008616AeE75"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "address": "0xF17e65822b568B3903685a7c9F496CF7656Cc6C2",
+        "name": "Biconomy",
+        "symbol": "BICO",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/21061/thumb/biconomy_logo.jpg?1638269749",
+        "extensions": {
+          "bridgeInfo": {
+            "137": {
+              "tokenAddress": "0x91c89A94567980f0e9723b487b0beD586eE96aa7"
+            },
+            "42161": {
+              "tokenAddress": "0xa68Ec98D7ca870cF1Dd0b00EBbb7c4bF60A8e74d"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "address": "0x1A4b46696b2bB4794Eb3D4c26f1c55F9170fa4C5",
+        "name": "BitDAO",
+        "symbol": "BIT",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/17627/thumb/rI_YptK8.png?1653983088",
+        "extensions": {
+          "bridgeInfo": {
+            "42161": {
+              "tokenAddress": "0x406C8dB506653D882295875F633bEC0bEb921C2A"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "address": "0x5732046A883704404F284Ce41FfADd5b007FD668",
+        "name": "Bluzelle",
+        "symbol": "BLZ",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/2848/thumb/ColorIcon_3x.png?1622516510",
+        "extensions": {
+          "bridgeInfo": {
+            "137": {
+              "tokenAddress": "0x438B28C5AA5F00a817b7Def7cE2Fb3d5d1970974"
+            }
+          }
+        }
+      },
+      {
+        "name": "Bancor Network Token",
+        "address": "0x1F573D6Fb3F13d689FF844B4cE37794d79a7FF1C",
+        "symbol": "BNT",
+        "decimals": 18,
+        "chainId": 1,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x1F573D6Fb3F13d689FF844B4cE37794d79a7FF1C/logo.png",
+        "extensions": {
+          "bridgeInfo": {
+            "137": {
+              "tokenAddress": "0xc26D47d5c33aC71AC5CF9F776D63Ba292a4F7842"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "address": "0x42bBFa2e77757C645eeaAd1655E0911a7553Efbc",
+        "name": "Boba Network",
+        "symbol": "BOBA",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/20285/thumb/BOBA.png?1636811576",
+        "extensions": {
+          "bridgeInfo": {
+            "137": {
+              "tokenAddress": "0xa4B2B20b2C73c7046ED19AC6bfF5E5285c58F20a"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "address": "0x0391D2021f89DC339F60Fff84546EA23E337750f",
+        "name": "BarnBridge",
+        "symbol": "BOND",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/12811/thumb/barnbridge.jpg?1602728853",
+        "extensions": {
+          "bridgeInfo": {
+            "10": {
+              "tokenAddress": "0x3e7eF8f50246f725885102E8238CBba33F276747"
+            },
+            "137": {
+              "tokenAddress": "0xA041544fe2BE56CCe31Ebb69102B965E06aacE80"
+            },
+            "42161": {
+              "tokenAddress": "0x0D81E50bC677fa67341c44D7eaA9228DEE64A4e1"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "address": "0x799ebfABE77a6E34311eeEe9825190B9ECe32824",
+        "name": "Braintrust",
+        "symbol": "BTRST",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/18100/thumb/braintrust.PNG?1630475394"
+      },
+      {
+        "chainId": 1,
+        "address": "0x4Fabb145d64652a948d72533023f6E7A623C7C53",
+        "name": "Binance USD",
+        "symbol": "BUSD",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/9576/thumb/BUSD.png?1568947766",
+        "extensions": {
+          "bridgeInfo": {
+            "137": {
+              "tokenAddress": "0xdAb529f40E671A1D4bF91361c21bf9f0C9712ab7"
+            },
+            "42161": {
+              "tokenAddress": "0x31190254504622cEFdFA55a7d3d272e6462629a2"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "address": "0xAE12C5930881c53715B369ceC7606B70d8EB229f",
+        "name": "Coin98",
+        "symbol": "C98",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/17117/thumb/logo.png?1626412904"
+      },
+      {
+        "chainId": 1,
+        "address": "0x4F9254C83EB525f9FCf346490bbb3ed28a81C667",
+        "name": "Celer Network",
+        "symbol": "CELR",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/4379/thumb/Celr.png?1554705437",
+        "extensions": {
+          "bridgeInfo": {
+            "137": {
+              "tokenAddress": "0x91a4635F620766145C099E15889Bd2766906A559"
+            },
+            "42161": {
+              "tokenAddress": "0x3a8B787f78D775AECFEEa15706D4221B40F345AB"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "address": "0x8A2279d4A90B6fe1C4B30fa660cC9f926797bAA2",
+        "name": "Chromia",
+        "symbol": "CHR",
+        "decimals": 6,
+        "logoURI": "https://assets.coingecko.com/coins/images/5000/thumb/Chromia.png?1559038018",
+        "extensions": {
+          "bridgeInfo": {
+            "137": {
+              "tokenAddress": "0x594C984E3318e91313f881B021A0C4203fF5E59F"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "address": "0x3506424F91fD33084466F402d5D97f05F8e3b4AF",
+        "name": "Chiliz",
+        "symbol": "CHZ",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/8834/thumb/Chiliz.png?1561970540",
+        "extensions": {
+          "bridgeInfo": {
+            "137": {
+              "tokenAddress": "0xf1938Ce12400f9a761084E7A80d37e732a4dA056"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "address": "0x80C62FE4487E1351b47Ba49809EBD60ED085bf52",
+        "name": "Clover Finance",
+        "symbol": "CLV",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/15278/thumb/clover.png?1645084454"
+      },
+      {
+        "name": "Compound",
+        "address": "0xc00e94Cb662C3520282E6f5717214004A7f26888",
+        "symbol": "COMP",
+        "decimals": 18,
+        "chainId": 1,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xc00e94Cb662C3520282E6f5717214004A7f26888/logo.png",
+        "extensions": {
+          "bridgeInfo": {
+            "137": {
+              "tokenAddress": "0x8505b9d2254A7Ae468c0E9dd10Ccea3A837aef5c"
+            },
+            "42161": {
+              "tokenAddress": "0x354A6dA3fcde098F8389cad84b0182725c6C91dE"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "address": "0xDDB3422497E61e13543BeA06989C0789117555c5",
+        "name": "COTI",
+        "symbol": "COTI",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/2962/thumb/Coti.png?1559653863",
+        "extensions": {
+          "bridgeInfo": {
+            "42161": {
+              "tokenAddress": "0x6FE14d3CC2f7bDdffBa5CdB3BBE7467dd81ea101"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "address": "0x3D658390460295FB963f54dC0899cfb1c30776Df",
+        "name": "Circuits of Value",
+        "symbol": "COVAL",
+        "decimals": 8,
+        "logoURI": "https://assets.coingecko.com/coins/images/588/thumb/coval-logo.png?1599493950"
+      },
+      {
+        "chainId": 1,
+        "address": "0xD417144312DbF50465b1C641d016962017Ef6240",
+        "name": "Covalent",
+        "symbol": "CQT",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/14168/thumb/covalent-cqt.png?1624545218",
+        "extensions": {
+          "bridgeInfo": {
+            "137": {
+              "tokenAddress": "0x93B0fF1C8828F6eB039D345Ff681eD735086d925"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "address": "0xA0b73E1Ff0B80914AB6fe0444E65848C4C34450b",
+        "name": "Cronos",
+        "symbol": "CRO",
+        "decimals": 8,
+        "logoURI": "https://assets.coingecko.com/coins/images/7310/thumb/oCw2s3GI_400x400.jpeg?1645172042",
+        "extensions": {
+          "bridgeInfo": {
+            "137": {
+              "tokenAddress": "0xAdA58DF0F643D959C2A47c9D4d4c1a4deFe3F11C"
+            },
+            "42161": {
+              "tokenAddress": "0x8ea3156f834A0dfC78F1A5304fAC2CdA676F354C"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "address": "0x08389495D7456E1951ddF7c3a1314A4bfb646d8B",
+        "name": "Crypterium",
+        "symbol": "CRPT",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/1901/thumb/crypt.png?1547036205"
+      },
+      {
+        "name": "Curve DAO Token",
+        "address": "0xD533a949740bb3306d119CC777fa900bA034cd52",
+        "symbol": "CRV",
+        "decimals": 18,
+        "chainId": 1,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xD533a949740bb3306d119CC777fa900bA034cd52/logo.png",
+        "extensions": {
+          "bridgeInfo": {
+            "10": {
+              "tokenAddress": "0x0994206dfE8De6Ec6920FF4D779B0d950605Fb53"
+            },
+            "137": {
+              "tokenAddress": "0x172370d5Cd63279eFa6d502DAB29171933a610AF"
+            },
+            "42161": {
+              "tokenAddress": "0x11cDb42B0EB46D95f990BeDD4695A6e3fA034978"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "address": "0x491604c0FDF08347Dd1fa4Ee062a822A5DD06B5D",
+        "name": "Cartesi",
+        "symbol": "CTSI",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/11038/thumb/cartesi.png?1592288021",
+        "extensions": {
+          "bridgeInfo": {
+            "137": {
+              "tokenAddress": "0x2727Ab1c2D22170ABc9b595177B2D5C6E1Ab7B7B"
+            },
+            "42161": {
+              "tokenAddress": "0x319f865b287fCC10b30d8cE6144e8b6D1b476999"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "address": "0x321C2fE4446C7c963dc41Dd58879AF648838f98D",
+        "name": "Cryptex Finance",
+        "symbol": "CTX",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/14932/thumb/glossy_icon_-_C200px.png?1619073171",
+        "extensions": {
+          "bridgeInfo": {
+            "137": {
+              "tokenAddress": "0x8c208BC2A808a088a78398fed8f2640cab0b6EDb"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "address": "0xDf801468a808a32656D2eD2D2d80B72A129739f4",
+        "name": "Somnium Space CUBEs",
+        "symbol": "CUBE",
+        "decimals": 8,
+        "logoURI": "https://assets.coingecko.com/coins/images/10687/thumb/CUBE_icon.png?1617026861",
+        "extensions": {
+          "bridgeInfo": {
+            "137": {
+              "tokenAddress": "0x276C9cbaa4BDf57d7109a41e67BD09699536FA3d"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "address": "0x41e5560054824eA6B0732E656E3Ad64E20e94E45",
+        "name": "Civic",
+        "symbol": "CVC",
+        "decimals": 8,
+        "logoURI": "https://assets.coingecko.com/coins/images/788/thumb/civic.png?1547034556",
+        "extensions": {
+          "bridgeInfo": {
+            "137": {
+              "tokenAddress": "0x66Dc5A08091d1968e08C16aA5b27BAC8398b02Be"
+            },
+            "42161": {
+              "tokenAddress": "0x9DfFB23CAd3322440bCcFF7aB1C58E781dDBF144"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "address": "0x4e3FBD56CD56c3e72c1403e103b45Db9da5B9D2B",
+        "name": "Convex Finance",
+        "symbol": "CVX",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/15585/thumb/convex.png?1621256328",
+        "extensions": {
+          "bridgeInfo": {
+            "137": {
+              "tokenAddress": "0x4257EA7637c355F81616050CbB6a9b709fd72683"
+            }
+          }
+        }
+      },
+      {
+        "name": "Dai Stablecoin",
+        "address": "0x6B175474E89094C44Da98b954EedeAC495271d0F",
+        "symbol": "DAI",
+        "decimals": 18,
+        "chainId": 1,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x6B175474E89094C44Da98b954EedeAC495271d0F/logo.png",
+        "extensions": {
+          "bridgeInfo": {
+            "10": {
+              "tokenAddress": "0xDA10009cBd5D07dd0CeCc66161FC93D7c9000da1"
+            },
+            "137": {
+              "tokenAddress": "0x8f3Cf7ad23Cd3CaDbD9735AFf958023239c6A063"
+            },
+            "42161": {
+              "tokenAddress": "0xDA10009cBd5D07dd0CeCc66161FC93D7c9000da1"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "address": "0x081131434f93063751813C619Ecca9C4dC7862a3",
+        "name": "Mines of Dalarnia",
+        "symbol": "DAR",
+        "decimals": 6,
+        "logoURI": "https://assets.coingecko.com/coins/images/19837/thumb/dar.png?1636014223"
+      },
+      {
+        "chainId": 1,
+        "address": "0x3A880652F47bFaa771908C07Dd8673A787dAEd3A",
+        "name": "DerivaDAO",
+        "symbol": "DDX",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/13453/thumb/ddx_logo.png?1608741641",
+        "extensions": {
+          "bridgeInfo": {
+            "137": {
+              "tokenAddress": "0x26f5FB1e6C8a65b3A873fF0a213FA16EFF5a7828"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "address": "0x3597bfD533a99c9aa083587B074434E61Eb0A258",
+        "name": "Dent",
+        "symbol": "DENT",
+        "decimals": 8,
+        "logoURI": "https://assets.coingecko.com/coins/images/1152/thumb/gLCEA2G.png?1604543239"
+      },
+      {
+        "chainId": 1,
+        "address": "0xfB7B4564402E5500dB5bB6d63Ae671302777C75a",
+        "name": "DexTools",
+        "symbol": "DEXT",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/11603/thumb/dext.png?1605790188",
+        "extensions": {
+          "bridgeInfo": {
+            "137": {
+              "tokenAddress": "0xff835562C761205659939B64583dd381a6AA4D92"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "address": "0x84cA8bc7997272c7CfB4D0Cd3D55cd942B3c9419",
+        "name": "DIA",
+        "symbol": "DIA",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/11955/thumb/image.png?1646041751",
+        "extensions": {
+          "bridgeInfo": {
+            "137": {
+              "tokenAddress": "0x993f2CafE9dbE525243f4A78BeBC69DAc8D36000"
+            },
+            "42161": {
+              "tokenAddress": "0xca642467C6Ebe58c13cB4A7091317f34E17ac05e"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "address": "0x0AbdAce70D3790235af448C88547603b945604ea",
+        "name": "district0x",
+        "symbol": "DNT",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/849/thumb/district0x.png?1547223762"
+      },
+      {
+        "chainId": 1,
+        "address": "0x1494CA1F11D487c2bBe4543E90080AeBa4BA3C2b",
+        "name": "DeFi Pulse Index",
+        "symbol": "DPI",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/12465/thumb/defi_pulse_index_set.png?1600051053",
+        "extensions": {
+          "bridgeInfo": {
+            "137": {
+              "tokenAddress": "0x85955046DF4668e1DD369D2DE9f3AEB98DD2A369"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "address": "0x3Ab6Ed69Ef663bd986Ee59205CCaD8A20F98b4c2",
+        "name": "Drep",
+        "symbol": "DREP",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/14578/thumb/KotgsCgS_400x400.jpg?1617094445"
+      },
+      {
+        "chainId": 1,
+        "address": "0x92D6C1e31e14520e676a687F0a93788B716BEff5",
+        "name": "dYdX",
+        "symbol": "DYDX",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/17500/thumb/hjnIm9bV.jpg?1628009360",
+        "extensions": {
+          "bridgeInfo": {
+            "137": {
+              "tokenAddress": "0x4C3bF0a3DE9524aF68327d1D2558a3B70d17D42a"
+            },
+            "42161": {
+              "tokenAddress": "0x51863cB90Ce5d6dA9663106F292fA27c8CC90c5a"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "address": "0x961C8c0B1aaD0c0b10a51FeF6a867E3091BCef17",
+        "name": "DeFi Yield Protocol",
+        "symbol": "DYP",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/13480/thumb/DYP_Logo_Symbol-8.png?1655809066"
+      },
+      {
+        "chainId": 1,
+        "address": "0xe6fd75ff38Adca4B97FBCD938c86b98772431867",
+        "name": "Elastos",
+        "symbol": "ELA",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/2780/thumb/Elastos.png?1597048112"
+      },
+      {
+        "chainId": 1,
+        "address": "0x761D38e5ddf6ccf6Cf7c55759d5210750B5D60F3",
+        "name": "Dogelon Mars",
+        "symbol": "ELON",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/14962/thumb/6GxcPRo3_400x400.jpg?1619157413",
+        "extensions": {
+          "bridgeInfo": {
+            "137": {
+              "tokenAddress": "0xE0339c80fFDE91F3e20494Df88d4206D86024cdF"
+            },
+            "42161": {
+              "tokenAddress": "0x3e4Cff6E50F37F731284A92d44AE943e17077fD4"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "address": "0xF629cBd94d3791C9250152BD8dfBDF380E2a3B9c",
+        "name": "Enjin Coin",
+        "symbol": "ENJ",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/1102/thumb/enjin-coin-logo.png?1547035078",
+        "extensions": {
+          "bridgeInfo": {
+            "137": {
+              "tokenAddress": "0x7eC26842F195c852Fa843bB9f6D8B583a274a157"
+            },
+            "42161": {
+              "tokenAddress": "0x7fa9549791EFc9030e1Ed3F25D18014163806758"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "address": "0xC18360217D8F7Ab5e7c516566761Ea12Ce7F9D72",
+        "name": "Ethereum Name Service",
+        "symbol": "ENS",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/19785/thumb/acatxTm8_400x400.jpg?1635850140",
+        "extensions": {
+          "bridgeInfo": {
+            "10": {
+              "tokenAddress": "0x65559aA14915a70190438eF90104769e5E890A00"
+            },
+            "137": {
+              "tokenAddress": "0xbD7A5Cf51d22930B8B3Df6d834F9BCEf90EE7c4f"
+            },
+            "42161": {
+              "tokenAddress": "0xfeA31d704DEb0975dA8e77Bf13E04239e70d7c28"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "address": "0xBBc2AE13b23d715c30720F079fcd9B4a74093505",
+        "name": "Ethernity Chain",
+        "symbol": "ERN",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/14238/thumb/LOGO_HIGH_QUALITY.png?1647831402",
+        "extensions": {
+          "bridgeInfo": {
+            "137": {
+              "tokenAddress": "0x0E50BEA95Fe001A370A4F1C220C49AEdCB982DeC"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "address": "0xd9Fcd98c322942075A5C3860693e9f4f03AAE07b",
+        "name": "Euler",
+        "symbol": "EUL",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/26149/thumb/YCvKDfl8_400x400.jpeg?1656041509"
+      },
+      {
+        "chainId": 1,
+        "address": "0x1aBaEA1f7C830bD89Acc67eC4af516284b1bC33c",
+        "name": "Euro Coin",
+        "symbol": "EUROC",
+        "decimals": 6,
+        "logoURI": "https://assets.coingecko.com/coins/images/26045/thumb/euro-coin.png?1655394420",
+        "extensions": {
+          "bridgeInfo": {
+            "137": {
+              "tokenAddress": "0x8a037dbcA8134FFc72C362e394e35E0Cad618F85"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "address": "0xa0246c9032bC3A600820415aE600c6388619A14D",
+        "name": "Harvest Finance",
+        "symbol": "FARM",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/12304/thumb/Harvest.png?1613016180",
+        "extensions": {
+          "bridgeInfo": {
+            "137": {
+              "tokenAddress": "0x176f5AB638cf4Ff3B6239Ba609C3fadAA46ef5B0"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "address": "0xaea46A60368A7bD060eec7DF8CBa43b7EF41Ad85",
+        "name": "Fetch ai",
+        "symbol": "FET",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/5681/thumb/Fetch.jpg?1572098136",
+        "extensions": {
+          "bridgeInfo": {
+            "137": {
+              "tokenAddress": "0x7583FEDDbceFA813dc18259940F76a02710A8905"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "address": "0xef3A930e1FfFFAcd2fc13434aC81bD278B0ecC8d",
+        "name": "Stafi",
+        "symbol": "FIS",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/12423/thumb/stafi_logo.jpg?1599730991",
+        "extensions": {
+          "bridgeInfo": {
+            "137": {
+              "tokenAddress": "0x7A7B94F18EF6AD056CDa648588181CDA84800f94"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "address": "0x41545f8b9472D758bB669ed8EaEEEcD7a9C4Ec29",
+        "name": "Forta",
+        "symbol": "FORT",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/25060/thumb/Forta_lgo_%281%29.png?1655353696",
+        "extensions": {
+          "bridgeInfo": {
+            "137": {
+              "tokenAddress": "0x9ff62d1FC52A907B6DCbA8077c2DDCA6E6a9d3e1"
+            },
+            "42161": {
+              "tokenAddress": "0x3A1429d50E0cBBc45c997aF600541Fe1cc3D2923"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "address": "0x77FbA179C79De5B7653F68b5039Af940AdA60ce0",
+        "name": "Ampleforth Governance Token",
+        "symbol": "FORTH",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/14917/thumb/photo_2021-04-22_00.00.03.jpeg?1619020835",
+        "extensions": {
+          "bridgeInfo": {
+            "137": {
+              "tokenAddress": "0x5eCbA59DAcc1ADc5bDEA35f38A732823fc3dE977"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "address": "0xc770EEfAd204B5180dF6a14Ee197D99d808ee52d",
+        "name": "ShapeShift FOX Token",
+        "symbol": "FOX",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/9988/thumb/FOX.png?1574330622",
+        "extensions": {
+          "bridgeInfo": {
+            "137": {
+              "tokenAddress": "0x65A05DB8322701724c197AF82C9CaE41195B0aA8"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "address": "0x853d955aCEf822Db058eb8505911ED77F175b99e",
+        "name": "Frax",
+        "symbol": "FRAX",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/13422/thumb/frax_logo.png?1608476506",
+        "extensions": {
+          "bridgeInfo": {
+            "137": {
+              "tokenAddress": "0x104592a158490a9228070E0A8e5343B499e125D0"
+            },
+            "42161": {
+              "tokenAddress": "0x7468a5d8E02245B00E8C0217fCE021C70Bc51305"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "address": "0x4E15361FD6b4BB609Fa63C81A2be19d873717870",
+        "name": "Fantom",
+        "symbol": "FTM",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/4001/thumb/Fantom.png?1558015016",
+        "extensions": {
+          "bridgeInfo": {
+            "137": {
+              "tokenAddress": "0xC9c1c1c20B3658F8787CC2FD702267791f224Ce1"
+            },
+            "42161": {
+              "tokenAddress": "0xd42785D323e608B9E99fa542bd8b1000D4c2Df37"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "address": "0x8c15Ef5b4B21951d50E53E4fbdA8298FFAD25057",
+        "name": "Function X",
+        "symbol": "FX",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/8186/thumb/47271330_590071468072434_707260356350705664_n.jpg?1556096683"
+      },
+      {
+        "chainId": 1,
+        "address": "0x3432B6A60D23Ca0dFCa7761B7ab56459D9C964D0",
+        "name": "Frax Share",
+        "symbol": "FXS",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/13423/thumb/frax_share.png?1608478989",
+        "extensions": {
+          "bridgeInfo": {
+            "137": {
+              "tokenAddress": "0x3e121107F6F22DA4911079845a470757aF4e1A1b"
+            },
+            "42161": {
+              "tokenAddress": "0xd9f9d2Ee2d3EFE420699079f16D9e924affFdEA4"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "address": "0x5fAa989Af96Af85384b8a938c2EdE4A7378D9875",
+        "name": "Project Galaxy",
+        "symbol": "GAL",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/24530/thumb/GAL-Token-Icon.png?1651483533"
+      },
+      {
+        "chainId": 1,
+        "address": "0x15D4c048F83bd7e37d49eA4C83a07267Ec4203dA",
+        "name": "Gala",
+        "symbol": "GALA",
+        "decimals": 8,
+        "logoURI": "https://assets.coingecko.com/coins/images/12493/thumb/GALA-COINGECKO.png?1600233435",
+        "extensions": {
+          "bridgeInfo": {
+            "137": {
+              "tokenAddress": "0x09E1943Dd2A4e82032773594f50CF54453000b97"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "address": "0xdab396cCF3d84Cf2D07C4454e10C8A6F5b008D2b",
+        "name": "Goldfinch",
+        "symbol": "GFI",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/19081/thumb/GOLDFINCH.png?1634369662"
+      },
+      {
+        "chainId": 1,
+        "address": "0x3F382DbD960E3a9bbCeaE22651E88158d2791550",
+        "name": "Aavegotchi",
+        "symbol": "GHST",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/12467/thumb/ghst_200.png?1600750321",
+        "extensions": {
+          "bridgeInfo": {
+            "137": {
+              "tokenAddress": "0x385Eeac5cB85A38A9a07A70c73e0a3271CfB54A7"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "address": "0x7DD9c5Cba05E151C895FDe1CF355C9A1D5DA6429",
+        "name": "Golem",
+        "symbol": "GLM",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/542/thumb/Golem_Submark_Positive_RGB.png?1606392013",
+        "extensions": {
+          "bridgeInfo": {
+            "137": {
+              "tokenAddress": "0x0B220b82F3eA3B7F6d9A1D8ab58930C064A2b5Bf"
+            }
+          }
+        }
+      },
+      {
+        "name": "Gnosis Token",
+        "address": "0x6810e776880C02933D47DB1b9fc05908e5386b96",
+        "symbol": "GNO",
+        "decimals": 18,
+        "chainId": 1,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x6810e776880C02933D47DB1b9fc05908e5386b96/logo.png",
+        "extensions": {
+          "bridgeInfo": {
+            "137": {
+              "tokenAddress": "0x5FFD62D3C3eE2E81C00A7b9079FB248e7dF024A8"
+            },
+            "42161": {
+              "tokenAddress": "0xa0b862F60edEf4452F25B4160F177db44DeB6Cf1"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "address": "0xccC8cb5229B0ac8069C51fd58367Fd1e622aFD97",
+        "name": "Gods Unchained",
+        "symbol": "GODS",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/17139/thumb/10631.png?1635718182",
+        "extensions": {
+          "bridgeInfo": {
+            "137": {
+              "tokenAddress": "0xF88fc6b493eda7650E4bcf7A290E8d108F677CfE"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "address": "0xc944E90C64B2c07662A292be6244BDf05Cda44a7",
+        "name": "The Graph",
+        "symbol": "GRT",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/13397/thumb/Graph_Token.png?1608145566",
+        "extensions": {
+          "bridgeInfo": {
+            "137": {
+              "tokenAddress": "0x5fe2B58c013d7601147DcdD68C143A77499f5531"
+            },
+            "42161": {
+              "tokenAddress": "0x23A941036Ae778Ac51Ab04CEa08Ed6e2FE103614"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "address": "0xDe30da39c46104798bB5aA3fe8B9e0e1F348163F",
+        "name": "Gitcoin",
+        "symbol": "GTC",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/15810/thumb/gitcoin.png?1621992929",
+        "extensions": {
+          "bridgeInfo": {
+            "137": {
+              "tokenAddress": "0xdb95f9188479575F3F718a245EcA1B3BF74567EC"
+            },
+            "42161": {
+              "tokenAddress": "0x7f9a7DB853Ca816B9A138AEe3380Ef34c437dEe0"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "address": "0x056Fd409E1d7A124BD7017459dFEa2F387b6d5Cd",
+        "name": "Gemini Dollar",
+        "symbol": "GUSD",
+        "decimals": 2,
+        "logoURI": "https://assets.coingecko.com/coins/images/5992/thumb/gemini-dollar-gusd.png?1536745278",
+        "extensions": {
+          "bridgeInfo": {
+            "137": {
+              "tokenAddress": "0xC8A94a3d3D2dabC3C1CaffFFDcA6A7543c3e3e65"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "address": "0xC08512927D12348F6620a698105e1BAac6EcD911",
+        "name": "GYEN",
+        "symbol": "GYEN",
+        "decimals": 6,
+        "logoURI": "https://assets.coingecko.com/coins/images/14191/thumb/icon_gyen_200_200.png?1614843343",
+        "extensions": {
+          "bridgeInfo": {
+            "137": {
+              "tokenAddress": "0x482bc619eE7662759CDc0685B4E78f464Da39C73"
+            },
+            "42161": {
+              "tokenAddress": "0x3fEcB65993e4835884baF6452d1ebfdBC3A78480"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "address": "0x71Ab77b7dbB4fa7e017BC15090b2163221420282",
+        "name": "Highstreet",
+        "symbol": "HIGH",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/18973/thumb/logosq200200Coingecko.png?1634090470"
+      },
+      {
+        "chainId": 1,
+        "name": "HOPR",
+        "symbol": "HOPR",
+        "logoURI": "https://assets.coingecko.com/coins/images/14061/thumb/Shared_HOPR_logo_512px.png?1614073468",
+        "address": "0xF5581dFeFD8Fb0e4aeC526bE659CFaB1f8c781dA",
+        "decimals": 18,
+        "extensions": {
+          "bridgeInfo": {
+            "137": {
+              "tokenAddress": "0x6cCBF3627b2C83AFEF05bf2F035E7f7B210Fe30D"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "address": "0xB705268213D593B8FD88d3FDEFF93AFF5CbDcfAE",
+        "name": "IDEX",
+        "symbol": "IDEX",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/2565/thumb/logomark-purple-286x286.png?1638362736",
+        "extensions": {
+          "bridgeInfo": {
+            "137": {
+              "tokenAddress": "0x9Cb74C8032b007466865f060ad2c46145d45553D"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "address": "0xF57e7e7C23978C3cAEC3C3548E3D615c346e79fF",
+        "name": "Immutable X",
+        "symbol": "IMX",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/17233/thumb/imx.png?1636691817",
+        "extensions": {
+          "bridgeInfo": {
+            "137": {
+              "tokenAddress": "0x183070C90B34A63292cC908Ce1b263Cb56D49A7F"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "name": "Index Cooperative",
+        "symbol": "INDEX",
+        "logoURI": "https://assets.coingecko.com/coins/images/12729/thumb/index.png?1634894321",
+        "address": "0x0954906da0Bf32d5479e25f46056d22f08464cab",
+        "decimals": 18,
+        "extensions": {
+          "bridgeInfo": {
+            "137": {
+              "tokenAddress": "0xfBd8A3b908e764dBcD51e27992464B4432A1132b"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "address": "0xe28b3B32B6c345A34Ff64674606124Dd5Aceca30",
+        "name": "Injective",
+        "symbol": "INJ",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/12882/thumb/Secondary_Symbol.png?1628233237",
+        "extensions": {
+          "bridgeInfo": {
+            "137": {
+              "tokenAddress": "0x4E8dc2149EaC3f3dEf36b1c281EA466338249371"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "address": "0x41D5D79431A913C4aE7d69a668ecdfE5fF9DFB68",
+        "name": "Inverse Finance",
+        "symbol": "INV",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/14205/thumb/inverse_finance.jpg?1614921871",
+        "extensions": {
+          "bridgeInfo": {
+            "137": {
+              "tokenAddress": "0xF18Ac368001b0DdC80aA6a8374deb49e868EFDb8"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "address": "0x6fB3e0A217407EFFf7Ca062D46c26E5d60a14d69",
+        "name": "IoTeX",
+        "symbol": "IOTX",
+        "decimals": 18,
+        "logoURI": "https://s2.coinmarketcap.com/static/img/coins/64x64/2777.png",
+        "extensions": {
+          "bridgeInfo": {
+            "137": {
+              "tokenAddress": "0xf6372cDb9c1d3674E83842e3800F2A62aC9F3C66"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "name": "Geojam",
+        "symbol": "JAM",
+        "logoURI": "https://assets.coingecko.com/coins/images/24648/thumb/ey40AzBN_400x400.jpg?1648507272",
+        "address": "0x23894DC9da6c94ECb439911cAF7d337746575A72",
+        "decimals": 18
+      },
+      {
+        "chainId": 1,
+        "address": "0x7420B4b9a0110cdC71fB720908340C03F9Bc03EC",
+        "name": "JasmyCoin",
+        "symbol": "JASMY",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/13876/thumb/JASMY200x200.jpg?1612473259",
+        "extensions": {
+          "bridgeInfo": {
+            "137": {
+              "tokenAddress": "0xb87f5c1E81077FfcfE821dA240fd20C99c533aF1"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "name": "Jupiter",
+        "symbol": "JUP",
+        "logoURI": "https://assets.coingecko.com/coins/images/10351/thumb/logo512.png?1632480932",
+        "address": "0x4B1E80cAC91e2216EEb63e29B957eB91Ae9C2Be8",
+        "decimals": 18
+      },
+      {
+        "chainId": 1,
+        "address": "0x85Eee30c52B0b379b046Fb0F85F4f3Dc3009aFEC",
+        "name": "Keep Network",
+        "symbol": "KEEP",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/3373/thumb/IuNzUb5b_400x400.jpg?1589526336",
+        "extensions": {
+          "bridgeInfo": {
+            "137": {
+              "tokenAddress": "0x42f37A1296b2981F7C3cAcEd84c5096b2Eb0C72C"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "name": "SelfKey",
+        "symbol": "KEY",
+        "logoURI": "https://assets.coingecko.com/coins/images/2034/thumb/selfkey.png?1548608934",
+        "address": "0x4CC19356f2D37338b9802aa8E8fc58B0373296E7",
+        "decimals": 18
+      },
+      {
+        "name": "Kyber Network Crystal",
+        "address": "0xdd974D5C2e2928deA5F71b9825b8b646686BD200",
+        "symbol": "KNC",
+        "decimals": 18,
+        "chainId": 1,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xdd974D5C2e2928deA5F71b9825b8b646686BD200/logo.png",
+        "extensions": {
+          "bridgeInfo": {
+            "137": {
+              "tokenAddress": "0x324b28d6565f784d596422B0F2E5aB6e9CFA1Dc7"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "address": "0x1cEB5cB57C4D4E2b2433641b95Dd330A33185A44",
+        "name": "Keep3rV1",
+        "symbol": "KP3R",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/12966/thumb/kp3r_logo.jpg?1607057458",
+        "extensions": {
+          "bridgeInfo": {
+            "137": {
+              "tokenAddress": "0x53AEc293212E3B792563Bc16f1be26956adb12e9"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "address": "0x464eBE77c293E473B48cFe96dDCf88fcF7bFDAC0",
+        "name": "KRYLL",
+        "symbol": "KRL",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/2807/thumb/krl.png?1547036979"
+      },
+      {
+        "chainId": 1,
+        "address": "0x037A54AaB062628C9Bbae1FDB1583c195585fe41",
+        "name": "LCX",
+        "symbol": "LCX",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/9985/thumb/zRPSu_0o_400x400.jpg?1574327008",
+        "extensions": {
+          "bridgeInfo": {
+            "137": {
+              "tokenAddress": "0xE8A51D0dD1b4525189ddA2187F90ddF0932b5482"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "address": "0x5A98FcBEA516Cf06857215779Fd812CA3beF1B32",
+        "name": "Lido DAO",
+        "symbol": "LDO",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/13573/thumb/Lido_DAO.png?1609873644",
+        "extensions": {
+          "bridgeInfo": {
+            "137": {
+              "tokenAddress": "0xC3C7d422809852031b44ab29EEC9F1EfF2A58756"
+            },
+            "42161": {
+              "tokenAddress": "0x13Ad51ed4F1B7e9Dc168d8a00cB3f4dDD85EfA60"
+            }
+          }
+        }
+      },
+      {
+        "name": "ChainLink Token",
+        "address": "0x514910771AF9Ca656af840dff83E8264EcF986CA",
+        "symbol": "LINK",
+        "decimals": 18,
+        "chainId": 1,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x514910771AF9Ca656af840dff83E8264EcF986CA/logo.png",
+        "extensions": {
+          "bridgeInfo": {
+            "10": {
+              "tokenAddress": "0x350a791Bfc2C21F9Ed5d10980Dad2e2638ffa7f6"
+            },
+            "137": {
+              "tokenAddress": "0x53E0bca35eC356BD5ddDFebbD1Fc0fD03FaBad39"
+            },
+            "42161": {
+              "tokenAddress": "0xf97f4df75117a78c1A5a0DBb814Af92458539FB4"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "name": "League of Kingdoms",
+        "symbol": "LOKA",
+        "logoURI": "https://assets.coingecko.com/coins/images/22572/thumb/loka_64pix.png?1642643271",
+        "address": "0x61E90A50137E1F645c9eF4a0d3A4f01477738406",
+        "decimals": 18
+      },
+      {
+        "name": "Loom Network",
+        "address": "0xA4e8C3Ec456107eA67d3075bF9e3DF3A75823DB0",
+        "symbol": "LOOM",
+        "decimals": 18,
+        "chainId": 1,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xA4e8C3Ec456107eA67d3075bF9e3DF3A75823DB0/logo.png",
+        "extensions": {
+          "bridgeInfo": {
+            "137": {
+              "tokenAddress": "0x66EfB7cC647e0efab02eBA4316a2d2941193F6b3"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "address": "0x58b6A8A3302369DAEc383334672404Ee733aB239",
+        "name": "Livepeer",
+        "symbol": "LPT",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/7137/thumb/logo-circle-green.png?1619593365",
+        "extensions": {
+          "bridgeInfo": {
+            "137": {
+              "tokenAddress": "0x3962F4A0A0051DccE0be73A7e09cEf5756736712"
+            },
+            "42161": {
+              "tokenAddress": "0x289ba1701C2F088cf0faf8B3705246331cB8A839"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "address": "0x6DEA81C8171D0bA574754EF6F8b412F2Ed88c54D",
+        "name": "Liquity",
+        "symbol": "LQTY",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/14665/thumb/200-lqty-icon.png?1617631180",
+        "extensions": {
+          "bridgeInfo": {
+            "137": {
+              "tokenAddress": "0x8Ab2Fec94d17ae69FB90E7c773f2C85Ed1802c01"
+            }
+          }
+        }
+      },
+      {
+        "name": "LoopringCoin V2",
+        "address": "0xBBbbCA6A901c926F240b89EacB641d8Aec7AEafD",
+        "symbol": "LRC",
+        "decimals": 18,
+        "chainId": 1,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xBBbbCA6A901c926F240b89EacB641d8Aec7AEafD/logo.png",
+        "extensions": {
+          "bridgeInfo": {
+            "10": {
+              "tokenAddress": "0xFEaA9194F9F8c1B65429E31341a103071464907E"
+            },
+            "137": {
+              "tokenAddress": "0x84e1670F61347CDaeD56dcc736FB990fBB47ddC1"
+            },
+            "42161": {
+              "tokenAddress": "0x46d0cE7de6247b0A95f67b43B589b4041BaE7fbE"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "name": "Liquity USD",
+        "symbol": "LUSD",
+        "logoURI": "https://assets.coingecko.com/coins/images/14666/thumb/Group_3.png?1617631327",
+        "address": "0x5f98805A4E8be255a32880FDeC7F6728C6568bA0",
+        "decimals": 18,
+        "extensions": {
+          "bridgeInfo": {
+            "10": {
+              "tokenAddress": "0xc40F949F8a4e094D1b49a23ea9241D289B7b2819"
+            },
+            "137": {
+              "tokenAddress": "0x23001f892c0C82b79303EDC9B9033cD190BB21c7"
+            },
+            "42161": {
+              "tokenAddress": "0x93b346b6BC2548dA6A1E7d98E9a421B42541425b"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "address": "0x0F5D2fB29fb7d3CFeE444a200298f468908cC942",
+        "name": "Decentraland",
+        "symbol": "MANA",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/878/thumb/decentraland-mana.png?1550108745",
+        "extensions": {
+          "bridgeInfo": {
+            "137": {
+              "tokenAddress": "0xA1c57f48F0Deb89f569dFbE6E2B7f46D33606fD4"
+            },
+            "42161": {
+              "tokenAddress": "0x442d24578A564EF628A65e6a7E3e7be2a165E231"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "address": "0x69af81e73A73B40adF4f3d4223Cd9b1ECE623074",
+        "name": "Mask Network",
+        "symbol": "MASK",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/14051/thumb/Mask_Network.jpg?1614050316",
+        "extensions": {
+          "bridgeInfo": {
+            "10": {
+              "tokenAddress": "0x3390108E913824B8eaD638444cc52B9aBdF63798"
+            },
+            "137": {
+              "tokenAddress": "0x2B9E7ccDF0F4e5B24757c1E1a80e311E34Cb10c7"
+            },
+            "42161": {
+              "tokenAddress": "0x533A7B414CD1236815a5e09F1E97FC7d5c313739"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "name": "MATH",
+        "symbol": "MATH",
+        "logoURI": "https://assets.coingecko.com/coins/images/11335/thumb/2020-05-19-token-200.png?1589940590",
+        "address": "0x08d967bb0134F2d07f7cfb6E246680c53927DD30",
+        "decimals": 18,
+        "extensions": {
+          "bridgeInfo": {
+            "137": {
+              "tokenAddress": "0x347ACCAFdA7F8c5BdeC57fa34a5b663CBd1aeca7"
+            },
+            "42161": {
+              "tokenAddress": "0x99F40b01BA9C469193B360f72740E416B17Ac332"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "address": "0x7D1AfA7B718fb893dB30A3aBc0Cfc608AaCfeBB0",
+        "name": "Polygon",
+        "symbol": "MATIC",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/4713/thumb/matic-token-icon.png?1624446912",
+        "extensions": {
+          "bridgeInfo": {
+            "137": {
+              "tokenAddress": "0x0000000000000000000000000000000000001010"
+            },
+            "42161": {
+              "tokenAddress": "0x561877b6b3DD7651313794e5F2894B2F18bE0766"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "address": "0x949D48EcA67b17269629c7194F4b727d4Ef9E5d6",
+        "name": "Merit Circle",
+        "symbol": "MC",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/19304/thumb/Db4XqML.png?1634972154"
+      },
+      {
+        "chainId": 1,
+        "address": "0xfC98e825A2264D890F9a1e68ed50E1526abCcacD",
+        "name": "Moss Carbon Credit",
+        "symbol": "MCO2",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/14414/thumb/ENtxnThA_400x400.jpg?1615948522",
+        "extensions": {
+          "bridgeInfo": {
+            "137": {
+              "tokenAddress": "0xAa7DbD1598251f856C12f63557A4C4397c253Cea"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "address": "0x814e0908b12A99FeCf5BC101bB5d0b8B5cDf7d26",
+        "name": "Measurable Data Token",
+        "symbol": "MDT",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/2441/thumb/mdt_logo.png?1569813574"
+      },
+      {
+        "chainId": 1,
+        "name": "Metis",
+        "symbol": "METIS",
+        "logoURI": "https://assets.coingecko.com/coins/images/15595/thumb/metis.jpeg?1660285312",
+        "address": "0x9E32b13ce7f2E80A01932B42553652E053D6ed8e",
+        "decimals": 18,
+        "extensions": {
+          "bridgeInfo": {
+            "137": {
+              "tokenAddress": "0x1B9D40715E757Bdb9bdEC3215B898E46d8a3b71a"
+            },
+            "42161": {
+              "tokenAddress": "0x7F728F3595db17B0B359f4FC47aE80FAd2e33769"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "address": "0x99D8a9C45b2ecA8864373A26D1459e3Dff1e17F3",
+        "name": "Magic Internet Money",
+        "symbol": "MIM",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/16786/thumb/mimlogopng.png?1624979612",
+        "extensions": {
+          "bridgeInfo": {
+            "137": {
+              "tokenAddress": "0x01288e04435bFcd4718FF203D6eD18146C17Cd4b"
+            },
+            "42161": {
+              "tokenAddress": "0xB20A02dfFb172C474BC4bDa3fD6f4eE70C04daf2"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "address": "0x09a3EcAFa817268f77BE1283176B946C4ff2E608",
+        "name": "Mirror Protocol",
+        "symbol": "MIR",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/13295/thumb/mirror_logo_transparent.png?1611554658",
+        "extensions": {
+          "bridgeInfo": {
+            "137": {
+              "tokenAddress": "0x1C5cccA2CB59145A4B25F452660cbA6436DDce9b"
+            }
+          }
+        }
+      },
+      {
+        "name": "Maker",
+        "address": "0x9f8F72aA9304c8B593d555F12eF6589cC3A579A2",
+        "symbol": "MKR",
+        "decimals": 18,
+        "chainId": 1,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x9f8F72aA9304c8B593d555F12eF6589cC3A579A2/logo.png",
+        "extensions": {
+          "bridgeInfo": {
+            "10": {
+              "tokenAddress": "0xab7bAdEF82E9Fe11f6f33f87BC9bC2AA27F2fCB5"
+            },
+            "137": {
+              "tokenAddress": "0x6f7C932e7684666C9fd1d44527765433e01fF61d"
+            },
+            "42161": {
+              "tokenAddress": "0x2e9a6Df78E42a30712c10a9Dc4b1C8656f8F2879"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "address": "0xec67005c4E498Ec7f55E092bd1d35cbC47C91892",
+        "name": "Melon",
+        "symbol": "MLN",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/605/thumb/melon.png?1547034295",
+        "extensions": {
+          "bridgeInfo": {
+            "137": {
+              "tokenAddress": "0xa9f37D84c856fDa3812ad0519Dad44FA0a3Fe207"
+            },
+            "42161": {
+              "tokenAddress": "0x8f5c1A99b1df736Ad685006Cb6ADCA7B7Ae4b514"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "name": "Monavale",
+        "symbol": "MONA",
+        "logoURI": "https://assets.coingecko.com/coins/images/13298/thumb/monavale_logo.jpg?1607232721",
+        "address": "0x275f5Ad03be0Fa221B4C6649B8AeE09a42D9412A",
+        "decimals": 18,
+        "extensions": {
+          "bridgeInfo": {
+            "137": {
+              "tokenAddress": "0x6968105460f67c3BF751bE7C15f92F5286Fd0CE5"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "address": "0x33349B282065b0284d756F0577FB39c158F935e6",
+        "name": "Maple",
+        "symbol": "MPL",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/14097/thumb/photo_2021-05-03_14.20.41.jpeg?1620022863"
+      },
+      {
+        "chainId": 1,
+        "name": "Metal",
+        "symbol": "MTL",
+        "logoURI": "https://assets.coingecko.com/coins/images/763/thumb/Metal.png?1592195010",
+        "address": "0xF433089366899D83a9f26A773D59ec7eCF30355e",
+        "decimals": 8
+      },
+      {
+        "chainId": 1,
+        "address": "0x65Ef703f5594D2573eb71Aaf55BC0CB548492df4",
+        "name": "Multichain",
+        "symbol": "MULTI",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/22087/thumb/1_Wyot-SDGZuxbjdkaOeT2-A.png?1640764238"
+      },
+      {
+        "chainId": 1,
+        "address": "0xe2f2a5C287993345a840Db3B0845fbC70f5935a5",
+        "name": "mStable USD",
+        "symbol": "MUSD",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/11576/thumb/mStable_USD.png?1595591803"
+      },
+      {
+        "chainId": 1,
+        "name": "Muse DAO",
+        "symbol": "MUSE",
+        "logoURI": "https://assets.coingecko.com/coins/images/13230/thumb/muse_logo.png?1606460453",
+        "address": "0xB6Ca7399B4F9CA56FC27cBfF44F4d2e4Eef1fc81",
+        "decimals": 18
+      },
+      {
+        "chainId": 1,
+        "name": "GensoKishi Metaverse",
+        "symbol": "MV",
+        "logoURI": "https://s2.coinmarketcap.com/static/img/coins/64x64/17704.png",
+        "address": "0xAE788F80F2756A86aa2F410C651F2aF83639B95b",
+        "decimals": 18,
+        "extensions": {
+          "bridgeInfo": {
+            "137": {
+              "tokenAddress": "0xA3c322Ad15218fBFAEd26bA7f616249f7705D945"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "name": "MXC",
+        "symbol": "MXC",
+        "logoURI": "https://assets.coingecko.com/coins/images/4604/thumb/mxc.png?1655534336",
+        "address": "0x5Ca381bBfb58f0092df149bD3D243b08B9a8386e",
+        "decimals": 18
+      },
+      {
+        "chainId": 1,
+        "address": "0x9E46A38F5DaaBe8683E10793b06749EEF7D733d1",
+        "name": "PolySwarm",
+        "symbol": "NCT",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/2843/thumb/ImcYCVfX_400x400.jpg?1628519767",
+        "extensions": {
+          "bridgeInfo": {
+            "137": {
+              "tokenAddress": "0x4985E0B13554fB521840e893574D3848C10Fcc6f"
+            },
+            "42161": {
+              "tokenAddress": "0x53236015A675fcB937485F1AE58040e4Fb920d5b"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "name": "Nest Protocol",
+        "symbol": "NEST",
+        "logoURI": "https://assets.coingecko.com/coins/images/11284/thumb/52954052.png?1589868539",
+        "address": "0x04abEdA201850aC0124161F037Efd70c74ddC74C",
+        "decimals": 18
+      },
+      {
+        "chainId": 1,
+        "address": "0x5Cf04716BA20127F1E2297AdDCf4B5035000c9eb",
+        "name": "NKN",
+        "symbol": "NKN",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/3375/thumb/nkn.png?1548329212"
+      },
+      {
+        "name": "Numeraire",
+        "address": "0x1776e1F26f98b1A5dF9cD347953a26dd3Cb46671",
+        "symbol": "NMR",
+        "decimals": 18,
+        "chainId": 1,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x1776e1F26f98b1A5dF9cD347953a26dd3Cb46671/logo.png",
+        "extensions": {
+          "bridgeInfo": {
+            "137": {
+              "tokenAddress": "0x0Bf519071b02F22C17E7Ed5F4002ee1911f46729"
+            },
+            "42161": {
+              "tokenAddress": "0x597701b32553b9fa473e21362D480b3a6B569711"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "address": "0x4fE83213D56308330EC302a8BD641f1d0113A4Cc",
+        "name": "NuCypher",
+        "symbol": "NU",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/3318/thumb/photo1198982838879365035.jpg?1547037916"
+      },
+      {
+        "chainId": 1,
+        "address": "0x967da4048cD07aB37855c090aAF366e4ce1b9F48",
+        "name": "Ocean Protocol",
+        "symbol": "OCEAN",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/3687/thumb/ocean-protocol-logo.jpg?1547038686",
+        "extensions": {
+          "bridgeInfo": {
+            "137": {
+              "tokenAddress": "0x282d8efCe846A88B159800bd4130ad77443Fa1A1"
+            },
+            "42161": {
+              "tokenAddress": "0x933d31561e470478079FEB9A6Dd2691fAD8234DF"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "address": "0x8207c1FfC5B6804F6024322CcF34F29c3541Ae26",
+        "name": "Origin Protocol",
+        "symbol": "OGN",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/3296/thumb/op.jpg?1547037878",
+        "extensions": {
+          "bridgeInfo": {
+            "137": {
+              "tokenAddress": "0xa63Beffd33AB3a2EfD92a39A7D2361CEE14cEbA8"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "address": "0xd26114cd6EE289AccF82350c8d8487fedB8A0C07",
+        "name": "OMG Network",
+        "symbol": "OMG",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/776/thumb/OMG_Network.jpg?1591167168",
+        "extensions": {
+          "bridgeInfo": {
+            "137": {
+              "tokenAddress": "0x62414D03084EeB269E18C970a21f45D2967F0170"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "address": "0x6F59e0461Ae5E2799F1fB3847f05a63B16d0DbF8",
+        "name": "ORCA Alliance",
+        "symbol": "ORCA",
+        "decimals": 18,
+        "logoURI": "https://s2.coinmarketcap.com/static/img/coins/64x64/5183.png"
+      },
+      {
+        "chainId": 1,
+        "address": "0x0258F474786DdFd37ABCE6df6BBb1Dd5dfC4434a",
+        "name": "Orion Protocol",
+        "symbol": "ORN",
+        "decimals": 8,
+        "logoURI": "https://assets.coingecko.com/coins/images/11841/thumb/orion_logo.png?1594943318",
+        "extensions": {
+          "bridgeInfo": {
+            "137": {
+              "tokenAddress": "0x0EE392bA5ef1354c9bd75a98044667d307C0e773"
+            }
+          }
+        }
+      },
+      {
+        "name": "Orchid",
+        "address": "0x4575f41308EC1483f3d399aa9a2826d74Da13Deb",
+        "symbol": "OXT",
+        "decimals": 18,
+        "chainId": 1,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x4575f41308EC1483f3d399aa9a2826d74Da13Deb/logo.png",
+        "extensions": {
+          "bridgeInfo": {
+            "137": {
+              "tokenAddress": "0x9880e3dDA13c8e7D4804691A45160102d31F6060"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "address": "0xc1D204d77861dEf49b6E769347a883B15EC397Ff",
+        "name": "PayperEx",
+        "symbol": "PAX",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/1601/thumb/pax.png?1547035800"
+      },
+      {
+        "chainId": 1,
+        "address": "0x45804880De22913dAFE09f4980848ECE6EcbAf78",
+        "name": "PAX Gold",
+        "symbol": "PAXG",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/9519/thumb/paxg.PNG?1568542565",
+        "extensions": {
+          "bridgeInfo": {
+            "137": {
+              "tokenAddress": "0x553d3D295e0f695B9228246232eDF400ed3560B5"
+            },
+            "42161": {
+              "tokenAddress": "0xfEb4DfC8C4Cf7Ed305bb08065D08eC6ee6728429"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "address": "0xbC396689893D065F41bc2C6EcbeE5e0085233447",
+        "name": "Perpetual Protocol",
+        "symbol": "PERP",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/12381/thumb/60d18e06844a844ad75901a9_mark_only_03.png?1628674771",
+        "extensions": {
+          "bridgeInfo": {
+            "10": {
+              "tokenAddress": "0x9e1028F5F1D5eDE59748FFceE5532509976840E0"
+            },
+            "137": {
+              "tokenAddress": "0x263534a4Fe3cb249dF46810718B7B612a30ebbff"
+            },
+            "42161": {
+              "tokenAddress": "0x753D224bCf9AAFaCD81558c32341416df61D3DAC"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "address": "0x3a4f40631a4f906c2BaD353Ed06De7A5D3fCb430",
+        "name": "PlayDapp",
+        "symbol": "PLA",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/14316/thumb/54023228.png?1615366911",
+        "extensions": {
+          "bridgeInfo": {
+            "137": {
+              "tokenAddress": "0x8765f05ADce126d70bcdF1b0a48Db573316662eB"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "address": "0xD8912C10681D8B21Fd3742244f44658dBA12264E",
+        "name": "Pluton",
+        "symbol": "PLU",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/1241/thumb/pluton.png?1548331624",
+        "extensions": {
+          "bridgeInfo": {
+            "137": {
+              "tokenAddress": "0x7dc0cb65EC6019330a6841e9c274f2EE57A6CA6C"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "address": "0x83e6f1E41cdd28eAcEB20Cb649155049Fac3D5Aa",
+        "name": "Polkastarter",
+        "symbol": "POLS",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/12648/thumb/polkastarter.png?1609813702",
+        "extensions": {
+          "bridgeInfo": {
+            "137": {
+              "tokenAddress": "0x8dc302e2141DA59c934d900886DbF1518Fd92cd4"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "address": "0x9992eC3cF6A55b00978cdDF2b27BC6882d88D1eC",
+        "name": "Polymath",
+        "symbol": "POLY",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/2784/thumb/inKkF01.png?1605007034",
+        "extensions": {
+          "bridgeInfo": {
+            "137": {
+              "tokenAddress": "0xcB059C5573646047D6d88dDdb87B745C18161d3b"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "name": "Marlin",
+        "symbol": "POND",
+        "logoURI": "https://assets.coingecko.com/coins/images/8903/thumb/POND_200x200.png?1622515451",
+        "address": "0x57B946008913B82E4dF85f501cbAeD910e58D26C",
+        "decimals": 18,
+        "extensions": {
+          "bridgeInfo": {
+            "137": {
+              "tokenAddress": "0x73580A2416A57f1C4b6391DBA688A9e4f7DBECE0"
+            },
+            "42161": {
+              "tokenAddress": "0xdA0a57B710768ae17941a9Fa33f8B720c8bD9ddD"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "address": "0x595832F8FC6BF59c85C527fEC3740A1b7a361269",
+        "name": "Power Ledger",
+        "symbol": "POWR",
+        "decimals": 6,
+        "logoURI": "https://assets.coingecko.com/coins/images/1104/thumb/power-ledger.png?1547035082",
+        "extensions": {
+          "bridgeInfo": {
+            "137": {
+              "tokenAddress": "0x0AaB8DC887D34f00D50E19aee48371a941390d14"
+            },
+            "42161": {
+              "tokenAddress": "0x4e91F2AF1ee0F84B529478f19794F5AFD423e4A6"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "address": "0x226bb599a12C826476e3A771454697EA52E9E220",
+        "name": "Propy",
+        "symbol": "PRO",
+        "decimals": 8,
+        "logoURI": "https://assets.coingecko.com/coins/images/869/thumb/propy.png?1548332100",
+        "extensions": {
+          "bridgeInfo": {
+            "137": {
+              "tokenAddress": "0x82FFdFD1d8699E8886a4e77CeFA9dd9710a7FefD"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "name": "PARSIQ",
+        "symbol": "PRQ",
+        "logoURI": "https://assets.coingecko.com/coins/images/11973/thumb/DsNgK0O.png?1596590280",
+        "address": "0x362bc847A3a9637d3af6624EeC853618a43ed7D2",
+        "decimals": 18,
+        "extensions": {
+          "bridgeInfo": {
+            "137": {
+              "tokenAddress": "0x9377Eeb7419486FD4D485671d50baa4BF77c2222"
+            },
+            "42161": {
+              "tokenAddress": "0x82164a8B646401a8776F9dC5c8Cba35DcAf60Cd2"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "name": "pSTAKE Finance",
+        "symbol": "PSTAKE",
+        "logoURI": "https://assets.coingecko.com/coins/images/23931/thumb/PSTAKE_Dark.png?1645709930",
+        "address": "0xfB5c6815cA3AC72Ce9F5006869AE67f18bF77006",
+        "decimals": 18
+      },
+      {
+        "chainId": 1,
+        "address": "0x4a220E6096B25EADb88358cb44068A3248254675",
+        "name": "Quant",
+        "symbol": "QNT",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/3370/thumb/5ZOu7brX_400x400.jpg?1612437252",
+        "extensions": {
+          "bridgeInfo": {
+            "137": {
+              "tokenAddress": "0x36B77a184bE8ee56f5E81C56727B20647A42e28E"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "name": "Qredo",
+        "symbol": "QRDO",
+        "logoURI": "https://assets.coingecko.com/coins/images/17541/thumb/qrdo.png?1630637735",
+        "address": "0x4123a133ae3c521FD134D7b13A2dEC35b56c2463",
+        "decimals": 8
+      },
+      {
+        "chainId": 1,
+        "address": "0x99ea4dB9EE77ACD40B119BD1dC4E33e1C070b80d",
+        "name": "Quantstamp",
+        "symbol": "QSP",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/1219/thumb/0_E0kZjb4dG4hUnoDD_.png?1604815917"
+      },
+      {
+        "chainId": 1,
+        "address": "0x6c28AeF8977c9B773996d0e8376d2EE379446F2f",
+        "name": "Quickswap",
+        "symbol": "QUICK",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/13970/thumb/1_pOU6pBMEmiL-ZJVb0CYRjQ.png?1613386659",
+        "extensions": {
+          "bridgeInfo": {
+            "137": {
+              "tokenAddress": "0x831753DD7087CaC61aB5644b308642cc1c33Dc13"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "address": "0x31c8EAcBFFdD875c74b94b077895Bd78CF1E64A3",
+        "name": "Radicle",
+        "symbol": "RAD",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/14013/thumb/radicle.png?1614402918",
+        "extensions": {
+          "bridgeInfo": {
+            "137": {
+              "tokenAddress": "0x2f81e176471CC57fDC76f7d332FB4511bF2bebDD"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "address": "0x03ab458634910AaD20eF5f1C8ee96F1D6ac54919",
+        "name": "Rai Reflex Index",
+        "symbol": "RAI",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/14004/thumb/RAI-logo-coin.png?1613592334",
+        "extensions": {
+          "bridgeInfo": {
+            "10": {
+              "tokenAddress": "0x7FB688CCf682d58f86D7e38e03f9D22e7705448B"
+            },
+            "137": {
+              "tokenAddress": "0x00e5646f60AC6Fb446f621d146B6E1886f002905"
+            },
+            "42161": {
+              "tokenAddress": "0xaeF5bbcbFa438519a5ea80B4c7181B4E78d419f2"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "address": "0xba5BDe662c17e2aDFF1075610382B9B691296350",
+        "name": "SuperRare",
+        "symbol": "RARE",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/17753/thumb/RARE.jpg?1629220534"
+      },
+      {
+        "chainId": 1,
+        "address": "0xFca59Cd816aB1eaD66534D82bc21E7515cE441CF",
+        "name": "Rarible",
+        "symbol": "RARI",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/11845/thumb/Rari.png?1594946953",
+        "extensions": {
+          "bridgeInfo": {
+            "137": {
+              "tokenAddress": "0x780053837cE2CeEaD2A90D9151aA21FC89eD49c2"
+            },
+            "42161": {
+              "tokenAddress": "0xCF8600347Dc375C5f2FdD6Dab9BB66e0b6773cd7"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "address": "0xA4EED63db85311E22dF4473f87CcfC3DaDCFA3E3",
+        "name": "Rubic",
+        "symbol": "RBC",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/12629/thumb/200x200.png?1607952509",
+        "extensions": {
+          "bridgeInfo": {
+            "137": {
+              "tokenAddress": "0xc3cFFDAf8F3fdF07da6D5e3A89B8723D5E385ff8"
+            },
+            "42161": {
+              "tokenAddress": "0x2E9AE8f178d5Ea81970C7799A377B3985cbC335F"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "address": "0x6123B0049F904d730dB3C36a31167D9d4121fA6B",
+        "name": "Ribbon Finance",
+        "symbol": "RBN",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/15823/thumb/RBN_64x64.png?1633529723"
+      },
+      {
+        "name": "Republic Token",
+        "address": "0x408e41876cCCDC0F92210600ef50372656052a38",
+        "symbol": "REN",
+        "decimals": 18,
+        "chainId": 1,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x408e41876cCCDC0F92210600ef50372656052a38/logo.png",
+        "extensions": {
+          "bridgeInfo": {
+            "137": {
+              "tokenAddress": "0x19782D3Dc4701cEeeDcD90f0993f0A9126ed89d0"
+            },
+            "42161": {
+              "tokenAddress": "0x9fA891e1dB0a6D1eEAC4B929b5AAE1011C79a204"
+            }
+          }
+        }
+      },
+      {
+        "name": "Reputation Augur v1",
+        "address": "0x1985365e9f78359a9B6AD760e32412f4a445E862",
+        "symbol": "REP",
+        "decimals": 18,
+        "chainId": 1,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x1985365e9f78359a9B6AD760e32412f4a445E862/logo.png"
+      },
+      {
+        "name": "Reputation Augur v2",
+        "address": "0x221657776846890989a759BA2973e427DfF5C9bB",
+        "symbol": "REPv2",
+        "decimals": 18,
+        "chainId": 1,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x221657776846890989a759BA2973e427DfF5C9bB/logo.png",
+        "extensions": {
+          "bridgeInfo": {
+            "137": {
+              "tokenAddress": "0x6563c1244820CfBd6Ca8820FBdf0f2847363F733"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "address": "0x8f8221aFbB33998d8584A2B05749bA73c37a938a",
+        "name": "Request",
+        "symbol": "REQ",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/1031/thumb/Request_icon_green.png?1643250951",
+        "extensions": {
+          "bridgeInfo": {
+            "137": {
+              "tokenAddress": "0xAdf2F2Ed91755eA3f4bcC9107a494879f633ae7C"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "name": "REVV",
+        "symbol": "REVV",
+        "logoURI": "https://assets.coingecko.com/coins/images/12373/thumb/REVV_TOKEN_Refined_2021_%281%29.png?1627652390",
+        "address": "0x557B933a7C2c45672B610F8954A3deB39a51A8Ca",
+        "decimals": 18,
+        "extensions": {
+          "bridgeInfo": {
+            "137": {
+              "tokenAddress": "0x70c006878a5A50Ed185ac4C87d837633923De296"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "address": "0xD291E7a03283640FDc51b121aC401383A46cC623",
+        "name": "Rari Governance Token",
+        "symbol": "RGT",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/12900/thumb/Rari_Logo_Transparent.png?1613978014",
+        "extensions": {
+          "bridgeInfo": {
+            "10": {
+              "tokenAddress": "0xB548f63D4405466B36C0c0aC3318a22fDcec711a"
+            },
+            "137": {
+              "tokenAddress": "0x3b9dB434F08003A89554CDB43b3e0b1f8734BdE7"
+            },
+            "42161": {
+              "tokenAddress": "0xef888bcA6AB6B1d26dbeC977C455388ecd794794"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "address": "0x607F4C5BB672230e8672085532f7e901544a7375",
+        "name": "iExec RLC",
+        "symbol": "RLC",
+        "decimals": 9,
+        "logoURI": "https://assets.coingecko.com/coins/images/646/thumb/pL1VuXm.png?1604543202",
+        "extensions": {
+          "bridgeInfo": {
+            "137": {
+              "tokenAddress": "0xbe662058e00849C3Eef2AC9664f37fEfdF2cdbFE"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "address": "0xf1f955016EcbCd7321c7266BccFB96c68ea5E49b",
+        "name": "Rally",
+        "symbol": "RLY",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/12843/thumb/image.png?1611212077",
+        "extensions": {
+          "bridgeInfo": {
+            "137": {
+              "tokenAddress": "0x76b8D57e5ac6afAc5D415a054453d1DD2c3C0094"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "address": "0x6De037ef9aD2725EB40118Bb1702EBb27e4Aeb24",
+        "name": "Render Token",
+        "symbol": "RNDR",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/11636/thumb/rndr.png?1638840934",
+        "extensions": {
+          "bridgeInfo": {
+            "137": {
+              "tokenAddress": "0x61299774020dA444Af134c82fa83E3810b309991"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "name": "Rook",
+        "symbol": "ROOK",
+        "logoURI": "https://assets.coingecko.com/coins/images/13005/thumb/keeper_dao_logo.jpg?1604316506",
+        "address": "0xfA5047c9c78B8877af97BDcb85Db743fD7313d4a",
+        "decimals": 18,
+        "extensions": {
+          "bridgeInfo": {
+            "137": {
+              "tokenAddress": "0xF92501c8213da1D6C74A76372CCc720Dc8818407"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "address": "0x3845badAde8e6dFF049820680d1F14bD3903a5d0",
+        "name": "The Sandbox",
+        "symbol": "SAND",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/12129/thumb/sandbox_logo.jpg?1597397942",
+        "extensions": {
+          "bridgeInfo": {
+            "137": {
+              "tokenAddress": "0xBbba073C31bF03b8ACf7c28EF0738DeCF3695683"
+            },
+            "42161": {
+              "tokenAddress": "0xd1318eb19DBF2647743c720ed35174efd64e3DAC"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "address": "0x95aD61b0a150d79219dCF64E1E6Cc01f0B64C4cE",
+        "name": "Shiba Inu",
+        "symbol": "SHIB",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/11939/thumb/shiba.png?1622619446",
+        "extensions": {
+          "bridgeInfo": {
+            "137": {
+              "tokenAddress": "0x6f8a06447Ff6FcF75d803135a7de15CE88C1d4ec"
+            },
+            "42161": {
+              "tokenAddress": "0x5033833c9fe8B9d3E09EEd2f73d2aaF7E3872fd1"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "address": "0x7C84e62859D0715eb77d1b1C4154Ecd6aBB21BEC",
+        "name": "Shping",
+        "symbol": "SHPING",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/2588/thumb/r_yabKKi_400x400.jpg?1639470164"
+      },
+      {
+        "chainId": 1,
+        "address": "0x00c83aeCC790e8a4453e5dD3B0B4b3680501a7A7",
+        "name": "SKALE",
+        "symbol": "SKL",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/13245/thumb/SKALE_token_300x300.png?1606789574"
+      },
+      {
+        "chainId": 1,
+        "address": "0xCC8Fa225D80b9c7D42F96e9570156c65D6cAAa25",
+        "name": "Smooth Love Potion",
+        "symbol": "SLP",
+        "decimals": 0,
+        "logoURI": "https://assets.coingecko.com/coins/images/10366/thumb/SLP.png?1578640057",
+        "extensions": {
+          "bridgeInfo": {
+            "137": {
+              "tokenAddress": "0x0C7304fBAf2A320a1c50c46FE03752722F729946"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "address": "0x744d70FDBE2Ba4CF95131626614a1763DF805B9E",
+        "name": "Status",
+        "symbol": "SNT",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/779/thumb/status.png?1548610778"
+      },
+      {
+        "name": "Synthetix Network Token",
+        "address": "0xC011a73ee8576Fb46F5E1c5751cA3B9Fe0af2a6F",
+        "symbol": "SNX",
+        "decimals": 18,
+        "chainId": 1,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xC011a73ee8576Fb46F5E1c5751cA3B9Fe0af2a6F/logo.png",
+        "extensions": {
+          "bridgeInfo": {
+            "10": {
+              "tokenAddress": "0x8700dAec35aF8Ff88c16BdF0418774CB3D7599B4"
+            },
+            "137": {
+              "tokenAddress": "0x50B728D8D964fd00C2d0AAD81718b71311feF68a"
+            },
+            "42161": {
+              "tokenAddress": "0xcBA56Cd8216FCBBF3fA6DF6137F3147cBcA37D60"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "address": "0x23B608675a2B2fB1890d3ABBd85c5775c51691d5",
+        "name": "Unisocks",
+        "symbol": "SOCKS",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/10717/thumb/qFrcoiM.png?1582525244",
+        "extensions": {
+          "bridgeInfo": {
+            "42161": {
+              "tokenAddress": "0xb2BE52744a804Cc732d606817C2572C5A3B264e7"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "address": "0xD31a59c85aE9D8edEFeC411D448f90841571b89c",
+        "name": "SOL Wormhole ",
+        "symbol": "SOL",
+        "decimals": 9,
+        "logoURI": "https://assets.coingecko.com/coins/images/22876/thumb/SOL_wh_small.png?1644224316",
+        "extensions": {
+          "bridgeInfo": {
+            "42161": {
+              "tokenAddress": "0xb74Da9FE2F96B9E0a5f4A3cf0b92dd2bEC617124"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "address": "0x090185f2135308BaD17527004364eBcC2D37e5F6",
+        "name": "Spell Token",
+        "symbol": "SPELL",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/15861/thumb/abracadabra-3.png?1622544862",
+        "extensions": {
+          "bridgeInfo": {
+            "137": {
+              "tokenAddress": "0xcdB3C70CD25FD15307D84C4F9D37d5C043B33Fb2"
+            },
+            "42161": {
+              "tokenAddress": "0x3E6648C5a70A150A88bCE65F4aD4d506Fe15d2AF"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "name": "Stargate Finance",
+        "symbol": "STG",
+        "logoURI": "https://assets.coingecko.com/coins/images/24413/thumb/STG_LOGO.png?1647654518",
+        "address": "0xAf5191B0De278C7286d6C7CC6ab6BB8A73bA2Cd6",
+        "decimals": 18,
+        "extensions": {
+          "bridgeInfo": {
+            "42161": {
+              "tokenAddress": "0xe018C7a3d175Fb0fE15D70Da2c874d3CA16313EC"
+            }
+          }
+        }
+      },
+      {
+        "name": "Storj Token",
+        "address": "0xB64ef51C888972c908CFacf59B47C1AfBC0Ab8aC",
+        "symbol": "STORJ",
+        "decimals": 8,
+        "chainId": 1,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xB64ef51C888972c908CFacf59B47C1AfBC0Ab8aC/logo.png",
+        "extensions": {
+          "bridgeInfo": {
+            "137": {
+              "tokenAddress": "0xd72357dAcA2cF11A5F155b9FF7880E595A3F5792"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "address": "0x006BeA43Baa3f7A6f765F14f10A1a1b08334EF45",
+        "name": "Stox",
+        "symbol": "STX",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/1230/thumb/stox-token.png?1547035256",
+        "extensions": {
+          "bridgeInfo": {
+            "137": {
+              "tokenAddress": "0xB36e3391B22a970d31A9b620Ae1A414C6c256d2a"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "address": "0x0763fdCCF1aE541A5961815C0872A8c5Bc6DE4d7",
+        "name": "SUKU",
+        "symbol": "SUKU",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/11969/thumb/UmfW5S6f_400x400.jpg?1596602238",
+        "extensions": {
+          "bridgeInfo": {
+            "137": {
+              "tokenAddress": "0x60Ea918FC64360269Da4efBDA11d8fC6514617C6"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "address": "0xe53EC727dbDEB9E2d5456c3be40cFF031AB40A55",
+        "name": "SuperFarm",
+        "symbol": "SUPER",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/14040/thumb/6YPdWn6.png?1613975899",
+        "extensions": {
+          "bridgeInfo": {
+            "137": {
+              "tokenAddress": "0xa1428174F516F527fafdD146b883bB4428682737"
+            },
+            "42161": {
+              "tokenAddress": "0x7f9cf5a2630a0d58567122217dF7609c26498956"
+            }
+          }
+        }
+      },
+      {
+        "name": "Synth sUSD",
+        "address": "0x57Ab1ec28D129707052df4dF418D58a2D46d5f51",
+        "symbol": "sUSD",
+        "decimals": 18,
+        "chainId": 1,
+        "logoURI": "https://assets.coingecko.com/coins/images/5013/thumb/sUSD.png?1616150765",
+        "extensions": {
+          "bridgeInfo": {
+            "137": {
+              "tokenAddress": "0xF81b4Bec6Ca8f9fe7bE01CA734F55B2b6e03A7a0"
+            },
+            "42161": {
+              "tokenAddress": "0xA970AF1a584579B618be4d69aD6F73459D112F95"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "address": "0x6B3595068778DD592e39A122f4f5a5cF09C90fE2",
+        "name": "Sushi",
+        "symbol": "SUSHI",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/12271/thumb/512x512_Logo_no_chop.png?1606986688",
+        "extensions": {
+          "bridgeInfo": {
+            "137": {
+              "tokenAddress": "0x0b3F868E0BE5597D5DB7fEB59E1CADBb0fdDa50a"
+            },
+            "42161": {
+              "tokenAddress": "0xd4d42F0b6DEF4CE0383636770eF773390d85c61A"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "name": "SWFTCOIN",
+        "symbol": "SWFTC",
+        "logoURI": "https://assets.coingecko.com/coins/images/2346/thumb/SWFTCoin.jpg?1618392022",
+        "address": "0x0bb217E40F8a5Cb79Adf04E1aAb60E5abd0dfC1e",
+        "decimals": 8
+      },
+      {
+        "chainId": 1,
+        "name": "Swipe",
+        "symbol": "SXP",
+        "logoURI": "https://assets.coingecko.com/coins/images/9368/thumb/swipe.png?1566792311",
+        "address": "0x8CE9137d39326AD0cD6491fb5CC0CbA0e089b6A9",
+        "decimals": 18,
+        "extensions": {
+          "bridgeInfo": {
+            "137": {
+              "tokenAddress": "0x6aBB753C1893194DE4a83c6e8B4EadFc105Fd5f5"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "name": "Sylo",
+        "symbol": "SYLO",
+        "logoURI": "https://assets.coingecko.com/coins/images/6430/thumb/SYLO.svg?1589527756",
+        "address": "0xf293d23BF2CDc05411Ca0edDD588eb1977e8dcd4",
+        "decimals": 18
+      },
+      {
+        "chainId": 1,
+        "address": "0x0f2D719407FdBeFF09D87557AbB7232601FD9F29",
+        "name": "Synapse",
+        "symbol": "SYN",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/18024/thumb/syn.png?1635002049",
+        "extensions": {
+          "bridgeInfo": {
+            "42161": {
+              "tokenAddress": "0x1bCfc0B4eE1471674cd6A9F6B363A034375eAD84"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "name": "Threshold Network",
+        "symbol": "T",
+        "logoURI": "https://assets.coingecko.com/coins/images/22228/thumb/nFPNiSbL_400x400.jpg?1641220340",
+        "address": "0xCdF7028ceAB81fA0C6971208e83fa7872994beE5",
+        "decimals": 18
+      },
+      {
+        "chainId": 1,
+        "address": "0x8dAEBADE922dF735c38C80C7eBD708Af50815fAa",
+        "name": "tBTC",
+        "symbol": "TBTC",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/11224/thumb/tBTC.png?1589620754",
+        "extensions": {
+          "bridgeInfo": {
+            "137": {
+              "tokenAddress": "0x50a4a434247089848991DD8f09b889D4e2870aB6"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "name": "ChronoTech",
+        "symbol": "TIME",
+        "logoURI": "https://assets.coingecko.com/coins/images/604/thumb/time-32x32.png?1627130666",
+        "address": "0x485d17A6f1B8780392d53D64751824253011A260",
+        "decimals": 8
+      },
+      {
+        "chainId": 1,
+        "name": "Alien Worlds",
+        "symbol": "TLM",
+        "logoURI": "https://assets.coingecko.com/coins/images/14676/thumb/kY-C4o7RThfWrDQsLCAG4q4clZhBDDfJQVhWUEKxXAzyQYMj4Jmq1zmFwpRqxhAJFPOa0AsW_PTSshoPuMnXNwq3rU7Imp15QimXTjlXMx0nC088mt1rIwRs75GnLLugWjSllxgzvQ9YrP4tBgclK4_rb17hjnusGj_c0u2fx0AvVokjSNB-v2poTj0xT9BZRCbzRE3-lF1.jpg?1617700061",
+        "address": "0x888888848B652B3E3a0f34c96E00EEC0F3a23F72",
+        "decimals": 4
+      },
+      {
+        "chainId": 1,
+        "address": "0x2e9d63788249371f1DFC918a52f8d799F4a38C94",
+        "name": "Tokemak",
+        "symbol": "TOKE",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/17495/thumb/tokemak-avatar-200px-black.png?1628131614",
+        "extensions": {
+          "bridgeInfo": {
+            "137": {
+              "tokenAddress": "0xe1708AbDE4847B4929b70547E5197F1Ba1db2250"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "name": "TE FOOD",
+        "symbol": "TONE",
+        "logoURI": "https://assets.coingecko.com/coins/images/2325/thumb/tec.png?1547036538",
+        "address": "0x2Ab6Bb8408ca3199B8Fa6C92d5b455F820Af03c4",
+        "decimals": 18
+      },
+      {
+        "chainId": 1,
+        "address": "0xaA7a9CA87d3694B5755f213B5D04094b8d0F0A6F",
+        "name": "OriginTrail",
+        "symbol": "TRAC",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/1877/thumb/TRAC.jpg?1635134367",
+        "extensions": {
+          "bridgeInfo": {
+            "137": {
+              "tokenAddress": "0xA7b98d63a137bF402b4570799ac4caD0BB1c4B1c"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "address": "0x88dF592F8eb5D7Bd38bFeF7dEb0fBc02cf3778a0",
+        "name": "Tellor",
+        "symbol": "TRB",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/9644/thumb/Blk_icon_current.png?1584980686",
+        "extensions": {
+          "bridgeInfo": {
+            "137": {
+              "tokenAddress": "0xE3322702BEdaaEd36CdDAb233360B939775ae5f1"
+            },
+            "42161": {
+              "tokenAddress": "0xd58D345Fd9c82262E087d2D0607624B410D88242"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "address": "0xc7283b66Eb1EB5FB86327f08e1B5816b0720212B",
+        "name": "Tribe",
+        "symbol": "TRIBE",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/14575/thumb/tribe.PNG?1617487954",
+        "extensions": {
+          "bridgeInfo": {
+            "137": {
+              "tokenAddress": "0x8676815789211E799a6DC86d02748ADF9cF86836"
+            },
+            "42161": {
+              "tokenAddress": "0xBfAE6fecD8124ba33cbB2180aAb0Fe4c03914A5A"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "address": "0x4C19596f5aAfF459fA38B0f7eD92F11AE6543784",
+        "name": "TrueFi",
+        "symbol": "TRU",
+        "decimals": 8,
+        "logoURI": "https://assets.coingecko.com/coins/images/13180/thumb/truefi_glyph_color.png?1617610941",
+        "extensions": {
+          "bridgeInfo": {
+            "137": {
+              "tokenAddress": "0x5b77bCA482bd3E7958b1103d123888EfCCDaF803"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "name": "The Virtua Kolect",
+        "symbol": "TVK",
+        "logoURI": "https://assets.coingecko.com/coins/images/13330/thumb/virtua_original.png?1656043619",
+        "address": "0xd084B83C305daFD76AE3E1b4E1F1fe2eCcCb3988",
+        "decimals": 18,
+        "extensions": {
+          "bridgeInfo": {
+            "137": {
+              "tokenAddress": "0x5667dcC0ab74D1b1355C3b2061893399331B57e2"
+            }
+          }
+        }
+      },
+      {
+        "name": "UMA Voting Token v1",
+        "address": "0x04Fa0d235C4abf4BcF4787aF4CF447DE572eF828",
+        "symbol": "UMA",
+        "decimals": 18,
+        "chainId": 1,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x04Fa0d235C4abf4BcF4787aF4CF447DE572eF828/logo.png",
+        "extensions": {
+          "bridgeInfo": {
+            "10": {
+              "tokenAddress": "0xE7798f023fC62146e8Aa1b36Da45fb70855a77Ea"
+            },
+            "137": {
+              "tokenAddress": "0x3066818837c5e6eD6601bd5a91B0762877A6B731"
+            },
+            "42161": {
+              "tokenAddress": "0xd693Ec944A85eeca4247eC1c3b130DCa9B0C3b22"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "address": "0x441761326490cACF7aF299725B6292597EE822c2",
+        "name": "Unifi Protocol DAO",
+        "symbol": "UNFI",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/13152/thumb/logo-2.png?1605748967"
+      },
+      {
+        "name": "Uniswap",
+        "address": "0x1f9840a85d5aF5bf1D1762F925BDADdC4201F984",
+        "symbol": "UNI",
+        "decimals": 18,
+        "chainId": 1,
+        "logoURI": "ipfs://QmXttGpZrECX5qCyXbBQiqgQNytVGeZW5Anewvh2jc4psg",
+        "extensions": {
+          "bridgeInfo": {
+            "10": {
+              "tokenAddress": "0x6fd9d7AD17242c41f7131d257212c54A0e816691"
+            },
+            "137": {
+              "tokenAddress": "0xb33EaAd8d922B1083446DC23f610c2567fB5180f"
+            },
+            "42161": {
+              "tokenAddress": "0xFa7F8980b0f1E64A2062791cc3b0871572f1F7f0"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "address": "0x70D2b7C19352bB76e4409858FF5746e500f2B67c",
+        "name": "Pawtocol",
+        "symbol": "UPI",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/12186/thumb/pawtocol.jpg?1597962008"
+      },
+      {
+        "name": "USDCoin",
+        "address": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+        "symbol": "USDC",
+        "decimals": 6,
+        "chainId": 1,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/logo.png",
+        "extensions": {
+          "bridgeInfo": {
+            "10": {
+              "tokenAddress": "0x7F5c764cBc14f9669B88837ca1490cCa17c31607"
+            },
+            "137": {
+              "tokenAddress": "0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174"
+            },
+            "42161": {
+              "tokenAddress": "0xFF970A61A04b1cA14834A43f5dE4533eBDDB5CC8"
+            }
+          }
+        }
+      },
+      {
+        "name": "Tether USD",
+        "address": "0xdAC17F958D2ee523a2206206994597C13D831ec7",
+        "symbol": "USDT",
+        "decimals": 6,
+        "chainId": 1,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xdAC17F958D2ee523a2206206994597C13D831ec7/logo.png",
+        "extensions": {
+          "bridgeInfo": {
+            "10": {
+              "tokenAddress": "0x94b008aA00579c1307B0EF2c499aD98a8ce58e58"
+            },
+            "137": {
+              "tokenAddress": "0xc2132D05D31c914a87C6611C10748AEb04B58e8F"
+            },
+            "42161": {
+              "tokenAddress": "0xFd086bC7CD5C481DCC9C85ebE478A1C0b69FCbb9"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "address": "0x3C4B6E6e1eA3D4863700D7F76b36B7f3D3f13E3d",
+        "name": "Voyager Token",
+        "symbol": "VGX",
+        "decimals": 8,
+        "logoURI": "https://assets.coingecko.com/coins/images/794/thumb/Voyager-vgx.png?1575693595"
+      },
+      {
+        "chainId": 1,
+        "name": "Wrapped Ampleforth",
+        "symbol": "WAMPL",
+        "logoURI": "https://assets.coingecko.com/coins/images/20825/thumb/photo_2021-11-25_02-05-11.jpg?1637811951",
+        "address": "0xEDB171C18cE90B633DB442f2A6F72874093b49Ef",
+        "decimals": 18
+      },
+      {
+        "name": "Wrapped BTC",
+        "address": "0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599",
+        "symbol": "WBTC",
+        "decimals": 8,
+        "chainId": 1,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599/logo.png",
+        "extensions": {
+          "bridgeInfo": {
+            "10": {
+              "tokenAddress": "0x68f180fcCe6836688e9084f035309E29Bf0A2095"
+            },
+            "137": {
+              "tokenAddress": "0x1BFD67037B42Cf73acF2047067bd4F2C47D9BfD6"
+            },
+            "42161": {
+              "tokenAddress": "0x2f2a2543B76A4166549F7aaB2e75Bef0aefC5B0f"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "name": "Wrapped Centrifuge",
+        "symbol": "WCFG",
+        "logoURI": "https://assets.coingecko.com/coins/images/17106/thumb/WCFG.jpg?1626266462",
+        "address": "0xc221b7E65FfC80DE234bbB6667aBDd46593D34F0",
+        "decimals": 18,
+        "extensions": {
+          "bridgeInfo": {
+            "137": {
+              "tokenAddress": "0x90bb6fEB70A9a43CfAaA615F856BA309FD759A90"
+            }
+          }
+        }
+      },
+      {
+        "name": "Wrapped Ether",
+        "address": "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
+        "symbol": "WETH",
+        "decimals": 18,
+        "chainId": 1,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2/logo.png",
+        "extensions": {
+          "bridgeInfo": {
+            "10": {
+              "tokenAddress": "0x4200000000000000000000000000000000000006"
+            },
+            "137": {
+              "tokenAddress": "0x7ceB23fD6bC0adD59E62ac25578270cFf1b9f619"
+            },
+            "42161": {
+              "tokenAddress": "0x82aF49447D8a07e3bd95BD0d56f35241523fBab1"
+            },
+            "42220": {
+              "tokenAddress": "0x2DEf4285787d58a2f811AF24755A8150622f4361"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "name": "WOO Network",
+        "symbol": "WOO",
+        "logoURI": "https://assets.coingecko.com/coins/images/12921/thumb/w2UiemF__400x400.jpg?1603670367",
+        "address": "0x4691937a7508860F876c9c0a2a617E7d9E945D4B",
+        "decimals": 18,
+        "extensions": {
+          "bridgeInfo": {
+            "137": {
+              "tokenAddress": "0x1B815d120B3eF02039Ee11dC2d33DE7aA4a8C603"
+            },
+            "42161": {
+              "tokenAddress": "0xcAFcD85D8ca7Ad1e1C6F82F651fA15E33AEfD07b"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "name": "Chain",
+        "symbol": "XCN",
+        "logoURI": "https://assets.coingecko.com/coins/images/24210/thumb/Chain_icon_200x200.png?1646895054",
+        "address": "0xA2cd3D43c775978A96BdBf12d733D5A1ED94fb18",
+        "decimals": 18
+      },
+      {
+        "chainId": 1,
+        "address": "0x55296f69f40Ea6d20E478533C15A6B08B654E758",
+        "name": "XYO Network",
+        "symbol": "XYO",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/4519/thumb/XYO_Network-logo.png?1547039819",
+        "extensions": {
+          "bridgeInfo": {
+            "137": {
+              "tokenAddress": "0xd2507e7b5794179380673870d88B22F94da6abe0"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "address": "0x0bc529c00C6401aEF6D220BE8C6Ea1667F6Ad93e",
+        "name": "yearn finance",
+        "symbol": "YFI",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/11849/thumb/yfi-192x192.png?1598325330",
+        "extensions": {
+          "bridgeInfo": {
+            "137": {
+              "tokenAddress": "0xDA537104D6A5edd53c6fBba9A898708E465260b6"
+            },
+            "42161": {
+              "tokenAddress": "0x82e3A8F066a6989666b031d916c43672085b1582"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "address": "0xa1d0E215a23d7030842FC67cE582a6aFa3CCaB83",
+        "name": "DFI money",
+        "symbol": "YFII",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/11902/thumb/YFII-logo.78631676.png?1598677348",
+        "extensions": {
+          "bridgeInfo": {
+            "137": {
+              "tokenAddress": "0xb8cb8a7F4C2885C03e57E973C74827909Fdc2032"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 1,
+        "name": "Yield Guild Games",
+        "symbol": "YGG",
+        "logoURI": "https://assets.coingecko.com/coins/images/17358/thumb/le1nzlO6_400x400.jpg?1632465691",
+        "address": "0x25f8087EAD173b73D6e8B84329989A8eEA16CF73",
+        "decimals": 18,
+        "extensions": {
+          "bridgeInfo": {
+            "137": {
+              "tokenAddress": "0x82617aA52dddf5Ed9Bb7B370ED777b3182A30fd1"
+            }
+          }
+        }
+      },
+      {
+        "name": "0x Protocol Token",
+        "address": "0xE41d2489571d322189246DaFA5ebDe1F4699F498",
+        "symbol": "ZRX",
+        "decimals": 18,
+        "chainId": 1,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xE41d2489571d322189246DaFA5ebDe1F4699F498/logo.png",
+        "extensions": {
+          "bridgeInfo": {
+            "137": {
+              "tokenAddress": "0x5559Edb74751A0edE9DeA4DC23aeE72cCA6bE3D5"
+            },
+            "42161": {
+              "tokenAddress": "0xBD591Bd4DdB64b77B5f76Eab8f03d02519235Ae2"
+            }
+          }
+        }
+      },
+      {
+        "name": "Dai Stablecoin",
+        "address": "0xaD6D458402F60fD3Bd25163575031ACDce07538D",
+        "symbol": "DAI",
+        "decimals": 18,
+        "chainId": 3,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xaD6D458402F60fD3Bd25163575031ACDce07538D/logo.png"
+      },
+      {
+        "name": "Uniswap",
+        "address": "0x1f9840a85d5aF5bf1D1762F925BDADdC4201F984",
+        "symbol": "UNI",
+        "decimals": 18,
+        "chainId": 3,
+        "logoURI": "ipfs://QmXttGpZrECX5qCyXbBQiqgQNytVGeZW5Anewvh2jc4psg"
+      },
+      {
+        "name": "Wrapped Ether",
+        "address": "0xc778417E063141139Fce010982780140Aa0cD5Ab",
+        "symbol": "WETH",
+        "decimals": 18,
+        "chainId": 3,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xc778417E063141139Fce010982780140Aa0cD5Ab/logo.png"
+      },
+      {
+        "name": "Dai Stablecoin",
+        "address": "0xc7AD46e0b8a400Bb3C915120d284AafbA8fc4735",
+        "symbol": "DAI",
+        "decimals": 18,
+        "chainId": 4,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xc7AD46e0b8a400Bb3C915120d284AafbA8fc4735/logo.png"
+      },
+      {
+        "name": "Maker",
+        "address": "0xF9bA5210F91D0474bd1e1DcDAeC4C58E359AaD85",
+        "symbol": "MKR",
+        "decimals": 18,
+        "chainId": 4,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xF9bA5210F91D0474bd1e1DcDAeC4C58E359AaD85/logo.png"
+      },
+      {
+        "name": "Uniswap",
+        "address": "0x1f9840a85d5aF5bf1D1762F925BDADdC4201F984",
+        "symbol": "UNI",
+        "decimals": 18,
+        "chainId": 4,
+        "logoURI": "ipfs://QmXttGpZrECX5qCyXbBQiqgQNytVGeZW5Anewvh2jc4psg"
+      },
+      {
+        "name": "Wrapped Ether",
+        "address": "0xc778417E063141139Fce010982780140Aa0cD5Ab",
+        "symbol": "WETH",
+        "decimals": 18,
+        "chainId": 4,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xc778417E063141139Fce010982780140Aa0cD5Ab/logo.png"
+      },
+      {
+        "name": "Uniswap",
+        "address": "0x1f9840a85d5aF5bf1D1762F925BDADdC4201F984",
+        "symbol": "UNI",
+        "decimals": 18,
+        "chainId": 5,
+        "logoURI": "ipfs://QmXttGpZrECX5qCyXbBQiqgQNytVGeZW5Anewvh2jc4psg"
+      },
+      {
+        "name": "Wrapped Ether",
+        "address": "0xB4FBF271143F4FBf7B91A5ded31805e42b2208d6",
+        "symbol": "WETH",
+        "decimals": 18,
+        "chainId": 5,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xB4FBF271143F4FBf7B91A5ded31805e42b2208d6/logo.png"
+      },
+      {
+        "chainId": 10,
+        "address": "0x76FB31fb4af56892A25e32cFC43De717950c9278",
+        "name": "Aave",
+        "symbol": "AAVE",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/12645/thumb/AAVE.png?1601374110",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x7Fc66500c84A76Ad7e9c93437bFc5Ac33E2DDaE9"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 10,
+        "address": "0x3e7eF8f50246f725885102E8238CBba33F276747",
+        "name": "BarnBridge",
+        "symbol": "BOND",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/12811/thumb/barnbridge.jpg?1602728853",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x0391D2021f89DC339F60Fff84546EA23E337750f"
+            }
+          }
+        }
+      },
+      {
+        "name": "Curve DAO Token",
+        "address": "0x0994206dfE8De6Ec6920FF4D779B0d950605Fb53",
+        "symbol": "CRV",
+        "decimals": 18,
+        "chainId": 10,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xD533a949740bb3306d119CC777fa900bA034cd52/logo.png",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0xD533a949740bb3306d119CC777fa900bA034cd52"
+            }
+          }
+        }
+      },
+      {
+        "name": "Dai Stablecoin",
+        "address": "0xDA10009cBd5D07dd0CeCc66161FC93D7c9000da1",
+        "symbol": "DAI",
+        "decimals": 18,
+        "chainId": 10,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x6B175474E89094C44Da98b954EedeAC495271d0F/logo.png",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x6B175474E89094C44Da98b954EedeAC495271d0F"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 10,
+        "address": "0x65559aA14915a70190438eF90104769e5E890A00",
+        "name": "Ethereum Name Service",
+        "symbol": "ENS",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/19785/thumb/acatxTm8_400x400.jpg?1635850140",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0xC18360217D8F7Ab5e7c516566761Ea12Ce7F9D72"
+            }
+          }
+        }
+      },
+      {
+        "name": "ChainLink Token",
+        "address": "0x350a791Bfc2C21F9Ed5d10980Dad2e2638ffa7f6",
+        "symbol": "LINK",
+        "decimals": 18,
+        "chainId": 10,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x514910771AF9Ca656af840dff83E8264EcF986CA/logo.png",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x514910771AF9Ca656af840dff83E8264EcF986CA"
+            }
+          }
+        }
+      },
+      {
+        "name": "LoopringCoin V2",
+        "address": "0xFEaA9194F9F8c1B65429E31341a103071464907E",
+        "symbol": "LRC",
+        "decimals": 18,
+        "chainId": 10,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xBBbbCA6A901c926F240b89EacB641d8Aec7AEafD/logo.png",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0xBBbbCA6A901c926F240b89EacB641d8Aec7AEafD"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 10,
+        "name": "Liquity USD",
+        "symbol": "LUSD",
+        "logoURI": "https://assets.coingecko.com/coins/images/14666/thumb/Group_3.png?1617631327",
+        "address": "0xc40F949F8a4e094D1b49a23ea9241D289B7b2819",
+        "decimals": 18,
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x5f98805A4E8be255a32880FDeC7F6728C6568bA0"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 10,
+        "address": "0x3390108E913824B8eaD638444cc52B9aBdF63798",
+        "name": "Mask Network",
+        "symbol": "MASK",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/14051/thumb/Mask_Network.jpg?1614050316",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x69af81e73A73B40adF4f3d4223Cd9b1ECE623074"
+            }
+          }
+        }
+      },
+      {
+        "name": "Maker",
+        "address": "0xab7bAdEF82E9Fe11f6f33f87BC9bC2AA27F2fCB5",
+        "symbol": "MKR",
+        "decimals": 18,
+        "chainId": 10,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x9f8F72aA9304c8B593d555F12eF6589cC3A579A2/logo.png",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x9f8F72aA9304c8B593d555F12eF6589cC3A579A2"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 10,
+        "address": "0x4200000000000000000000000000000000000042",
+        "name": "Optimism",
+        "symbol": "OP",
+        "decimals": 18,
+        "logoURI": "https://ethereum-optimism.github.io/data/OP/logo.png"
+      },
+      {
+        "chainId": 10,
+        "address": "0x9e1028F5F1D5eDE59748FFceE5532509976840E0",
+        "name": "Perpetual Protocol",
+        "symbol": "PERP",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/12381/thumb/60d18e06844a844ad75901a9_mark_only_03.png?1628674771",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0xbC396689893D065F41bc2C6EcbeE5e0085233447"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 10,
+        "address": "0x7FB688CCf682d58f86D7e38e03f9D22e7705448B",
+        "name": "Rai Reflex Index",
+        "symbol": "RAI",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/14004/thumb/RAI-logo-coin.png?1613592334",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x03ab458634910AaD20eF5f1C8ee96F1D6ac54919"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 10,
+        "address": "0xB548f63D4405466B36C0c0aC3318a22fDcec711a",
+        "name": "Rari Governance Token",
+        "symbol": "RGT",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/12900/thumb/Rari_Logo_Transparent.png?1613978014",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0xD291E7a03283640FDc51b121aC401383A46cC623"
+            }
+          }
+        }
+      },
+      {
+        "name": "Synthetix Network Token",
+        "address": "0x8700dAec35aF8Ff88c16BdF0418774CB3D7599B4",
+        "symbol": "SNX",
+        "decimals": 18,
+        "chainId": 10,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xC011a73ee8576Fb46F5E1c5751cA3B9Fe0af2a6F/logo.png",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0xC011a73ee8576Fb46F5E1c5751cA3B9Fe0af2a6F"
+            }
+          }
+        }
+      },
+      {
+        "name": "UMA Voting Token v1",
+        "address": "0xE7798f023fC62146e8Aa1b36Da45fb70855a77Ea",
+        "symbol": "UMA",
+        "decimals": 18,
+        "chainId": 10,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x04Fa0d235C4abf4BcF4787aF4CF447DE572eF828/logo.png",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x04Fa0d235C4abf4BcF4787aF4CF447DE572eF828"
+            }
+          }
+        }
+      },
+      {
+        "name": "Uniswap",
+        "address": "0x6fd9d7AD17242c41f7131d257212c54A0e816691",
+        "symbol": "UNI",
+        "decimals": 18,
+        "chainId": 10,
+        "logoURI": "ipfs://QmXttGpZrECX5qCyXbBQiqgQNytVGeZW5Anewvh2jc4psg",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x1f9840a85d5aF5bf1D1762F925BDADdC4201F984"
+            }
+          }
+        }
+      },
+      {
+        "name": "USDCoin",
+        "address": "0x7F5c764cBc14f9669B88837ca1490cCa17c31607",
+        "symbol": "USDC",
+        "decimals": 6,
+        "chainId": 10,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/logo.png",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"
+            }
+          }
+        }
+      },
+      {
+        "name": "Tether USD",
+        "address": "0x94b008aA00579c1307B0EF2c499aD98a8ce58e58",
+        "symbol": "USDT",
+        "decimals": 6,
+        "chainId": 10,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xdAC17F958D2ee523a2206206994597C13D831ec7/logo.png",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0xdAC17F958D2ee523a2206206994597C13D831ec7"
+            }
+          }
+        }
+      },
+      {
+        "name": "Wrapped BTC",
+        "address": "0x68f180fcCe6836688e9084f035309E29Bf0A2095",
+        "symbol": "WBTC",
+        "decimals": 8,
+        "chainId": 10,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599/logo.png",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599"
+            }
+          }
+        }
+      },
+      {
+        "name": "Wrapped Ether",
+        "address": "0x4200000000000000000000000000000000000006",
+        "symbol": "WETH",
+        "decimals": 18,
+        "chainId": 10,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2/logo.png",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2"
+            }
+          }
+        }
+      },
+      {
+        "name": "Dai Stablecoin",
+        "address": "0x4F96Fe3b7A6Cf9725f59d353F723c1bDb64CA6Aa",
+        "symbol": "DAI",
+        "decimals": 18,
+        "chainId": 42,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x4F96Fe3b7A6Cf9725f59d353F723c1bDb64CA6Aa/logo.png"
+      },
+      {
+        "name": "Maker",
+        "address": "0xAaF64BFCC32d0F15873a02163e7E500671a4ffcD",
+        "symbol": "MKR",
+        "decimals": 18,
+        "chainId": 42,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xAaF64BFCC32d0F15873a02163e7E500671a4ffcD/logo.png"
+      },
+      {
+        "name": "Uniswap",
+        "address": "0x1f9840a85d5aF5bf1D1762F925BDADdC4201F984",
+        "symbol": "UNI",
+        "decimals": 18,
+        "chainId": 42,
+        "logoURI": "ipfs://QmXttGpZrECX5qCyXbBQiqgQNytVGeZW5Anewvh2jc4psg"
+      },
+      {
+        "name": "Wrapped Ether",
+        "address": "0xd0A1E359811322d97991E03f863a0C30C2cF029C",
+        "symbol": "WETH",
+        "decimals": 18,
+        "chainId": 42,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xd0A1E359811322d97991E03f863a0C30C2cF029C/logo.png"
+      },
+      {
+        "chainId": 137,
+        "address": "0x9c2C5fd7b07E95EE044DDeba0E97a665F142394f",
+        "name": "1inch",
+        "symbol": "1INCH",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/13469/thumb/1inch-token.png?1608803028",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x111111111117dC0aa78b770fA6A738034120C302"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 137,
+        "address": "0xD6DF932A45C0f255f85145f286eA0b292B21C90B",
+        "name": "Aave",
+        "symbol": "AAVE",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/12645/thumb/AAVE.png?1601374110",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x7Fc66500c84A76Ad7e9c93437bFc5Ac33E2DDaE9"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 137,
+        "address": "0xdDa7b23D2D72746663E7939743f929a3d85FC975",
+        "name": "Ambire AdEx",
+        "symbol": "ADX",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/847/thumb/Ambire_AdEx_Symbol_color.png?1655432540",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0xADE00C28244d5CE17D72E40330B1c318cD12B7c3"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 137,
+        "address": "0x6a6bD53d677F8632631662C48bD47b1D4D6524ee",
+        "name": "Adventure Gold",
+        "symbol": "AGLD",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/18125/thumb/lpgblc4h_400x400.jpg?1630570955",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x32353A6C91143bfd6C7d363B546e62a9A2489A20"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 137,
+        "address": "0xe2341718c6C0CbFa8e6686102DD8FbF4047a9e9B",
+        "name": "AIOZ Network",
+        "symbol": "AIOZ",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/14631/thumb/aioz_logo.png?1617413126",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x626E8036dEB333b408Be468F951bdB42433cBF18"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 137,
+        "address": "0x95c300e7740D2A88a44124B424bFC1cB2F9c3b89",
+        "name": "Alchemix",
+        "symbol": "ALCX",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/14113/thumb/Alchemix.png?1614409874",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0xdBdb4d16EdA451D0503b854CF79D55697F90c8DF"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 137,
+        "address": "0x82dCf1Df86AdA26b2dCd9ba6334CeDb8c2448e9e",
+        "name": "Aleph im",
+        "symbol": "ALEPH",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/11676/thumb/Monochram-aleph.png?1608483725",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x27702a26126e0B3702af63Ee09aC4d1A084EF628"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 137,
+        "address": "0x50858d870FAF55da2fD90FB6DF7c34b5648305C6",
+        "name": "My Neighbor Alice",
+        "symbol": "ALICE",
+        "decimals": 6,
+        "logoURI": "https://assets.coingecko.com/coins/images/14375/thumb/alice_logo.jpg?1615782968",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0xAC51066d7bEC65Dc4589368da368b212745d63E8"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 137,
+        "address": "0x3AE490db48d74B1bC626400135d4616377D0109f",
+        "name": "Alpha Venture DAO",
+        "symbol": "ALPHA",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/12738/thumb/AlphaToken_256x256.png?1617160876",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0xa1faa113cbE53436Df28FF0aEe54275c13B40975"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 137,
+        "address": "0x0621d647cecbFb64b79E44302c1933cB4f27054d",
+        "name": "Amp",
+        "symbol": "AMP",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/12409/thumb/amp-200x200.png?1599625397",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0xfF20817765cB7f73d4bde2e66e067E58D11095C2"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 137,
+        "address": "0x101A023270368c0D50BFfb62780F4aFd4ea79C35",
+        "name": "Ankr",
+        "symbol": "ANKR",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/4324/thumb/U85xTl2.png?1608111978",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x8290333ceF9e6D528dD5618Fb97a76f268f3EDD4"
+            }
+          }
+        }
+      },
+      {
+        "name": "Aragon",
+        "address": "0x2b8504ab5eFc246d0eC5Ec7E74565683227497de",
+        "symbol": "ANT",
+        "decimals": 18,
+        "chainId": 137,
+        "logoURI": "https://assets.coingecko.com/coins/images/681/thumb/JelZ58cv_400x400.png?1601449653",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0xa117000000f279D81A1D3cc75430fAA017FA5A2e"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 137,
+        "address": "0xB7b31a6BC18e48888545CE79e83E06003bE70930",
+        "name": "ApeCoin",
+        "symbol": "APE",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/24383/small/apecoin.jpg?1647476455",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x4d224452801ACEd8B2F0aebE155379bb5D594381"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 137,
+        "address": "0x45C27821E80F8789b60Fd8B600C73815d34DDa6C",
+        "name": "API3",
+        "symbol": "API3",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/13256/thumb/api3.jpg?1606751424",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x0b38210ea11411557c13457D4dA7dC6ea731B88a"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 137,
+        "address": "0xEE800B277A96B0f490a1A732e1D6395FAD960A26",
+        "name": "ARPA Chain",
+        "symbol": "ARPA",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/8506/thumb/9u0a23XY_400x400.jpg?1559027357",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0xBA50933C268F567BDC86E1aC131BE072C6B0b71a"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 137,
+        "address": "0x04bEa9FCE76943E90520489cCAb84E84C0198E29",
+        "name": "AirSwap",
+        "symbol": "AST",
+        "decimals": 4,
+        "logoURI": "https://assets.coingecko.com/coins/images/1019/thumb/Airswap.png?1630903484",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x27054b13b1B798B345b591a4d22e6562d47eA75a"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 137,
+        "address": "0x0df0f72EE0e5c9B7ca761ECec42754992B2Da5BF",
+        "name": "Automata",
+        "symbol": "ATA",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/15985/thumb/ATA.jpg?1622535745",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0xA2120b9e674d3fC3875f415A7DF52e382F141225"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 137,
+        "address": "0x5eB8D998371971D01954205c7AFE90A7AF6a95AC",
+        "name": "Audius",
+        "symbol": "AUDIO",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/12913/thumb/AudiusCoinLogo_2x.png?1603425727",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x18aAA7115705e8be94bfFEBDE57Af9BFc265B998"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 137,
+        "address": "0x61BDD9C7d4dF4Bf47A4508c0c8245505F2Af5b7b",
+        "name": "Axie Infinity",
+        "symbol": "AXS",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/13029/thumb/axie_infinity_logo.png?1604471082",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0xBB0E17EF65F82Ab018d8EDd776e8DD940327B28b"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 137,
+        "address": "0x1FcbE5937B0cc2adf69772D228fA4205aCF4D9b2",
+        "name": "Badger DAO",
+        "symbol": "BADGER",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/13287/thumb/badger_dao_logo.jpg?1607054976",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x3472A5A71965499acd81997a54BBA8D852C6E53d"
+            }
+          }
+        }
+      },
+      {
+        "name": "Balancer",
+        "address": "0x9a71012B13CA4d3D0Cdc72A177DF3ef03b0E76A3",
+        "symbol": "BAL",
+        "decimals": 18,
+        "chainId": 137,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xba100000625a3754423978a60c9317c58a424e3D/logo.png",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0xba100000625a3754423978a60c9317c58a424e3D"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 137,
+        "address": "0xA8b1E0764f85f53dfe21760e8AfE5446D82606ac",
+        "name": "Band Protocol",
+        "symbol": "BAND",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/9545/thumb/band-protocol.png?1568730326",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0xBA11D00c5f74255f56a5E366F4F77f5A186d7f55"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 137,
+        "address": "0x3Cef98bb43d732E2F285eE605a8158cDE967D219",
+        "name": "Basic Attention Token",
+        "symbol": "BAT",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/677/thumb/basic-attention-token.png?1547034427",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x0D8775F648430679A709E98d2b0Cb6250d2887EF"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 137,
+        "address": "0x91c89A94567980f0e9723b487b0beD586eE96aa7",
+        "name": "Biconomy",
+        "symbol": "BICO",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/21061/thumb/biconomy_logo.jpg?1638269749",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0xF17e65822b568B3903685a7c9F496CF7656Cc6C2"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 137,
+        "address": "0x438B28C5AA5F00a817b7Def7cE2Fb3d5d1970974",
+        "name": "Bluzelle",
+        "symbol": "BLZ",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/2848/thumb/ColorIcon_3x.png?1622516510",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x5732046A883704404F284Ce41FfADd5b007FD668"
+            }
+          }
+        }
+      },
+      {
+        "name": "Bancor Network Token",
+        "address": "0xc26D47d5c33aC71AC5CF9F776D63Ba292a4F7842",
+        "symbol": "BNT",
+        "decimals": 18,
+        "chainId": 137,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x1F573D6Fb3F13d689FF844B4cE37794d79a7FF1C/logo.png",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x1F573D6Fb3F13d689FF844B4cE37794d79a7FF1C"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 137,
+        "address": "0xa4B2B20b2C73c7046ED19AC6bfF5E5285c58F20a",
+        "name": "Boba Network",
+        "symbol": "BOBA",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/20285/thumb/BOBA.png?1636811576",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x42bBFa2e77757C645eeaAd1655E0911a7553Efbc"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 137,
+        "address": "0xA041544fe2BE56CCe31Ebb69102B965E06aacE80",
+        "name": "BarnBridge",
+        "symbol": "BOND",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/12811/thumb/barnbridge.jpg?1602728853",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x0391D2021f89DC339F60Fff84546EA23E337750f"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 137,
+        "address": "0xdAb529f40E671A1D4bF91361c21bf9f0C9712ab7",
+        "name": "Binance USD",
+        "symbol": "BUSD",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/9576/thumb/BUSD.png?1568947766",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x4Fabb145d64652a948d72533023f6E7A623C7C53"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 137,
+        "address": "0x91a4635F620766145C099E15889Bd2766906A559",
+        "name": "Celer Network",
+        "symbol": "CELR",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/4379/thumb/Celr.png?1554705437",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x4F9254C83EB525f9FCf346490bbb3ed28a81C667"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 137,
+        "address": "0x594C984E3318e91313f881B021A0C4203fF5E59F",
+        "name": "Chromia",
+        "symbol": "CHR",
+        "decimals": 6,
+        "logoURI": "https://assets.coingecko.com/coins/images/5000/thumb/Chromia.png?1559038018",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x8A2279d4A90B6fe1C4B30fa660cC9f926797bAA2"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 137,
+        "address": "0xf1938Ce12400f9a761084E7A80d37e732a4dA056",
+        "name": "Chiliz",
+        "symbol": "CHZ",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/8834/thumb/Chiliz.png?1561970540",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x3506424F91fD33084466F402d5D97f05F8e3b4AF"
+            }
+          }
+        }
+      },
+      {
+        "name": "Compound",
+        "address": "0x8505b9d2254A7Ae468c0E9dd10Ccea3A837aef5c",
+        "symbol": "COMP",
+        "decimals": 18,
+        "chainId": 137,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xc00e94Cb662C3520282E6f5717214004A7f26888/logo.png",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0xc00e94Cb662C3520282E6f5717214004A7f26888"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 137,
+        "address": "0x93B0fF1C8828F6eB039D345Ff681eD735086d925",
+        "name": "Covalent",
+        "symbol": "CQT",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/14168/thumb/covalent-cqt.png?1624545218",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0xD417144312DbF50465b1C641d016962017Ef6240"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 137,
+        "address": "0xAdA58DF0F643D959C2A47c9D4d4c1a4deFe3F11C",
+        "name": "Cronos",
+        "symbol": "CRO",
+        "decimals": 8,
+        "logoURI": "https://assets.coingecko.com/coins/images/7310/thumb/oCw2s3GI_400x400.jpeg?1645172042",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0xA0b73E1Ff0B80914AB6fe0444E65848C4C34450b"
+            }
+          }
+        }
+      },
+      {
+        "name": "Curve DAO Token",
+        "address": "0x172370d5Cd63279eFa6d502DAB29171933a610AF",
+        "symbol": "CRV",
+        "decimals": 18,
+        "chainId": 137,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xD533a949740bb3306d119CC777fa900bA034cd52/logo.png",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0xD533a949740bb3306d119CC777fa900bA034cd52"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 137,
+        "address": "0x2727Ab1c2D22170ABc9b595177B2D5C6E1Ab7B7B",
+        "name": "Cartesi",
+        "symbol": "CTSI",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/11038/thumb/cartesi.png?1592288021",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x491604c0FDF08347Dd1fa4Ee062a822A5DD06B5D"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 137,
+        "address": "0x8c208BC2A808a088a78398fed8f2640cab0b6EDb",
+        "name": "Cryptex Finance",
+        "symbol": "CTX",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/14932/thumb/glossy_icon_-_C200px.png?1619073171",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x321C2fE4446C7c963dc41Dd58879AF648838f98D"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 137,
+        "address": "0x276C9cbaa4BDf57d7109a41e67BD09699536FA3d",
+        "name": "Somnium Space CUBEs",
+        "symbol": "CUBE",
+        "decimals": 8,
+        "logoURI": "https://assets.coingecko.com/coins/images/10687/thumb/CUBE_icon.png?1617026861",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0xDf801468a808a32656D2eD2D2d80B72A129739f4"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 137,
+        "address": "0x66Dc5A08091d1968e08C16aA5b27BAC8398b02Be",
+        "name": "Civic",
+        "symbol": "CVC",
+        "decimals": 8,
+        "logoURI": "https://assets.coingecko.com/coins/images/788/thumb/civic.png?1547034556",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x41e5560054824eA6B0732E656E3Ad64E20e94E45"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 137,
+        "address": "0x4257EA7637c355F81616050CbB6a9b709fd72683",
+        "name": "Convex Finance",
+        "symbol": "CVX",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/15585/thumb/convex.png?1621256328",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x4e3FBD56CD56c3e72c1403e103b45Db9da5B9D2B"
+            }
+          }
+        }
+      },
+      {
+        "name": "Dai Stablecoin",
+        "address": "0x8f3Cf7ad23Cd3CaDbD9735AFf958023239c6A063",
+        "symbol": "DAI",
+        "decimals": 18,
+        "chainId": 137,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x6B175474E89094C44Da98b954EedeAC495271d0F/logo.png",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x6B175474E89094C44Da98b954EedeAC495271d0F"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 137,
+        "address": "0x26f5FB1e6C8a65b3A873fF0a213FA16EFF5a7828",
+        "name": "DerivaDAO",
+        "symbol": "DDX",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/13453/thumb/ddx_logo.png?1608741641",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x3A880652F47bFaa771908C07Dd8673A787dAEd3A"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 137,
+        "address": "0xff835562C761205659939B64583dd381a6AA4D92",
+        "name": "DexTools",
+        "symbol": "DEXT",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/11603/thumb/dext.png?1605790188",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0xfB7B4564402E5500dB5bB6d63Ae671302777C75a"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 137,
+        "address": "0x993f2CafE9dbE525243f4A78BeBC69DAc8D36000",
+        "name": "DIA",
+        "symbol": "DIA",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/11955/thumb/image.png?1646041751",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x84cA8bc7997272c7CfB4D0Cd3D55cd942B3c9419"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 137,
+        "address": "0x85955046DF4668e1DD369D2DE9f3AEB98DD2A369",
+        "name": "DeFi Pulse Index",
+        "symbol": "DPI",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/12465/thumb/defi_pulse_index_set.png?1600051053",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x1494CA1F11D487c2bBe4543E90080AeBa4BA3C2b"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 137,
+        "address": "0x4C3bF0a3DE9524aF68327d1D2558a3B70d17D42a",
+        "name": "dYdX",
+        "symbol": "DYDX",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/17500/thumb/hjnIm9bV.jpg?1628009360",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x92D6C1e31e14520e676a687F0a93788B716BEff5"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 137,
+        "address": "0xE0339c80fFDE91F3e20494Df88d4206D86024cdF",
+        "name": "Dogelon Mars",
+        "symbol": "ELON",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/14962/thumb/6GxcPRo3_400x400.jpg?1619157413",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x761D38e5ddf6ccf6Cf7c55759d5210750B5D60F3"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 137,
+        "address": "0x7eC26842F195c852Fa843bB9f6D8B583a274a157",
+        "name": "Enjin Coin",
+        "symbol": "ENJ",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/1102/thumb/enjin-coin-logo.png?1547035078",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0xF629cBd94d3791C9250152BD8dfBDF380E2a3B9c"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 137,
+        "address": "0xbD7A5Cf51d22930B8B3Df6d834F9BCEf90EE7c4f",
+        "name": "Ethereum Name Service",
+        "symbol": "ENS",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/19785/thumb/acatxTm8_400x400.jpg?1635850140",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0xC18360217D8F7Ab5e7c516566761Ea12Ce7F9D72"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 137,
+        "address": "0x0E50BEA95Fe001A370A4F1C220C49AEdCB982DeC",
+        "name": "Ethernity Chain",
+        "symbol": "ERN",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/14238/thumb/LOGO_HIGH_QUALITY.png?1647831402",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0xBBc2AE13b23d715c30720F079fcd9B4a74093505"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 137,
+        "address": "0x8a037dbcA8134FFc72C362e394e35E0Cad618F85",
+        "name": "Euro Coin",
+        "symbol": "EUROC",
+        "decimals": 6,
+        "logoURI": "https://assets.coingecko.com/coins/images/26045/thumb/euro-coin.png?1655394420",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x1aBaEA1f7C830bD89Acc67eC4af516284b1bC33c"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 137,
+        "address": "0x176f5AB638cf4Ff3B6239Ba609C3fadAA46ef5B0",
+        "name": "Harvest Finance",
+        "symbol": "FARM",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/12304/thumb/Harvest.png?1613016180",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0xa0246c9032bC3A600820415aE600c6388619A14D"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 137,
+        "address": "0x7583FEDDbceFA813dc18259940F76a02710A8905",
+        "name": "Fetch ai",
+        "symbol": "FET",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/5681/thumb/Fetch.jpg?1572098136",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0xaea46A60368A7bD060eec7DF8CBa43b7EF41Ad85"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 137,
+        "address": "0x7A7B94F18EF6AD056CDa648588181CDA84800f94",
+        "name": "Stafi",
+        "symbol": "FIS",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/12423/thumb/stafi_logo.jpg?1599730991",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0xef3A930e1FfFFAcd2fc13434aC81bD278B0ecC8d"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 137,
+        "address": "0x9ff62d1FC52A907B6DCbA8077c2DDCA6E6a9d3e1",
+        "name": "Forta",
+        "symbol": "FORT",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/25060/thumb/Forta_lgo_%281%29.png?1655353696",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x41545f8b9472D758bB669ed8EaEEEcD7a9C4Ec29"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 137,
+        "address": "0x5eCbA59DAcc1ADc5bDEA35f38A732823fc3dE977",
+        "name": "Ampleforth Governance Token",
+        "symbol": "FORTH",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/14917/thumb/photo_2021-04-22_00.00.03.jpeg?1619020835",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x77FbA179C79De5B7653F68b5039Af940AdA60ce0"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 137,
+        "address": "0x65A05DB8322701724c197AF82C9CaE41195B0aA8",
+        "name": "ShapeShift FOX Token",
+        "symbol": "FOX",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/9988/thumb/FOX.png?1574330622",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0xc770EEfAd204B5180dF6a14Ee197D99d808ee52d"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 137,
+        "address": "0x104592a158490a9228070E0A8e5343B499e125D0",
+        "name": "Frax",
+        "symbol": "FRAX",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/13422/thumb/frax_logo.png?1608476506",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x853d955aCEf822Db058eb8505911ED77F175b99e"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 137,
+        "address": "0xC9c1c1c20B3658F8787CC2FD702267791f224Ce1",
+        "name": "Fantom",
+        "symbol": "FTM",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/4001/thumb/Fantom.png?1558015016",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x4E15361FD6b4BB609Fa63C81A2be19d873717870"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 137,
+        "address": "0x3e121107F6F22DA4911079845a470757aF4e1A1b",
+        "name": "Frax Share",
+        "symbol": "FXS",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/13423/thumb/frax_share.png?1608478989",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x3432B6A60D23Ca0dFCa7761B7ab56459D9C964D0"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 137,
+        "address": "0x09E1943Dd2A4e82032773594f50CF54453000b97",
+        "name": "Gala",
+        "symbol": "GALA",
+        "decimals": 8,
+        "logoURI": "https://assets.coingecko.com/coins/images/12493/thumb/GALA-COINGECKO.png?1600233435",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x15D4c048F83bd7e37d49eA4C83a07267Ec4203dA"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 137,
+        "address": "0x385Eeac5cB85A38A9a07A70c73e0a3271CfB54A7",
+        "name": "Aavegotchi",
+        "symbol": "GHST",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/12467/thumb/ghst_200.png?1600750321",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x3F382DbD960E3a9bbCeaE22651E88158d2791550"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 137,
+        "address": "0x0B220b82F3eA3B7F6d9A1D8ab58930C064A2b5Bf",
+        "name": "Golem",
+        "symbol": "GLM",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/542/thumb/Golem_Submark_Positive_RGB.png?1606392013",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x7DD9c5Cba05E151C895FDe1CF355C9A1D5DA6429"
+            }
+          }
+        }
+      },
+      {
+        "name": "Gnosis Token",
+        "address": "0x5FFD62D3C3eE2E81C00A7b9079FB248e7dF024A8",
+        "symbol": "GNO",
+        "decimals": 18,
+        "chainId": 137,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x6810e776880C02933D47DB1b9fc05908e5386b96/logo.png",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x6810e776880C02933D47DB1b9fc05908e5386b96"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 137,
+        "address": "0xF88fc6b493eda7650E4bcf7A290E8d108F677CfE",
+        "name": "Gods Unchained",
+        "symbol": "GODS",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/17139/thumb/10631.png?1635718182",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0xccC8cb5229B0ac8069C51fd58367Fd1e622aFD97"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 137,
+        "address": "0x5fe2B58c013d7601147DcdD68C143A77499f5531",
+        "name": "The Graph",
+        "symbol": "GRT",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/13397/thumb/Graph_Token.png?1608145566",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0xc944E90C64B2c07662A292be6244BDf05Cda44a7"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 137,
+        "address": "0xdb95f9188479575F3F718a245EcA1B3BF74567EC",
+        "name": "Gitcoin",
+        "symbol": "GTC",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/15810/thumb/gitcoin.png?1621992929",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0xDe30da39c46104798bB5aA3fe8B9e0e1F348163F"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 137,
+        "address": "0xC8A94a3d3D2dabC3C1CaffFFDcA6A7543c3e3e65",
+        "name": "Gemini Dollar",
+        "symbol": "GUSD",
+        "decimals": 2,
+        "logoURI": "https://assets.coingecko.com/coins/images/5992/thumb/gemini-dollar-gusd.png?1536745278",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x056Fd409E1d7A124BD7017459dFEa2F387b6d5Cd"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 137,
+        "address": "0x482bc619eE7662759CDc0685B4E78f464Da39C73",
+        "name": "GYEN",
+        "symbol": "GYEN",
+        "decimals": 6,
+        "logoURI": "https://assets.coingecko.com/coins/images/14191/thumb/icon_gyen_200_200.png?1614843343",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0xC08512927D12348F6620a698105e1BAac6EcD911"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 137,
+        "name": "HOPR",
+        "symbol": "HOPR",
+        "logoURI": "https://assets.coingecko.com/coins/images/14061/thumb/Shared_HOPR_logo_512px.png?1614073468",
+        "address": "0x6cCBF3627b2C83AFEF05bf2F035E7f7B210Fe30D",
+        "decimals": 18,
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0xF5581dFeFD8Fb0e4aeC526bE659CFaB1f8c781dA"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 137,
+        "address": "0x9Cb74C8032b007466865f060ad2c46145d45553D",
+        "name": "IDEX",
+        "symbol": "IDEX",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/2565/thumb/logomark-purple-286x286.png?1638362736",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0xB705268213D593B8FD88d3FDEFF93AFF5CbDcfAE"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 137,
+        "address": "0x183070C90B34A63292cC908Ce1b263Cb56D49A7F",
+        "name": "Immutable X",
+        "symbol": "IMX",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/17233/thumb/imx.png?1636691817",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0xF57e7e7C23978C3cAEC3C3548E3D615c346e79fF"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 137,
+        "name": "Index Cooperative",
+        "symbol": "INDEX",
+        "logoURI": "https://assets.coingecko.com/coins/images/12729/thumb/index.png?1634894321",
+        "address": "0xfBd8A3b908e764dBcD51e27992464B4432A1132b",
+        "decimals": 18,
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x0954906da0Bf32d5479e25f46056d22f08464cab"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 137,
+        "address": "0x4E8dc2149EaC3f3dEf36b1c281EA466338249371",
+        "name": "Injective",
+        "symbol": "INJ",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/12882/thumb/Secondary_Symbol.png?1628233237",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0xe28b3B32B6c345A34Ff64674606124Dd5Aceca30"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 137,
+        "address": "0xF18Ac368001b0DdC80aA6a8374deb49e868EFDb8",
+        "name": "Inverse Finance",
+        "symbol": "INV",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/14205/thumb/inverse_finance.jpg?1614921871",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x41D5D79431A913C4aE7d69a668ecdfE5fF9DFB68"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 137,
+        "address": "0xf6372cDb9c1d3674E83842e3800F2A62aC9F3C66",
+        "name": "IoTeX",
+        "symbol": "IOTX",
+        "decimals": 18,
+        "logoURI": "https://s2.coinmarketcap.com/static/img/coins/64x64/2777.png",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x6fB3e0A217407EFFf7Ca062D46c26E5d60a14d69"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 137,
+        "address": "0xb87f5c1E81077FfcfE821dA240fd20C99c533aF1",
+        "name": "JasmyCoin",
+        "symbol": "JASMY",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/13876/thumb/JASMY200x200.jpg?1612473259",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x7420B4b9a0110cdC71fB720908340C03F9Bc03EC"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 137,
+        "address": "0x42f37A1296b2981F7C3cAcEd84c5096b2Eb0C72C",
+        "name": "Keep Network",
+        "symbol": "KEEP",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/3373/thumb/IuNzUb5b_400x400.jpg?1589526336",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x85Eee30c52B0b379b046Fb0F85F4f3Dc3009aFEC"
+            }
+          }
+        }
+      },
+      {
+        "name": "Kyber Network Crystal",
+        "address": "0x324b28d6565f784d596422B0F2E5aB6e9CFA1Dc7",
+        "symbol": "KNC",
+        "decimals": 18,
+        "chainId": 137,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xdd974D5C2e2928deA5F71b9825b8b646686BD200/logo.png",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0xdd974D5C2e2928deA5F71b9825b8b646686BD200"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 137,
+        "address": "0x53AEc293212E3B792563Bc16f1be26956adb12e9",
+        "name": "Keep3rV1",
+        "symbol": "KP3R",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/12966/thumb/kp3r_logo.jpg?1607057458",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x1cEB5cB57C4D4E2b2433641b95Dd330A33185A44"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 137,
+        "address": "0xE8A51D0dD1b4525189ddA2187F90ddF0932b5482",
+        "name": "LCX",
+        "symbol": "LCX",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/9985/thumb/zRPSu_0o_400x400.jpg?1574327008",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x037A54AaB062628C9Bbae1FDB1583c195585fe41"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 137,
+        "address": "0xC3C7d422809852031b44ab29EEC9F1EfF2A58756",
+        "name": "Lido DAO",
+        "symbol": "LDO",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/13573/thumb/Lido_DAO.png?1609873644",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x5A98FcBEA516Cf06857215779Fd812CA3beF1B32"
+            }
+          }
+        }
+      },
+      {
+        "name": "ChainLink Token",
+        "address": "0x53E0bca35eC356BD5ddDFebbD1Fc0fD03FaBad39",
+        "symbol": "LINK",
+        "decimals": 18,
+        "chainId": 137,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x514910771AF9Ca656af840dff83E8264EcF986CA/logo.png",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x514910771AF9Ca656af840dff83E8264EcF986CA"
+            }
+          }
+        }
+      },
+      {
+        "name": "Loom Network",
+        "address": "0x66EfB7cC647e0efab02eBA4316a2d2941193F6b3",
+        "symbol": "LOOM",
+        "decimals": 18,
+        "chainId": 137,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xA4e8C3Ec456107eA67d3075bF9e3DF3A75823DB0/logo.png",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0xA4e8C3Ec456107eA67d3075bF9e3DF3A75823DB0"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 137,
+        "address": "0x3962F4A0A0051DccE0be73A7e09cEf5756736712",
+        "name": "Livepeer",
+        "symbol": "LPT",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/7137/thumb/logo-circle-green.png?1619593365",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x58b6A8A3302369DAEc383334672404Ee733aB239"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 137,
+        "address": "0x8Ab2Fec94d17ae69FB90E7c773f2C85Ed1802c01",
+        "name": "Liquity",
+        "symbol": "LQTY",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/14665/thumb/200-lqty-icon.png?1617631180",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x6DEA81C8171D0bA574754EF6F8b412F2Ed88c54D"
+            }
+          }
+        }
+      },
+      {
+        "name": "LoopringCoin V2",
+        "address": "0x84e1670F61347CDaeD56dcc736FB990fBB47ddC1",
+        "symbol": "LRC",
+        "decimals": 18,
+        "chainId": 137,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xBBbbCA6A901c926F240b89EacB641d8Aec7AEafD/logo.png",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0xBBbbCA6A901c926F240b89EacB641d8Aec7AEafD"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 137,
+        "name": "Liquity USD",
+        "symbol": "LUSD",
+        "logoURI": "https://assets.coingecko.com/coins/images/14666/thumb/Group_3.png?1617631327",
+        "address": "0x23001f892c0C82b79303EDC9B9033cD190BB21c7",
+        "decimals": 18,
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x5f98805A4E8be255a32880FDeC7F6728C6568bA0"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 137,
+        "address": "0xA1c57f48F0Deb89f569dFbE6E2B7f46D33606fD4",
+        "name": "Decentraland",
+        "symbol": "MANA",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/878/thumb/decentraland-mana.png?1550108745",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x0F5D2fB29fb7d3CFeE444a200298f468908cC942"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 137,
+        "address": "0x2B9E7ccDF0F4e5B24757c1E1a80e311E34Cb10c7",
+        "name": "Mask Network",
+        "symbol": "MASK",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/14051/thumb/Mask_Network.jpg?1614050316",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x69af81e73A73B40adF4f3d4223Cd9b1ECE623074"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 137,
+        "name": "MATH",
+        "symbol": "MATH",
+        "logoURI": "https://assets.coingecko.com/coins/images/11335/thumb/2020-05-19-token-200.png?1589940590",
+        "address": "0x347ACCAFdA7F8c5BdeC57fa34a5b663CBd1aeca7",
+        "decimals": 18,
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x08d967bb0134F2d07f7cfb6E246680c53927DD30"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 137,
+        "address": "0x0000000000000000000000000000000000001010",
+        "name": "Polygon",
+        "symbol": "MATIC",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/4713/thumb/matic-token-icon.png?1624446912",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x7D1AfA7B718fb893dB30A3aBc0Cfc608AaCfeBB0"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 137,
+        "address": "0xAa7DbD1598251f856C12f63557A4C4397c253Cea",
+        "name": "Moss Carbon Credit",
+        "symbol": "MCO2",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/14414/thumb/ENtxnThA_400x400.jpg?1615948522",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0xfC98e825A2264D890F9a1e68ed50E1526abCcacD"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 137,
+        "name": "Metis",
+        "symbol": "METIS",
+        "logoURI": "https://assets.coingecko.com/coins/images/15595/thumb/metis.jpeg?1660285312",
+        "address": "0x1B9D40715E757Bdb9bdEC3215B898E46d8a3b71a",
+        "decimals": 18,
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x9E32b13ce7f2E80A01932B42553652E053D6ed8e"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 137,
+        "address": "0x01288e04435bFcd4718FF203D6eD18146C17Cd4b",
+        "name": "Magic Internet Money",
+        "symbol": "MIM",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/16786/thumb/mimlogopng.png?1624979612",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x99D8a9C45b2ecA8864373A26D1459e3Dff1e17F3"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 137,
+        "address": "0x1C5cccA2CB59145A4B25F452660cbA6436DDce9b",
+        "name": "Mirror Protocol",
+        "symbol": "MIR",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/13295/thumb/mirror_logo_transparent.png?1611554658",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x09a3EcAFa817268f77BE1283176B946C4ff2E608"
+            }
+          }
+        }
+      },
+      {
+        "name": "Maker",
+        "address": "0x6f7C932e7684666C9fd1d44527765433e01fF61d",
+        "symbol": "MKR",
+        "decimals": 18,
+        "chainId": 137,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x9f8F72aA9304c8B593d555F12eF6589cC3A579A2/logo.png",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x9f8F72aA9304c8B593d555F12eF6589cC3A579A2"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 137,
+        "address": "0xa9f37D84c856fDa3812ad0519Dad44FA0a3Fe207",
+        "name": "Melon",
+        "symbol": "MLN",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/605/thumb/melon.png?1547034295",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0xec67005c4E498Ec7f55E092bd1d35cbC47C91892"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 137,
+        "name": "Monavale",
+        "symbol": "MONA",
+        "logoURI": "https://assets.coingecko.com/coins/images/13298/thumb/monavale_logo.jpg?1607232721",
+        "address": "0x6968105460f67c3BF751bE7C15f92F5286Fd0CE5",
+        "decimals": 18,
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x275f5Ad03be0Fa221B4C6649B8AeE09a42D9412A"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 137,
+        "name": "GensoKishi Metaverse",
+        "symbol": "MV",
+        "logoURI": "https://s2.coinmarketcap.com/static/img/coins/64x64/17704.png",
+        "address": "0xA3c322Ad15218fBFAEd26bA7f616249f7705D945",
+        "decimals": 18,
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0xAE788F80F2756A86aa2F410C651F2aF83639B95b"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 137,
+        "address": "0x4985E0B13554fB521840e893574D3848C10Fcc6f",
+        "name": "PolySwarm",
+        "symbol": "NCT",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/2843/thumb/ImcYCVfX_400x400.jpg?1628519767",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x9E46A38F5DaaBe8683E10793b06749EEF7D733d1"
+            }
+          }
+        }
+      },
+      {
+        "name": "Numeraire",
+        "address": "0x0Bf519071b02F22C17E7Ed5F4002ee1911f46729",
+        "symbol": "NMR",
+        "decimals": 18,
+        "chainId": 137,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x1776e1F26f98b1A5dF9cD347953a26dd3Cb46671/logo.png",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x1776e1F26f98b1A5dF9cD347953a26dd3Cb46671"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 137,
+        "address": "0x282d8efCe846A88B159800bd4130ad77443Fa1A1",
+        "name": "Ocean Protocol",
+        "symbol": "OCEAN",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/3687/thumb/ocean-protocol-logo.jpg?1547038686",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x967da4048cD07aB37855c090aAF366e4ce1b9F48"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 137,
+        "address": "0xa63Beffd33AB3a2EfD92a39A7D2361CEE14cEbA8",
+        "name": "Origin Protocol",
+        "symbol": "OGN",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/3296/thumb/op.jpg?1547037878",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x8207c1FfC5B6804F6024322CcF34F29c3541Ae26"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 137,
+        "address": "0x62414D03084EeB269E18C970a21f45D2967F0170",
+        "name": "OMG Network",
+        "symbol": "OMG",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/776/thumb/OMG_Network.jpg?1591167168",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0xd26114cd6EE289AccF82350c8d8487fedB8A0C07"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 137,
+        "address": "0x0EE392bA5ef1354c9bd75a98044667d307C0e773",
+        "name": "Orion Protocol",
+        "symbol": "ORN",
+        "decimals": 8,
+        "logoURI": "https://assets.coingecko.com/coins/images/11841/thumb/orion_logo.png?1594943318",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x0258F474786DdFd37ABCE6df6BBb1Dd5dfC4434a"
+            }
+          }
+        }
+      },
+      {
+        "name": "Orchid",
+        "address": "0x9880e3dDA13c8e7D4804691A45160102d31F6060",
+        "symbol": "OXT",
+        "decimals": 18,
+        "chainId": 137,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x4575f41308EC1483f3d399aa9a2826d74Da13Deb/logo.png",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x4575f41308EC1483f3d399aa9a2826d74Da13Deb"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 137,
+        "address": "0x553d3D295e0f695B9228246232eDF400ed3560B5",
+        "name": "PAX Gold",
+        "symbol": "PAXG",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/9519/thumb/paxg.PNG?1568542565",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x45804880De22913dAFE09f4980848ECE6EcbAf78"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 137,
+        "address": "0x263534a4Fe3cb249dF46810718B7B612a30ebbff",
+        "name": "Perpetual Protocol",
+        "symbol": "PERP",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/12381/thumb/60d18e06844a844ad75901a9_mark_only_03.png?1628674771",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0xbC396689893D065F41bc2C6EcbeE5e0085233447"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 137,
+        "address": "0x8765f05ADce126d70bcdF1b0a48Db573316662eB",
+        "name": "PlayDapp",
+        "symbol": "PLA",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/14316/thumb/54023228.png?1615366911",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x3a4f40631a4f906c2BaD353Ed06De7A5D3fCb430"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 137,
+        "address": "0x7dc0cb65EC6019330a6841e9c274f2EE57A6CA6C",
+        "name": "Pluton",
+        "symbol": "PLU",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/1241/thumb/pluton.png?1548331624",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0xD8912C10681D8B21Fd3742244f44658dBA12264E"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 137,
+        "address": "0x8dc302e2141DA59c934d900886DbF1518Fd92cd4",
+        "name": "Polkastarter",
+        "symbol": "POLS",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/12648/thumb/polkastarter.png?1609813702",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x83e6f1E41cdd28eAcEB20Cb649155049Fac3D5Aa"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 137,
+        "address": "0xcB059C5573646047D6d88dDdb87B745C18161d3b",
+        "name": "Polymath",
+        "symbol": "POLY",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/2784/thumb/inKkF01.png?1605007034",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x9992eC3cF6A55b00978cdDF2b27BC6882d88D1eC"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 137,
+        "name": "Marlin",
+        "symbol": "POND",
+        "logoURI": "https://assets.coingecko.com/coins/images/8903/thumb/POND_200x200.png?1622515451",
+        "address": "0x73580A2416A57f1C4b6391DBA688A9e4f7DBECE0",
+        "decimals": 18,
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x57B946008913B82E4dF85f501cbAeD910e58D26C"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 137,
+        "address": "0x0AaB8DC887D34f00D50E19aee48371a941390d14",
+        "name": "Power Ledger",
+        "symbol": "POWR",
+        "decimals": 6,
+        "logoURI": "https://assets.coingecko.com/coins/images/1104/thumb/power-ledger.png?1547035082",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x595832F8FC6BF59c85C527fEC3740A1b7a361269"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 137,
+        "address": "0x82FFdFD1d8699E8886a4e77CeFA9dd9710a7FefD",
+        "name": "Propy",
+        "symbol": "PRO",
+        "decimals": 8,
+        "logoURI": "https://assets.coingecko.com/coins/images/869/thumb/propy.png?1548332100",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x226bb599a12C826476e3A771454697EA52E9E220"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 137,
+        "name": "PARSIQ",
+        "symbol": "PRQ",
+        "logoURI": "https://assets.coingecko.com/coins/images/11973/thumb/DsNgK0O.png?1596590280",
+        "address": "0x9377Eeb7419486FD4D485671d50baa4BF77c2222",
+        "decimals": 18,
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x362bc847A3a9637d3af6624EeC853618a43ed7D2"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 137,
+        "address": "0x36B77a184bE8ee56f5E81C56727B20647A42e28E",
+        "name": "Quant",
+        "symbol": "QNT",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/3370/thumb/5ZOu7brX_400x400.jpg?1612437252",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x4a220E6096B25EADb88358cb44068A3248254675"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 137,
+        "address": "0x831753DD7087CaC61aB5644b308642cc1c33Dc13",
+        "name": "Quickswap",
+        "symbol": "QUICK",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/13970/thumb/1_pOU6pBMEmiL-ZJVb0CYRjQ.png?1613386659",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x6c28AeF8977c9B773996d0e8376d2EE379446F2f"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 137,
+        "address": "0x2f81e176471CC57fDC76f7d332FB4511bF2bebDD",
+        "name": "Radicle",
+        "symbol": "RAD",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/14013/thumb/radicle.png?1614402918",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x31c8EAcBFFdD875c74b94b077895Bd78CF1E64A3"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 137,
+        "address": "0x00e5646f60AC6Fb446f621d146B6E1886f002905",
+        "name": "Rai Reflex Index",
+        "symbol": "RAI",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/14004/thumb/RAI-logo-coin.png?1613592334",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x03ab458634910AaD20eF5f1C8ee96F1D6ac54919"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 137,
+        "address": "0x780053837cE2CeEaD2A90D9151aA21FC89eD49c2",
+        "name": "Rarible",
+        "symbol": "RARI",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/11845/thumb/Rari.png?1594946953",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0xFca59Cd816aB1eaD66534D82bc21E7515cE441CF"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 137,
+        "address": "0xc3cFFDAf8F3fdF07da6D5e3A89B8723D5E385ff8",
+        "name": "Rubic",
+        "symbol": "RBC",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/12629/thumb/200x200.png?1607952509",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0xA4EED63db85311E22dF4473f87CcfC3DaDCFA3E3"
+            }
+          }
+        }
+      },
+      {
+        "name": "Republic Token",
+        "address": "0x19782D3Dc4701cEeeDcD90f0993f0A9126ed89d0",
+        "symbol": "REN",
+        "decimals": 18,
+        "chainId": 137,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x408e41876cCCDC0F92210600ef50372656052a38/logo.png",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x408e41876cCCDC0F92210600ef50372656052a38"
+            }
+          }
+        }
+      },
+      {
+        "name": "Reputation Augur v2",
+        "address": "0x6563c1244820CfBd6Ca8820FBdf0f2847363F733",
+        "symbol": "REPv2",
+        "decimals": 18,
+        "chainId": 137,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x221657776846890989a759BA2973e427DfF5C9bB/logo.png",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x221657776846890989a759BA2973e427DfF5C9bB"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 137,
+        "address": "0xAdf2F2Ed91755eA3f4bcC9107a494879f633ae7C",
+        "name": "Request",
+        "symbol": "REQ",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/1031/thumb/Request_icon_green.png?1643250951",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x8f8221aFbB33998d8584A2B05749bA73c37a938a"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 137,
+        "name": "REVV",
+        "symbol": "REVV",
+        "logoURI": "https://assets.coingecko.com/coins/images/12373/thumb/REVV_TOKEN_Refined_2021_%281%29.png?1627652390",
+        "address": "0x70c006878a5A50Ed185ac4C87d837633923De296",
+        "decimals": 18,
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x557B933a7C2c45672B610F8954A3deB39a51A8Ca"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 137,
+        "address": "0x3b9dB434F08003A89554CDB43b3e0b1f8734BdE7",
+        "name": "Rari Governance Token",
+        "symbol": "RGT",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/12900/thumb/Rari_Logo_Transparent.png?1613978014",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0xD291E7a03283640FDc51b121aC401383A46cC623"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 137,
+        "address": "0xbe662058e00849C3Eef2AC9664f37fEfdF2cdbFE",
+        "name": "iExec RLC",
+        "symbol": "RLC",
+        "decimals": 9,
+        "logoURI": "https://assets.coingecko.com/coins/images/646/thumb/pL1VuXm.png?1604543202",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x607F4C5BB672230e8672085532f7e901544a7375"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 137,
+        "address": "0x76b8D57e5ac6afAc5D415a054453d1DD2c3C0094",
+        "name": "Rally",
+        "symbol": "RLY",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/12843/thumb/image.png?1611212077",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0xf1f955016EcbCd7321c7266BccFB96c68ea5E49b"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 137,
+        "address": "0x61299774020dA444Af134c82fa83E3810b309991",
+        "name": "Render Token",
+        "symbol": "RNDR",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/11636/thumb/rndr.png?1638840934",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x6De037ef9aD2725EB40118Bb1702EBb27e4Aeb24"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 137,
+        "name": "Rook",
+        "symbol": "ROOK",
+        "logoURI": "https://assets.coingecko.com/coins/images/13005/thumb/keeper_dao_logo.jpg?1604316506",
+        "address": "0xF92501c8213da1D6C74A76372CCc720Dc8818407",
+        "decimals": 18,
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0xfA5047c9c78B8877af97BDcb85Db743fD7313d4a"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 137,
+        "address": "0xBbba073C31bF03b8ACf7c28EF0738DeCF3695683",
+        "name": "The Sandbox",
+        "symbol": "SAND",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/12129/thumb/sandbox_logo.jpg?1597397942",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x3845badAde8e6dFF049820680d1F14bD3903a5d0"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 137,
+        "address": "0x6f8a06447Ff6FcF75d803135a7de15CE88C1d4ec",
+        "name": "Shiba Inu",
+        "symbol": "SHIB",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/11939/thumb/shiba.png?1622619446",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x95aD61b0a150d79219dCF64E1E6Cc01f0B64C4cE"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 137,
+        "address": "0x0C7304fBAf2A320a1c50c46FE03752722F729946",
+        "name": "Smooth Love Potion",
+        "symbol": "SLP",
+        "decimals": 0,
+        "logoURI": "https://assets.coingecko.com/coins/images/10366/thumb/SLP.png?1578640057",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0xCC8Fa225D80b9c7D42F96e9570156c65D6cAAa25"
+            }
+          }
+        }
+      },
+      {
+        "name": "Synthetix Network Token",
+        "address": "0x50B728D8D964fd00C2d0AAD81718b71311feF68a",
+        "symbol": "SNX",
+        "decimals": 18,
+        "chainId": 137,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xC011a73ee8576Fb46F5E1c5751cA3B9Fe0af2a6F/logo.png",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0xC011a73ee8576Fb46F5E1c5751cA3B9Fe0af2a6F"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 137,
+        "address": "0xcdB3C70CD25FD15307D84C4F9D37d5C043B33Fb2",
+        "name": "Spell Token",
+        "symbol": "SPELL",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/15861/thumb/abracadabra-3.png?1622544862",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x090185f2135308BaD17527004364eBcC2D37e5F6"
+            }
+          }
+        }
+      },
+      {
+        "name": "Storj Token",
+        "address": "0xd72357dAcA2cF11A5F155b9FF7880E595A3F5792",
+        "symbol": "STORJ",
+        "decimals": 8,
+        "chainId": 137,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xB64ef51C888972c908CFacf59B47C1AfBC0Ab8aC/logo.png",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0xB64ef51C888972c908CFacf59B47C1AfBC0Ab8aC"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 137,
+        "address": "0xB36e3391B22a970d31A9b620Ae1A414C6c256d2a",
+        "name": "Stox",
+        "symbol": "STX",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/1230/thumb/stox-token.png?1547035256",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x006BeA43Baa3f7A6f765F14f10A1a1b08334EF45"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 137,
+        "address": "0x60Ea918FC64360269Da4efBDA11d8fC6514617C6",
+        "name": "SUKU",
+        "symbol": "SUKU",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/11969/thumb/UmfW5S6f_400x400.jpg?1596602238",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x0763fdCCF1aE541A5961815C0872A8c5Bc6DE4d7"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 137,
+        "address": "0xa1428174F516F527fafdD146b883bB4428682737",
+        "name": "SuperFarm",
+        "symbol": "SUPER",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/14040/thumb/6YPdWn6.png?1613975899",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0xe53EC727dbDEB9E2d5456c3be40cFF031AB40A55"
+            }
+          }
+        }
+      },
+      {
+        "name": "Synth sUSD",
+        "address": "0xF81b4Bec6Ca8f9fe7bE01CA734F55B2b6e03A7a0",
+        "symbol": "sUSD",
+        "decimals": 18,
+        "chainId": 137,
+        "logoURI": "https://assets.coingecko.com/coins/images/5013/thumb/sUSD.png?1616150765",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x57Ab1ec28D129707052df4dF418D58a2D46d5f51"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 137,
+        "address": "0x0b3F868E0BE5597D5DB7fEB59E1CADBb0fdDa50a",
+        "name": "Sushi",
+        "symbol": "SUSHI",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/12271/thumb/512x512_Logo_no_chop.png?1606986688",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x6B3595068778DD592e39A122f4f5a5cF09C90fE2"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 137,
+        "name": "Swipe",
+        "symbol": "SXP",
+        "logoURI": "https://assets.coingecko.com/coins/images/9368/thumb/swipe.png?1566792311",
+        "address": "0x6aBB753C1893194DE4a83c6e8B4EadFc105Fd5f5",
+        "decimals": 18,
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x8CE9137d39326AD0cD6491fb5CC0CbA0e089b6A9"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 137,
+        "address": "0x50a4a434247089848991DD8f09b889D4e2870aB6",
+        "name": "tBTC",
+        "symbol": "TBTC",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/11224/thumb/tBTC.png?1589620754",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x8dAEBADE922dF735c38C80C7eBD708Af50815fAa"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 137,
+        "address": "0xe1708AbDE4847B4929b70547E5197F1Ba1db2250",
+        "name": "Tokemak",
+        "symbol": "TOKE",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/17495/thumb/tokemak-avatar-200px-black.png?1628131614",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x2e9d63788249371f1DFC918a52f8d799F4a38C94"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 137,
+        "address": "0xA7b98d63a137bF402b4570799ac4caD0BB1c4B1c",
+        "name": "OriginTrail",
+        "symbol": "TRAC",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/1877/thumb/TRAC.jpg?1635134367",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0xaA7a9CA87d3694B5755f213B5D04094b8d0F0A6F"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 137,
+        "address": "0xE3322702BEdaaEd36CdDAb233360B939775ae5f1",
+        "name": "Tellor",
+        "symbol": "TRB",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/9644/thumb/Blk_icon_current.png?1584980686",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x88dF592F8eb5D7Bd38bFeF7dEb0fBc02cf3778a0"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 137,
+        "address": "0x8676815789211E799a6DC86d02748ADF9cF86836",
+        "name": "Tribe",
+        "symbol": "TRIBE",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/14575/thumb/tribe.PNG?1617487954",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0xc7283b66Eb1EB5FB86327f08e1B5816b0720212B"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 137,
+        "address": "0x5b77bCA482bd3E7958b1103d123888EfCCDaF803",
+        "name": "TrueFi",
+        "symbol": "TRU",
+        "decimals": 8,
+        "logoURI": "https://assets.coingecko.com/coins/images/13180/thumb/truefi_glyph_color.png?1617610941",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x4C19596f5aAfF459fA38B0f7eD92F11AE6543784"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 137,
+        "name": "The Virtua Kolect",
+        "symbol": "TVK",
+        "logoURI": "https://assets.coingecko.com/coins/images/13330/thumb/virtua_original.png?1656043619",
+        "address": "0x5667dcC0ab74D1b1355C3b2061893399331B57e2",
+        "decimals": 18,
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0xd084B83C305daFD76AE3E1b4E1F1fe2eCcCb3988"
+            }
+          }
+        }
+      },
+      {
+        "name": "UMA Voting Token v1",
+        "address": "0x3066818837c5e6eD6601bd5a91B0762877A6B731",
+        "symbol": "UMA",
+        "decimals": 18,
+        "chainId": 137,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x04Fa0d235C4abf4BcF4787aF4CF447DE572eF828/logo.png",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x04Fa0d235C4abf4BcF4787aF4CF447DE572eF828"
+            }
+          }
+        }
+      },
+      {
+        "name": "Uniswap",
+        "address": "0xb33EaAd8d922B1083446DC23f610c2567fB5180f",
+        "symbol": "UNI",
+        "decimals": 18,
+        "chainId": 137,
+        "logoURI": "ipfs://QmXttGpZrECX5qCyXbBQiqgQNytVGeZW5Anewvh2jc4psg",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x1f9840a85d5aF5bf1D1762F925BDADdC4201F984"
+            }
+          }
+        }
+      },
+      {
+        "name": "USDCoin",
+        "address": "0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174",
+        "symbol": "USDC",
+        "decimals": 6,
+        "chainId": 137,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/logo.png",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"
+            }
+          }
+        }
+      },
+      {
+        "name": "Tether USD",
+        "address": "0xc2132D05D31c914a87C6611C10748AEb04B58e8F",
+        "symbol": "USDT",
+        "decimals": 6,
+        "chainId": 137,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xdAC17F958D2ee523a2206206994597C13D831ec7/logo.png",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0xdAC17F958D2ee523a2206206994597C13D831ec7"
+            }
+          }
+        }
+      },
+      {
+        "name": "Wrapped BTC",
+        "address": "0x1BFD67037B42Cf73acF2047067bd4F2C47D9BfD6",
+        "symbol": "WBTC",
+        "decimals": 8,
+        "chainId": 137,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599/logo.png",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 137,
+        "name": "Wrapped Centrifuge",
+        "symbol": "WCFG",
+        "logoURI": "https://assets.coingecko.com/coins/images/17106/thumb/WCFG.jpg?1626266462",
+        "address": "0x90bb6fEB70A9a43CfAaA615F856BA309FD759A90",
+        "decimals": 18,
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0xc221b7E65FfC80DE234bbB6667aBDd46593D34F0"
+            }
+          }
+        }
+      },
+      {
+        "name": "Wrapped Ether",
+        "address": "0x7ceB23fD6bC0adD59E62ac25578270cFf1b9f619",
+        "symbol": "WETH",
+        "decimals": 18,
+        "chainId": 137,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2/logo.png",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2"
+            }
+          }
+        }
+      },
+      {
+        "name": "Wrapped Matic",
+        "address": "0x0d500B1d8E8eF31E21C99d1Db9A6444d3ADf1270",
+        "symbol": "WMATIC",
+        "decimals": 18,
+        "chainId": 137,
+        "logoURI": "https://assets.coingecko.com/coins/images/4713/thumb/matic-token-icon.png?1624446912"
+      },
+      {
+        "chainId": 137,
+        "name": "WOO Network",
+        "symbol": "WOO",
+        "logoURI": "https://assets.coingecko.com/coins/images/12921/thumb/w2UiemF__400x400.jpg?1603670367",
+        "address": "0x1B815d120B3eF02039Ee11dC2d33DE7aA4a8C603",
+        "decimals": 18,
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x4691937a7508860F876c9c0a2a617E7d9E945D4B"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 137,
+        "address": "0xd2507e7b5794179380673870d88B22F94da6abe0",
+        "name": "XYO Network",
+        "symbol": "XYO",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/4519/thumb/XYO_Network-logo.png?1547039819",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x55296f69f40Ea6d20E478533C15A6B08B654E758"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 137,
+        "address": "0xDA537104D6A5edd53c6fBba9A898708E465260b6",
+        "name": "yearn finance",
+        "symbol": "YFI",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/11849/thumb/yfi-192x192.png?1598325330",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x0bc529c00C6401aEF6D220BE8C6Ea1667F6Ad93e"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 137,
+        "address": "0xb8cb8a7F4C2885C03e57E973C74827909Fdc2032",
+        "name": "DFI money",
+        "symbol": "YFII",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/11902/thumb/YFII-logo.78631676.png?1598677348",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0xa1d0E215a23d7030842FC67cE582a6aFa3CCaB83"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 137,
+        "name": "Yield Guild Games",
+        "symbol": "YGG",
+        "logoURI": "https://assets.coingecko.com/coins/images/17358/thumb/le1nzlO6_400x400.jpg?1632465691",
+        "address": "0x82617aA52dddf5Ed9Bb7B370ED777b3182A30fd1",
+        "decimals": 18,
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x25f8087EAD173b73D6e8B84329989A8eEA16CF73"
+            }
+          }
+        }
+      },
+      {
+        "name": "0x Protocol Token",
+        "address": "0x5559Edb74751A0edE9DeA4DC23aeE72cCA6bE3D5",
+        "symbol": "ZRX",
+        "decimals": 18,
+        "chainId": 137,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xE41d2489571d322189246DaFA5ebDe1F4699F498/logo.png",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0xE41d2489571d322189246DaFA5ebDe1F4699F498"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 42161,
+        "address": "0x6314C31A7a1652cE482cffe247E9CB7c3f4BB9aF",
+        "name": "1inch",
+        "symbol": "1INCH",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/13469/thumb/1inch-token.png?1608803028",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x111111111117dC0aa78b770fA6A738034120C302"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 42161,
+        "address": "0xba5DdD1f9d7F570dc94a51479a000E3BCE967196",
+        "name": "Aave",
+        "symbol": "AAVE",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/12645/thumb/AAVE.png?1601374110",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x7Fc66500c84A76Ad7e9c93437bFc5Ac33E2DDaE9"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 42161,
+        "address": "0x74885b4D524d497261259B38900f54e6dbAd2210",
+        "name": "ApeCoin",
+        "symbol": "APE",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/24383/small/apecoin.jpg?1647476455",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x4d224452801ACEd8B2F0aebE155379bb5D594381"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 42161,
+        "address": "0xAC9Ac2C17cdFED4AbC80A53c5553388575714d03",
+        "name": "Automata",
+        "symbol": "ATA",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/15985/thumb/ATA.jpg?1622535745",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0xA2120b9e674d3fC3875f415A7DF52e382F141225"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 42161,
+        "address": "0xe88998Fb579266628aF6a03e3821d5983e5D0089",
+        "name": "Axie Infinity",
+        "symbol": "AXS",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/13029/thumb/axie_infinity_logo.png?1604471082",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0xBB0E17EF65F82Ab018d8EDd776e8DD940327B28b"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 42161,
+        "address": "0xBfa641051Ba0a0Ad1b0AcF549a89536A0D76472E",
+        "name": "Badger DAO",
+        "symbol": "BADGER",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/13287/thumb/badger_dao_logo.jpg?1607054976",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x3472A5A71965499acd81997a54BBA8D852C6E53d"
+            }
+          }
+        }
+      },
+      {
+        "name": "Balancer",
+        "address": "0x040d1EdC9569d4Bab2D15287Dc5A4F10F56a56B8",
+        "symbol": "BAL",
+        "decimals": 18,
+        "chainId": 42161,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xba100000625a3754423978a60c9317c58a424e3D/logo.png",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0xba100000625a3754423978a60c9317c58a424e3D"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 42161,
+        "address": "0x3450687EF141dCd6110b77c2DC44B008616AeE75",
+        "name": "Basic Attention Token",
+        "symbol": "BAT",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/677/thumb/basic-attention-token.png?1547034427",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x0D8775F648430679A709E98d2b0Cb6250d2887EF"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 42161,
+        "address": "0xa68Ec98D7ca870cF1Dd0b00EBbb7c4bF60A8e74d",
+        "name": "Biconomy",
+        "symbol": "BICO",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/21061/thumb/biconomy_logo.jpg?1638269749",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0xF17e65822b568B3903685a7c9F496CF7656Cc6C2"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 42161,
+        "address": "0x406C8dB506653D882295875F633bEC0bEb921C2A",
+        "name": "BitDAO",
+        "symbol": "BIT",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/17627/thumb/rI_YptK8.png?1653983088",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x1A4b46696b2bB4794Eb3D4c26f1c55F9170fa4C5"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 42161,
+        "address": "0x0D81E50bC677fa67341c44D7eaA9228DEE64A4e1",
+        "name": "BarnBridge",
+        "symbol": "BOND",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/12811/thumb/barnbridge.jpg?1602728853",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x0391D2021f89DC339F60Fff84546EA23E337750f"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 42161,
+        "address": "0x31190254504622cEFdFA55a7d3d272e6462629a2",
+        "name": "Binance USD",
+        "symbol": "BUSD",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/9576/thumb/BUSD.png?1568947766",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x4Fabb145d64652a948d72533023f6E7A623C7C53"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 42161,
+        "address": "0x3a8B787f78D775AECFEEa15706D4221B40F345AB",
+        "name": "Celer Network",
+        "symbol": "CELR",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/4379/thumb/Celr.png?1554705437",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x4F9254C83EB525f9FCf346490bbb3ed28a81C667"
+            }
+          }
+        }
+      },
+      {
+        "name": "Compound",
+        "address": "0x354A6dA3fcde098F8389cad84b0182725c6C91dE",
+        "symbol": "COMP",
+        "decimals": 18,
+        "chainId": 42161,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xc00e94Cb662C3520282E6f5717214004A7f26888/logo.png",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0xc00e94Cb662C3520282E6f5717214004A7f26888"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 42161,
+        "address": "0x6FE14d3CC2f7bDdffBa5CdB3BBE7467dd81ea101",
+        "name": "COTI",
+        "symbol": "COTI",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/2962/thumb/Coti.png?1559653863",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0xDDB3422497E61e13543BeA06989C0789117555c5"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 42161,
+        "address": "0x8ea3156f834A0dfC78F1A5304fAC2CdA676F354C",
+        "name": "Cronos",
+        "symbol": "CRO",
+        "decimals": 8,
+        "logoURI": "https://assets.coingecko.com/coins/images/7310/thumb/oCw2s3GI_400x400.jpeg?1645172042",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0xA0b73E1Ff0B80914AB6fe0444E65848C4C34450b"
+            }
+          }
+        }
+      },
+      {
+        "name": "Curve DAO Token",
+        "address": "0x11cDb42B0EB46D95f990BeDD4695A6e3fA034978",
+        "symbol": "CRV",
+        "decimals": 18,
+        "chainId": 42161,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xD533a949740bb3306d119CC777fa900bA034cd52/logo.png",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0xD533a949740bb3306d119CC777fa900bA034cd52"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 42161,
+        "address": "0x319f865b287fCC10b30d8cE6144e8b6D1b476999",
+        "name": "Cartesi",
+        "symbol": "CTSI",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/11038/thumb/cartesi.png?1592288021",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x491604c0FDF08347Dd1fa4Ee062a822A5DD06B5D"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 42161,
+        "address": "0x9DfFB23CAd3322440bCcFF7aB1C58E781dDBF144",
+        "name": "Civic",
+        "symbol": "CVC",
+        "decimals": 8,
+        "logoURI": "https://assets.coingecko.com/coins/images/788/thumb/civic.png?1547034556",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x41e5560054824eA6B0732E656E3Ad64E20e94E45"
+            }
+          }
+        }
+      },
+      {
+        "name": "Dai Stablecoin",
+        "address": "0xDA10009cBd5D07dd0CeCc66161FC93D7c9000da1",
+        "symbol": "DAI",
+        "decimals": 18,
+        "chainId": 42161,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x6B175474E89094C44Da98b954EedeAC495271d0F/logo.png",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x6B175474E89094C44Da98b954EedeAC495271d0F"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 42161,
+        "address": "0xca642467C6Ebe58c13cB4A7091317f34E17ac05e",
+        "name": "DIA",
+        "symbol": "DIA",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/11955/thumb/image.png?1646041751",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x84cA8bc7997272c7CfB4D0Cd3D55cd942B3c9419"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 42161,
+        "address": "0x51863cB90Ce5d6dA9663106F292fA27c8CC90c5a",
+        "name": "dYdX",
+        "symbol": "DYDX",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/17500/thumb/hjnIm9bV.jpg?1628009360",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x92D6C1e31e14520e676a687F0a93788B716BEff5"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 42161,
+        "address": "0x3e4Cff6E50F37F731284A92d44AE943e17077fD4",
+        "name": "Dogelon Mars",
+        "symbol": "ELON",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/14962/thumb/6GxcPRo3_400x400.jpg?1619157413",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x761D38e5ddf6ccf6Cf7c55759d5210750B5D60F3"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 42161,
+        "address": "0x7fa9549791EFc9030e1Ed3F25D18014163806758",
+        "name": "Enjin Coin",
+        "symbol": "ENJ",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/1102/thumb/enjin-coin-logo.png?1547035078",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0xF629cBd94d3791C9250152BD8dfBDF380E2a3B9c"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 42161,
+        "address": "0xfeA31d704DEb0975dA8e77Bf13E04239e70d7c28",
+        "name": "Ethereum Name Service",
+        "symbol": "ENS",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/19785/thumb/acatxTm8_400x400.jpg?1635850140",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0xC18360217D8F7Ab5e7c516566761Ea12Ce7F9D72"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 42161,
+        "address": "0x3A1429d50E0cBBc45c997aF600541Fe1cc3D2923",
+        "name": "Forta",
+        "symbol": "FORT",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/25060/thumb/Forta_lgo_%281%29.png?1655353696",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x41545f8b9472D758bB669ed8EaEEEcD7a9C4Ec29"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 42161,
+        "address": "0x7468a5d8E02245B00E8C0217fCE021C70Bc51305",
+        "name": "Frax",
+        "symbol": "FRAX",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/13422/thumb/frax_logo.png?1608476506",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x853d955aCEf822Db058eb8505911ED77F175b99e"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 42161,
+        "address": "0xd42785D323e608B9E99fa542bd8b1000D4c2Df37",
+        "name": "Fantom",
+        "symbol": "FTM",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/4001/thumb/Fantom.png?1558015016",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x4E15361FD6b4BB609Fa63C81A2be19d873717870"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 42161,
+        "address": "0xd9f9d2Ee2d3EFE420699079f16D9e924affFdEA4",
+        "name": "Frax Share",
+        "symbol": "FXS",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/13423/thumb/frax_share.png?1608478989",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x3432B6A60D23Ca0dFCa7761B7ab56459D9C964D0"
+            }
+          }
+        }
+      },
+      {
+        "name": "Gnosis Token",
+        "address": "0xa0b862F60edEf4452F25B4160F177db44DeB6Cf1",
+        "symbol": "GNO",
+        "decimals": 18,
+        "chainId": 42161,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x6810e776880C02933D47DB1b9fc05908e5386b96/logo.png",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x6810e776880C02933D47DB1b9fc05908e5386b96"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 42161,
+        "address": "0x23A941036Ae778Ac51Ab04CEa08Ed6e2FE103614",
+        "name": "The Graph",
+        "symbol": "GRT",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/13397/thumb/Graph_Token.png?1608145566",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0xc944E90C64B2c07662A292be6244BDf05Cda44a7"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 42161,
+        "address": "0x7f9a7DB853Ca816B9A138AEe3380Ef34c437dEe0",
+        "name": "Gitcoin",
+        "symbol": "GTC",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/15810/thumb/gitcoin.png?1621992929",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0xDe30da39c46104798bB5aA3fe8B9e0e1F348163F"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 42161,
+        "address": "0x3fEcB65993e4835884baF6452d1ebfdBC3A78480",
+        "name": "GYEN",
+        "symbol": "GYEN",
+        "decimals": 6,
+        "logoURI": "https://assets.coingecko.com/coins/images/14191/thumb/icon_gyen_200_200.png?1614843343",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0xC08512927D12348F6620a698105e1BAac6EcD911"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 42161,
+        "address": "0x13Ad51ed4F1B7e9Dc168d8a00cB3f4dDD85EfA60",
+        "name": "Lido DAO",
+        "symbol": "LDO",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/13573/thumb/Lido_DAO.png?1609873644",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x5A98FcBEA516Cf06857215779Fd812CA3beF1B32"
+            }
+          }
+        }
+      },
+      {
+        "name": "ChainLink Token",
+        "address": "0xf97f4df75117a78c1A5a0DBb814Af92458539FB4",
+        "symbol": "LINK",
+        "decimals": 18,
+        "chainId": 42161,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x514910771AF9Ca656af840dff83E8264EcF986CA/logo.png",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x514910771AF9Ca656af840dff83E8264EcF986CA"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 42161,
+        "address": "0x289ba1701C2F088cf0faf8B3705246331cB8A839",
+        "name": "Livepeer",
+        "symbol": "LPT",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/7137/thumb/logo-circle-green.png?1619593365",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x58b6A8A3302369DAEc383334672404Ee733aB239"
+            }
+          }
+        }
+      },
+      {
+        "name": "LoopringCoin V2",
+        "address": "0x46d0cE7de6247b0A95f67b43B589b4041BaE7fbE",
+        "symbol": "LRC",
+        "decimals": 18,
+        "chainId": 42161,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xBBbbCA6A901c926F240b89EacB641d8Aec7AEafD/logo.png",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0xBBbbCA6A901c926F240b89EacB641d8Aec7AEafD"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 42161,
+        "name": "Liquity USD",
+        "symbol": "LUSD",
+        "logoURI": "https://assets.coingecko.com/coins/images/14666/thumb/Group_3.png?1617631327",
+        "address": "0x93b346b6BC2548dA6A1E7d98E9a421B42541425b",
+        "decimals": 18,
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x5f98805A4E8be255a32880FDeC7F6728C6568bA0"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 42161,
+        "address": "0x442d24578A564EF628A65e6a7E3e7be2a165E231",
+        "name": "Decentraland",
+        "symbol": "MANA",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/878/thumb/decentraland-mana.png?1550108745",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x0F5D2fB29fb7d3CFeE444a200298f468908cC942"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 42161,
+        "address": "0x533A7B414CD1236815a5e09F1E97FC7d5c313739",
+        "name": "Mask Network",
+        "symbol": "MASK",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/14051/thumb/Mask_Network.jpg?1614050316",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x69af81e73A73B40adF4f3d4223Cd9b1ECE623074"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 42161,
+        "name": "MATH",
+        "symbol": "MATH",
+        "logoURI": "https://assets.coingecko.com/coins/images/11335/thumb/2020-05-19-token-200.png?1589940590",
+        "address": "0x99F40b01BA9C469193B360f72740E416B17Ac332",
+        "decimals": 18,
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x08d967bb0134F2d07f7cfb6E246680c53927DD30"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 42161,
+        "address": "0x561877b6b3DD7651313794e5F2894B2F18bE0766",
+        "name": "Polygon",
+        "symbol": "MATIC",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/4713/thumb/matic-token-icon.png?1624446912",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x7D1AfA7B718fb893dB30A3aBc0Cfc608AaCfeBB0"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 42161,
+        "name": "Metis",
+        "symbol": "METIS",
+        "logoURI": "https://assets.coingecko.com/coins/images/15595/thumb/metis.jpeg?1660285312",
+        "address": "0x7F728F3595db17B0B359f4FC47aE80FAd2e33769",
+        "decimals": 18,
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x9E32b13ce7f2E80A01932B42553652E053D6ed8e"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 42161,
+        "address": "0xB20A02dfFb172C474BC4bDa3fD6f4eE70C04daf2",
+        "name": "Magic Internet Money",
+        "symbol": "MIM",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/16786/thumb/mimlogopng.png?1624979612",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x99D8a9C45b2ecA8864373A26D1459e3Dff1e17F3"
+            }
+          }
+        }
+      },
+      {
+        "name": "Maker",
+        "address": "0x2e9a6Df78E42a30712c10a9Dc4b1C8656f8F2879",
+        "symbol": "MKR",
+        "decimals": 18,
+        "chainId": 42161,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x9f8F72aA9304c8B593d555F12eF6589cC3A579A2/logo.png",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x9f8F72aA9304c8B593d555F12eF6589cC3A579A2"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 42161,
+        "address": "0x8f5c1A99b1df736Ad685006Cb6ADCA7B7Ae4b514",
+        "name": "Melon",
+        "symbol": "MLN",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/605/thumb/melon.png?1547034295",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0xec67005c4E498Ec7f55E092bd1d35cbC47C91892"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 42161,
+        "address": "0x53236015A675fcB937485F1AE58040e4Fb920d5b",
+        "name": "PolySwarm",
+        "symbol": "NCT",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/2843/thumb/ImcYCVfX_400x400.jpg?1628519767",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x9E46A38F5DaaBe8683E10793b06749EEF7D733d1"
+            }
+          }
+        }
+      },
+      {
+        "name": "Numeraire",
+        "address": "0x597701b32553b9fa473e21362D480b3a6B569711",
+        "symbol": "NMR",
+        "decimals": 18,
+        "chainId": 42161,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x1776e1F26f98b1A5dF9cD347953a26dd3Cb46671/logo.png",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x1776e1F26f98b1A5dF9cD347953a26dd3Cb46671"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 42161,
+        "address": "0x933d31561e470478079FEB9A6Dd2691fAD8234DF",
+        "name": "Ocean Protocol",
+        "symbol": "OCEAN",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/3687/thumb/ocean-protocol-logo.jpg?1547038686",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x967da4048cD07aB37855c090aAF366e4ce1b9F48"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 42161,
+        "address": "0xfEb4DfC8C4Cf7Ed305bb08065D08eC6ee6728429",
+        "name": "PAX Gold",
+        "symbol": "PAXG",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/9519/thumb/paxg.PNG?1568542565",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x45804880De22913dAFE09f4980848ECE6EcbAf78"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 42161,
+        "address": "0x753D224bCf9AAFaCD81558c32341416df61D3DAC",
+        "name": "Perpetual Protocol",
+        "symbol": "PERP",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/12381/thumb/60d18e06844a844ad75901a9_mark_only_03.png?1628674771",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0xbC396689893D065F41bc2C6EcbeE5e0085233447"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 42161,
+        "name": "Marlin",
+        "symbol": "POND",
+        "logoURI": "https://assets.coingecko.com/coins/images/8903/thumb/POND_200x200.png?1622515451",
+        "address": "0xdA0a57B710768ae17941a9Fa33f8B720c8bD9ddD",
+        "decimals": 18,
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x57B946008913B82E4dF85f501cbAeD910e58D26C"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 42161,
+        "address": "0x4e91F2AF1ee0F84B529478f19794F5AFD423e4A6",
+        "name": "Power Ledger",
+        "symbol": "POWR",
+        "decimals": 6,
+        "logoURI": "https://assets.coingecko.com/coins/images/1104/thumb/power-ledger.png?1547035082",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x595832F8FC6BF59c85C527fEC3740A1b7a361269"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 42161,
+        "name": "PARSIQ",
+        "symbol": "PRQ",
+        "logoURI": "https://assets.coingecko.com/coins/images/11973/thumb/DsNgK0O.png?1596590280",
+        "address": "0x82164a8B646401a8776F9dC5c8Cba35DcAf60Cd2",
+        "decimals": 18,
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x362bc847A3a9637d3af6624EeC853618a43ed7D2"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 42161,
+        "address": "0xaeF5bbcbFa438519a5ea80B4c7181B4E78d419f2",
+        "name": "Rai Reflex Index",
+        "symbol": "RAI",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/14004/thumb/RAI-logo-coin.png?1613592334",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x03ab458634910AaD20eF5f1C8ee96F1D6ac54919"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 42161,
+        "address": "0xCF8600347Dc375C5f2FdD6Dab9BB66e0b6773cd7",
+        "name": "Rarible",
+        "symbol": "RARI",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/11845/thumb/Rari.png?1594946953",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0xFca59Cd816aB1eaD66534D82bc21E7515cE441CF"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 42161,
+        "address": "0x2E9AE8f178d5Ea81970C7799A377B3985cbC335F",
+        "name": "Rubic",
+        "symbol": "RBC",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/12629/thumb/200x200.png?1607952509",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0xA4EED63db85311E22dF4473f87CcfC3DaDCFA3E3"
+            }
+          }
+        }
+      },
+      {
+        "name": "Republic Token",
+        "address": "0x9fA891e1dB0a6D1eEAC4B929b5AAE1011C79a204",
+        "symbol": "REN",
+        "decimals": 18,
+        "chainId": 42161,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x408e41876cCCDC0F92210600ef50372656052a38/logo.png",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x408e41876cCCDC0F92210600ef50372656052a38"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 42161,
+        "address": "0xef888bcA6AB6B1d26dbeC977C455388ecd794794",
+        "name": "Rari Governance Token",
+        "symbol": "RGT",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/12900/thumb/Rari_Logo_Transparent.png?1613978014",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0xD291E7a03283640FDc51b121aC401383A46cC623"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 42161,
+        "address": "0xd1318eb19DBF2647743c720ed35174efd64e3DAC",
+        "name": "The Sandbox",
+        "symbol": "SAND",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/12129/thumb/sandbox_logo.jpg?1597397942",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x3845badAde8e6dFF049820680d1F14bD3903a5d0"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 42161,
+        "address": "0x5033833c9fe8B9d3E09EEd2f73d2aaF7E3872fd1",
+        "name": "Shiba Inu",
+        "symbol": "SHIB",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/11939/thumb/shiba.png?1622619446",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x95aD61b0a150d79219dCF64E1E6Cc01f0B64C4cE"
+            }
+          }
+        }
+      },
+      {
+        "name": "Synthetix Network Token",
+        "address": "0xcBA56Cd8216FCBBF3fA6DF6137F3147cBcA37D60",
+        "symbol": "SNX",
+        "decimals": 18,
+        "chainId": 42161,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xC011a73ee8576Fb46F5E1c5751cA3B9Fe0af2a6F/logo.png",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0xC011a73ee8576Fb46F5E1c5751cA3B9Fe0af2a6F"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 42161,
+        "address": "0xb2BE52744a804Cc732d606817C2572C5A3B264e7",
+        "name": "Unisocks",
+        "symbol": "SOCKS",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/10717/thumb/qFrcoiM.png?1582525244",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x23B608675a2B2fB1890d3ABBd85c5775c51691d5"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 42161,
+        "address": "0xb74Da9FE2F96B9E0a5f4A3cf0b92dd2bEC617124",
+        "name": "SOL Wormhole ",
+        "symbol": "SOL",
+        "decimals": 9,
+        "logoURI": "https://assets.coingecko.com/coins/images/22876/thumb/SOL_wh_small.png?1644224316",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0xD31a59c85aE9D8edEFeC411D448f90841571b89c"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 42161,
+        "address": "0x3E6648C5a70A150A88bCE65F4aD4d506Fe15d2AF",
+        "name": "Spell Token",
+        "symbol": "SPELL",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/15861/thumb/abracadabra-3.png?1622544862",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x090185f2135308BaD17527004364eBcC2D37e5F6"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 42161,
+        "name": "Stargate Finance",
+        "symbol": "STG",
+        "logoURI": "https://assets.coingecko.com/coins/images/24413/thumb/STG_LOGO.png?1647654518",
+        "address": "0xe018C7a3d175Fb0fE15D70Da2c874d3CA16313EC",
+        "decimals": 18,
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0xAf5191B0De278C7286d6C7CC6ab6BB8A73bA2Cd6"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 42161,
+        "address": "0x7f9cf5a2630a0d58567122217dF7609c26498956",
+        "name": "SuperFarm",
+        "symbol": "SUPER",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/14040/thumb/6YPdWn6.png?1613975899",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0xe53EC727dbDEB9E2d5456c3be40cFF031AB40A55"
+            }
+          }
+        }
+      },
+      {
+        "name": "Synth sUSD",
+        "address": "0xA970AF1a584579B618be4d69aD6F73459D112F95",
+        "symbol": "sUSD",
+        "decimals": 18,
+        "chainId": 42161,
+        "logoURI": "https://assets.coingecko.com/coins/images/5013/thumb/sUSD.png?1616150765",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x57Ab1ec28D129707052df4dF418D58a2D46d5f51"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 42161,
+        "address": "0xd4d42F0b6DEF4CE0383636770eF773390d85c61A",
+        "name": "Sushi",
+        "symbol": "SUSHI",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/12271/thumb/512x512_Logo_no_chop.png?1606986688",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x6B3595068778DD592e39A122f4f5a5cF09C90fE2"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 42161,
+        "address": "0x1bCfc0B4eE1471674cd6A9F6B363A034375eAD84",
+        "name": "Synapse",
+        "symbol": "SYN",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/18024/thumb/syn.png?1635002049",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x0f2D719407FdBeFF09D87557AbB7232601FD9F29"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 42161,
+        "address": "0xd58D345Fd9c82262E087d2D0607624B410D88242",
+        "name": "Tellor",
+        "symbol": "TRB",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/9644/thumb/Blk_icon_current.png?1584980686",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x88dF592F8eb5D7Bd38bFeF7dEb0fBc02cf3778a0"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 42161,
+        "address": "0xBfAE6fecD8124ba33cbB2180aAb0Fe4c03914A5A",
+        "name": "Tribe",
+        "symbol": "TRIBE",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/14575/thumb/tribe.PNG?1617487954",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0xc7283b66Eb1EB5FB86327f08e1B5816b0720212B"
+            }
+          }
+        }
+      },
+      {
+        "name": "UMA Voting Token v1",
+        "address": "0xd693Ec944A85eeca4247eC1c3b130DCa9B0C3b22",
+        "symbol": "UMA",
+        "decimals": 18,
+        "chainId": 42161,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x04Fa0d235C4abf4BcF4787aF4CF447DE572eF828/logo.png",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x04Fa0d235C4abf4BcF4787aF4CF447DE572eF828"
+            }
+          }
+        }
+      },
+      {
+        "name": "Uniswap",
+        "address": "0xFa7F8980b0f1E64A2062791cc3b0871572f1F7f0",
+        "symbol": "UNI",
+        "decimals": 18,
+        "chainId": 42161,
+        "logoURI": "ipfs://QmXttGpZrECX5qCyXbBQiqgQNytVGeZW5Anewvh2jc4psg",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x1f9840a85d5aF5bf1D1762F925BDADdC4201F984"
+            }
+          }
+        }
+      },
+      {
+        "name": "USDCoin",
+        "address": "0xFF970A61A04b1cA14834A43f5dE4533eBDDB5CC8",
+        "symbol": "USDC",
+        "decimals": 6,
+        "chainId": 42161,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/logo.png",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"
+            }
+          }
+        }
+      },
+      {
+        "name": "Tether USD",
+        "address": "0xFd086bC7CD5C481DCC9C85ebE478A1C0b69FCbb9",
+        "symbol": "USDT",
+        "decimals": 6,
+        "chainId": 42161,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xdAC17F958D2ee523a2206206994597C13D831ec7/logo.png",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0xdAC17F958D2ee523a2206206994597C13D831ec7"
+            }
+          }
+        }
+      },
+      {
+        "name": "Wrapped BTC",
+        "address": "0x2f2a2543B76A4166549F7aaB2e75Bef0aefC5B0f",
+        "symbol": "WBTC",
+        "decimals": 8,
+        "chainId": 42161,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599/logo.png",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599"
+            }
+          }
+        }
+      },
+      {
+        "name": "Wrapped Ether",
+        "address": "0x82aF49447D8a07e3bd95BD0d56f35241523fBab1",
+        "symbol": "WETH",
+        "decimals": 18,
+        "chainId": 42161,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2/logo.png",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 42161,
+        "name": "WOO Network",
+        "symbol": "WOO",
+        "logoURI": "https://assets.coingecko.com/coins/images/12921/thumb/w2UiemF__400x400.jpg?1603670367",
+        "address": "0xcAFcD85D8ca7Ad1e1C6F82F651fA15E33AEfD07b",
+        "decimals": 18,
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x4691937a7508860F876c9c0a2a617E7d9E945D4B"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 42161,
+        "address": "0x82e3A8F066a6989666b031d916c43672085b1582",
+        "name": "yearn finance",
+        "symbol": "YFI",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/11849/thumb/yfi-192x192.png?1598325330",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0x0bc529c00C6401aEF6D220BE8C6Ea1667F6Ad93e"
+            }
+          }
+        }
+      },
+      {
+        "name": "0x Protocol Token",
+        "address": "0xBD591Bd4DdB64b77B5f76Eab8f03d02519235Ae2",
+        "symbol": "ZRX",
+        "decimals": 18,
+        "chainId": 42161,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xE41d2489571d322189246DaFA5ebDe1F4699F498/logo.png",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0xE41d2489571d322189246DaFA5ebDe1F4699F498"
+            }
+          }
+        }
+      },
+      {
+        "chainId": 42220,
+        "address": "0x471EcE3750Da237f93B8E339c536989b8978a438",
+        "name": "Celo",
+        "symbol": "CELO",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/ubeswap/default-token-list/master/assets/asset_CELO.png"
+      },
+      {
+        "name": "Wrapped Ether",
+        "address": "0x2DEf4285787d58a2f811AF24755A8150622f4361",
+        "symbol": "WETH",
+        "decimals": 18,
+        "chainId": 42220,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2/logo.png",
+        "extensions": {
+          "bridgeInfo": {
+            "1": {
+              "tokenAddress": "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2"
+            }
+          }
+        }
+      },
+      {
+        "name": "Wrapped Ether",
+        "address": "0xA6FA4fB5f76172d178d61B04b0ecd319C5d1C0aa",
+        "symbol": "WETH",
+        "decimals": 18,
+        "chainId": 80001,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2/logo.png"
+      },
+      {
+        "name": "Wrapped Matic",
+        "address": "0x9c3C9283D3e44854697Cd22D3Faa240Cfb032889",
+        "symbol": "WMATIC",
+        "decimals": 18,
+        "chainId": 80001,
+        "logoURI": "https://assets.coingecko.com/coins/images/4713/thumb/matic-token-icon.png?1624446912"
+      }
+    ]
+  },
+  "https://umaproject.org/uma.tokenlist.json": {
+    "name": "UMA",
+    "logoURI": "https://umaproject.org/assets/images/UMA_square_red_logo_circle.png",
+    "keywords": ["defi", "uma", "yield"],
+    "timestamp": "2020-11-23T01:40:34.305Z",
+    "tokens": [
+      {
+        "chainId": 1,
+        "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
+        "name": "UMA",
+        "symbol": "UMA",
+        "decimals": 18
+      },
+      {
+        "chainId": 1,
+        "address": "0x81ab848898b5ffD3354dbbEfb333D5D183eEDcB5",
+        "name": "yUSD Synthetic Expiring 1 September 2020",
+        "symbol": "yUSDSEP20",
+        "decimals": 18
+      },
+      {
+        "chainId": 1,
+        "address": "0xB2FdD60AD80ca7bA89B9BAb3b5336c2601C020b4",
+        "name": "yUSD Synthetic Expiring 1 October 2020",
+        "symbol": "yUSDOCT20",
+        "decimals": 18
+      },
+      {
+        "chainId": 1,
+        "address": "0x208d174775dc39fe18b1b374972f77ddec6c0f73",
+        "name": "uUSDrBTC Synthetic Expiring 1 Oct 2020",
+        "symbol": "uUSDrBTC-OCT",
+        "decimals": 18
+      },
+      {
+        "chainId": 1,
+        "address": "0xf06ddacf71e2992e2122a1a0168c6967afdf63ce",
+        "name": "uUSDrBTC Synthetic Expiring 31 Dec 2020",
+        "symbol": "uUSDrBTC-DEC",
+        "decimals": 18
+      },
+      {
+        "chainId": 1,
+        "address": "0xd16c79c8a39d44b2f3eb45d2019cd6a42b03e2a9",
+        "name": "uUSDwETH Synthetic Expiring 31 Dec 2020",
+        "symbol": "uUSDwETH-DEC",
+        "decimals": 18
+      },
+      {
+        "chainId": 1,
+        "address": "0x3d995510f8d82c2ea341845932b5ddde0bead9a3",
+        "name": "uGAS-JAN21 Token Expiring 31 Jan 2021",
+        "symbol": "uGAS-JAN21",
+        "decimals": 18
+      },
+      {
+        "chainId": 1,
+        "address": "0x90f802c7e8fb5d40b0de583e34c065a3bd2020d8",
+        "name": "YD-ETH-MAR21 Token Expiring 31 Mar 2021",
+        "symbol": "YD-ETH-MAR21",
+        "decimals": 18
+      },
+      {
+        "chainId": 1,
+        "address": "0x002f0b1a71c5730cf2f4da1970a889207bdb6d0d",
+        "name": "YD-BTC-MAR21 Token Expiring 31 Mar 2021",
+        "symbol": "YD-BTC-MAR21",
+        "decimals": 18
+      },
+      {
+        "chainId": 1,
+        "address": "0x1062ad0e59fa67fa0b27369113098cc941dd0d5f",
+        "name": "UMA 35 Call Expirying 30 Apr 2021",
+        "symbol": "UMAc35-0421",
+        "decimals": 18
+      },
+      {
+        "chainId": 1,
+        "address": "0xf93340b1a3adf7eedcaec25fae8171d4b736e89f",
+        "name": "pxUSD Synthetic USD Expiring 1 April 2021",
+        "symbol": "pxUSD_MAR2021",
+        "decimals": 18
+      },
+      {
+        "chainId": 1,
+        "address": "0x84bd083b1c8bf929f39c98bc17cf518f40154f58",
+        "name": "Mario Cash Synthetic Token Expiring 15 January 2021",
+        "symbol": "Mario Cash-JAN-2021",
+        "decimals": 18
+      },
+      {
+        "chainId": 1,
+        "address": "0x81fab276aec924fbde190cf379783526d413cf70",
+        "name": "uGAS-FEB21 Token Expiring 28 Feb 2021",
+        "symbol": "uGAS-FEB21",
+        "decimals": 18
+      },
+      {
+        "chainId": 1,
+        "address": "0x4e110603e70b0b5f1c403ee543b37e1f1244cf28",
+        "name": "uGAS-MAR21 Token Expiring 31 Mar 2021",
+        "symbol": "uGAS-MAR21",
+        "decimals": 18
+      },
+      {
+        "chainId": 1,
+        "address": "0xcf55a7f92d5e0c6683debbc1fc20c0a6e056df13",
+        "name": "Zelda Elastic Cash",
+        "symbol": "Zelda Elastic Cash",
+        "decimals": 18
+      },
+      {
+        "chainId": 1,
+        "address": "0x654eebac62240e6c56bab5f6adf7cfa74a894510",
+        "name": "Zelda Spring Nuts Cash",
+        "symbol": "Zelda Spring Nuts Cash",
+        "decimals": 18
+      },
+      {
+        "chainId": 1,
+        "address": "0xa48920cc1ad85d8ea13af5d7be180c0338c306dd",
+        "name": "Zelda Summer Nuts Cash",
+        "symbol": "Zelda Summer Nuts Cash",
+        "decimals": 18
+      },
+      {
+        "chainId": 1,
+        "address": "0x249a198d59b57fda5dda90630febc86fd8c7594c",
+        "name": "Zelda Whirlwind Cash",
+        "symbol": "Zelda Whirlwind Cash",
+        "decimals": 18
+      },
+      {
+        "chainId": 1,
+        "address": "0x5ed1406873c9eb91f6f9a67ac4e152387c1132e7",
+        "name": "Zelda Reinforced Cash",
+        "symbol": "Zelda Reinforced Cash",
+        "decimals": 18
+      },
+      {
+        "chainId": 1,
+        "address": "0x8104c9f13118320eefe5fbea8a44d600b85981ef",
+        "name": "Mini Mario Summer Cash",
+        "symbol": "Mini Mario Summer Cash",
+        "decimals": 18
+      },
+      {
+        "chainId": 1,
+        "address": "0x69746c719e59674b147df25f50e7cfa0673cb625",
+        "name": "Mini Mario Spring Cash",
+        "symbol": "Mini Mario Spring Cash",
+        "decimals": 18
+      },
+      {
+        "chainId": 1,
+        "address": "0x6b1257641d18791141f025eab36fb567c4b564ff",
+        "name": "Bitcoin Dominance Token 31 March 2021",
+        "symbol": "BTCDOM-MAR2021",
+        "decimals": 18
+      },
+      {
+        "chainId": 1,
+        "address": "0x4e83b6287588a96321b2661c5e041845ff7814af",
+        "name": "Altcoin Dominance Token 31 March 2021",
+        "symbol": "ALTDOM-MAR2021",
+        "decimals": 18
+      },
+      {
+        "chainId": 1,
+        "address": "0x59fec83ec709c893aedd1a144cf1828eb04127cd",
+        "name": "pxGOLD Synthetic GOLD Expiring 31 May 2021",
+        "symbol": "pxGOLD_MAY2021",
+        "decimals": 18
+      },
+      {
+        "chainId": 1,
+        "address": "0x89337BFb7938804c3776C9FB921EccAf5ab76758",
+        "name": "Compound Annualized Rate Future Expiring 28 March 2021",
+        "symbol": "CAR-USDC-MAR21",
+        "decimals": 18
+      },
+      {
+        "chainId": 1,
+        "address": "0xec58d3aefc9aaa2e0036fa65f70d569f49d9d1ed",
+        "name": "uSTONKS Index Token April 2021",
+        "symbol": "uSTONKS_APR21",
+        "decimals": 6
+      },
+      {
+        "chainId": 1,
+        "address": "0xa6B9d7E3d76cF23549293Fb22c488E0Ea591A44e",
+        "name": "uGAS-JUN21 Token Expiring 30 Jun 2021",
+        "symbol": "uGAS-JUN21",
+        "decimals": 18
+      },
+      {
+        "chainId": 1,
+        "address": "0xe813b65da6c38a04591aed3f082d32db7d53c382",
+        "name": "Yield Dollar [WETH Dec 2021]",
+        "symbol": "YD-ETH-DEC21",
+        "decimals": 18
+      },
+      {
+        "chainId": 1,
+        "address": "0x4b606e9eb2228c70f44453afe5a73e1fea258ce1",
+        "name": "pxUSD Synthetic USD Expiring 31 Mar 2022",
+        "symbol": "pxUSD_MAR2022",
+        "decimals": 18
+      },
+      {
+        "chainId": 1,
+        "address": "0x5247c0db4044fb6f97f32c7e1b48758019a5a912",
+        "name": "pxGOLD Synthetic Gold Expiring 31 Mar 2022",
+        "symbol": "pxGOLD_MAR2022",
+        "decimals": 18
+      },
+      {
+        "chainId": 1,
+        "address": "0x56fb1acaff95c0b6ebcd17c8361a63d98b1a5a11",
+        "name": "uForex CNYUSD Synthetic Token April 2021",
+        "symbol": "uCNYUSD-APR",
+        "decimals": 6
+      },
+      {
+        "chainId": 1,
+        "address": "0xd49fa405dce086c65d66ca1ca41f8e98583812b4",
+        "name": "uForex EURUSD Synthetic Token April 2021",
+        "symbol": "uEURUSD-APR",
+        "decimals": 6
+      },
+      {
+        "chainId": 1,
+        "address": "0x29dddacba3b231ee8d673dd0f0fa759ea145561b",
+        "name": "DEFI_PULSE_TOTAL_TVL Synthetic Token Expiring 15 April 2021",
+        "symbol": "TVL_ALL_APRIL15",
+        "decimals": 6
+      },
+      {
+        "chainId": 1,
+        "address": "0xcbe430927370e95b4b10cfc702c6017ec7abefc3",
+        "name": "Yield Dollar [WETH Jun 2021]",
+        "symbol": "YD-ETH-JUN21",
+        "decimals": 18
+      },
+      {
+        "chainId": 1,
+        "address": "0x4b7fb448df91c8ed973494f8c8c4f12daf3a8521",
+        "name": "Yield Dollar [renBTC Jun 2021]",
+        "symbol": "YD-BTC-JUN21",
+        "decimals": 8
+      },
+      {
+        "chainId": 1,
+        "address": "0x3108c33b6fb38efedaefd8b5f7ca01d5f5c7372d",
+        "name": "Yield Dollar UMA 21",
+        "symbol": "yUMA21",
+        "decimals": 18
+      }
+    ],
+    "version": { "major": 0, "minor": 0, "patch": 0 }
+  }
+}

--- a/public/data/tokenlists/tokens-42161.json
+++ b/public/data/tokenlists/tokens-42161.json
@@ -1,0 +1,676 @@
+{
+  "https://raw.githubusercontent.com/balancer-labs/assets/refactor-for-multichain/generated/arbitrum.listed.tokenlist.json": {
+    "name": "Balancer",
+    "timestamp": "2022-10-08T00:00:00.000Z",
+    "logoURI": "https://raw.githubusercontent.com/balancer-labs/pebbles/master/images/pebbles-pad.256w.png",
+    "keywords": ["balancer", "listed"],
+    "version": { "major": 1, "minor": 14, "patch": 0 },
+    "tokens": [
+      {
+        "address": "0x040d1EdC9569d4Bab2D15287Dc5A4F10F56a56B8",
+        "chainId": 42161,
+        "name": "Balancer",
+        "symbol": "BAL",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xba100000625a3754423978a60c9317c58a424e3D/logo.png"
+      },
+      {
+        "address": "0xa68Ec98D7ca870cF1Dd0b00EBbb7c4bF60A8e74d",
+        "chainId": 42161,
+        "name": "Biconomy Token",
+        "symbol": "BICO",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/balancer-labs/assets/refactor-for-multichain/assets/0xa68ec98d7ca870cf1dd0b00ebbb7c4bf60a8e74d.png"
+      },
+      {
+        "address": "0xb96B904ba83DdEeCE47CAADa8B40EE6936D92091",
+        "chainId": 42161,
+        "name": "CRE8R DAO",
+        "symbol": "CRE8R",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/balancer-labs/assets/refactor-for-multichain/assets/0xb96b904ba83ddeece47caada8b40ee6936d92091.png"
+      },
+      {
+        "address": "0xf97f4df75117a78c1A5a0DBb814Af92458539FB4",
+        "chainId": 42161,
+        "name": "ChainLink Token",
+        "symbol": "LINK",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x514910771AF9Ca656af840dff83E8264EcF986CA/logo.png"
+      },
+      {
+        "address": "0x354A6dA3fcde098F8389cad84b0182725c6C91dE",
+        "chainId": 42161,
+        "name": "Compound",
+        "symbol": "COMP",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xc00e94Cb662C3520282E6f5717214004A7f26888/logo.png"
+      },
+      {
+        "address": "0xf4D48Ce3ee1Ac3651998971541bAdbb9A14D7234",
+        "chainId": 42161,
+        "name": "Cream",
+        "symbol": "CREAM",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x2ba592F78dB6436527729929AAf6c908497cB200/logo.png"
+      },
+      {
+        "address": "0x11cDb42B0EB46D95f990BeDD4695A6e3fA034978",
+        "chainId": 42161,
+        "name": "Curve DAO Token",
+        "symbol": "CRV",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xD533a949740bb3306d119CC777fa900bA034cd52/logo.png"
+      },
+      {
+        "address": "0xdeBa25AF35e4097146d7629055E0EC3C71706324",
+        "chainId": 42161,
+        "name": "DEFI Top 5 Index",
+        "symbol": "DEFI5",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/13691/large/thGDKHo.png?1610959947"
+      },
+      {
+        "address": "0xC3Ae0333F0F34aa734D5493276223d95B8F9Cb37",
+        "chainId": 42161,
+        "name": "DXdao",
+        "symbol": "DXD",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xa1d65E8fB6e87b60FECCBc582F7f97804B725521/logo.png"
+      },
+      {
+        "address": "0xDA10009cBd5D07dd0CeCc66161FC93D7c9000da1",
+        "chainId": 42161,
+        "name": "Dai Stablecoin",
+        "symbol": "DAI",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x6B175474E89094C44Da98b954EedeAC495271d0F/logo.png"
+      },
+      {
+        "address": "0xF0B5cEeFc89684889e5F7e0A7775Bd100FcD3709",
+        "chainId": 42161,
+        "name": "DigitalDollar",
+        "symbol": "DUSD",
+        "decimals": 6,
+        "logoURI": "https://raw.githubusercontent.com/balancer-labs/assets/refactor-for-multichain/assets/0xf0b5ceefc89684889e5f7e0a7775bd100fcd3709.png"
+      },
+      {
+        "address": "0x6C2C06790b3E3E3c38e12Ee22F8183b37a13EE55",
+        "chainId": 42161,
+        "name": "Dopex",
+        "symbol": "DPX",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/16652/large/DPX_%281%29.png?1624598630"
+      },
+      {
+        "address": "0x32Eb7902D4134bf98A28b963D26de779AF92A212",
+        "chainId": 42161,
+        "name": "Dopex Rebate Token",
+        "symbol": "RDPX",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/16659/large/rDPX_200x200_Coingecko.png?1624614475"
+      },
+      {
+        "address": "0xfc5A1A6EB076a2C7aD06eD22C90d7E710E35ad0a",
+        "chainId": 42161,
+        "name": "GMX",
+        "symbol": "GMX",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/balancer-labs/assets/refactor-for-multichain/assets/0xfc5a1a6eb076a2c7ad06ed22c90d7e710e35ad0a.png"
+      },
+      {
+        "address": "0xa0b862F60edEf4452F25B4160F177db44DeB6Cf1",
+        "chainId": 42161,
+        "name": "Gnosis Token",
+        "symbol": "GNO",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x6810e776880C02933D47DB1b9fc05908e5386b96/logo.png"
+      },
+      {
+        "address": "0x23A941036Ae778Ac51Ab04CEa08Ed6e2FE103614",
+        "chainId": 42161,
+        "name": "Graph Token",
+        "symbol": "GRT",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xc944E90C64B2c07662A292be6244BDf05Cda44a7/logo.png"
+      },
+      {
+        "address": "0xB965029343D55189c25a7f3e0c9394DC0F5D41b1",
+        "chainId": 42161,
+        "name": "Indexed",
+        "symbol": "NDX",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x86772b1409b61c639EaAc9Ba0AcfBb6E238e5F83/logo.png"
+      },
+      {
+        "address": "0x13Ad51ed4F1B7e9Dc168d8a00cB3f4dDD85EfA60",
+        "chainId": 42161,
+        "name": "Lido DAO Token",
+        "symbol": "LDO",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/balancer-labs/assets/refactor-for-multichain/assets/0x13ad51ed4f1b7e9dc168d8a00cb3f4ddd85efa60.png"
+      },
+      {
+        "address": "0x539bdE0d7Dbd336b79148AA742883198BBF60342",
+        "chainId": 42161,
+        "name": "Magic",
+        "symbol": "MAGIC",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/balancer-labs/assets/refactor-for-multichain/assets/0x539bde0d7dbd336b79148aa742883198bbf60342.png"
+      },
+      {
+        "address": "0x3F56e0c36d275367b8C502090EDF38289b3dEa0d",
+        "chainId": 42161,
+        "name": "Mai Stablecoin",
+        "symbol": "MAI",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/balancer-labs/assets/refactor-for-multichain/assets/0x3f56e0c36d275367b8c502090edf38289b3dea0d.png"
+      },
+      {
+        "address": "0x2e9a6Df78E42a30712c10a9Dc4b1C8656f8F2879",
+        "chainId": 42161,
+        "name": "Maker",
+        "symbol": "MKR",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x9f8F72aA9304c8B593d555F12eF6589cC3A579A2/logo.png"
+      },
+      {
+        "address": "0x39A49bc5017Fc668299Cd32e734C9269aCc35295",
+        "chainId": 42161,
+        "name": "Phonon DAO",
+        "symbol": "PHONON",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/balancer-labs/assets/refactor-for-multichain/assets/0x39a49bc5017fc668299cd32e734c9269acc35295.png"
+      },
+      {
+        "address": "0x965772e0E9c84b6f359c8597C891108DcF1c5B1A",
+        "chainId": 42161,
+        "name": "Pickle Finance",
+        "symbol": "PICKLE",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x429881672B9AE42b8EbA0E26cD9C73711b891Ca5/logo.png"
+      },
+      {
+        "address": "0xef888bcA6AB6B1d26dbeC977C455388ecd794794",
+        "chainId": 42161,
+        "name": "Rari Governance Token",
+        "symbol": "RGT",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/12900/large/Rari_Logo_Transparent.png?1613978014"
+      },
+      {
+        "address": "0x6694340fc020c5E6B96567843da2df01b2CE1eb6",
+        "chainId": 42161,
+        "name": "Stargate Finance",
+        "symbol": "STG",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/balancer-labs/assets/refactor-for-multichain/assets/0x6694340fc020c5e6b96567843da2df01b2ce1eb6.png"
+      },
+      {
+        "address": "0xd4d42F0b6DEF4CE0383636770eF773390d85c61A",
+        "chainId": 42161,
+        "name": "SushiToken",
+        "symbol": "SUSHI",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x6B3595068778DD592e39A122f4f5a5cF09C90fE2/logo.png"
+      },
+      {
+        "address": "0xA970AF1a584579B618be4d69aD6F73459D112F95",
+        "chainId": 42161,
+        "name": "Synth sUSD",
+        "symbol": "sUSD",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/balancer-labs/assets/master/assets/0x57ab1ec28d129707052df4df418d58a2d46d5f51.png"
+      },
+      {
+        "address": "0xFd086bC7CD5C481DCC9C85ebE478A1C0b69FCbb9",
+        "chainId": 42161,
+        "name": "Tether",
+        "symbol": "USDT",
+        "decimals": 6,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xdAC17F958D2ee523a2206206994597C13D831ec7/logo.png"
+      },
+      {
+        "address": "0xA72159FC390f0E3C6D415e658264c7c4051E9b87",
+        "chainId": 42161,
+        "name": "Tracer DAO",
+        "symbol": "TCR",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/18271/large/tracer_logo.png?1631176676"
+      },
+      {
+        "address": "0x4d15a3a2286d883af0aa1b3f21367843fac63e07",
+        "chainId": 42161,
+        "name": "TrueUSD",
+        "symbol": "TUSD",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x0000000000085d4780B73119b644AE5ecd22b376/logo.png"
+      },
+      {
+        "address": "0xFF970A61A04b1cA14834A43f5dE4533eBDDB5CC8",
+        "chainId": 42161,
+        "name": "USD Coin",
+        "symbol": "USDC",
+        "decimals": 6,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/logo.png"
+      },
+      {
+        "address": "0xFa7F8980b0f1E64A2062791cc3b0871572f1F7f0",
+        "chainId": 42161,
+        "name": "Uniswap",
+        "symbol": "UNI",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x1f9840a85d5aF5bf1D1762F925BDADdC4201F984/logo.png"
+      },
+      {
+        "address": "0xa684cd057951541187f288294a1e1C2646aA2d24",
+        "chainId": 42161,
+        "name": "Vesta",
+        "symbol": "VSTA",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/balancer-labs/assets/refactor-for-multichain/assets/0xa684cd057951541187f288294a1e1c2646aa2d24.png"
+      },
+      {
+        "address": "0x64343594Ab9b56e99087BfA6F2335Db24c2d1F17",
+        "chainId": 42161,
+        "name": "Vesta Stable",
+        "symbol": "VST",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/balancer-labs/assets/refactor-for-multichain/assets/0x64343594ab9b56e99087bfa6f2335db24c2d1f17.png"
+      },
+      {
+        "address": "0x2f2a2543B76A4166549F7aaB2e75Bef0aefC5B0f",
+        "chainId": 42161,
+        "name": "Wrapped BTC",
+        "symbol": "WBTC",
+        "decimals": 8,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599/logo.png"
+      },
+      {
+        "address": "0x82aF49447D8a07e3bd95BD0d56f35241523fBab1",
+        "chainId": 42161,
+        "name": "Wrapped Ether",
+        "symbol": "WETH",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2/logo.png"
+      },
+      {
+        "address": "0x5979D7b546E38E414F7E9822514be443A4800529",
+        "chainId": 42161,
+        "name": "Wrapped liquid staked Ether 2.0",
+        "symbol": "wstETH",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/balancer-labs/assets/refactor-for-multichain/assets/0x5979d7b546e38e414f7e9822514be443a4800529.png"
+      },
+      {
+        "address": "0x8038F3C971414FD1FC220bA727F2D4A0fC98cb65",
+        "chainId": 42161,
+        "name": "dHedge DAO Token",
+        "symbol": "DHT",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xca1207647Ff814039530D7d35df0e1Dd2e91Fa84/logo.png"
+      },
+      {
+        "address": "0xDb298285FE4C5410B05390cA80e8Fbe9DE1F259B",
+        "chainId": 42161,
+        "name": "handleFOREX",
+        "symbol": "FOREX",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/balancer-labs/assets/refactor-for-multichain/assets/0xdb298285fe4c5410b05390ca80e8fbe9de1f259b.png"
+      },
+      {
+        "address": "0x8616E8EA83f048ab9A5eC513c9412Dd2993bcE3F",
+        "chainId": 42161,
+        "name": "handleUSD",
+        "symbol": "fxUSD",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/balancer-labs/assets/refactor-for-multichain/assets/0x8616e8ea83f048ab9a5ec513c9412dd2993bce3f.png"
+      },
+      {
+        "address": "0x82e3A8F066a6989666b031d916c43672085b1582",
+        "chainId": 42161,
+        "name": "yearn.finance",
+        "symbol": "YFI",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x0bc529c00C6401aEF6D220BE8C6Ea1667F6Ad93e/logo.png"
+      }
+    ]
+  },
+  "https://raw.githubusercontent.com/balancer-labs/assets/refactor-for-multichain/generated/arbitrum.vetted.tokenlist.json": {
+    "name": "Balancer",
+    "timestamp": "2022-10-08T00:00:00.000Z",
+    "logoURI": "https://raw.githubusercontent.com/balancer-labs/pebbles/master/images/pebbles-pad.256w.png",
+    "keywords": ["balancer", "vetted"],
+    "version": { "major": 1, "minor": 14, "patch": 0 },
+    "tokens": [
+      {
+        "address": "0x040d1EdC9569d4Bab2D15287Dc5A4F10F56a56B8",
+        "chainId": 42161,
+        "name": "Balancer",
+        "symbol": "BAL",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xba100000625a3754423978a60c9317c58a424e3D/logo.png"
+      },
+      {
+        "address": "0xa68Ec98D7ca870cF1Dd0b00EBbb7c4bF60A8e74d",
+        "chainId": 42161,
+        "name": "Biconomy Token",
+        "symbol": "BICO",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/balancer-labs/assets/refactor-for-multichain/assets/0xa68ec98d7ca870cf1dd0b00ebbb7c4bf60a8e74d.png"
+      },
+      {
+        "address": "0xb96B904ba83DdEeCE47CAADa8B40EE6936D92091",
+        "chainId": 42161,
+        "name": "CRE8R DAO",
+        "symbol": "CRE8R",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/balancer-labs/assets/refactor-for-multichain/assets/0xb96b904ba83ddeece47caada8b40ee6936d92091.png"
+      },
+      {
+        "address": "0xf97f4df75117a78c1A5a0DBb814Af92458539FB4",
+        "chainId": 42161,
+        "name": "ChainLink Token",
+        "symbol": "LINK",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x514910771AF9Ca656af840dff83E8264EcF986CA/logo.png"
+      },
+      {
+        "address": "0x354A6dA3fcde098F8389cad84b0182725c6C91dE",
+        "chainId": 42161,
+        "name": "Compound",
+        "symbol": "COMP",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xc00e94Cb662C3520282E6f5717214004A7f26888/logo.png"
+      },
+      {
+        "address": "0xf4D48Ce3ee1Ac3651998971541bAdbb9A14D7234",
+        "chainId": 42161,
+        "name": "Cream",
+        "symbol": "CREAM",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x2ba592F78dB6436527729929AAf6c908497cB200/logo.png"
+      },
+      {
+        "address": "0x11cDb42B0EB46D95f990BeDD4695A6e3fA034978",
+        "chainId": 42161,
+        "name": "Curve DAO Token",
+        "symbol": "CRV",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xD533a949740bb3306d119CC777fa900bA034cd52/logo.png"
+      },
+      {
+        "address": "0xdeBa25AF35e4097146d7629055E0EC3C71706324",
+        "chainId": 42161,
+        "name": "DEFI Top 5 Index",
+        "symbol": "DEFI5",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/13691/large/thGDKHo.png?1610959947"
+      },
+      {
+        "address": "0xC3Ae0333F0F34aa734D5493276223d95B8F9Cb37",
+        "chainId": 42161,
+        "name": "DXdao",
+        "symbol": "DXD",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xa1d65E8fB6e87b60FECCBc582F7f97804B725521/logo.png"
+      },
+      {
+        "address": "0xDA10009cBd5D07dd0CeCc66161FC93D7c9000da1",
+        "chainId": 42161,
+        "name": "Dai Stablecoin",
+        "symbol": "DAI",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x6B175474E89094C44Da98b954EedeAC495271d0F/logo.png"
+      },
+      {
+        "address": "0xF0B5cEeFc89684889e5F7e0A7775Bd100FcD3709",
+        "chainId": 42161,
+        "name": "DigitalDollar",
+        "symbol": "DUSD",
+        "decimals": 6,
+        "logoURI": "https://raw.githubusercontent.com/balancer-labs/assets/refactor-for-multichain/assets/0xf0b5ceefc89684889e5f7e0a7775bd100fcd3709.png"
+      },
+      {
+        "address": "0x6C2C06790b3E3E3c38e12Ee22F8183b37a13EE55",
+        "chainId": 42161,
+        "name": "Dopex",
+        "symbol": "DPX",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/16652/large/DPX_%281%29.png?1624598630"
+      },
+      {
+        "address": "0x32Eb7902D4134bf98A28b963D26de779AF92A212",
+        "chainId": 42161,
+        "name": "Dopex Rebate Token",
+        "symbol": "RDPX",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/16659/large/rDPX_200x200_Coingecko.png?1624614475"
+      },
+      {
+        "address": "0xfc5A1A6EB076a2C7aD06eD22C90d7E710E35ad0a",
+        "chainId": 42161,
+        "name": "GMX",
+        "symbol": "GMX",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/balancer-labs/assets/refactor-for-multichain/assets/0xfc5a1a6eb076a2c7ad06ed22c90d7e710e35ad0a.png"
+      },
+      {
+        "address": "0xa0b862F60edEf4452F25B4160F177db44DeB6Cf1",
+        "chainId": 42161,
+        "name": "Gnosis Token",
+        "symbol": "GNO",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x6810e776880C02933D47DB1b9fc05908e5386b96/logo.png"
+      },
+      {
+        "address": "0x23A941036Ae778Ac51Ab04CEa08Ed6e2FE103614",
+        "chainId": 42161,
+        "name": "Graph Token",
+        "symbol": "GRT",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xc944E90C64B2c07662A292be6244BDf05Cda44a7/logo.png"
+      },
+      {
+        "address": "0xB965029343D55189c25a7f3e0c9394DC0F5D41b1",
+        "chainId": 42161,
+        "name": "Indexed",
+        "symbol": "NDX",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x86772b1409b61c639EaAc9Ba0AcfBb6E238e5F83/logo.png"
+      },
+      {
+        "address": "0x13Ad51ed4F1B7e9Dc168d8a00cB3f4dDD85EfA60",
+        "chainId": 42161,
+        "name": "Lido DAO Token",
+        "symbol": "LDO",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/balancer-labs/assets/refactor-for-multichain/assets/0x13ad51ed4f1b7e9dc168d8a00cb3f4ddd85efa60.png"
+      },
+      {
+        "address": "0x539bdE0d7Dbd336b79148AA742883198BBF60342",
+        "chainId": 42161,
+        "name": "MAGIC",
+        "symbol": "MAGIC",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/balancer-labs/assets/refactor-for-multichain/assets/0x539bde0d7dbd336b79148aa742883198bbf60342.png"
+      },
+      {
+        "address": "0x3F56e0c36d275367b8C502090EDF38289b3dEa0d",
+        "chainId": 42161,
+        "name": "Mai Stablecoin",
+        "symbol": "MAI",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/balancer-labs/assets/refactor-for-multichain/assets/0x3f56e0c36d275367b8c502090edf38289b3dea0d.png"
+      },
+      {
+        "address": "0x2e9a6Df78E42a30712c10a9Dc4b1C8656f8F2879",
+        "chainId": 42161,
+        "name": "Maker",
+        "symbol": "MKR",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x9f8F72aA9304c8B593d555F12eF6589cC3A579A2/logo.png"
+      },
+      {
+        "address": "0x39A49bc5017Fc668299Cd32e734C9269aCc35295",
+        "chainId": 42161,
+        "name": "Phonon DAO",
+        "symbol": "PHONON",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/balancer-labs/assets/refactor-for-multichain/assets/0x39a49bc5017fc668299cd32e734c9269acc35295.png"
+      },
+      {
+        "address": "0x965772e0E9c84b6f359c8597C891108DcF1c5B1A",
+        "chainId": 42161,
+        "name": "Pickle Finance",
+        "symbol": "PICKLE",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x429881672B9AE42b8EbA0E26cD9C73711b891Ca5/logo.png"
+      },
+      {
+        "address": "0xef888bcA6AB6B1d26dbeC977C455388ecd794794",
+        "chainId": 42161,
+        "name": "Rari Governance Token",
+        "symbol": "RGT",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/12900/large/Rari_Logo_Transparent.png?1613978014"
+      },
+      {
+        "address": "0x6694340fc020c5E6B96567843da2df01b2CE1eb6",
+        "chainId": 42161,
+        "name": "Stargate Finance",
+        "symbol": "STG",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/balancer-labs/assets/refactor-for-multichain/assets/0x6694340fc020c5e6b96567843da2df01b2ce1eb6.png"
+      },
+      {
+        "address": "0xd4d42F0b6DEF4CE0383636770eF773390d85c61A",
+        "chainId": 42161,
+        "name": "SushiToken",
+        "symbol": "SUSHI",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x6B3595068778DD592e39A122f4f5a5cF09C90fE2/logo.png"
+      },
+      {
+        "address": "0xA970AF1a584579B618be4d69aD6F73459D112F95",
+        "chainId": 42161,
+        "name": "Synth sUSD",
+        "symbol": "sUSD",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/balancer-labs/assets/master/assets/0x57ab1ec28d129707052df4df418d58a2d46d5f51.png"
+      },
+      {
+        "address": "0xFd086bC7CD5C481DCC9C85ebE478A1C0b69FCbb9",
+        "chainId": 42161,
+        "name": "Tether",
+        "symbol": "USDT",
+        "decimals": 6,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xdAC17F958D2ee523a2206206994597C13D831ec7/logo.png"
+      },
+      {
+        "address": "0xA72159FC390f0E3C6D415e658264c7c4051E9b87",
+        "chainId": 42161,
+        "name": "Tracer DAO",
+        "symbol": "TCR",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/18271/large/tracer_logo.png?1631176676"
+      },
+      {
+        "address": "0x4d15a3a2286d883af0aa1b3f21367843fac63e07",
+        "chainId": 42161,
+        "name": "TrueUSD",
+        "symbol": "TUSD",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x0000000000085d4780B73119b644AE5ecd22b376/logo.png"
+      },
+      {
+        "address": "0xFF970A61A04b1cA14834A43f5dE4533eBDDB5CC8",
+        "chainId": 42161,
+        "name": "USD Coin",
+        "symbol": "USDC",
+        "decimals": 6,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/logo.png"
+      },
+      {
+        "address": "0xFa7F8980b0f1E64A2062791cc3b0871572f1F7f0",
+        "chainId": 42161,
+        "name": "Uniswap",
+        "symbol": "UNI",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x1f9840a85d5aF5bf1D1762F925BDADdC4201F984/logo.png"
+      },
+      {
+        "address": "0xa684cd057951541187f288294a1e1C2646aA2d24",
+        "chainId": 42161,
+        "name": "Vesta",
+        "symbol": "VSTA",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/balancer-labs/assets/refactor-for-multichain/assets/0xa684cd057951541187f288294a1e1c2646aa2d24.png"
+      },
+      {
+        "address": "0x64343594Ab9b56e99087BfA6F2335Db24c2d1F17",
+        "chainId": 42161,
+        "name": "Vesta Stable",
+        "symbol": "VST",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/balancer-labs/assets/refactor-for-multichain/assets/0x64343594ab9b56e99087bfa6f2335db24c2d1f17.png"
+      },
+      {
+        "address": "0x2f2a2543B76A4166549F7aaB2e75Bef0aefC5B0f",
+        "chainId": 42161,
+        "name": "Wrapped BTC",
+        "symbol": "WBTC",
+        "decimals": 8,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599/logo.png"
+      },
+      {
+        "address": "0x82aF49447D8a07e3bd95BD0d56f35241523fBab1",
+        "chainId": 42161,
+        "name": "Wrapped Ether",
+        "symbol": "WETH",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2/logo.png"
+      },
+      {
+        "address": "0x5979D7b546E38E414F7E9822514be443A4800529",
+        "chainId": 42161,
+        "name": "Wrapped liquid staked Ether 2.0",
+        "symbol": "wstETH",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/balancer-labs/assets/refactor-for-multichain/assets/0x5979d7b546e38e414f7e9822514be443a4800529.png"
+      },
+      {
+        "address": "0x8038F3C971414FD1FC220bA727F2D4A0fC98cb65",
+        "chainId": 42161,
+        "name": "dHedge DAO Token",
+        "symbol": "DHT",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xca1207647Ff814039530D7d35df0e1Dd2e91Fa84/logo.png"
+      },
+      {
+        "address": "0xDb298285FE4C5410B05390cA80e8Fbe9DE1F259B",
+        "chainId": 42161,
+        "name": "handleFOREX",
+        "symbol": "FOREX",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/balancer-labs/assets/refactor-for-multichain/assets/0xdb298285fe4c5410b05390ca80e8fbe9de1f259b.png"
+      },
+      {
+        "address": "0x8616E8EA83f048ab9A5eC513c9412Dd2993bcE3F",
+        "chainId": 42161,
+        "name": "handleUSD",
+        "symbol": "fxUSD",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/balancer-labs/assets/refactor-for-multichain/assets/0x8616e8ea83f048ab9a5ec513c9412dd2993bce3f.png"
+      },
+      {
+        "address": "0x82e3A8F066a6989666b031d916c43672085b1582",
+        "chainId": 42161,
+        "name": "yearn.finance",
+        "symbol": "YFI",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x0bc529c00C6401aEF6D220BE8C6Ea1667F6Ad93e/logo.png"
+      }
+    ]
+  }
+}

--- a/public/data/tokenlists/tokens-5.json
+++ b/public/data/tokenlists/tokens-5.json
@@ -1,0 +1,196 @@
+{
+  "https://raw.githubusercontent.com/balancer-labs/assets/refactor-for-multichain/generated/goerli.listed.tokenlist.json": {
+    "name": "Balancer",
+    "timestamp": "2022-08-02T00:00:00.000Z",
+    "logoURI": "https://raw.githubusercontent.com/balancer-labs/pebbles/master/images/pebbles-pad.256w.png",
+    "keywords": ["balancer", "listed"],
+    "version": { "major": 0, "minor": 1, "patch": 1 },
+    "tokens": [
+      {
+        "address": "0xfA8449189744799aD2AcE7e0EBAC8BB7575eff47",
+        "chainId": 5,
+        "name": "Balancer",
+        "symbol": "BAL",
+        "decimals": 18,
+        "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0xba100000625a3754423978a60c9317c58a424e3D/logo.png"
+      },
+      {
+        "address": "0x8c9e6c40d3402480ACE624730524fACC5482798c",
+        "chainId": 5,
+        "name": "Dai",
+        "symbol": "DAI",
+        "decimals": 18,
+        "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0x6B175474E89094C44Da98b954EedeAC495271d0F/logo.png"
+      },
+      {
+        "address": "0x1f1f156E0317167c11Aa412E3d1435ea29Dc3cCE",
+        "chainId": 5,
+        "name": "Tether",
+        "symbol": "USDT",
+        "decimals": 6,
+        "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0xdAC17F958D2ee523a2206206994597C13D831ec7/logo.png"
+      },
+      {
+        "address": "0xe0C9275E44Ea80eF17579d33c55136b7DA269aEb",
+        "chainId": 5,
+        "name": "USD Coin",
+        "symbol": "USDC",
+        "decimals": 6,
+        "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/logo.png"
+      },
+      {
+        "address": "0xdFCeA9088c8A88A76FF74892C1457C17dfeef9C1",
+        "chainId": 5,
+        "name": "WETH",
+        "symbol": "WETH",
+        "decimals": 18,
+        "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2/logo.png"
+      },
+      {
+        "address": "0x37f03a12241E9FD3658ad6777d289c3fb8512Bc9",
+        "chainId": 5,
+        "name": "Wrapped Bitcoin",
+        "symbol": "WBTC",
+        "decimals": 8,
+        "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599/logo.png"
+      },
+      {
+        "address": "0x398106564948fEeb1fEdeA0709AE7D969D62a391",
+        "chainId": 5,
+        "name": "miMATIC",
+        "symbol": "miMATIC",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/15264/large/mimatic-red.png?1620281018"
+      }
+    ]
+  },
+  "https://raw.githubusercontent.com/balancer-labs/assets/refactor-for-multichain/generated/goerli.vetted.tokenlist.json": {
+    "name": "Balancer",
+    "timestamp": "2022-06-09T00:00:00.000Z",
+    "logoURI": "https://raw.githubusercontent.com/balancer-labs/pebbles/master/images/pebbles-pad.256w.png",
+    "keywords": ["balancer", "vetted"],
+    "version": { "major": 1, "minor": 0, "patch": 1 },
+    "tokens": [
+      {
+        "address": "0xfA8449189744799aD2AcE7e0EBAC8BB7575eff47",
+        "chainId": 5,
+        "name": "Balancer",
+        "symbol": "BAL",
+        "decimals": 18,
+        "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0xba100000625a3754423978a60c9317c58a424e3D/logo.png"
+      },
+      {
+        "address": "0x5cEA6A84eD13590ED14903925Fa1A73c36297d99",
+        "chainId": 5,
+        "name": "Balancer Aave Boosted Pool (DAI)",
+        "symbol": "bb-a-DAI",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/balancer-labs/assets/master/assets/0x804cdb9116a10bb78768d3252355a1b18067bf8f.png"
+      },
+      {
+        "address": "0x0595D1Df64279ddB51F1bdC405Fe2D0b4Cc86681",
+        "chainId": 5,
+        "name": "Balancer Aave Boosted Pool (USDC)",
+        "symbol": "bb-a-USDC",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/balancer-labs/assets/master/assets/0x9210f1204b5a24742eba12f710636d76240df3d0.png"
+      },
+      {
+        "address": "0xeFD681A82970AC5d980b9B2D40499735e7BF3F1F",
+        "chainId": 5,
+        "name": "Balancer Aave Boosted Pool (USDT)",
+        "symbol": "bb-a-USDT",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/balancer-labs/assets/master/assets/0x2bbf681cc4eb09218bee85ea2a5d3d13fa40fc0c.png"
+      },
+      {
+        "address": "0x13ACD41C585d7EbB4a9460f7C8f50BE60DC080Cd",
+        "chainId": 5,
+        "name": "Balancer Aave Boosted StablePool (USD)",
+        "symbol": "bb-a-USD",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/balancer-labs/assets/master/assets/0x7b50775383d3d6f0215a8f290f2c9e2eebbeceb2.png"
+      },
+      {
+        "address": "0x8c9e6c40d3402480ACE624730524fACC5482798c",
+        "chainId": 5,
+        "name": "Dai",
+        "symbol": "DAI",
+        "decimals": 18,
+        "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0x6B175474E89094C44Da98b954EedeAC495271d0F/logo.png"
+      },
+      {
+        "address": "0x829f35cEBBCd47d3c120793c12f7A232c903138B",
+        "chainId": 5,
+        "name": "Fei USD",
+        "symbol": "FEI",
+        "decimals": 18,
+        "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0x956F47F50A910163D8BF957Cf5846D573E7f87CA/logo.png"
+      },
+      {
+        "address": "0xFF386a3d08f80AC38c77930d173Fa56C6286Dc8B",
+        "chainId": 5,
+        "name": "Gnosis",
+        "symbol": "GNO",
+        "decimals": 18,
+        "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0x6810e776880C02933D47DB1b9fc05908e5386b96/logo.png"
+      },
+      {
+        "address": "0x1f1f156E0317167c11Aa412E3d1435ea29Dc3cCE",
+        "chainId": 5,
+        "name": "Tether",
+        "symbol": "USDT",
+        "decimals": 6,
+        "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0xdAC17F958D2ee523a2206206994597C13D831ec7/logo.png"
+      },
+      {
+        "address": "0xe0C9275E44Ea80eF17579d33c55136b7DA269aEb",
+        "chainId": 5,
+        "name": "USD Coin",
+        "symbol": "USDC",
+        "decimals": 6,
+        "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/logo.png"
+      },
+      {
+        "address": "0xdFCeA9088c8A88A76FF74892C1457C17dfeef9C1",
+        "chainId": 5,
+        "name": "WETH",
+        "symbol": "WETH",
+        "decimals": 18,
+        "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2/logo.png"
+      },
+      {
+        "address": "0x37f03a12241E9FD3658ad6777d289c3fb8512Bc9",
+        "chainId": 5,
+        "name": "Wrapped Bitcoin",
+        "symbol": "WBTC",
+        "decimals": 8,
+        "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599/logo.png"
+      },
+      {
+        "address": "0x89534a24450081Aa267c79B07411e9617D984052",
+        "chainId": 5,
+        "name": "Wrapped aDAI",
+        "symbol": "aDAI",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/balancer-labs/assets/master/assets/0x02d60b84491589974263d922d9cc7a3152618ef6.png"
+      },
+      {
+        "address": "0x811151066392fd641Fe74A9B55a712670572D161",
+        "chainId": 5,
+        "name": "Wrapped aUSDC",
+        "symbol": "aUSDC",
+        "decimals": 6,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x9bA00D6856a4eDF4665BcA2C2309936572473B7E/logo.png"
+      },
+      {
+        "address": "0x4Cb1892FdDF14f772b2E39E299f44B2E5DA90d04",
+        "chainId": 5,
+        "name": "Wrapped aUSDT",
+        "symbol": "aUSDT",
+        "decimals": 6,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x71fc860F7D3A592A4a98740e39dB31d25db65ae8/logo.png"
+      }
+    ]
+  }
+}

--- a/src/components/contextual/stake/StakePreview.vue
+++ b/src/components/contextual/stake/StakePreview.vue
@@ -51,7 +51,12 @@ const {
 } = useStaking();
 const { getTokenApprovalActionsForSpender } = useTokenApprovalActions(
   [props.pool.address],
-  ref([balanceFor(props.pool.address).toString()])
+  ref([
+    (props.action === 'restake'
+      ? stakedSharesForProvidedPool.value
+      : balanceFor(props.pool.address)
+    ).toString(),
+  ])
 );
 
 const stakeAction = {


### PR DESCRIPTION
# Description

When restaking from old gauge to new gauge, the user needs to approve spend on the new gauge address. This is now included in the restaking modal.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

Have a look at a pool where you have balance staked in an old gauge. Remove all approvals for this pool in e.g. https://revoke.cash - then go to restake modal. You should see approval step.

## Visual context

N/A

## Checklist:

- [x] I have performed a self-review of my own code
- [x]  I have requested at least 2 reviews (If the PR is significant enough, use best judgement here)
- [ ] I have commented my code where relevant, particularly in hard-to-understand areas
- [ ] If package-lock.json has changes, it was intentional.
- [x] The base of this PR is `master` if hotfix, `develop` if not
