### PR TITLE
Use gauge reward helper contract to claim rewards on layer 2s

### DIFF
--- a/src/components/btns/ClaimRewardsBtn/ClaimRewardsBtn.vue
+++ b/src/components/btns/ClaimRewardsBtn/ClaimRewardsBtn.vue
@@ -41,15 +41,15 @@ const gaugesQuery = useGaugesDecorationQuery(subgraphGauges);
  */
 const gaugeAddress = getAddress(props.gauge.id);
 const liquidityGaugeContract = new LiquidityGauge(gaugeAddress);
-const liquidityGaugeRewardsHelperContract = new LiquidityGaugeRewardsHelper(
-  configService.network.addresses.gaugeRewardsHelper || ''
-);
 
 /**
  * METHODS
  */
 function claimTx() {
   if (isL2.value) {
+    const liquidityGaugeRewardsHelperContract = new LiquidityGaugeRewardsHelper(
+      configService.network.addresses.gaugeRewardsHelper || ''
+    );
     return liquidityGaugeRewardsHelperContract.claimRewardsForGauge(
       gaugeAddress,
       account.value

--- a/src/components/btns/ClaimRewardsBtn/ClaimRewardsBtn.vue
+++ b/src/components/btns/ClaimRewardsBtn/ClaimRewardsBtn.vue
@@ -6,9 +6,13 @@ import useGaugesDecorationQuery from '@/composables/queries/useGaugesDecorationQ
 import useGaugesQuery from '@/composables/queries/useGaugesQuery';
 import useNumbers, { FNumFormats } from '@/composables/useNumbers';
 import { LiquidityGauge } from '@/services/balancer/contracts/contracts/liquidity-gauge';
+import { LiquidityGaugeRewardsHelper } from '@/services/balancer/contracts/contracts/gauge-reward-helper';
 import { Gauge } from '@/services/balancer/gauges/types';
 
 import TxActionBtn from '../TxActionBtn/TxActionBtn.vue';
+import { configService } from '@/services/config/config.service';
+import { isL2 } from '@/composables/useNetwork';
+import useWeb3 from '@/services/web3/useWeb3';
 
 /**
  * TYPES
@@ -29,6 +33,7 @@ const props = defineProps<Props>();
 const { t } = useI18n();
 const { fNum2 } = useNumbers();
 const { data: subgraphGauges } = useGaugesQuery();
+const { account } = useWeb3();
 const gaugesQuery = useGaugesDecorationQuery(subgraphGauges);
 
 /**
@@ -36,11 +41,20 @@ const gaugesQuery = useGaugesDecorationQuery(subgraphGauges);
  */
 const gaugeAddress = getAddress(props.gauge.id);
 const liquidityGaugeContract = new LiquidityGauge(gaugeAddress);
+const liquidityGaugeRewardsHelperContract = new LiquidityGaugeRewardsHelper(
+  configService.network.addresses.gaugeRewardsHelper || ''
+);
 
 /**
  * METHODS
  */
 function claimTx() {
+  if (isL2.value) {
+    return liquidityGaugeRewardsHelperContract.claimRewardsForGauge(
+      gaugeAddress,
+      account.value
+    );
+  }
   return liquidityGaugeContract.claimRewards();
 }
 </script>

--- a/src/lib/abi/LiquidityGaugeHelperAbi.json
+++ b/src/lib/abi/LiquidityGaugeHelperAbi.json
@@ -1,0 +1,52 @@
+[
+  {
+    "inputs": [],
+    "name": "CLAIM_FREQUENCY",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "contract IRewardsOnlyGauge",
+        "name": "gauge",
+        "type": "address"
+      },
+      { "internalType": "address", "name": "user", "type": "address" }
+    ],
+    "name": "claimRewardsFromGauge",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "contract IRewardsOnlyGauge[]",
+        "name": "gauges",
+        "type": "address[]"
+      },
+      { "internalType": "address", "name": "user", "type": "address" }
+    ],
+    "name": "claimRewardsFromGauges",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "contract IRewardsOnlyGauge",
+        "name": "gauge",
+        "type": "address"
+      },
+      { "internalType": "address", "name": "user", "type": "address" },
+      { "internalType": "address", "name": "token", "type": "address" }
+    ],
+    "name": "getPendingRewards",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  }
+]

--- a/src/lib/config/arbitrum.json
+++ b/src/lib/config/arbitrum.json
@@ -59,7 +59,8 @@
     "veBALHelpers": "",
     "feeDistributor": "",
     "feeDistributorDeprecated": "",
