### PR TITLE
Hotfix: issue with preferential gauges for unstake

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.78.0",
+  "version": "1.78.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@balancer-labs/frontend-v2",
-      "version": "1.78.0",
+      "version": "1.78.1",
       "license": "MIT",
       "devDependencies": {
         "@aave/protocol-js": "^4.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.78.0",
+  "version": "1.78.1",
   "engines": {
     "node": "14.x",
     "npm": ">=7"

--- a/src/components/contextual/stake/StakePreview.vue
+++ b/src/components/contextual/stake/StakePreview.vue
@@ -126,7 +126,7 @@ const totalUserPoolSharePct = ref(
  * LIFECYCLE
  */
 onBeforeMount(async () => {
-  await loadApprovalsForGauge();
+  if (props.action !== 'unstake') await loadApprovalsForGauge();
 });
 
 /** METHODS */

--- a/src/components/pool/PoolPageHeader.vue
+++ b/src/components/pool/PoolPageHeader.vue
@@ -223,7 +223,7 @@ const poolTypeLabel = computed(() => {
       block
     />
     <BalAlert
-      v-if="hasNonPrefGaugeBalances"
+      v-if="hasNonPrefGaugeBalances && !isAffected"
       :title="$t('staking.restakeGauge')"
       :type="'warning'"
       class="mt-2"

--- a/src/providers/local/staking/userUserStakingData.ts
+++ b/src/providers/local/staking/userUserStakingData.ts
@@ -348,8 +348,6 @@ export default function useUserStakingData(
       );
     }
 
-    if (!poolGaugeAddresses.value?.preferentialGauge?.id) return '0';
-
     // sum balances from all gauges in the pool
     const totalBalance = await poolGaugeAddresses.value.gauges.reduce(
       async (totalPromise, value) => {


### PR DESCRIPTION
# Description

Allow users to unstake if a preferential gauge is not set. Removes restake pool page header if the pool is affected by a vulnerability.

Replaces: #2419

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## How should this be tested?

Test old bb-a-usd staking form shows correctly with a staked address

## Visual context

Please provide any relevant visual context for UI changes or additions. This could be static screenshots or a loom screencast.

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have requested at least 2 reviews (If the PR is significant enough, use best judgement here)
- [ ] I have commented my code where relevant, particularly in hard-to-understand areas
- [ ] If package-lock.json has changes, it was intentional.
- [ ] The base of this PR is `master` if hotfix, `develop` if not
