### PR TITLE
Refactor: use query for query instead of debounce

### DIFF
--- a/src/components/forms/pool_actions/InvestForm/components/InvestPreviewModal/InvestPreviewModalV2.vue
+++ b/src/components/forms/pool_actions/InvestForm/components/InvestPreviewModal/InvestPreviewModalV2.vue
@@ -58,7 +58,7 @@ const {
   rektPriceImpact,
   isLoadingQuery,
   txInProgress,
-  debounceQueryJoin,
+  queryJoinQuery,
   resetAmounts,
 } = useJoinPool();
 
@@ -151,7 +151,7 @@ function handleShowStakeModal() {
 // the preview modal, not at the JoinPoolProvider level.
 watch(blockNumber, () => {
   if (!isLoadingQuery.value && !txInProgress.value) {
-    debounceQueryJoin.value();
+    queryJoinQuery.refetch.value();
   }
 });
 </script>

--- a/src/components/forms/pool_actions/InvestForm/components/InvestPreviewModal/InvestPreviewModalV2.vue
+++ b/src/components/forms/pool_actions/InvestForm/components/InvestPreviewModal/InvestPreviewModalV2.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, ref, watch } from 'vue';
+import { computed, ref } from 'vue';
 import { useI18n } from 'vue-i18n';
 
 import useNumbers from '@/composables/useNumbers';
@@ -12,7 +12,8 @@ import InvestSummary from './components/InvestSummary.vue';
 import TokenAmounts from './components/TokenAmounts.vue';
 import InvestActionsV2 from './components/InvestActionsV2.vue';
 import useJoinPool from '@/composables/pools/useJoinPool';
-import useWeb3 from '@/services/web3/useWeb3';
+import { useIntervalFn } from '@vueuse/shared';
+import { oneSecondInMs } from '@/composables/useTime';
 
 /**
  * TYPES
@@ -46,7 +47,6 @@ const investmentConfirmed = ref(false);
 const { t } = useI18n();
 const { getToken } = useTokens();
 const { toFiat } = useNumbers();
-const { blockNumber } = useWeb3();
 const {
   isSingleAssetJoin,
   amountsIn,
@@ -146,14 +146,17 @@ function handleShowStakeModal() {
 /**
  * WATCHERS
  */
-// On every block we should re-trigger queryJoin in case the expected output
+// Every 10s we should re-trigger queryJoin in case the expected output
 // has changed as a result of pool state changing. This should only happen in
 // the preview modal, not at the JoinPoolProvider level.
-watch(blockNumber, () => {
+//
+// Originally we did it every block but this is overfetching on short blocktime
+// networks like Polygon.
+useIntervalFn(() => {
   if (!isLoadingQuery.value && !txInProgress.value) {
     queryJoinQuery.refetch.value();
   }
-});
+}, oneSecondInMs * 10);
 </script>
   
 <template>

--- a/src/constants/queryKeys.ts
+++ b/src/constants/queryKeys.ts
@@ -70,7 +70,18 @@ const QUERY_KEYS = {
       { networkId, id },
     ],
     Joins: {
-      QueryJoin: () => [POOLS_ROOT_KEY, 'query', 'join'],
+      QueryJoin: (
+        amountsIn: Ref<unknown>,
+        hasFetchedPoolsForSor: Ref<unknown>,
+        isSingleAssetJoin: Ref<unknown>
+      ) => [
+        POOLS_ROOT_KEY,
+        'query',
+        'join',
+        amountsIn,
+        hasFetchedPoolsForSor,
+        isSingleAssetJoin,
+      ],
     },
   },
   TokenLists: {

--- a/src/constants/queryKeys.ts
+++ b/src/constants/queryKeys.ts
@@ -78,9 +78,11 @@ const QUERY_KEYS = {
         POOLS_ROOT_KEY,
         'query',
         'join',
-        amountsIn,
-        hasFetchedPoolsForSor,
-        isSingleAssetJoin,
+        {
+          amountsIn,
+          hasFetchedPoolsForSor,
+          isSingleAssetJoin,
+        }
       ],
     },
   },

--- a/src/constants/queryKeys.ts
+++ b/src/constants/queryKeys.ts
@@ -69,6 +69,9 @@ const QUERY_KEYS = {
       'historicalPrices',
       { networkId, id },
     ],
+    Joins: {
+      QueryJoin: () => [POOLS_ROOT_KEY, 'query', 'join'],
+    },
   },
   TokenLists: {
     All: (networkId: Ref<Network>) => ['tokenLists', 'all', { networkId }],

--- a/src/constants/queryKeys.ts
+++ b/src/constants/queryKeys.ts
@@ -82,7 +82,7 @@ const QUERY_KEYS = {
           amountsIn,
           hasFetchedPoolsForSor,
           isSingleAssetJoin,
-        }
+        },
       ],
     },
   },

--- a/src/providers/local/join-pool.provider.ts
+++ b/src/providers/local/join-pool.provider.ts
@@ -69,7 +69,15 @@ const provider = (props: Props) => {
   const txError = ref<string>('');
 
   const queryJoinQuery = useQuery<void, Error>(
-    QUERY_KEYS.Pools.Joins.QueryJoin(),
+    QUERY_KEYS.Pools.Joins.QueryJoin(
+      // If amountsIn change we should call queryJoin to get expected output.
+      amountsIn,
+      // If the global pool fetching for the SOR changes it's been set to true. In
+      // this case we should re-trigger queryJoin to fetch the expected output for
+      // any existing input.
+      hasFetchedPoolsForSor,
+      isSingleAssetJoin
+    ),
     queryJoin,
     reactive({ enabled: true })
   );
@@ -262,22 +270,6 @@ const provider = (props: Props) => {
   /**
    * WATCHERS
    */
-  // If amountsIn change we should call queryJoin to get expected output.
-  watch(
-    amountsIn,
-    () => {
-      resetQueryJoinState();
-      queryJoinQuery.refetch.value();
-    },
-    { deep: true }
-  );
-
-  // If the global pool fetching for the SOR changes it's been set to true. In
-  // this case we should re-trigger queryJoin to fetch the expected output for
-  // any existing input.
-  watch(hasFetchedPoolsForSor, () => {
-    queryJoinQuery.refetch.value();
-  });
 
   // If singleAssetJoin is toggled we need to reset previous query state. queryJoin
   // will be re-triggered by the amountsIn state change. We also need to call


### PR DESCRIPTION
# Description

Replaces `debounceQueryJoin` with `queryJoinQuery` that uses useQuery.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [x] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## How should this be tested?

- [ ] Test price impact loading state in join flow works as expected.

## Visual context

n/a

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have requested at least 2 reviews (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] If package-lock.json has changes, it was intentional.
- [x] The base of this PR is `master` if hotfix, `develop` if not
