### PR TITLE
Hotfix: no default decimals

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.79.7",
+  "version": "1.79.8",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@balancer-labs/frontend-v2",
-      "version": "1.79.7",
+      "version": "1.79.8",
       "license": "MIT",
       "devDependencies": {
         "@aave/protocol-js": "^4.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.79.7",
+  "version": "1.79.8",
   "engines": {
     "node": "14.x",
     "npm": ">=7"

--- a/src/services/pool/exchange/serializers/ExitParams.ts
+++ b/src/services/pool/exchange/serializers/ExitParams.ts
@@ -89,13 +89,18 @@ export default class ExitParams {
   }
 
   private parseAmounts(amounts: string[]): BigNumber[] {
-    return amounts.map((amount, i) => {
-      const token = this.pool.value.tokensList[i];
-      return parseUnits(
-        amount,
-        this.pool.value?.onchain?.tokens?.[token]?.decimals || 18
-      );
-    });
+    try {
+      return amounts.map((amount, i) => {
+        const token = this.pool.value.tokensList[i];
+        return parseUnits(
+          amount,
+          this.pool.value?.onchain?.tokens?.[token]?.decimals
+        );
+      });
+    } catch (error) {
+      console.error('Failed to parse amountsOut', error);
+      throw new Error('Failed to parse amounts out.');
+    }
   }
 
   private parseTokensOut(tokensOut: string[]): string[] {


### PR DESCRIPTION
# Description

In the exit params, for amountsOut, we were defaulting to 18 decimals if no decimals for the token could be found. For certain tokens where the decimals were `0` this meant the resulting conditional `0 || 18` which in JS resolves to `18`.

The fix, we should not use defaults in the exit params and throw and error if we can't access the decimals.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## How should this be tested?

- [ ] Test SLP case from discord.

## Visual context

n/a

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have requested at least 2 reviews (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] If package-lock.json has changes, it was intentional.
- [x] The base of this PR is `master` if hotfix, `develop` if not
