### PR TITLE
Fix BigNumber from method error

### DIFF
--- a/src/composables/trade/useSor.ts
+++ b/src/composables/trade/useSor.ts
@@ -352,7 +352,7 @@ export default function useSor({
 
       console.log('[SOR Manager] swapExactIn');
 
-      const swapReturn: SorReturn = await sorManager.getBestSwap(
+      const swapReturn = await sorManager.getBestSwap(
         tokenInAddress,
         tokenOutAddress,
         tokenInDecimals,
@@ -360,6 +360,9 @@ export default function useSor({
         SwapTypes.SwapExactIn,
         tokenInAmountScaled
       );
+      if (!swapReturn) {
+        return;
+      }
 
       sorReturn.value = swapReturn; // TO DO - is it needed?
       const tokenOutAmountNormalised = bnum(
@@ -404,7 +407,7 @@ export default function useSor({
 
       console.log('[SOR Manager] swapExactOut');
 
-      const swapReturn: SorReturn = await sorManager.getBestSwap(
+      const swapReturn = await sorManager.getBestSwap(
         tokenInAddress,
         tokenOutAddress,
         tokenInDecimals,
@@ -412,6 +415,10 @@ export default function useSor({
         SwapTypes.SwapExactOut,
         tokenOutAmount
       );
+
+      if (!swapReturn) {
+        return;
+      }
 
       sorReturn.value = swapReturn; // TO DO - is it needed?
 

--- a/src/lib/utils/balancer/helpers/sor/sorManager.ts
+++ b/src/lib/utils/balancer/helpers/sor/sorManager.ts
@@ -126,7 +126,7 @@ export class SorManager {
     tokenOutDecimals: number,
     swapType: SwapTypes,
     amountScaled: OldBigNumber
-  ): Promise<SorReturn> {
+  ): Promise<SorReturn | void> {
     const v2TokenIn = tokenIn === NATIVE_ASSET_ADDRESS ? AddressZero : tokenIn;
     const v2TokenOut =
       tokenOut === NATIVE_ASSET_ADDRESS ? AddressZero : tokenOut;
@@ -143,11 +143,16 @@ export class SorManager {
       forceRefresh: true,
     };
 
+    const swapAmount = this.getSwapAmount(amountScaled);
+    if (!swapAmount) {
+      return;
+    }
+
     const swapInfoV2: SwapInfo = await this.sorV2.getSwaps(
       v2TokenIn.toLowerCase(),
       v2TokenOut.toLowerCase(),
       swapType,
-      BigNumber.from(amountScaled.toString()),
+      swapAmount,
       swapOptions
     );
 
@@ -169,6 +174,15 @@ export class SorManager {
       result: swapInfoV2,
       marketSpNormalised: swapInfoV2.marketSp,
     };
+  }
+
+  getSwapAmount(amountScaled: OldBigNumber): BigNumber | void {
+    try {
+      return BigNumber.from(amountScaled.toString());
+    } catch (e) {
+      // there is a bug/feature in BigNumber.from() that throws an error when the number is too big
+      console.log(e);
+    }
   }
 
   // Check if pool info fetch

--- a/src/lib/utils/balancer/helpers/sor/sorManager.ts
+++ b/src/lib/utils/balancer/helpers/sor/sorManager.ts
@@ -180,7 +180,8 @@ export class SorManager {
     try {
       return BigNumber.from(amountScaled.toString());
     } catch (e) {
-      // there is a bug/feature in BigNumber.from() that throws an error when the number is too big
+      // BigNumber.from() throws an error when there is more than 15 digits
+      // not sure that we should process this specifically
       console.log(e);
     }
   }


### PR DESCRIPTION
# Description
BigNumber.from() throws an error when there is more than 15 digits provided, this error falls into sentry. I am not sure that we should process this specifically.
Or may be we can restrict typing more than 15 digits in inputs. what do you think @pkattera @garethfuller ?
or show some hint?

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## How should this be tested?

Please provide instructions so we can test. Please also list any relevant details for your test configuration.

- [ ] Test A
- [ ] Test B

## Visual context

Please provide any relevant visual context for UI changes or additions. This could be static screenshots or a loom screencast.

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have requested at least 2 reviews (If the PR is significant enough, use best judgement here)
- [ ] I have commented my code where relevant, particularly in hard-to-understand areas
- [ ] If package-lock.json has changes, it was intentional.
- [ ] The base of this PR is `master` if hotfix, `develop` if not
