### PR TITLE
Hotfix: handle Optimism external urls on veBAL page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.77.3",
+  "version": "1.77.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@balancer-labs/frontend-v2",
-      "version": "1.77.3",
+      "version": "1.77.4",
       "license": "MIT",
       "devDependencies": {
         "@aave/protocol-js": "^4.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.77.3",
+  "version": "1.77.4",
   "engines": {
     "node": "14.x",
     "npm": ">=7"

--- a/src/components/_global/BalTable/BalTable.vue
+++ b/src/components/_global/BalTable/BalTable.vue
@@ -39,6 +39,7 @@ type Props = {
     to: string;
     getParams: (data: any) => Record<string, string>;
   } | null;
+  href?: { getHref: (data: any) => string | null } | null;
   initialState?: InitialState;
   // eslint-disable-next-line vue/require-default-prop -- TODO: Define default prop
   pin?: DataPinState | null;
@@ -50,6 +51,7 @@ const props = withDefaults(defineProps<Props>(), {
   isPaginated: false,
   noResultsLabel: '',
   link: null,
+  href: null,
   initialState: () => ({
     sortColumn: null,
     sortDirection: null,
@@ -307,6 +309,7 @@ watch(
           :columns="filteredColumns"
           :onRowClick="onRowClick"
           :link="link"
+          :href="href"
           :sticky="sticky"
           :isColumnStuck="isColumnStuck"
           pinned
@@ -330,6 +333,7 @@ watch(
           :columns="filteredColumns"
           :onRowClick="onRowClick"
           :link="link"
+          :href="href"
           :sticky="sticky"
           :isColumnStuck="isColumnStuck"
         >

--- a/src/components/_global/BalTable/BalTableRow.vue
+++ b/src/components/_global/BalTable/BalTableRow.vue
@@ -16,6 +16,7 @@ type Props = {
     to: string;
     getParams: (data: any) => Record<string, string>;
   } | null;
+  href?: { getHref: (data: any) => string | null } | null;
   sticky?: Sticky;
   isColumnStuck?: boolean;
   pinned?: boolean;
@@ -59,12 +60,17 @@ function getHorizontalStickyClass(index: number) {
         isColumnStuck ? 'isSticky' : '',
       ]"
     >
-      <router-link
-        v-if="link"
-        :to="{
-          name: link.to,
-          params: link.getParams(data),
-        }"
+      <component
+        :is="href?.getHref(data) ? 'a' : link ? 'router-link' : 'div'"
+        :to="
+          link
+            ? {
+                name: link.to,
+                params: link.getParams(data),
+              }
+            : null
+        "
+        :href="href?.getHref(data)"
       >
         <slot v-if="column.Cell" v-bind="data" :name="column.Cell" />
         <div
@@ -83,26 +89,7 @@ function getHorizontalStickyClass(index: number) {
               : column.accessor(data)
           }}
         </div>
-      </router-link>
-      <template v-else>
-        <slot v-if="column.Cell" v-bind="data" :name="column.Cell" />
-        <div
-          v-else
-          :class="
-            compact([
-              'px-6 py-4',
-              column.align === 'right' ? 'text-right' : 'text-left',
-              column.cellClassName,
-            ])
-          "
-        >
-          {{
-            typeof column.accessor === 'string'
-              ? data[column.accessor]
-              : column.accessor(data)
-          }}
-        </div>
-      </template>
+      </component>
     </td>
   </tr>
 </template>

--- a/src/components/contextual/pages/vebal/LMVoting/GaugesTable.vue
+++ b/src/components/contextual/pages/vebal/LMVoting/GaugesTable.vue
@@ -151,7 +151,7 @@ function networkSrc(network: Network) {
 
 function redirectToPool(gauge: VotingGaugeWithVotes) {
   const redirectUrl = poolURLFor(gauge.pool.id, gauge.network);
-  if (redirectUrl.includes('https://')) {
+  if (redirectUrl.startsWith('https://')) {
     window.location.href = redirectUrl;
   } else {
     router.push({

--- a/src/components/contextual/pages/vebal/LMVoting/GaugesTable.vue
+++ b/src/components/contextual/pages/vebal/LMVoting/GaugesTable.vue
@@ -17,6 +17,7 @@ import {
   isStableLike,
   isUnknownType,
   orderedPoolTokens,
+  poolURLFor,
 } from '@/composables/usePool';
 import { isSameAddress } from '@/lib/utils';
 import { scale } from '@/lib/utils';
@@ -149,10 +150,20 @@ function networkSrc(network: Network) {
 }
 
 function redirectToPool(gauge: VotingGaugeWithVotes) {
-  router.push({
-    name: 'pool',
-    params: { id: gauge.pool.id, networkSlug: getNetworkSlug(gauge.network) },
-  });
+  const redirectUrl = poolURLFor(gauge.pool.id, gauge.network);
+  if (redirectUrl.includes('https://')) {
+    window.location.href = redirectUrl;
+  } else {
+    router.push({
+      name: 'pool',
+      params: { id: gauge.pool.id, networkSlug: getNetworkSlug(gauge.network) },
+    });
+  }
+}
+
+function getPoolExternalUrl(gauge: VotingGaugeWithVotes) {
+  const poolUrl = poolURLFor(gauge.pool.id, gauge.network);
+  return poolUrl.startsWith('https://') ? poolUrl : null;
 }
 
 function getIsGaugeNew(addedTimestamp: number): boolean {
@@ -198,6 +209,7 @@ function getTableRowClass(gauge: VotingGaugeWithVotes): string {
           networkSlug: getNetworkSlug(gauge.network),
         }),
       }"
+      :href="{ getHref: gauge => getPoolExternalUrl(gauge) }"
       :onRowClick="redirectToPool"
       :getTableRowClass="getTableRowClass"
       :initialState="{


### PR DESCRIPTION
# Description

veBAL table allows user to click or middle click on the row which opens pool page. However, Optimism pools use external explorer. This merge requests turns row into `a` element if the pool url is external.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## How should this be tested?

Please provide instructions so we can test. Please also list any relevant details for your test configuration.

- [ ] Test A
- [ ] Test B

## Visual context

Please provide any relevant visual context for UI changes or additions. This could be static screenshots or a loom screencast.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have requested at least 2 reviews (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] If package-lock.json has changes, it was intentional.
- [x] The base of this PR is `master` if hotfix, `develop` if not
