### PR TITLE
Hotfix: Move guards directly before tx

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.81.2",
+  "version": "1.81.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@balancer-labs/frontend-v2",
-      "version": "1.81.2",
+      "version": "1.81.3",
       "license": "MIT",
       "devDependencies": {
         "@aave/protocol-js": "^4.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.81.2",
+  "version": "1.81.3",
   "engines": {
     "node": "14.x",
     "npm": ">=7"

--- a/src/services/web3/transactions/concerns/contract.concern.ts
+++ b/src/services/web3/transactions/concerns/contract.concern.ts
@@ -33,10 +33,6 @@ export class ContractConcern extends TransactionConcern {
     forceLegacyTxType = false,
   }: SendTransactionOpts): Promise<TransactionResponse> {
     const contractWithSigner = new Contract(contractAddress, abi, this.signer);
-    await Promise.all([
-      verifyTransactionSender(this.signer),
-      verifyNetwork(this.signer),
-    ]);
 
     const block = await this.signer.provider.getBlockNumber();
     console.log(`Contract: ${contractAddress} Action: ${action}`);
@@ -51,6 +47,11 @@ export class ContractConcern extends TransactionConcern {
         forceLegacyTxType
       );
       const txOptions = { ...options, ...gasSettings };
+
+      await Promise.all([
+        verifyTransactionSender(this.signer),
+        verifyNetwork(this.signer),
+      ]);
 
       trackGoal(Goals.ContractTransactionSubmitted);
       return await contractWithSigner[action](...params, txOptions);

--- a/src/services/web3/transactions/concerns/raw.concern.ts
+++ b/src/services/web3/transactions/concerns/raw.concern.ts
@@ -19,10 +19,6 @@ export class RawConcern extends TransactionConcern {
     forceLegacyTxType = false
   ): Promise<TransactionResponse> {
     console.log('sendTransaction', options);
-    await Promise.all([
-      verifyTransactionSender(this.signer),
-      verifyNetwork(this.signer),
-    ]);
 
     try {
       const gasSettings = await this.gasPrice.settings(
@@ -31,6 +27,11 @@ export class RawConcern extends TransactionConcern {
         forceLegacyTxType
       );
       const txOptions = { ...options, ...gasSettings };
+
+      await Promise.all([
+        verifyTransactionSender(this.signer),
+        verifyNetwork(this.signer),
+      ]);
 
       trackGoal(Goals.RawTransactionSubmitted);
       return await this.signer.sendTransaction(txOptions);


### PR DESCRIPTION
# Description

We should only trigger guards if tx gas settings have been fetched successfully and we are ready to trigger the tx.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [x] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## How should this be tested?

n/a

## Visual context

n/a

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have requested at least 2 reviews (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] If package-lock.json has changes, it was intentional.
- [x] The base of this PR is `master` if hotfix, `develop` if not
