### PR TITLE
Fix: veBAL pool voting button not working

### DIFF
--- a/src/components/contextual/pages/vebal/LMVoting/GaugesTable.vue
+++ b/src/components/contextual/pages/vebal/LMVoting/GaugesTable.vue
@@ -312,8 +312,7 @@ function getTableRowClass(gauge: VotingGaugeWithVotes): string {
           <GaugesTableVoteBtn
             :hasUserVotes="getHasUserVotes(gauge.userVotes)"
             :isGaugeExpired="getIsGaugeExpired(gauge.address)"
-            @click.stop="emit('clickedVote', gauge)"
-            @click.prevent=""
+            @click.stop.prevent="emit('clickedVote', gauge)"
           />
         </div>
       </template>

--- a/src/components/contextual/pages/vebal/LMVoting/GaugesTable.vue
+++ b/src/components/contextual/pages/vebal/LMVoting/GaugesTable.vue
@@ -313,6 +313,7 @@ function getTableRowClass(gauge: VotingGaugeWithVotes): string {
             :hasUserVotes="getHasUserVotes(gauge.userVotes)"
             :isGaugeExpired="getIsGaugeExpired(gauge.address)"
             @click.stop="emit('clickedVote', gauge)"
+            @click.prevent=""
           />
         </div>
       </template>


### PR DESCRIPTION
# Description

On veBAL page, vote button wasn't working because of row click event. Added preventDefault to stop bubbling.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## How should this be tested?

Go to veBAL page and open vote modal for a pool.

## Visual context

Please provide any relevant visual context for UI changes or additions. This could be static screenshots or a loom screencast.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have requested at least 2 reviews (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] If package-lock.json has changes, it was intentional.
- [x] The base of this PR is `master` if hotfix, `develop` if not
