### PR TITLE
Deep pool ui/ux tweaks

### DIFF
--- a/src/components/_global/BalCheckbox/BalCheckbox.vue
+++ b/src/components/_global/BalCheckbox/BalCheckbox.vue
@@ -1,16 +1,19 @@
 <template>
   <div :class="['bal-checkbox', wrapperClasses]">
     <div class="flex">
-      <div class="flex items-center">
+      <div class="flex items-start">
         <input
           type="checkbox"
           :name="name"
           :checked="modelValue"
-          :class="['bal-checkbox-input', inputClasses]"
+          :class="[
+            'bal-checkbox-input relative top-2 hover:border-blue-600 dark:hover:border-blue-400 cursor-pointer transition-colors',
+            inputClasses,
+          ]"
           @change="onChange"
         />
       </div>
-      <div class="relative flex-col ml-2">
+      <div class="relative flex-col ml-3">
         <label
           v-if="$slots.label || label"
           :for="name"
@@ -20,7 +23,7 @@
             {{ label }}
           </slot>
         </label>
-        <div v-if="hasError" class="bal-checkbox-error">
+        <div v-if="hasError" class="font-medium bal-checkbox-error">
           <div class="relative">
             {{ errors[0] }}
           </div>
@@ -107,7 +110,7 @@ export default defineComponent({
 
     const wrapperClasses = computed(() => {
       return {
-        'mb-5': !props.noMargin,
+        'mb-1': !props.noMargin,
       };
     });
 
@@ -164,6 +167,6 @@ export default defineComponent({
 }
 
 .bal-checkbox-error {
-  @apply absolute text-red-500 text-sm;
+  @apply text-red-500 text-sm pt-1;
 }
 </style>

--- a/src/components/cards/MyWallet/MyWallet.vue
+++ b/src/components/cards/MyWallet/MyWallet.vue
@@ -116,7 +116,10 @@ const emit = defineEmits<{
         <BalLoadingBlock v-if="isLoadingBalances" class="h-8" />
         <div v-else-if="isWalletReady">
           <template v-if="pool">
-            <MyWalletSubheader v-if="isDeepPool" class="border-b">
+            <MyWalletSubheader
+              v-if="isDeepPool"
+              class="text-sm border-b text-secondary"
+            >
               Pool tokens (lowest price impact)
             </MyWalletSubheader>
             <div class="mt-5">
@@ -135,7 +138,9 @@ const emit = defineEmits<{
               />
             </div>
             <template v-if="isDeepPool">
-              <MyWalletSubheader class="my-5 border-t border-b">
+              <MyWalletSubheader
+                class="my-5 text-sm border-t border-b text-secondary"
+              >
                 Other tokens (higher price impact)
               </MyWalletSubheader>
               <BalAssetSet

--- a/src/components/contextual/pages/pool/MyPoolBalancesCard.vue
+++ b/src/components/contextual/pages/pool/MyPoolBalancesCard.vue
@@ -79,7 +79,7 @@ function navigateToPoolMigration(pool: Pool) {
         <h5>
           {{ $t('poolTransfer.myPoolBalancesCard.title') }}
         </h5>
-        <h5>
+        <h5 class="text-2xl">
           {{ isWalletReady ? fNum2(fiatValue, FNumFormats.fiat) : '-' }}
         </h5>
       </div>

--- a/src/components/contextual/pages/pool/PoolActionsCard.vue
+++ b/src/components/contextual/pages/pool/PoolActionsCard.vue
@@ -1,12 +1,8 @@
 <script setup lang="ts">
-import { computed, toRef } from 'vue';
-
+import { toRef } from 'vue';
 import useWithdrawMath from '@/components/forms/pool_actions/WithdrawForm/composables/useWithdrawMath';
-import useNumbers, { FNumFormats } from '@/composables/useNumbers';
-import { tokenTreeLeafs, usePool } from '@/composables/usePool';
-import useTokens from '@/composables/useTokens';
+import { usePool } from '@/composables/usePool';
 import useNetwork from '@/composables/useNetwork';
-import { bnum, isSameAddress } from '@/lib/utils';
 import { Pool } from '@/services/pool/types';
 import useWeb3 from '@/services/web3/useWeb3';
 import { isSoftMigratablePool } from '@/components/forms/pool_actions/MigrateForm/constants';
@@ -32,53 +28,14 @@ const { hasBpt } = useWithdrawMath(toRef(props, 'pool'));
 const { isMigratablePool, hasNonApprovedRateProviders } = usePool(
   toRef(props, 'pool')
 );
-const { balanceFor, nativeAsset, wrappedNativeAsset } = useTokens();
-const { fNum2, toFiat } = useNumbers();
 const { isWalletReady, startConnectWithInjectedProvider } = useWeb3();
 const { networkSlug } = useNetwork();
-
-/**
- * COMPUTED
- */
-const fiatTotal = computed(() => {
-  const fiatValue = tokenTreeLeafs(props.pool.tokens)
-    .map(address => {
-      let tokenBalance = '0';
-
-      if (isSameAddress(address, wrappedNativeAsset.value.address)) {
-        const wrappedBalance = balanceFor(address);
-        const nativeBalance = balanceFor(nativeAsset.address);
-        tokenBalance = bnum(nativeBalance).gt(wrappedBalance)
-          ? nativeBalance
-          : wrappedBalance;
-      } else {
-        tokenBalance = balanceFor(address);
-      }
-
-      return toFiat(tokenBalance, address);
-    })
-    .reduce((total, value) => bnum(total).plus(value).toString());
-
-  return fNum2(fiatValue, FNumFormats.fiat);
-});
 </script>
 
 <template>
   <div
     class="p-4 w-full bg-gray-50 dark:bg-gray-800 border-t border-gray-200 dark:border-gray-900"
   >
-    <div class="text-sm text-secondary">
-      {{ $t('basedOnTokensInWallet') }}
-    </div>
-    <div class="flex justify-between items-center mb-4">
-      <h5>
-        {{ $t('youCanAdd') }}
-      </h5>
-      <h5>
-        {{ isWalletReady ? fiatTotal : '-' }}
-      </h5>
-    </div>
-
     <BalBtn
       v-if="!isWalletReady"
       :label="$t('connectWallet')"

--- a/src/components/forms/pool_actions/InvestForm/InvestFormV2.vue
+++ b/src/components/forms/pool_actions/InvestForm/InvestFormV2.vue
@@ -147,7 +147,7 @@ watch([isSingleAssetJoin, poolTokensWithBalance], ([isSingleAsset]) => {
 
     <div
       v-if="highPriceImpact"
-      class="p-2 pb-2 mt-5 rounded-lg border dark:border-gray-700"
+      class="p-2 pb-2 mt-5 rounded-lg border dark:border-gray-700 high-price-impact"
     >
       <BalCheckbox
         v-model="highPriceImpactAccepted"
@@ -211,3 +211,8 @@ watch([isSingleAssetJoin, poolTokensWithBalance], ([isSingleAsset]) => {
     </StakingProvider>
   </div>
 </template>
+<style scoped>
+.high-price-impact:has(.bal-checkbox-error) {
+  @apply border-red-500 bg-red-50 dark:bg-red-500 bg-opacity-50 dark:bg-opacity-5 transition-colors;
+}
+</style>

--- a/src/composables/pools/useInvestPageTabs.ts
+++ b/src/composables/pools/useInvestPageTabs.ts
@@ -6,10 +6,10 @@ export enum Tab {
 }
 
 export const tabs = [
-  { value: Tab.PoolTokens, label: 'Pool Tokens' },
+  { value: Tab.PoolTokens, label: 'Pool tokens' },
   {
     value: Tab.SingleToken,
-    label: 'Single Token',
+    label: 'Single token',
   },
 ];
 

--- a/src/composables/pools/useWithdrawPageTabs.ts
+++ b/src/composables/pools/useWithdrawPageTabs.ts
@@ -6,10 +6,10 @@ export enum Tab {
 }
 
 export const tabs = [
-  { value: Tab.PoolTokens, label: 'Pool Tokens (proportional)' },
+  { value: Tab.PoolTokens, label: 'Pool tokens (proportional)' },
   {
     value: Tab.SingleToken,
-    label: 'Single Token',
+    label: 'Single token',
   },
 ];
 

--- a/src/locales/default.json
+++ b/src/locales/default.json
@@ -1265,7 +1265,7 @@
     "createPool": "Create pool",
     "fundPool": "Fund pool",
     "migratePool": "Migrate pool",
-    "invest": "Pool",
+    "invest": "Add liquidity",
     "trade": "Swap",
     "unwrap": "Unwrap",
     "voteForGauge": "Vote",


### PR DESCRIPTION
# Description

This change includes:
- Minor UI & UX tweaks for the deep pool flow
  - Removed the 'You can add' section on the pool page, which no longer made sense since people can add non-pool tokens as liquidity.
  - Updated text in toaster notifications from 'Pool pending' and 'Pool confirmed' to 'Add liquidity pending' and 'Add liquidity confirmed'.
  - Minor typography changes to the invest flow.
- Enhanced bal checkbox for high price impact acknowledgment

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [x] Other: UX improvements

## How should this be tested?

- [ ] View the style tweaks appear as per the screenshot below.
- [ ] Review high price impact acceptance interaction (try adding a large amount of liquidity with a single token)

## Visual context

![deep-pool-tweaks](https://user-images.githubusercontent.com/1121139/205342019-44d78bf0-acfe-4bd7-85bf-3adbed44a8a4.png)

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have requested at least 2 reviews (If the PR is significant enough, use best judgement here)
- [ ] I have commented my code where relevant, particularly in hard-to-understand areas
- [ ] If package-lock.json has changes, it was intentional.
- [ ] The base of this PR is `master` if hotfix, `develop` if not
