### PR TITLE
fix redirect to pool on different network

### DIFF
--- a/src/components/contextual/pages/vebal/LMVoting/GaugesTable.vue
+++ b/src/components/contextual/pages/vebal/LMVoting/GaugesTable.vue
@@ -2,6 +2,7 @@
 import { Network } from '@balancer-labs/sdk';
 import BigNumber from 'bignumber.js';
 import { computed, ref } from 'vue';
+import { useRouter } from 'vue-router';
 import { useI18n } from 'vue-i18n';
 
 import { ColumnDefinition } from '@/components/_global/BalTable/types';
@@ -16,7 +17,6 @@ import {
   isStableLike,
   isUnknownType,
   orderedPoolTokens,
-  poolURLFor,
 } from '@/composables/usePool';
 import { isSameAddress } from '@/lib/utils';
 import { scale } from '@/lib/utils';
@@ -64,6 +64,7 @@ const emit = defineEmits<{
  * COMPOSABLES
  */
 const { fNum2 } = useNumbers();
+const router = useRouter();
 const { t } = useI18n();
 const { upToLargeBreakpoint } = useBreakpoints();
 const { isWalletReady } = useWeb3();
@@ -148,11 +149,10 @@ function networkSrc(network: Network) {
 }
 
 function redirectToPool(gauge: VotingGaugeWithVotes) {
-  window.location.href = poolURLFor(
-    gauge.pool.id,
-    gauge.network,
-    gauge.pool.poolType
-  );
+  router.push({
+    name: 'pool',
+    params: { id: gauge.pool.id, networkSlug: getNetworkSlug(gauge.network) },
+  });
 }
 
 function getIsGaugeNew(addedTimestamp: number): boolean {
@@ -191,6 +191,13 @@ function getTableRowClass(gauge: VotingGaugeWithVotes): string {
       sticky="both"
       :square="upToLargeBreakpoint"
       :isPaginated="isPaginated"
+      :link="{
+        to: 'pool',
+        getParams: gauge => ({
+          id: gauge.pool.id || '',
+          networkSlug: getNetworkSlug(gauge.network),
+        }),
+      }"
       :onRowClick="redirectToPool"
       :getTableRowClass="getTableRowClass"
       :initialState="{


### PR DESCRIPTION
# Description

Was using a broken window redirect. Fixes the links to different network pools in the gauge list and adds a href so an user can hover and see the link.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## How should this be tested?

Please provide instructions so we can test. Please also list any relevant details for your test configuration.

- [ ] Test A
- [ ] Test B

## Visual context

Please provide any relevant visual context for UI changes or additions. This could be static screenshots or a loom screencast.

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have requested at least 2 reviews (If the PR is significant enough, use best judgement here)
- [ ] I have commented my code where relevant, particularly in hard-to-understand areas
- [ ] If package-lock.json has changes, it was intentional.
- [ ] The base of this PR is `master` if hotfix, `develop` if not