-    "faucet": ""
+    "faucet": "",
+    "gaugeRewardsHelper": "0xA0DAbEBAAd1b243BBb243f933013d560819eB66f"
   },
   "keys": {
     "infura": "daaa68ec242643719749dd1caba2fc66",

--- a/src/lib/config/goerli.json
+++ b/src/lib/config/goerli.json
@@ -57,7 +57,8 @@
     "veBALHelpers": "0xE9aac58a051314C085773668f27DD6F673fc0B3F",
     "feeDistributor": "0x7F91dcdE02F72b478Dc73cB21730cAcA907c8c44",
     "feeDistributorDeprecated": "0x7F91dcdE02F72b478Dc73cB21730cAcA907c8c44",
-    "faucet": "0xccb0F4Cf5D3F97f4a55bb5f5cA321C3ED033f244"
+    "faucet": "0xccb0F4Cf5D3F97f4a55bb5f5cA321C3ED033f244",
+    "gaugeRewardsHelper": "0xC128a9954e6c874eA3d62ce62B468bA073093F25"
   },
   "keys": {
     "infura": "daaa68ec242643719749dd1caba2fc66",

--- a/src/lib/config/index.ts
+++ b/src/lib/config/index.ts
@@ -69,6 +69,7 @@ export interface Config {
     feeDistributor: string;
     feeDistributorDeprecated: string;
     faucet: string;
+    gaugeRewardsHelper?: string;
   };
   keys: {
     infura: string;

--- a/src/lib/config/polygon.json
+++ b/src/lib/config/polygon.json
@@ -59,7 +59,8 @@
     "veBALHelpers": "",
     "feeDistributor": "",
     "feeDistributorDeprecated": "",
-    "faucet": ""
+    "faucet": "",
+    "gaugeRewardsHelper": "0xaEb406b0E430BF5Ea2Dc0B9Fe62E4E53f74B3a33"
   },
   "keys": {
     "infura": "daaa68ec242643719749dd1caba2fc66",

--- a/src/services/balancer/contracts/contracts/gauge-reward-helper.ts
+++ b/src/services/balancer/contracts/contracts/gauge-reward-helper.ts
@@ -1,0 +1,49 @@
+import { Contract } from '@ethersproject/contracts';
+import { JsonRpcProvider, TransactionResponse } from '@ethersproject/providers';
+
+import LiquidityGaugeRewardHelperAbi from '@/lib/abi/LiquidityGaugeHelperAbi.json';
+import { Multicaller } from '@/lib/utils/balancer/contract';
+import { configService } from '@/services/config/config.service';
+import { rpcProviderService } from '@/services/rpc-provider/rpc-provider.service';
+import { web3Service } from '@/services/web3/web3.service';
+
+export class LiquidityGaugeRewardsHelper {
+  instance: Contract;
+
+  constructor(
+    public readonly address: string,
+    private readonly provider = rpcProviderService.jsonProvider,
+    private readonly abi = LiquidityGaugeRewardHelperAbi,
+    private readonly config = configService,
+    private readonly web3 = web3Service
+  ) {
+    this.instance = new Contract(this.address, this.abi, this.provider);
+  }
+
+  /**
+   * @summary Claim all user's reward tokens on L2
+   */
+  async claimRewardsForGauge(
+    gaugeAddress: string,
+    userAddress: string
+  ): Promise<TransactionResponse> {
+    return await this.web3.txBuilder.contract.sendTransaction({
+      contractAddress: this.address,
+      abi: this.abi,
+      action: 'claimRewardsFromGauge()',
+      params: [gaugeAddress, userAddress],
+    });
+  }
+
+  private getMulticaller(): Multicaller {
+    return new Multicaller(this.config.network.key, this.provider, this.abi);
+  }
+
+  static getMulticaller(provider?: JsonRpcProvider): Multicaller {
+    return new Multicaller(
+      configService.network.key,
+      provider || rpcProviderService.jsonProvider,
+      LiquidityGaugeRewardHelperAbi
+    );
+  }
+}

--- a/src/services/balancer/contracts/contracts/gauge-reward-helper.ts
+++ b/src/services/balancer/contracts/contracts/gauge-reward-helper.ts
@@ -2,7 +2,6 @@ import { Contract } from '@ethersproject/contracts';
 import { TransactionResponse } from '@ethersproject/providers';
 
 import LiquidityGaugeRewardHelperAbi from '@/lib/abi/LiquidityGaugeHelperAbi.json';
-import { configService } from '@/services/config/config.service';
 import { rpcProviderService } from '@/services/rpc-provider/rpc-provider.service';
 import { web3Service } from '@/services/web3/web3.service';
 
@@ -13,7 +12,6 @@ export class LiquidityGaugeRewardsHelper {
     public readonly address: string,
     private readonly provider = rpcProviderService.jsonProvider,
     private readonly abi = LiquidityGaugeRewardHelperAbi,
-    private readonly config = configService,
     private readonly web3 = web3Service
   ) {
     this.instance = new Contract(this.address, this.abi, this.provider);
@@ -29,7 +27,7 @@ export class LiquidityGaugeRewardsHelper {
     return await this.web3.txBuilder.contract.sendTransaction({
       contractAddress: this.address,
       abi: this.abi,
-      action: 'claimRewardsFromGauge()',
+      action: 'claimRewardsFromGauge',
       params: [gaugeAddress, userAddress],
     });
   }

--- a/src/services/balancer/contracts/contracts/gauge-reward-helper.ts
+++ b/src/services/balancer/contracts/contracts/gauge-reward-helper.ts
@@ -1,8 +1,7 @@
 import { Contract } from '@ethersproject/contracts';
-import { JsonRpcProvider, TransactionResponse } from '@ethersproject/providers';
+import { TransactionResponse } from '@ethersproject/providers';
 
 import LiquidityGaugeRewardHelperAbi from '@/lib/abi/LiquidityGaugeHelperAbi.json';
-import { Multicaller } from '@/lib/utils/balancer/contract';
 import { configService } from '@/services/config/config.service';
 import { rpcProviderService } from '@/services/rpc-provider/rpc-provider.service';
 import { web3Service } from '@/services/web3/web3.service';
@@ -33,17 +32,5 @@ export class LiquidityGaugeRewardsHelper {
       action: 'claimRewardsFromGauge()',
       params: [gaugeAddress, userAddress],
     });
-  }
-
-  private getMulticaller(): Multicaller {
-    return new Multicaller(this.config.network.key, this.provider, this.abi);
-  }
-
-  static getMulticaller(provider?: JsonRpcProvider): Multicaller {
-    return new Multicaller(
-      configService.network.key,
-      provider || rpcProviderService.jsonProvider,
-      LiquidityGaugeRewardHelperAbi
-    );
   }
 }

