### PR TITLE
Fix cmd+click pool row functionality

### DIFF
--- a/src/components/_global/BalTable/BalTable.vue
+++ b/src/components/_global/BalTable/BalTable.vue
@@ -28,7 +28,7 @@ type Props = {
   isLoading?: boolean;
   isLoadingMore?: boolean;
   skeletonClass?: string;
-  onRowClick?: (data: Data) => void;
+  onRowClick?: (data: Data, inNewTab?: boolean) => void;
   sticky?: Sticky;
   square?: boolean;
   isPaginated?: boolean;

--- a/src/components/_global/BalTable/BalTableRow.vue
+++ b/src/components/_global/BalTable/BalTableRow.vue
@@ -10,7 +10,7 @@ import {
 
 type Props = {
   columns: ColumnDefinition<any>[];
-  onRowClick?: (data: any) => void;
+  onRowClick?: (data: any, inNewTab?: boolean) => void;
   data: Ref<any>;
   link?: {
     to: string;
@@ -24,9 +24,9 @@ type Props = {
 
 const props = defineProps<Props>();
 
-function handleRowClick(data: Data) {
+function handleRowClick(data: Data, inNewTab = false) {
   if (props.link?.to) return;
-  props.onRowClick && props.onRowClick(data);
+  props.onRowClick && props.onRowClick(data, inNewTab);
 }
 
 // Need a method for horizontal stickiness as we need to
@@ -49,7 +49,8 @@ function getHorizontalStickyClass(index: number) {
         'border-b dark:border-gray-700': pinned,
       },
     ]"
-    @click="handleRowClick(data)"
+    @click.exact="handleRowClick(data)"
+    @click.meta="handleRowClick(data, true)"
   >
     <td
       v-for="(column, columnIndex) in columns"

--- a/src/components/contextual/pages/vebal/LMVoting/GaugesTable.vue
+++ b/src/components/contextual/pages/vebal/LMVoting/GaugesTable.vue
@@ -149,21 +149,26 @@ function networkSrc(network: Network) {
   )}.svg`);
 }
 
-function redirectToPool(gauge: VotingGaugeWithVotes) {
+function isInternalUrl(url: string): boolean {
+  return url.includes('balancer.fi') || url.includes('localhost');
+}
+
+function redirectToPool(gauge: VotingGaugeWithVotes, inNewTab) {
   const redirectUrl = poolURLFor(gauge.pool.id, gauge.network);
-  if (redirectUrl.startsWith('https://')) {
+  if (!isInternalUrl(redirectUrl)) {
     window.location.href = redirectUrl;
   } else {
-    router.push({
+    const route = router.resolve({
       name: 'pool',
       params: { id: gauge.pool.id, networkSlug: getNetworkSlug(gauge.network) },
     });
+    inNewTab ? window.open(route.href) : router.push(route);
   }
 }
 
 function getPoolExternalUrl(gauge: VotingGaugeWithVotes) {
   const poolUrl = poolURLFor(gauge.pool.id, gauge.network);
-  return poolUrl.startsWith('https://') ? poolUrl : null;
+  return isInternalUrl(poolUrl) ? null : poolUrl;
 }
 
 function getIsGaugeNew(addedTimestamp: number): boolean {
@@ -202,13 +207,6 @@ function getTableRowClass(gauge: VotingGaugeWithVotes): string {
       sticky="both"
       :square="upToLargeBreakpoint"
       :isPaginated="isPaginated"
-      :link="{
-        to: 'pool',
-        getParams: gauge => ({
-          id: gauge.pool.id || '',
-          networkSlug: getNetworkSlug(gauge.network),
-        }),
-      }"
       :href="{ getHref: gauge => getPoolExternalUrl(gauge) }"
       :onRowClick="redirectToPool"
       :getTableRowClass="getTableRowClass"

--- a/src/components/tables/PoolsTable/PoolsTable.vue
+++ b/src/components/tables/PoolsTable/PoolsTable.vue
@@ -212,7 +212,7 @@ const visibleColumns = computed(() =>
 /**
  * METHODS
  */
-function handleRowClick(pool: PoolWithShares, inNewTab: boolean) {
+function handleRowClick(pool: PoolWithShares, inNewTab?: boolean) {
   trackGoal(Goals.ClickPoolsTableRow);
   const route = router.resolve({
     name: 'pool',

--- a/src/components/tables/PoolsTable/PoolsTable.vue
+++ b/src/components/tables/PoolsTable/PoolsTable.vue
@@ -212,9 +212,13 @@ const visibleColumns = computed(() =>
 /**
  * METHODS
  */
-function handleRowClick(pool: PoolWithShares) {
+function handleRowClick(pool: PoolWithShares, inNewTab: boolean) {
   trackGoal(Goals.ClickPoolsTableRow);
-  router.push({ name: 'pool', params: { id: pool.id, networkSlug } });
+  const route = router.resolve({
+    name: 'pool',
+    params: { id: pool.id, networkSlug },
+  });
+  inNewTab ? window.open(route.href) : router.push(route);
 }
 
 function navigateToPoolMigration(pool: PoolWithShares) {
@@ -262,10 +266,6 @@ function iconAddresses(pool: PoolWithShares) {
       :skeletonClass="skeletonClass"
       sticky="both"
       :square="upToLargeBreakpoint"
-      :link="{
-        to: 'pool',
-        getParams: pool => ({ id: pool.id || '', networkSlug }),
-      }"
       :onRowClick="handleRowClick"
       :isPaginated="isPaginated"
       :initialState="{


### PR DESCRIPTION
# Description

Adds support for cmd+click on rows in pool table so that pool pages open in new tab.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## How should this be tested?

Please provide instructions so we can test. Please also list any relevant details for your test configuration.

- [ ] Test clicking on rows in pools table without CMD/CTRL. Page should redirect to pool page.
- [ ] Test cmd/ctrl+click on rows in pools table. New tab should open in background with pool page.

## Visual context

n/a

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have requested at least 2 reviews (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] If package-lock.json has changes, it was intentional.
- [x] The base of this PR is `master` if hotfix, `develop` if not
