### PR TITLE
Remove orphan loading prop

### DIFF
--- a/src/components/contextual/pages/pool/PoolContractDetails.vue
+++ b/src/components/contextual/pages/pool/PoolContractDetails.vue
@@ -13,15 +13,12 @@ import { useI18n } from 'vue-i18n';
  */
 type Props = {
   pool: Pool;
-  loading: boolean;
 };
 
 /**
  * PROPS
  */
-const props = withDefaults(defineProps<Props>(), {
-  loading: false,
-});
+const props = defineProps<Props>();
 
 /**
  * COMPOSABLES


### PR DESCRIPTION
# Description

`loading` prop removed from `PoolContractDetails` because it is not actually being used. 

It clears this warning when rendering `_id.vue`
<img width="1506" alt="Screenshot 2022-10-26 at 12 30 03" src="https://user-images.githubusercontent.com/1316240/198004751-9714c2aa-90f0-4f14-8760-92db6b8cdde5.png">


## Type of change

- [x] Code refactor / cleanup

## Visual context

Please provide any relevant visual context for UI changes or additions. This could be static screenshots or a loom screencast.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have requested at least 2 reviews (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] If package-lock.json has changes, it was intentional.
- [x] The base of this PR is `master` if hotfix, `develop` if not
