### PR TITLE
Add timestamps in new pool charts

### DIFF
--- a/src/components/contextual/pages/pool/PoolChart.vue
+++ b/src/components/contextual/pages/pool/PoolChart.vue
@@ -13,6 +13,7 @@ import useNumbers from '@/composables/useNumbers';
 import useTailwind from '@/composables/useTailwind';
 import { HistoricalPrices } from '@/services/coingecko/api/price.service';
 import { PoolSnapshot, PoolSnapshots, PoolType } from '@/services/pool/types';
+import { twentyFourHoursInSecs } from '@/composables/useTime';
 
 /**
  * TYPES
@@ -264,6 +265,11 @@ function getFeesData(
     }
   );
 
+  // add 0 values in order to show chart properly
+  if (periodSnapshots.length < 30) {
+    feesValues.push(...addLackingTimestamps());
+  }
+
   const defaultHeaderStateValue =
     Number(periodSnapshots[0].swapFees) -
     (isAllTimeSelected
@@ -308,6 +314,11 @@ function getVolumeData(
       value - prevValue,
     ]);
   });
+
+  // add 0 values in order to show chart properly
+  if (periodSnapshots.length < 30) {
+    volumeData.push(...addLackingTimestamps());
+  }
 
   const defaultHeaderStateValue =
     Number(periodSnapshots[0].swapVolume) -
@@ -389,6 +400,28 @@ function setCurrentChartValue(payload: {
   currentChartDate.value = format(
     new Date(payload.chartDate),
     PRETTY_DATE_FORMAT
+  );
+}
+
+function addLackingTimestamps() {
+  const lastDate =
+    snapshotValues.value[snapshotValues.value.length - 1].timestamp / 1000;
+  const days = 30 - snapshotValues.value.length;
+
+  const timestampsArr: number[] = [];
+  for (let i = 1; i <= days; i++) {
+    const timestamp = lastDate - i * twentyFourHoursInSecs;
+    timestampsArr.push(timestamp * 1000);
+  }
+
+  return timestampsArr.map(timestamp =>
+    Object.freeze<[string, number]>([
+      format(
+        addMinutes(timestamp, new Date(timestamp).getTimezoneOffset()),
+        'yyyy/MM/dd'
+      ),
+      0,
+    ])
   );
 }
 </script>

--- a/src/components/contextual/pages/pool/PoolChart.vue
+++ b/src/components/contextual/pages/pool/PoolChart.vue
@@ -267,7 +267,7 @@ function getFeesData(
 
   // add 0 values in order to show chart properly
   if (periodSnapshots.length < 30) {
-    feesValues.push(...addLackingTimestamps());
+    feesValues.push(...addLaggingTimestamps());
   }
 
   const defaultHeaderStateValue =
@@ -317,7 +317,7 @@ function getVolumeData(
 
   // add 0 values in order to show chart properly
   if (periodSnapshots.length < 30) {
-    volumeData.push(...addLackingTimestamps());
+    volumeData.push(...addLaggingTimestamps());
   }
 
   const defaultHeaderStateValue =
@@ -403,7 +403,7 @@ function setCurrentChartValue(payload: {
   );
 }
 
-function addLackingTimestamps() {
+function addLaggingTimestamps() {
   const lastDate =
     snapshotValues.value[snapshotValues.value.length - 1].timestamp / 1000;
   const days = 30 - snapshotValues.value.length;


### PR DESCRIPTION
# Description
Add timestamps in new pools in order to display charts better. 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## How should this be tested?

Please provide instructions so we can test. Please also list any relevant details for your test configuration.

- [ ] Test A
- [ ] Test B

## Visual context
![image](https://user-images.githubusercontent.com/46521087/205283367-95f8ede8-8697-4457-9e5b-dab28032310e.png)


## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have requested at least 2 reviews (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [ ] If package-lock.json has changes, it was intentional.
- [x] The base of this PR is `master` if hotfix, `develop` if not
