### PR TITLE
Fix ctrl click on table row for Windows

### DIFF
--- a/src/components/_global/BalTable/BalTableRow.vue
+++ b/src/components/_global/BalTable/BalTableRow.vue
@@ -51,6 +51,7 @@ function getHorizontalStickyClass(index: number) {
     ]"
     @click.exact="handleRowClick(data)"
     @click.meta="handleRowClick(data, true)"
+    @click.ctrl="handleRowClick(data, true)"
   >
     <td
       v-for="(column, columnIndex) in columns"


### PR DESCRIPTION
# Description

See title.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## How should this be tested?

- [ ] On a windows machine ctrl click a pool in the pools list should open the pool page in a new tab.

## Visual context

n/a

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have requested at least 2 reviews (If the PR is significant enough, use best judgement here)
- [ ] I have commented my code where relevant, particularly in hard-to-understand areas
- [ ] If package-lock.json has changes, it was intentional.
- [ ] The base of this PR is `master` if hotfix, `develop` if not
