### PR TITLE
Hotfix: sub overflow bug

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.81.1",
+  "version": "1.81.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@balancer-labs/frontend-v2",
-      "version": "1.81.1",
+      "version": "1.81.2",
       "license": "MIT",
       "devDependencies": {
         "@aave/protocol-js": "^4.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.81.1",
+  "version": "1.81.2",
   "engines": {
     "node": "14.x",
     "npm": ">=7"

--- a/src/components/forms/pool_actions/InvestForm/composables/useInvestMath.ts
+++ b/src/components/forms/pool_actions/InvestForm/composables/useInvestMath.ts
@@ -177,6 +177,7 @@ export default function useInvestMath(
     ) {
       _bptOut = queryBptOut.value;
     } else {
+      if (!hasAmounts.value) return '0';
       _bptOut = poolCalculator
         .exactTokensInForBPTOut(fullAmounts.value)
         .toString();


### PR DESCRIPTION
# Description

This pool on Arbitrum (0x64541216bafffeec8ea535bb71fbc927831d0595000100000000000000000002) was throwing a SUB_OVERFLOW error when loading the invest page. It was triggered by `exactTokensInForBPTOut` being called with zero values. This doesn't usually trigger this error but for some reason in this pool it was. The fix is simply to not call this function if the form has no input values.

Fixes https://sentry.io/organizations/balancer-labs/issues/3788917839

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## How should this be tested?

Please provide instructions so we can test. Please also list any relevant details for your test configuration.

- [ ] Test you can load the invest page for `arbitrum/pool/0x64541216bafffeec8ea535bb71fbc927831d0595000100000000000000000002`
- [ ] Test that investments in weighted/stable pools continue to work as expected.

## Visual context

n/a

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have requested at least 2 reviews (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] If package-lock.json has changes, it was intentional.
- [x] The base of this PR is `master` if hotfix, `develop` if not