--- a/src/services/balancer/gauges/gauges.decorator.ts
+++ b/src/services/balancer/gauges/gauges.decorator.ts
@@ -48,7 +48,6 @@ export class GaugesDecorator {
     gaugesDataMap = await this.multicaller.execute<OnchainGaugeDataMap>(
       gaugesDataMap
     );
-    console.log('gabesh', gaugesDataMap);
 
     return subgraphGauges.map(subgraphGauge => ({
       ...subgraphGauge,

--- a/src/services/balancer/gauges/gauges.decorator.ts
+++ b/src/services/balancer/gauges/gauges.decorator.ts
@@ -25,7 +25,7 @@ export class GaugesDecorator {
     private readonly provider = rpcProviderService.jsonProvider,
     private readonly config = configService
   ) {
-    this.multicaller = this.resetMulticaller();
+    this.multicaller = this.resetMulticaller(abi);
   }
 
   /**
@@ -35,14 +35,14 @@ export class GaugesDecorator {
     subgraphGauges: SubgraphGauge[],
     userAddress: string
   ): Promise<Gauge[]> {
-    this.multicaller = this.resetMulticaller();
+    this.multicaller = this.resetMulticaller(this.abi);
     this.callRewardTokens(subgraphGauges);
     this.callClaimableTokens(subgraphGauges, userAddress);
 
     let gaugesDataMap = await this.multicaller.execute<OnchainGaugeDataMap>();
 
     if (isL2.value) {
-      this.multicaller = this.resetHelperMulticaller();
+      this.multicaller = this.resetMulticaller(this.rewardsHelperAbi);
     }
     this.callClaimableRewards(subgraphGauges, userAddress, gaugesDataMap);
     gaugesDataMap = await this.multicaller.execute<OnchainGaugeDataMap>(
@@ -161,16 +161,10 @@ export class GaugesDecorator {
     return claimableRewards;
   }
 
-  private resetMulticaller(): Multicaller {
-    return new Multicaller(this.config.network.key, this.provider, this.abi);
-  }
-
-  private resetHelperMulticaller(): Multicaller {
-    return new Multicaller(
-      this.config.network.key,
-      this.provider,
-      this.rewardsHelperAbi
-    );
+  private resetMulticaller(
+    abi: typeof LiquidityGaugeAbi | typeof LiquidityGaugeRewardHelperAbi
+  ): Multicaller {
+    return new Multicaller(this.config.network.key, this.provider, abi);
   }
 }
 

--- a/src/services/balancer/gauges/gauges.decorator.ts
+++ b/src/services/balancer/gauges/gauges.decorator.ts
@@ -2,6 +2,7 @@ import { AddressZero } from '@ethersproject/constants';
 
 import { isL2 } from '@/composables/useNetwork';
 import LiquidityGaugeAbi from '@/lib/abi/LiquidityGaugeV5.json';
+import LiquidityGaugeRewardHelperAbi from '@/lib/abi/LiquidityGaugeHelperAbi.json';
 import { Multicaller } from '@/lib/utils/balancer/contract';
 import { configService } from '@/services/config/config.service';
 import { rpcProviderService } from '@/services/rpc-provider/rpc-provider.service';
@@ -20,6 +21,7 @@ export class GaugesDecorator {
 
   constructor(
     private readonly abi = LiquidityGaugeAbi,
+    private readonly rewardsHelperAbi = LiquidityGaugeRewardHelperAbi,
     private readonly provider = rpcProviderService.jsonProvider,
     private readonly config = configService
   ) {
@@ -39,11 +41,14 @@ export class GaugesDecorator {
 
     let gaugesDataMap = await this.multicaller.execute<OnchainGaugeDataMap>();
 
+    if (isL2.value) {
+      this.multicaller = this.resetHelperMulticaller();
+    }
     this.callClaimableRewards(subgraphGauges, userAddress, gaugesDataMap);
-
     gaugesDataMap = await this.multicaller.execute<OnchainGaugeDataMap>(
       gaugesDataMap
     );
+    console.log('gabesh', gaugesDataMap);
 
     return subgraphGauges.map(subgraphGauge => ({
       ...subgraphGauge,
@@ -118,18 +123,25 @@ export class GaugesDecorator {
     userAddress: string,
     gaugesDataMap: OnchainGaugeDataMap
   ) {
-    const methodName = isL2.value
-      ? 'claimable_reward_write'
-      : 'claimable_reward';
+    const methodName = isL2.value ? 'getPendingRewards' : 'claimable_reward';
+
     subgraphGauges.forEach(gauge => {
       gaugesDataMap[gauge.id].rewardTokens.forEach(rewardToken => {
         if (rewardToken === AddressZero) return;
 
+        const callArgs = isL2.value
+          ? [gauge.id, userAddress, rewardToken]
+          : [userAddress, rewardToken];
+
+        const contractAddress = isL2.value
+          ? configService.network.addresses.gaugeRewardsHelper
+          : gauge.id;
+
         this.multicaller.call(
           `${gauge.id}.claimableRewards.${rewardToken}`,
-          gauge.id,
+          contractAddress,
           methodName,
-          [userAddress, rewardToken]
+          callArgs
         );
       });
     });
@@ -152,6 +164,14 @@ export class GaugesDecorator {
 
   private resetMulticaller(): Multicaller {
     return new Multicaller(this.config.network.key, this.provider, this.abi);
+  }
+
+  private resetHelperMulticaller(): Multicaller {
+    return new Multicaller(
+      this.config.network.key,
+      this.provider,
+      this.rewardsHelperAbi
+    );
   }
 }
 


### PR DESCRIPTION
# Description

Currently gauge rewards shown on our front-end for alternate chains are not accurate. This change changes the pending rewards figures to come from the helper contract as well as claiming through the helper contract.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [X] Code refactor / cleanup
- [ ] Documentation or wording changes
- [X] Other

## How should this be tested?

Claiming and pending rewards behaviours should remain unbroken.

## Visual context
N/A

## Checklist:

- [X] I have performed a self-review of my own code
- [X] I have requested at least 2 reviews (If the PR is significant enough, use best judgement here)
- [X] I have commented my code where relevant, particularly in hard-to-understand areas
- [X] If package-lock.json has changes, it was intentional.
- [X] The base of this PR is `master` if hotfix, `develop` if not
