### PR TITLE
Fix: subdomain redirect loop

### DIFF
--- a/src/plugins/router/nav-guards.ts
+++ b/src/plugins/router/nav-guards.ts
@@ -42,7 +42,7 @@ function applyNetworkSubdomainRedirect(router: Router): Router {
       to.params
     );
 
-    if (redirectUrl) hardRedirectTo(redirectUrl, router);
+    if (redirectUrl) window.location.href = redirectUrl;
     else next();
   });
 


### PR DESCRIPTION
# Description

Subdomain format urls result in infinite loop redirect. This fixes it by not using router.go(0).

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## How should this be tested?

Please provide instructions so we can test. Please also list any relevant details for your test configuration.

- [ ] Test A
- [ ] Test B

## Visual context

Please provide any relevant visual context for UI changes or additions. This could be static screenshots or a loom screencast.

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have requested at least 2 reviews (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] If package-lock.json has changes, it was intentional.
- [x] The base of this PR is `master` if hotfix, `develop` if not
