### PR TITLE
Prevent trade preview and submission if network mismatch

### DIFF
--- a/src/components/cards/TradeCard/TradeCard.vue
+++ b/src/components/cards/TradeCard/TradeCard.vue
@@ -200,7 +200,7 @@ export default defineComponent({
     const { t } = useI18n();
     const { bp } = useBreakpoints();
     const { fNum2 } = useNumbers();
-    const { appNetworkConfig } = useWeb3();
+    const { appNetworkConfig, isMismatchedNetwork } = useWeb3();
     const { nativeAsset } = useTokens();
     const {
       tokenInAddress,
@@ -250,12 +250,18 @@ export default defineComponent({
         !dismissedErrors.value.highPriceImpact
     );
     const tradeDisabled = computed(() => {
+      const hasMismatchedNetwork = isMismatchedNetwork.value;
       const hasAmountsError = !tokenInAmount.value || !tokenOutAmount.value;
       const hasGnosisErrors =
         trading.isGnosisTrade.value && trading.gnosis.hasValidationError.value;
       const hasBalancerErrors =
         trading.isBalancerTrade.value && isHighPriceImpact.value;
-      return hasAmountsError || hasGnosisErrors || hasBalancerErrors;
+      return (
+        hasAmountsError ||
+        hasGnosisErrors ||
+        hasBalancerErrors ||
+        hasMismatchedNetwork
+      );
     });
     const title = computed(() => {
       if (trading.wrapType.value === WrapType.Wrap) {
@@ -273,6 +279,12 @@ export default defineComponent({
       }
     );
     const error = computed(() => {
+      if (isMismatchedNetwork.value) {
+        return {
+          header: t('switchNetwork'),
+          body: t('networkMismatch', [appNetworkConfig.name]),
+        };
+      }
       if (trading.isBalancerTrade.value && !trading.isLoading.value) {
         if (errorMessage.value === TradeValidation.NO_LIQUIDITY) {
           return {


### PR DESCRIPTION
# Description

The app was allowing users to submit trades when the wallet provider didn't match the network being used in the app. This was failing silently with the metamask simulated tx fail.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## How should this be tested?

Confirm preview button is disabled and an error shown if the networks don't match on the swap interface

## Visual context

Please provide any relevant visual context for UI changes or additions. This could be static screenshots or a loom screencast.

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have requested at least 2 reviews (If the PR is significant enough, use best judgement here)
- [ ] I have commented my code where relevant, particularly in hard-to-understand areas
- [ ] If package-lock.json has changes, it was intentional.
- [ ] The base of this PR is `master` if hotfix, `develop` if not
