### PR TITLE
Hotfix: Pass check-wallet address as a query param

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.79.6",
+  "version": "1.79.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@balancer-labs/frontend-v2",
-      "version": "1.79.6",
+      "version": "1.79.7",
       "license": "MIT",
       "devDependencies": {
         "@aave/protocol-js": "^4.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.79.6",
+  "version": "1.79.7",
   "engines": {
     "node": "14.x",
     "npm": ">=7"

--- a/src/services/web3/web3.plugin.ts
+++ b/src/services/web3/web3.plugin.ts
@@ -78,7 +78,7 @@ export async function isBlockedAddress(
     trackGoal(Goals.WalletScreenRequest);
 
     const response = await axios.get<WalletScreenResponse>(
-      `${WALLET_SCREEN_ENDPOINT}/${address.toLowerCase()}`
+      `${WALLET_SCREEN_ENDPOINT}?address=${address.toLowerCase()}`
     );
 
     trackGoal(Goals.WalletScreened);

--- a/src/tests/msw/handlers.ts
+++ b/src/tests/msw/handlers.ts
@@ -56,12 +56,12 @@ export const handlers = [
     }
   ),
 
-  rest.post('https://api.balancer.fi/wallet-check', (req, res, ctx) => {
-    return req.json().then(data => {
-      if (data.address === SANCTIONED_ADDRESS)
-        return res(ctx.json({ is_blocked: true }));
-      // NOT SANCTIONED:
-      return res(ctx.json({ is_blocked: false }));
-    });
+  rest.get('https://api.balancer.fi/check-wallet', (req, res, ctx) => {
+    const query = req.url.searchParams;
+    const address = query.get('address');
+    if (address === SANCTIONED_ADDRESS)
+      return res(ctx.json({ is_blocked: true }));
+    // NOT SANCTIONED:
+    return res(ctx.json({ is_blocked: false }));
   }),
 ];


### PR DESCRIPTION
# Description

Changing check-wallet to take the wallet address as a query parameter instead of a path parameter (see https://github.com/balancer-labs/balancer-api/pull/129) so that it can be cached with Cloudflare. 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

- Load the frontend and perform a transaction, it should connect to the check-wallet endpoint and return a 200 status code with `{is_blocked: false}`
- Load the frontend with a malicious wallet (using impersonator), it should connect to the check-wallet endpoint and return a 200 status code with `{is_blocked: true}`

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have requested at least 2 reviews (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] If package-lock.json has changes, it was intentional.
- [x] The base of this PR is `master` if hotfix, `develop` if not
