### PR TITLE
no steth on arbitrum, fix tooltip

### DIFF
--- a/src/components/contextual/pages/pool/invest/WrapStEthLink.vue
+++ b/src/components/contextual/pages/pool/invest/WrapStEthLink.vue
@@ -22,7 +22,7 @@ const props = defineProps<Props>();
 /**
  * COMPOSABLES
  */
-const { isWstETHPool } = usePool(toRef(props, 'pool'));
+const { isMainnetWstETHPool } = usePool(toRef(props, 'pool'));
 const { networkConfig } = useConfig();
 const { getToken } = useTokens();
 const { networkSlug } = useNetwork();
@@ -35,7 +35,7 @@ const wstETH = computed(() => getToken(networkConfig.addresses.wstETH));
 </script>
 
 <template>
-  <div v-if="isWstETHPool" class="flex items-center mb-4">
+  <div v-if="isMainnetWstETHPool" class="flex items-center mb-4">
     <router-link
       :to="{
         name: 'trade',

--- a/src/composables/usePool.ts
+++ b/src/composables/usePool.ts
@@ -17,7 +17,7 @@ import { AnyPool, Pool, PoolAPRs, PoolToken } from '@/services/pool/types';
 import { PoolType } from '@/services/pool/types';
 import { hasBalEmissions } from '@/services/staking/utils';
 
-import { isTestnet, appUrl } from './useNetwork';
+import { isTestnet, isMainnet, appUrl } from './useNetwork';
 import useNumbers, { FNumFormats, numF } from './useNumbers';
 import { uniq } from 'lodash';
 
@@ -431,8 +431,9 @@ export function usePool(pool: Ref<AnyPool> | Ref<undefined>) {
   const isWethPool = computed(
     (): boolean => !!pool.value && isWeth(pool.value)
   );
-  const isWstETHPool = computed(
-    (): boolean => !!pool.value && includesWstEth(pool.value.tokensList)
+  const isMainnetWstETHPool = computed(
+    (): boolean =>
+      !!pool.value && includesWstEth(pool.value.tokensList) && isMainnet.value
   );
   const noInitLiquidityPool = computed(
     () => !!pool.value && noInitLiquidity(pool.value)
@@ -460,7 +461,7 @@ export function usePool(pool: Ref<AnyPool> | Ref<undefined>) {
     isLiquidityBootstrappingPool,
     managedPoolWithTradingHalted,
     isWethPool,
-    isWstETHPool,
+    isMainnetWstETHPool,
     noInitLiquidityPool,
     lpTokens,
     // methods


### PR DESCRIPTION
# Description

There's an existing component that shows the user an option to swap between wsteth and steth. On Arbitrum steth doesn't exist since wsteth is bridged. Renamed check to `isMainnetWstETHPool`

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## How should this be tested?

Please provide instructions so we can test. Please also list any relevant details for your test configuration.

- [ ] Test A
- [ ] Test B

## Visual context

Please provide any relevant visual context for UI changes or additions. This could be static screenshots or a loom screencast.

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have requested at least 2 reviews (If the PR is significant enough, use best judgement here)
- [ ] I have commented my code where relevant, particularly in hard-to-understand areas
- [ ] If package-lock.json has changes, it was intentional.
- [ ] The base of this PR is `master` if hotfix, `develop` if not
