### PR TITLE
Hotfix: Switch to new check-wallet endpoint

### DIFF
--- a/src/constants/exploits.ts
+++ b/src/constants/exploits.ts
@@ -8,7 +8,7 @@ export type Exploits = Record<
   }
 >;
 
-export const WALLET_SCREEN_ENDPOINT = 'https://api.balancer.fi/wallet-check';
+export const WALLET_SCREEN_ENDPOINT = 'https://api.balancer.fi/check-wallet';
 
 export const ACTIVE_EXPLOITS: Exploits = {
   sorbet_finance: {

--- a/src/services/web3/web3.plugin.ts
+++ b/src/services/web3/web3.plugin.ts
@@ -77,11 +77,8 @@ export async function isBlockedAddress(
     if (!configService.env.WALLET_SCREENING) return false;
     trackGoal(Goals.WalletScreenRequest);
 
-    const response = await axios.post<WalletScreenResponse>(
-      WALLET_SCREEN_ENDPOINT,
-      {
-        address: address.toLowerCase(),
-      }
+    const response = await axios.get<WalletScreenResponse>(
+      `${WALLET_SCREEN_ENDPOINT}/${address.toLowerCase()}`
     );
 
     trackGoal(Goals.WalletScreened);


### PR DESCRIPTION
# Description

We've setup a new API endpoint at /check-wallet that is a GET request with the wallet address as the first parameter. This is so requests can easily be cached. It functions identically to the old endpoint just with a different interface. 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [x] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## How should this be tested?

- Start a swap on Balancer with a normal wallet, open networking in developer tools and ensure the request is sent to the check-wallet endpoint and that it returns a 200 status code. 
- Start a swap on Balancer with a sanctioned wallet (using impersonator), ensure that the wallet is blocked and disconnected as you start the swap. 

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have requested at least 2 reviews (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] If package-lock.json has changes, it was intentional.
- [x] The base of this PR is `master` if hotfix, `develop` if not
