### PR TITLE
Fix week/month charts on trade page

### DIFF
--- a/src/components/cards/PairPriceGraph/PairPriceGraph.vue
+++ b/src/components/cards/PairPriceGraph/PairPriceGraph.vue
@@ -47,7 +47,13 @@ async function getPairPriceData(
   if (inverse) {
     [_inputAsset, _outputAsset] = [_outputAsset, _inputAsset];
   }
-  const aggregateBy = days === 1 ? 'hour' : 'day';
+
+  /**
+   * @description
+   * due to coingecko docs if we query from 1 to 90 days from current time it returns hourly data
+   * @see https://www.coingecko.com/en/api/documentation
+   */
+  const aggregateBy = days <= 90 ? 'hour' : 'day';
   const getInputAssetData = coingeckoService.prices.getTokensHistorical(
     [_inputAsset],
     days,


### PR DESCRIPTION
# Description
Fix week/month charts on trade page. They are not working currently on production.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## How should this be tested?
- Go to trade page
- Open charts
- Choose week/month filter and chart should be visible

There may be 429 error from coingecko. Please pay attention to it.
## Visual context

Please provide any relevant visual context for UI changes or additions. This could be static screenshots or a loom screencast.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have requested at least 2 reviews (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [ ] If package-lock.json has changes, it was intentional.
- [x] The base of this PR is `master` if hotfix, `develop` if not
