### PR TITLE
My pool balance should include staked position

### DIFF
--- a/src/components/contextual/pages/pool/MyPoolBalancesCard.vue
+++ b/src/components/contextual/pages/pool/MyPoolBalancesCard.vue
@@ -43,7 +43,11 @@ const router = useRouter();
 /**
  * COMPUTED
  */
-const bptBalance = computed((): string => balanceFor(props.pool.address));
+const bptBalance = computed((): string =>
+  bnum(balanceFor(props.pool.address))
+    .plus(stakedSharesForProvidedPool.value)
+    .toString()
+);
 
 const fiatValue = computed(() => fiatValueOf(props.pool, bptBalance.value));
 


### PR DESCRIPTION
# Description

Includes staked shares in calculation for 'My pool balance'.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## How should this be tested?

- [ ] Test 'My pool balance' adds up unstaked and staked positions in pool.

## Visual context

n/a

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have requested at least 2 reviews (If the PR is significant enough, use best judgement here)
- [ ] I have commented my code where relevant, particularly in hard-to-understand areas
- [ ] If package-lock.json has changes, it was intentional.
- [ ] The base of this PR is `master` if hotfix, `develop` if not
