### PR TITLE
Fix: always redirect pool urls to mainnet

### DIFF
--- a/src/lib/config/arbitrum.json
+++ b/src/lib/config/arbitrum.json
@@ -1,8 +1,8 @@
 {
   "key": "42161",
   "chainId": 42161,
-  "chainName": "Arbitrum One",
-  "name": "Arbitrum One",
+  "chainName": "Arbitrum",
+  "name": "Arbitrum",
   "shortName": "Arbitrum",
   "slug": "arbitrum",
   "network": "arbitrum-one",

--- a/src/lib/config/goerli.json
+++ b/src/lib/config/goerli.json
@@ -1,7 +1,7 @@
 {
   "key": "5",
   "chainId": 5,
-  "chainName": "Ethereum",
+  "chainName": "Goerli",
   "name": "Ethereum Testnet Goerli",
   "shortName": "Goerli",
   "slug": "goerli",

--- a/src/lib/config/kovan.json
+++ b/src/lib/config/kovan.json
@@ -1,7 +1,7 @@
 {
   "key": "42",
   "chainId": 42,
-  "chainName": "Ethereum",
+  "chainName": "Kovan",
   "name": "Ethereum Testnet Kovan",
   "shortName": "Kovan",
   "slug": "kovan",

--- a/src/lib/config/rinkeby.json
+++ b/src/lib/config/rinkeby.json
@@ -1,7 +1,7 @@
 {
   "key": "4",
   "chainId": 4,
-  "chainName": "Ethereum",
+  "chainName": "Rinkeby",
   "name": "Ethereum Testnet Rinkeby",
   "shortName": "Rinkeby",
   "slug": "rinkeby",

--- a/src/pages/index.vue
+++ b/src/pages/index.vue
@@ -28,7 +28,7 @@ const {
 } = useStreamedPoolsQuery(selectedTokens);
 const { upToMediumBreakpoint } = useBreakpoints();
 const { priceQueryLoading } = useTokens();
-const { networkSlug } = useNetwork();
+const { networkSlug, networkConfig } = useNetwork();
 
 const isInvestmentPoolsTableLoading = computed(
   () => dataStates.value['basic'] === 'loading' || priceQueryLoading.value
@@ -50,9 +50,7 @@ function navigateToCreatePool() {
     <BalStack vertical>
       <div class="px-4 xl:px-0">
         <div class="flex justify-between items-end mb-8">
-          <h3>
-            {{ $t('investmentPools') }}
-          </h3>
+          <h3>{{ networkConfig.chainName }} {{ $t('pools') }}</h3>
           <BalBtn
             v-if="upToMediumBreakpoint"
             color="blue"

--- a/src/plugins/router/nav-guards.ts
+++ b/src/plugins/router/nav-guards.ts
@@ -4,6 +4,8 @@ import {
   networkFromSlug,
   networkSlug,
 } from '@/composables/useNetwork';
+import config from '@/lib/config';
+import { Network } from '@balancer-labs/sdk';
 import { Router } from 'vue-router';
 
 /**
@@ -88,7 +90,10 @@ function applyNetworkPathRedirects(router: Router): Router {
       ];
       if (to.redirectedFrom || !nonNetworkedRoutes.includes(to.fullPath)) {
         const newPath = to.redirectedFrom?.fullPath ?? to.fullPath;
-        router.push({ path: `/${networkSlug}${newPath}` });
+        const newNetwork = newPath.includes('/pool')
+          ? config[Network.MAINNET].slug
+          : networkSlug;
+        router.push({ path: `/${newNetwork}${newPath}` });
       } else {
         next();
       }


### PR DESCRIPTION
# Description

If url requested doesn't have networkSlug, and it is using pool route, then always redirect to ethereum mainnet url.

Also, on main page, show network name in pools heading.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## How should this be tested?

Please provide instructions so we can test. Please also list any relevant details for your test configuration.

- [ ] Test A
- [ ] Test B

## Visual context

Please provide any relevant visual context for UI changes or additions. This could be static screenshots or a loom screencast.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have requested at least 2 reviews (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] If package-lock.json has changes, it was intentional.
- [x] The base of this PR is `master` if hotfix, `develop` if not
