### PR TITLE
fix: Vebal redirect modal routing

### DIFF
--- a/src/components/modals/VeBalRedirectModal.vue
+++ b/src/components/modals/VeBalRedirectModal.vue
@@ -1,5 +1,6 @@
 <script lang="ts" setup>
-import { ref, computed } from 'vue';
+import { ref } from 'vue';
+import { useRouter } from 'vue-router';
 
 import { Network } from '@balancer-labs/sdk';
 
@@ -16,13 +17,7 @@ const redirectModal = ref<typeof BalModal>();
  * COMPOSABLES
  */
 const { showRedirectModal, setShowRedirectModal } = useVeBAL();
-
-/**
- * COPUTED
- */
-const vebalURL = computed(
-  (): string => `/#/${getNetworkSlug(Network.MAINNET)}/vebal`
-);
+const router = useRouter();
 
 /**
  * METHODS
@@ -51,9 +46,14 @@ function handleInternalClose() {
       <div class="grid grid-cols-2 grid-rows-1 gap-4 mt-4">
         <BalBtn
           tag="a"
-          :href="vebalURL"
           :label="$t('proceed')"
           color="gradient"
+          @click="
+            router.push({
+              name: 'vebal',
+              params: { networkSlug: getNetworkSlug(Network.MAINNET) },
+            })
+          "
         />
         <BalBtn
           color="gray"


### PR DESCRIPTION
# Description

Currently, "Proceed" button on VeBAL redirect modal uses href to take user to ethereum page. This sometimes doesn't work. Changed to vue router.


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## How should this be tested?

Change to non-ethereum network. Go to vebal page. Click Proceed.

## Visual context

Please provide any relevant visual context for UI changes or additions. This could be static screenshots or a loom screencast.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have requested at least 2 reviews (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] If package-lock.json has changes, it was intentional.
- [x] The base of this PR is `master` if hotfix, `develop` if not
