### PR TITLE
Exclude native asset selection from swap joins/exits

### DIFF
--- a/src/components/contextual/pages/pool/invest/InvestPageMyWallet.vue
+++ b/src/components/contextual/pages/pool/invest/InvestPageMyWallet.vue
@@ -11,6 +11,7 @@ import useInvestPageTabs, {
   Tab,
   tabs,
 } from '@/composables/pools/useInvestPageTabs';
+import useVeBal from '@/composables/useVeBAL';
 
 /**
  * COMPOSABLES
@@ -23,12 +24,15 @@ const { tokenAddresses, amounts } = useInvestState();
 const { setAmountsIn, isSingleAssetJoin, amountsIn } = useJoinPool();
 const { nativeAsset, wrappedNativeAsset, getMaxBalanceFor } = useTokens();
 const { activeTab } = useInvestPageTabs();
+const { veBalTokenInfo } = useVeBal();
 
 /**
  * COMPUTED
  */
 const excludedTokens = computed<string[]>(() => {
-  return pool.value?.address ? [pool.value.address] : [];
+  const tokens = [veBalTokenInfo.value?.address, nativeAsset.address];
+  if (pool.value?.address) tokens.push(pool.value.address);
+  return tokens;
 });
 
 /**
@@ -113,7 +117,6 @@ function handleMyWalletTokenClick(tokenAddress: string, isPoolToken: boolean) {
   />
   <MyWallet
     v-else
-    includeNativeAsset
     :excludedTokens="excludedTokens"
     :pool="pool"
     @click:asset="handleMyWalletTokenClick"

--- a/src/components/forms/pool_actions/InvestForm/InvestFormV2.vue
+++ b/src/components/forms/pool_actions/InvestForm/InvestFormV2.vue
@@ -46,7 +46,7 @@ const { managedPoolWithTradingHalted } = usePool(toRef(props, 'pool'));
 const { veBalTokenInfo } = useVeBal();
 const { isWalletReady, startConnectWithInjectedProvider, isMismatchedNetwork } =
   useWeb3();
-const { wrappedNativeAsset } = useTokens();
+const { wrappedNativeAsset, nativeAsset } = useTokens();
 const {
   isLoadingQuery,
   isSingleAssetJoin,
@@ -134,7 +134,11 @@ watch([isSingleAssetJoin, poolTokensWithBalance], ([isSingleAsset]) => {
       :name="amountIn.address"
       class="mb-4"
       :fixedToken="!isSingleAssetJoin"
-      :excludedTokens="[veBalTokenInfo?.address, pool.address]"
+      :excludedTokens="[
+        veBalTokenInfo?.address,
+        pool.address,
+        nativeAsset.address,
+      ]"
     />
 
     <MissingPoolTokensAlert

--- a/src/components/forms/pool_actions/WithdrawForm/WithdrawFormV2.vue
+++ b/src/components/forms/pool_actions/WithdrawForm/WithdrawFormV2.vue
@@ -37,7 +37,7 @@ const showPreview = ref(false);
  */
 const { t } = useI18n();
 const { veBalTokenInfo } = useVeBal();
-const { wrappedNativeAsset } = useTokens();
+const { wrappedNativeAsset, nativeAsset } = useTokens();
 
 const { maxSlider } = useWithdrawalState(toRef(props, 'pool'));
 
@@ -105,7 +105,11 @@ onBeforeMount(() => {
           :customBalance="singleAmountOut.max || '0'"
           :balanceLabel="$t('max')"
           :balanceLoading="isLoadingMax"
-          :excludedTokens="[veBalTokenInfo?.address, pool.address]"
+          :excludedTokens="[
+            veBalTokenInfo?.address,
+            pool.address,
+            nativeAsset.address,
+          ]"
           :tokenSelectProps="{ ignoreBalances: true }"
           ignoreWalletBalance
         />


### PR DESCRIPTION
# Description

See title.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## How should this be tested?

- [ ] Test that you can't join or exit with native asset in single asset flow for boosted pools.

## Visual context

n/a

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have requested at least 2 reviews (If the PR is significant enough, use best judgement here)
- [ ] I have commented my code where relevant, particularly in hard-to-understand areas
- [ ] If package-lock.json has changes, it was intentional.
- [ ] The base of this PR is `master` if hotfix, `develop` if not
