### PR TITLE
Add test to cover token lists provider

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -15,4 +15,9 @@ module.exports = {
   testEnvironment: 'jsdom',
   testMatch: null,
   testRegex: '(\\.|/)(test|spec)\\.[jt]sx?$',
+  //TODO: replace with a smaller version
+  moduleNameMapper: {
+    '/public/data/tokenlists/tokens-5.json':
+      '<rootDir>/src/tests/tokenlists/tokens-5.json',
+  },
 };

--- a/jest.config.js
+++ b/jest.config.js
@@ -15,7 +15,6 @@ module.exports = {
   testEnvironment: 'jsdom',
   testMatch: null,
   testRegex: '(\\.|/)(test|spec)\\.[jt]sx?$',
-  //TODO: replace with a smaller version
   moduleNameMapper: {
     '/public/data/tokenlists/tokens-5.json':
       '<rootDir>/src/tests/tokenlists/tokens-5.json',

--- a/src/providers/token-lists.provider.spec.ts
+++ b/src/providers/token-lists.provider.spec.ts
@@ -1,0 +1,91 @@
+import { TokenList, TokenListMap } from '@/types/TokenList';
+import { render, screen } from '@testing-library/vue';
+import TokenListsProvider from './token-lists.provider';
+import useTokenLists from '@/composables/useTokenLists';
+import { h } from 'vue';
+
+function renderWithTokenListProvider(componentUnderTest) {
+  render(TokenListsProvider, {
+    slots: { default: () => h(componentUnderTest) },
+  });
+}
+
+function renderFirstTokenListSymbols(tokenList: TokenListMap) {
+  return JSON.stringify(Object.values(tokenList)[0].tokens.map(t => t.symbol));
+}
+function renderTokenListSymbols(tokenList: TokenList) {
+  return JSON.stringify(tokenList.tokens.map(t => t.symbol));
+}
+
+describe('Token lists provider should', () => {
+  test('provide active TokenList', async () => {
+    const ComponentUnderTest = {
+      setup() {
+        const { activeTokenLists } = useTokenLists();
+
+        return () => `${renderFirstTokenListSymbols(activeTokenLists.value)}`;
+      },
+    };
+
+    renderWithTokenListProvider(ComponentUnderTest);
+    await screen.findByText(
+      '["BAL","DAI","USDT","USDC","WETH","WBTC","miMATIC"]'
+    );
+  });
+
+  test('provide approved TokenList', async () => {
+    const ComponentUnderTest = {
+      setup() {
+        const { approvedTokenLists } = useTokenLists();
+
+        return () => `${renderFirstTokenListSymbols(approvedTokenLists.value)}`;
+      },
+    };
+    renderWithTokenListProvider(ComponentUnderTest);
+    await screen.findByText(
+      '["BAL","DAI","USDT","USDC","WETH","WBTC","miMATIC"]'
+    );
+  });
+
+  test('provide balancer TokenList', async () => {
+    const ComponentUnderTest = {
+      setup() {
+        const { balancerTokenLists } = useTokenLists();
+
+        return () => `${renderFirstTokenListSymbols(balancerTokenLists.value)}`;
+      },
+    };
+    renderWithTokenListProvider(ComponentUnderTest);
+    await screen.findByText(
+      '["BAL","DAI","USDT","USDC","WETH","WBTC","miMATIC"]'
+    );
+  });
+
+  test('provide default TokenList', async () => {
+    const ComponentUnderTest = {
+      setup() {
+        const { defaultTokenList } = useTokenLists();
+
+        return () => `${renderTokenListSymbols(defaultTokenList.value)}`;
+      },
+    };
+    renderWithTokenListProvider(ComponentUnderTest);
+    await screen.findByText(
+      '["BAL","DAI","USDT","USDC","WETH","WBTC","miMATIC"]'
+    );
+  });
+
+  test('provide vetted TokenList', async () => {
+    const ComponentUnderTest = {
+      setup() {
+        const { vettedTokenList } = useTokenLists();
+
+        return () => `${renderTokenListSymbols(vettedTokenList.value)}`;
+      },
+    };
+    renderWithTokenListProvider(ComponentUnderTest);
+    await screen.findByText(
+      '["BAL","bb-a-DAI","bb-a-USDC","bb-a-USDT","bb-a-USD","DAI","FEI","GNO","USDT","USDC","WETH","WBTC","aDAI","aUSDC","aUSDT"]'
+    );
+  });
+});

--- a/src/tests/msw/handlers.ts
+++ b/src/tests/msw/handlers.ts
@@ -33,6 +33,8 @@ export const handlers = [
   }),
 
   rest.post('https://mainnet.infura.io/v3/*', chainIdHandler),
+  rest.post('https://goerli.infura.io/v3/*', chainIdHandler),
+  rest.post('https://eth-goerli.alchemyapi.io/v2/*', chainIdHandler),
 
   rest.get(
     'https://api.coingecko.com/api/v3/coins/ethereum/contract/*/market_chart/range',

--- a/src/tests/tokenlists/tokens-5.json
+++ b/src/tests/tokenlists/tokens-5.json
@@ -1,0 +1,196 @@
+{
+  "https://raw.githubusercontent.com/balancer-labs/assets/refactor-for-multichain/generated/goerli.listed.tokenlist.json": {
+    "name": "Balancer",
+    "timestamp": "2022-08-02T00:00:00.000Z",
+    "logoURI": "https://raw.githubusercontent.com/balancer-labs/pebbles/master/images/pebbles-pad.256w.png",
+    "keywords": ["balancer", "listed"],
+    "version": { "major": 0, "minor": 1, "patch": 1 },
+    "tokens": [
+      {
+        "address": "0xfA8449189744799aD2AcE7e0EBAC8BB7575eff47",
+        "chainId": 5,
+        "name": "Balancer",
+        "symbol": "BAL",
+        "decimals": 18,
+        "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0xba100000625a3754423978a60c9317c58a424e3D/logo.png"
+      },
+      {
+        "address": "0x8c9e6c40d3402480ACE624730524fACC5482798c",
+        "chainId": 5,
+        "name": "Dai",
+        "symbol": "DAI",
+        "decimals": 18,
+        "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0x6B175474E89094C44Da98b954EedeAC495271d0F/logo.png"
+      },
+      {
+        "address": "0x1f1f156E0317167c11Aa412E3d1435ea29Dc3cCE",
+        "chainId": 5,
+        "name": "Tether",
+        "symbol": "USDT",
+        "decimals": 6,
+        "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0xdAC17F958D2ee523a2206206994597C13D831ec7/logo.png"
+      },
+      {
+        "address": "0xe0C9275E44Ea80eF17579d33c55136b7DA269aEb",
+        "chainId": 5,
+        "name": "USD Coin",
+        "symbol": "USDC",
+        "decimals": 6,
+        "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/logo.png"
+      },
+      {
+        "address": "0xdFCeA9088c8A88A76FF74892C1457C17dfeef9C1",
+        "chainId": 5,
+        "name": "WETH",
+        "symbol": "WETH",
+        "decimals": 18,
+        "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2/logo.png"
+      },
+      {
+        "address": "0x37f03a12241E9FD3658ad6777d289c3fb8512Bc9",
+        "chainId": 5,
+        "name": "Wrapped Bitcoin",
+        "symbol": "WBTC",
+        "decimals": 8,
+        "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599/logo.png"
+      },
+      {
+        "address": "0x398106564948fEeb1fEdeA0709AE7D969D62a391",
+        "chainId": 5,
+        "name": "miMATIC",
+        "symbol": "miMATIC",
+        "decimals": 18,
+        "logoURI": "https://assets.coingecko.com/coins/images/15264/large/mimatic-red.png?1620281018"
+      }
+    ]
+  },
+  "https://raw.githubusercontent.com/balancer-labs/assets/refactor-for-multichain/generated/goerli.vetted.tokenlist.json": {
+    "name": "Balancer",
+    "timestamp": "2022-06-09T00:00:00.000Z",
+    "logoURI": "https://raw.githubusercontent.com/balancer-labs/pebbles/master/images/pebbles-pad.256w.png",
+    "keywords": ["balancer", "vetted"],
+    "version": { "major": 1, "minor": 0, "patch": 1 },
+    "tokens": [
+      {
+        "address": "0xfA8449189744799aD2AcE7e0EBAC8BB7575eff47",
+        "chainId": 5,
+        "name": "Balancer",
+        "symbol": "BAL",
+        "decimals": 18,
+        "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0xba100000625a3754423978a60c9317c58a424e3D/logo.png"
+      },
+      {
+        "address": "0x5cEA6A84eD13590ED14903925Fa1A73c36297d99",
+        "chainId": 5,
+        "name": "Balancer Aave Boosted Pool (DAI)",
+        "symbol": "bb-a-DAI",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/balancer-labs/assets/master/assets/0x804cdb9116a10bb78768d3252355a1b18067bf8f.png"
+      },
+      {
+        "address": "0x0595D1Df64279ddB51F1bdC405Fe2D0b4Cc86681",
+        "chainId": 5,
+        "name": "Balancer Aave Boosted Pool (USDC)",
+        "symbol": "bb-a-USDC",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/balancer-labs/assets/master/assets/0x9210f1204b5a24742eba12f710636d76240df3d0.png"
+      },
+      {
+        "address": "0xeFD681A82970AC5d980b9B2D40499735e7BF3F1F",
+        "chainId": 5,
+        "name": "Balancer Aave Boosted Pool (USDT)",
+        "symbol": "bb-a-USDT",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/balancer-labs/assets/master/assets/0x2bbf681cc4eb09218bee85ea2a5d3d13fa40fc0c.png"
+      },
+      {
+        "address": "0x13ACD41C585d7EbB4a9460f7C8f50BE60DC080Cd",
+        "chainId": 5,
+        "name": "Balancer Aave Boosted StablePool (USD)",
+        "symbol": "bb-a-USD",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/balancer-labs/assets/master/assets/0x7b50775383d3d6f0215a8f290f2c9e2eebbeceb2.png"
+      },
+      {
+        "address": "0x8c9e6c40d3402480ACE624730524fACC5482798c",
+        "chainId": 5,
+        "name": "Dai",
+        "symbol": "DAI",
+        "decimals": 18,
+        "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0x6B175474E89094C44Da98b954EedeAC495271d0F/logo.png"
+      },
+      {
+        "address": "0x829f35cEBBCd47d3c120793c12f7A232c903138B",
+        "chainId": 5,
+        "name": "Fei USD",
+        "symbol": "FEI",
+        "decimals": 18,
+        "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0x956F47F50A910163D8BF957Cf5846D573E7f87CA/logo.png"
+      },
+      {
+        "address": "0xFF386a3d08f80AC38c77930d173Fa56C6286Dc8B",
+        "chainId": 5,
+        "name": "Gnosis",
+        "symbol": "GNO",
+        "decimals": 18,
+        "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0x6810e776880C02933D47DB1b9fc05908e5386b96/logo.png"
+      },
+      {
+        "address": "0x1f1f156E0317167c11Aa412E3d1435ea29Dc3cCE",
+        "chainId": 5,
+        "name": "Tether",
+        "symbol": "USDT",
+        "decimals": 6,
+        "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0xdAC17F958D2ee523a2206206994597C13D831ec7/logo.png"
+      },
+      {
+        "address": "0xe0C9275E44Ea80eF17579d33c55136b7DA269aEb",
+        "chainId": 5,
+        "name": "USD Coin",
+        "symbol": "USDC",
+        "decimals": 6,
+        "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/logo.png"
+      },
+      {
+        "address": "0xdFCeA9088c8A88A76FF74892C1457C17dfeef9C1",
+        "chainId": 5,
+        "name": "WETH",
+        "symbol": "WETH",
+        "decimals": 18,
+        "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2/logo.png"
+      },
+      {
+        "address": "0x37f03a12241E9FD3658ad6777d289c3fb8512Bc9",
+        "chainId": 5,
+        "name": "Wrapped Bitcoin",
+        "symbol": "WBTC",
+        "decimals": 8,
+        "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599/logo.png"
+      },
+      {
+        "address": "0x89534a24450081Aa267c79B07411e9617D984052",
+        "chainId": 5,
+        "name": "Wrapped aDAI",
+        "symbol": "aDAI",
+        "decimals": 18,
+        "logoURI": "https://raw.githubusercontent.com/balancer-labs/assets/master/assets/0x02d60b84491589974263d922d9cc7a3152618ef6.png"
+      },
+      {
+        "address": "0x811151066392fd641Fe74A9B55a712670572D161",
+        "chainId": 5,
+        "name": "Wrapped aUSDC",
+        "symbol": "aUSDC",
+        "decimals": 6,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x9bA00D6856a4eDF4665BcA2C2309936572473B7E/logo.png"
+      },
+      {
+        "address": "0x4Cb1892FdDF14f772b2E39E299f44B2E5DA90d04",
+        "chainId": 5,
+        "name": "Wrapped aUSDT",
+        "symbol": "aUSDT",
+        "decimals": 6,
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x71fc860F7D3A592A4a98740e39dB31d25db65ae8/logo.png"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
# Description

This is a new unit test that covers `token-lists.provider`. I added it to better understand this provider during the vite migration spike. 

As pointed in [this PR](https://github.com/balancer-labs/frontend-v2/pull/2375), this kind of tests could be simplified by refactoring the current Root providers pattern. This test can be helpful until we have that discussion.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [x] Other


## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have requested at least 2 reviews (If the PR is significant enough, use best judgement here)
- [ ] I have commented my code where relevant, particularly in hard-to-understand areas
- [ ] If package-lock.json has changes, it was intentional.
- [ ] The base of this PR is `master` if hotfix, `develop` if not
