### PR TITLE
Add gaurds to TxBuilder to protect against wallet/app network mismatch

### DIFF
--- a/src/composables/useTransactionErrors.ts
+++ b/src/composables/useTransactionErrors.ts
@@ -29,9 +29,7 @@ export default function useTranasactionErrors() {
   function defaultError(message = ''): TransactionError {
     return {
       title: t('transactionErrors.default.title'),
-      description: `${message} ${t(
-        'transactionErrors.default.description'
-      )}`.trim(),
+      description: `${message}`.trim(),
     };
   }
 

--- a/src/composables/useTransactionErrors.ts
+++ b/src/composables/useTransactionErrors.ts
@@ -29,7 +29,7 @@ export default function useTranasactionErrors() {
   function defaultError(message = ''): TransactionError {
     return {
       title: t('transactionErrors.default.title'),
-      description: `${message}`.trim(),
+      description: message.trim(),
     };
   }
 

--- a/src/services/web3/transactions/concerns/contract.concern.ts
+++ b/src/services/web3/transactions/concerns/contract.concern.ts
@@ -33,9 +33,10 @@ export class ContractConcern extends TransactionConcern {
     forceLegacyTxType = false,
   }: SendTransactionOpts): Promise<TransactionResponse> {
     const contractWithSigner = new Contract(contractAddress, abi, this.signer);
-    // will throw an error if signer is a sanctioned address
-    await verifyTransactionSender(this.signer);
-    await verifyNetwork(this.signer);
+    await Promise.all([
+      verifyTransactionSender(this.signer),
+      verifyNetwork(this.signer),
+    ]);
 
     const block = await this.signer.provider.getBlockNumber();
     console.log(`Contract: ${contractAddress} Action: ${action}`);

--- a/src/services/web3/transactions/concerns/contract.concern.ts
+++ b/src/services/web3/transactions/concerns/contract.concern.ts
@@ -7,7 +7,7 @@ import {
 } from '@ethersproject/providers';
 import { captureException } from '@sentry/browser';
 import { Contract, ContractInterface } from 'ethers';
-import { verifyTransactionSender } from '../../web3.plugin';
+import { verifyNetwork, verifyTransactionSender } from '../../web3.plugin';
 import { TransactionConcern } from './transaction.concern';
 
 type SendTransactionOpts = {
@@ -35,6 +35,7 @@ export class ContractConcern extends TransactionConcern {
     const contractWithSigner = new Contract(contractAddress, abi, this.signer);
     // will throw an error if signer is a sanctioned address
     await verifyTransactionSender(this.signer);
+    await verifyNetwork(this.signer);
 
     const block = await this.signer.provider.getBlockNumber();
     console.log(`Contract: ${contractAddress} Action: ${action}`);

--- a/src/services/web3/transactions/concerns/raw.concern.ts
+++ b/src/services/web3/transactions/concerns/raw.concern.ts
@@ -19,9 +19,10 @@ export class RawConcern extends TransactionConcern {
     forceLegacyTxType = false
   ): Promise<TransactionResponse> {
     console.log('sendTransaction', options);
-    // will throw an error if signer is a sanctioned address
-    await verifyTransactionSender(this.signer);
-    await verifyNetwork(this.signer);
+    await Promise.all([
+      verifyTransactionSender(this.signer),
+      verifyNetwork(this.signer),
+    ]);
 
     try {
       const gasSettings = await this.gasPrice.settings(

--- a/src/services/web3/transactions/concerns/raw.concern.ts
+++ b/src/services/web3/transactions/concerns/raw.concern.ts
@@ -6,7 +6,7 @@ import {
   TransactionResponse,
 } from '@ethersproject/providers';
 import { captureException } from '@sentry/browser';
-import { verifyTransactionSender } from '../../web3.plugin';
+import { verifyNetwork, verifyTransactionSender } from '../../web3.plugin';
 import { TransactionConcern } from './transaction.concern';
 
 export class RawConcern extends TransactionConcern {
@@ -21,6 +21,7 @@ export class RawConcern extends TransactionConcern {
     console.log('sendTransaction', options);
     // will throw an error if signer is a sanctioned address
     await verifyTransactionSender(this.signer);
+    await verifyNetwork(this.signer);
 
     try {
       const gasSettings = await this.gasPrice.settings(

--- a/src/services/web3/transactions/transaction.builder.spec.ts
+++ b/src/services/web3/transactions/transaction.builder.spec.ts
@@ -14,6 +14,7 @@ jest.mock('@ethersproject/providers', () => {
         },
         getAddress: jest.fn().mockImplementation(),
         sendTransaction: jest.fn().mockImplementation(),
+        getChainId: jest.fn().mockReturnValue('5'),
       };
     }),
   };

--- a/src/services/web3/web3.plugin.ts
+++ b/src/services/web3/web3.plugin.ts
@@ -27,6 +27,7 @@ import { rpcProviderService } from '../rpc-provider/rpc-provider.service';
 import { Connector, ConnectorId } from './connectors/connector';
 import { configService } from '@/services/config/config.service';
 import { web3Service } from './web3.service';
+import { networkId } from '@/composables/useNetwork';
 
 export type Wallet =
   | 'metamask'
@@ -96,6 +97,13 @@ export async function verifyTransactionSender(signer: JsonRpcSigner) {
     throw new Error(
       `Rejecting transaction. [${_isBlockedAddress}] is a sanctioned wallet.`
     );
+  }
+}
+
+export async function verifyNetwork(signer: JsonRpcSigner) {
+  const userNetwork = await signer.getChainId();
+  if (userNetwork.toString() !== networkId.value.toString()) {
+    throw new Error('Wallet network does not match app network.');
   }
 }
 


### PR DESCRIPTION
# Description

See title.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## How should this be tested?

1. Load app and connect wallet.
2. Make sure wallet and app network are the same.
3. Switch to a different network in the app.
4. Try to stake or unstake an investment.
5. You should see an error message about a network mismatch in the modal.

## Visual context

n/a

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have requested at least 2 reviews (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] If package-lock.json has changes, it was intentional.
- [x] The base of this PR is `master` if hotfix, `develop` if not
