### PR TITLE
Fix: DOM errors on network change due to document hiding

### DIFF
--- a/src/components/navs/AppNav/AppNavNetworkSelect.vue
+++ b/src/components/navs/AppNav/AppNavNetworkSelect.vue
@@ -103,10 +103,10 @@ watchEffect(() => {
       n => Number(n.key) === chainId.value
     );
     if (newNetwork) {
-      document.write('');
+      document.body.style.display = 'none';
       localStorage.setItem('networkId', chainId.value.toString());
       window.location.href = getNetworkChangeUrl(newNetwork);
-      router.go(0);
+      location.reload();
     }
   }
   previousNetwork.value = chainId.value;

--- a/src/plugins/router/nav-guards.ts
+++ b/src/plugins/router/nav-guards.ts
@@ -24,10 +24,10 @@ export function applyNavGuards(router: Router): Router {
  * @param {string} url - URL to redirect to.
  * @param {Router} router - vue-router.
  */
-function hardRedirectTo(url: string, router: Router) {
-  document.write('');
+function hardRedirectTo(url: string) {
+  document.body.style.display = 'none';
   window.location.href = url;
-  router.go(0);
+  location.reload();
 }
 
 /**
@@ -73,7 +73,7 @@ function applyNetworkPathRedirects(router: Router): Router {
     if (networkFromPath) {
       const noNetworkChangeCallback = () => next();
       const networkChangeCallback = () => {
-        hardRedirectTo(`/#${to.fullPath}`, router);
+        hardRedirectTo(`/#${to.fullPath}`);
       };
 
       handleNetworkSlug(


### PR DESCRIPTION
# Description

On network change we hide what's on the page to prevent content flash (e.g. pools reloading). This causes errors in Sentry. Changed document.write('') to document.body.style.display = 'none'. Considered using visibility, takes too many resources.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## How should this be tested?

Changing networks, sentry logs.

## Visual context

Please provide any relevant visual context for UI changes or additions. This could be static screenshots or a loom screencast.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have requested at least 2 reviews (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] If package-lock.json has changes, it was intentional.
- [x] The base of this PR is `master` if hotfix, `develop` if not
