### PR TITLE
Cleanup join/exit flow loading states

### DIFF
--- a/src/composables/contextual/pool-transfers/usePoolTransfers.ts
+++ b/src/composables/contextual/pool-transfers/usePoolTransfers.ts
@@ -7,6 +7,7 @@ import { isDeep } from '@/composables/usePool';
 import useTokens from '@/composables/useTokens';
 import { includesAddress } from '@/lib/utils';
 import { Pool } from '@/services/pool/types';
+import { isQueryLoading } from '@/composables/queries/useQueryHelpers';
 
 /**
  * STATE
@@ -35,12 +36,7 @@ export default function usePoolTransfers() {
     return poolQuery.data.value;
   });
 
-  const poolQueryLoading = computed(
-    (): boolean =>
-      (poolQuery.isLoading.value as boolean) ||
-      (poolQuery.isIdle.value as boolean) ||
-      (poolQuery.error.value as boolean)
-  );
+  const poolQueryLoading = computed((): boolean => isQueryLoading(poolQuery));
 
   const loadingPool = computed(
     (): boolean => poolQueryLoading.value || !pool.value

--- a/src/lib/balancer.sdk.ts
+++ b/src/lib/balancer.sdk.ts
@@ -34,4 +34,4 @@ export async function fetchPoolsForSor() {
   console.timeEnd('fetchPoolsForSor');
 }
 
-fetchPoolsForSor();
+if (process.env.NODE_ENV !== 'test') fetchPoolsForSor();

--- a/src/lib/balancer.sdk.ts
+++ b/src/lib/balancer.sdk.ts
@@ -33,3 +33,5 @@ export async function fetchPoolsForSor() {
   hasFetchedPoolsForSor.value = true;
   console.timeEnd('fetchPoolsForSor');
 }
+
+fetchPoolsForSor();

--- a/src/pages/pool/withdraw.vue
+++ b/src/pages/pool/withdraw.vue
@@ -14,7 +14,8 @@ import useWithdrawPageTabs, {
 } from '@/composables/pools/useWithdrawPageTabs';
 import { oneMinInMs } from '@/composables/useTime';
 import { useIntervalFn } from '@vueuse/core';
-import { onMounted } from 'vue';
+import { computed, onMounted } from 'vue';
+import { hasFetchedPoolsForSor } from '@/lib/balancer.sdk';
 
 /**
  * COMPOSABLES
@@ -30,15 +31,25 @@ const { activeTab, resetTabs } = useWithdrawPageTabs();
 // onchain calls. i.e. only refetch what's required to be up to date for joins/exits.
 useIntervalFn(poolQuery.refetch.value, oneMinInMs);
 
+/**
+ * COMPUTED
+ */
+// We only need to wait for SOR if it's a deep pool.
+const isLoadingSor = computed(
+  (): boolean => isDeepPool.value && hasFetchedPoolsForSor.value
+);
+
+const isLoading = computed(
+  (): boolean =>
+    loadingPool.value || !transfersAllowed.value || isLoadingSor.value
+);
+
 onMounted(() => resetTabs());
 </script>
 
 <template>
   <div class="px-4 sm:px-0 mx-auto max-w-md">
-    <BalLoadingBlock
-      v-if="loadingPool || !pool || !transfersAllowed"
-      class="h-96"
-    />
+    <BalLoadingBlock v-if="isLoading || !pool" class="h-96" />
     <BalCard v-else shadow="xl" exposeOverflow noBorder>
       <template #header>
         <div class="w-full">

--- a/src/pages/pool/withdraw.vue
+++ b/src/pages/pool/withdraw.vue
@@ -36,7 +36,7 @@ useIntervalFn(poolQuery.refetch.value, oneMinInMs);
  */
 // We only need to wait for SOR if it's a deep pool.
 const isLoadingSor = computed(
-  (): boolean => isDeepPool.value && hasFetchedPoolsForSor.value
+  (): boolean => isDeepPool.value && !hasFetchedPoolsForSor.value
 );
 
 const isLoading = computed(

--- a/src/providers/local/exit-pool.provider.ts
+++ b/src/providers/local/exit-pool.provider.ts
@@ -19,7 +19,7 @@ import {
 } from '@/constants/poolLiquidity';
 import QUERY_KEYS from '@/constants/queryKeys';
 import symbolKeys from '@/constants/symbol.keys';
-import { fetchPoolsForSor, hasFetchedPoolsForSor } from '@/lib/balancer.sdk';
+import { hasFetchedPoolsForSor } from '@/lib/balancer.sdk';
 import { bnSum, bnum, isSameAddress, removeAddress } from '@/lib/utils';
 import { ExitPoolService } from '@/services/balancer/pools/exits/exit-pool.service';
 import { ExitType } from '@/services/balancer/pools/exits/handlers/exit-pool.handler';
@@ -412,9 +412,9 @@ const provider = (props: Props) => {
     // Ensure prices are fetched for token tree. When pool architecture is
     // refactoted probably won't be required.
     injectTokens([...exitTokenAddresses.value, pool.value.address]);
-    // Trigger SOR pool fetching in case swap exits are used.
-    fetchPoolsForSor();
+
     exitPoolService.setExitHandler(isSingleAssetExit.value);
+
     if (!props.isSingleAssetExit) {
       setInitialPropAmountsOut();
     }

--- a/src/providers/local/join-pool.provider.ts
+++ b/src/providers/local/join-pool.provider.ts
@@ -8,7 +8,7 @@ import {
   REKT_PRICE_IMPACT,
 } from '@/constants/poolLiquidity';
 import symbolKeys from '@/constants/symbol.keys';
-import { fetchPoolsForSor, hasFetchedPoolsForSor } from '@/lib/balancer.sdk';
+import { hasFetchedPoolsForSor } from '@/lib/balancer.sdk';
 import { bnSum, bnum, removeAddress } from '@/lib/utils';
 import { JoinPoolService } from '@/services/balancer/pools/joins/join-pool.service';
 import { Pool } from '@/services/pool/types';
@@ -318,8 +318,6 @@ const provider = (props: Props) => {
     // Ensure prices are fetched for token tree. When pool architecture is
     // refactoted probably won't be required.
     injectTokens(joinTokens.value);
-    // Trigger SOR pool fetching in case swap joins are used.
-    fetchPoolsForSor();
   });
 
   onMounted(() => (isMounted.value = true));


### PR DESCRIPTION
# Description

We were doing unecessary fetching of the SOR fetch pools function every time the user entered the join/exit flows. This PR moves SOR.fetchPools() to the global level so that it's fetched in the background as soon as the app loads. 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [x] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## How should this be tested?

- [ ] Test join/exit flows work as expected.

## Visual context

n/a

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have requested at least 2 reviews (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] If package-lock.json has changes, it was intentional.
- [x] The base of this PR is `master` if hotfix, `develop` if not
