### PR TITLE
Hotfix: wallet connect provider needs all rpcs used

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.77.2",
+  "version": "1.77.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@balancer-labs/frontend-v2",
-      "version": "1.77.2",
+      "version": "1.77.3",
       "license": "MIT",
       "devDependencies": {
         "@aave/protocol-js": "^4.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.77.2",
+  "version": "1.77.3",
   "engines": {
     "node": "14.x",
     "npm": ">=7"

--- a/src/services/config/config.service.ts
+++ b/src/services/config/config.service.ts
@@ -59,6 +59,15 @@ export default class ConfigService {
     return configs[key];
   }
 
+  public getNetworkRpc(network: Network): string {
+    const networkConfig = this.getNetworkConfig(network);
+
+    return template(networkConfig.rpc, {
+      INFURA_KEY: networkConfig.keys.infura,
+      ALCHEMY_KEY: networkConfig.keys.alchemy,
+    });
+  }
+
   public get rpc(): string {
     return template(this.network.rpc, {
       INFURA_KEY: this.env.INFURA_PROJECT_ID,

--- a/src/services/web3/connectors/trustwallet/walletconnect.connector.ts
+++ b/src/services/web3/connectors/trustwallet/walletconnect.connector.ts
@@ -1,8 +1,9 @@
 import WalletConnectProvider from '@walletconnect/web3-provider';
 
 import ConfigService from '@/services/config/config.service';
+import template from '@/lib/utils/template';
 import { WalletError } from '@/types';
-
+import { Network } from '@balancer-labs/sdk';
 import { Connector, ConnectorId } from '../connector';
 
 export class WalletConnectConnector extends Connector {
@@ -11,7 +12,33 @@ export class WalletConnectConnector extends Connector {
     const configService = new ConfigService();
     const provider = new WalletConnectProvider({
       rpc: {
-        [configService.env.NETWORK]: configService.rpc,
+        [Network.MAINNET]: template(
+          configService.getNetworkConfig(Network.MAINNET).rpc,
+          {
+            INFURA_KEY: configService.getNetworkConfig(Network.MAINNET).keys
+              .infura,
+            ALCHEMY_KEY: configService.getNetworkConfig(Network.MAINNET).keys
+              .alchemy,
+          }
+        ),
+        [Network.POLYGON]: template(
+          configService.getNetworkConfig(Network.POLYGON).rpc,
+          {
+            INFURA_KEY: configService.getNetworkConfig(Network.POLYGON).keys
+              .infura,
+            ALCHEMY_KEY: configService.getNetworkConfig(Network.POLYGON).keys
+              .alchemy,
+          }
+        ),
+        [Network.ARBITRUM]: template(
+          configService.getNetworkConfig(Network.ARBITRUM).rpc,
+          {
+            INFURA_KEY: configService.getNetworkConfig(Network.ARBITRUM).keys
+              .infura,
+            ALCHEMY_KEY: configService.getNetworkConfig(Network.ARBITRUM).keys
+              .alchemy,
+          }
+        ),
       },
     });
     this.provider = provider;

--- a/src/services/web3/connectors/trustwallet/walletconnect.connector.ts
+++ b/src/services/web3/connectors/trustwallet/walletconnect.connector.ts
@@ -14,6 +14,7 @@ export class WalletConnectConnector extends Connector {
         [Network.MAINNET]: configService.getNetworkRpc(Network.MAINNET),
         [Network.POLYGON]: configService.getNetworkRpc(Network.POLYGON),
         [Network.ARBITRUM]: configService.getNetworkRpc(Network.ARBITRUM),
+        [Network.GOERLI]: configService.getNetworkRpc(Network.GOERLI),
       },
     });
     this.provider = provider;

--- a/src/services/web3/connectors/trustwallet/walletconnect.connector.ts
+++ b/src/services/web3/connectors/trustwallet/walletconnect.connector.ts
@@ -1,7 +1,6 @@
 import WalletConnectProvider from '@walletconnect/web3-provider';
 
 import ConfigService from '@/services/config/config.service';
-import template from '@/lib/utils/template';
 import { WalletError } from '@/types';
 import { Network } from '@balancer-labs/sdk';
 import { Connector, ConnectorId } from '../connector';
@@ -12,33 +11,9 @@ export class WalletConnectConnector extends Connector {
     const configService = new ConfigService();
     const provider = new WalletConnectProvider({
       rpc: {
-        [Network.MAINNET]: template(
-          configService.getNetworkConfig(Network.MAINNET).rpc,
-          {
-            INFURA_KEY: configService.getNetworkConfig(Network.MAINNET).keys
-              .infura,
-            ALCHEMY_KEY: configService.getNetworkConfig(Network.MAINNET).keys
-              .alchemy,
-          }
-        ),
-        [Network.POLYGON]: template(
-          configService.getNetworkConfig(Network.POLYGON).rpc,
-          {
-            INFURA_KEY: configService.getNetworkConfig(Network.POLYGON).keys
-              .infura,
-            ALCHEMY_KEY: configService.getNetworkConfig(Network.POLYGON).keys
-              .alchemy,
-          }
-        ),
-        [Network.ARBITRUM]: template(
-          configService.getNetworkConfig(Network.ARBITRUM).rpc,
-          {
-            INFURA_KEY: configService.getNetworkConfig(Network.ARBITRUM).keys
-              .infura,
-            ALCHEMY_KEY: configService.getNetworkConfig(Network.ARBITRUM).keys
-              .alchemy,
-          }
-        ),
+        [Network.MAINNET]: configService.getNetworkRpc(Network.MAINNET),
+        [Network.POLYGON]: configService.getNetworkRpc(Network.POLYGON),
+        [Network.ARBITRUM]: configService.getNetworkRpc(Network.ARBITRUM),
       },
     });
     this.provider = provider;


### PR DESCRIPTION
# Description
Original #2400

The app was throwing lots of errors whenever a wallet connect user switched network. The `WalletConnectProvider` is supposed to be initialized with all of the RPCs. Let me know if there's a cleaner way to use the `ConfigService` here

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## How should this be tested?

- [ ] Test WalletConnect wallet connections and switching networks.

## Visual context

n/a

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have requested at least 2 reviews (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] If package-lock.json has changes, it was intentional.
- [x] The base of this PR is `master` if hotfix, `develop` if not
