### PR TITLE
Fix: removed trade preview fee overview since it's hardcoded as zero

### DIFF
--- a/src/components/modals/TradePreviewModalGP.vue
+++ b/src/components/modals/TradePreviewModalGP.vue
@@ -597,14 +597,14 @@ watch(blockNumber, () => {
             </div>
           </div>
         </template>
-        <div class="p-3 text-sm">
+        <div v-if="trading.isGnosisTrade.value" class="p-3 text-sm">
           <div class="summary-item-row">
             <div>
               {{ labels.tradeSummary.totalBeforeFees }}
             </div>
             <div v-html="summary.amountBeforeFees" />
           </div>
-          <div v-if="trading.isGnosisTrade.value" class="summary-item-row">
+          <div class="summary-item-row">
             <div>{{ $t('tradeSummary.gasCosts') }}</div>
             <div class="text-green-400">-{{ zeroFee }}</div>
           </div>
@@ -614,11 +614,9 @@ watch(blockNumber, () => {
               v-html="
                 trading.isWrapUnwrapTrade.value
                   ? zeroFee
-                  : trading.isGnosisTrade.value
-                  ? trading.exactIn.value
-                    ? `-${summary.tradeFees}`
-                    : `+${summary.tradeFees}`
-                  : summary.tradeFees
+                  : trading.exactIn.value
+                  ? `-${summary.tradeFees}`
+                  : `+${summary.tradeFees}`
               "
             />
           </div>


### PR DESCRIPTION
# Description

Since fee number on Trade Preview modal is always zero for default swaps (non gassless) - we have removed this front-end element altogether until a more accurate calculation can be displayed.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## How should this be tested?

Preview trade modal on Trade page - check gassless and standard swaps and calculated fees.

## Visual context

Please provide any relevant visual context for UI changes or additions. This could be static screenshots or a loom screencast.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have requested at least 2 reviews (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] If package-lock.json has changes, it was intentional.
- [x] The base of this PR is `master` if hotfix, `develop` if not
