### PR TITLE
Remove pool fetching on every block

### DIFF
--- a/src/composables/contextual/pool-transfers/usePoolTransfers.ts
+++ b/src/composables/contextual/pool-transfers/usePoolTransfers.ts
@@ -65,13 +65,6 @@ export default function usePoolTransfers() {
     );
   });
 
-  /**
-   * WATCHERS
-   */
-  watch(blockNumber, async () => {
-    poolQuery.refetch.value();
-  });
-
   return {
     pool,
     loadingPool,

--- a/src/composables/contextual/pool-transfers/usePoolTransfers.ts
+++ b/src/composables/contextual/pool-transfers/usePoolTransfers.ts
@@ -1,4 +1,4 @@
-import { computed, ref, watch } from 'vue';
+import { computed, ref } from 'vue';
 import { useRoute } from 'vue-router';
 
 // Composables
@@ -7,7 +7,6 @@ import { isDeep } from '@/composables/usePool';
 import useTokens from '@/composables/useTokens';
 import { includesAddress } from '@/lib/utils';
 import { Pool } from '@/services/pool/types';
-import useWeb3 from '@/services/web3/useWeb3';
 
 /**
  * STATE
@@ -23,7 +22,6 @@ export default function usePoolTransfers() {
    * COMPOSABLES
    */
   const { prices } = useTokens();
-  const { blockNumber } = useWeb3();
 
   /**
    * QUERIES
@@ -67,6 +65,7 @@ export default function usePoolTransfers() {
 
   return {
     pool,
+    poolQuery,
     loadingPool,
     useNativeAsset,
     missingPrices,

--- a/src/pages/pool/invest.vue
+++ b/src/pages/pool/invest.vue
@@ -12,14 +12,22 @@ import usePoolTransfers from '@/composables/contextual/pool-transfers/usePoolTra
 import { usePool } from '@/composables/usePool';
 import { forChange } from '@/lib/utils';
 import { configService } from '@/services/config/config.service';
+import { useIntervalFn } from '@vueuse/core';
+import { oneMinInMs } from '@/composables/useTime';
 
 /**
  * STATE
  */
 const { network } = configService;
-const { pool, loadingPool, transfersAllowed } = usePoolTransfers();
+const { pool, poolQuery, loadingPool, transfersAllowed } = usePoolTransfers();
 const { isDeepPool } = usePool(pool);
 const { sor, sorReady } = useInvestState();
+
+// Instead of refetching pool data on every block, we refetch every minute to prevent
+// overfetching a heavy request on short blocktime networks like Polygon.
+// TODO: Don't refetch whole pool, only update balances and weights with
+// onchain calls. i.e. only refetch what's required to be up to date for joins/exits.
+useIntervalFn(poolQuery.refetch.value, oneMinInMs);
 
 /**
  * CALLBACKS

--- a/src/pages/pool/withdraw.vue
+++ b/src/pages/pool/withdraw.vue
@@ -3,15 +3,22 @@ import WithdrawForm from '@/components/forms/pool_actions/WithdrawForm/WithdrawF
 import TradeSettingsPopover, {
   TradeSettingsContext,
 } from '@/components/popovers/TradeSettingsPopover.vue';
-// Composables
 import usePoolTransfers from '@/composables/contextual/pool-transfers/usePoolTransfers';
+import { oneMinInMs } from '@/composables/useTime';
 import { configService } from '@/services/config/config.service';
+import { useIntervalFn } from '@vueuse/core';
 
 /**
  * STATE
  */
 const { network } = configService;
-const { pool, loadingPool, transfersAllowed } = usePoolTransfers();
+const { pool, poolQuery, loadingPool, transfersAllowed } = usePoolTransfers();
+
+// Instead of refetching pool data on every block, we refetch every minute to prevent
+// overfetching a heavy request on short blocktime networks like Polygon.
+// TODO: Don't refetch whole pool, only update balances and weights with
+// onchain calls. i.e. only refetch what's required to be up to date for joins/exits.
+useIntervalFn(poolQuery.refetch.value, oneMinInMs);
 </script>
 
 <template>


### PR DESCRIPTION
# Description

We are re-fetching pool data on every block in the join/exit flows. The reason for adding this in the first place is to keep balances up to date for when the user submits a transaction. However, on L2s like Polygon this results in heavy data fetching every couple of seconds because of the block time.

I think we should remove this logic and accept that if the user is on the join/exit flow for a long time balances may go stale and the transaction may revert. I don't think this will be a common case.

In the future, we should only fetch new balances every 30s or so. i.e. only fetch the limited data we need to keep up to date and at a suitable interval.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [x] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## How should this be tested?

- [ ] Test  join/exit flows work as expected.

## Visual context

n/a

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have requested at least 2 reviews (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] If package-lock.json has changes, it was intentional.
- [x] The base of this PR is `master` if hotfix, `develop` if not
