### PR TITLE
Default to zero for in/out amount scaled computed property

### DIFF
--- a/src/composables/trade/useTrading.ts
+++ b/src/composables/trade/useTrading.ts
@@ -56,11 +56,11 @@ export default function useTrading(
   );
 
   const tokenInAmountScaled = computed(() =>
-    parseFixed(tokenInAmountInput.value, tokenIn.value.decimals)
+    parseFixed(tokenInAmountInput.value || '0', tokenIn.value.decimals)
   );
 
   const tokenOutAmountScaled = computed(() =>
-    parseFixed(tokenOutAmountInput.value, tokenOut.value.decimals)
+    parseFixed(tokenOutAmountInput.value || '0', tokenOut.value.decimals)
   );
 
   const requiresTokenApproval = computed(() => {


### PR DESCRIPTION
# Description

JS resolves '' || '0' to '0' so this change fixes this exception: https://sentry.io/organizations/balancer-labs/issues/3790589088

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## How should this be tested?

n/a

## Visual context

n/a

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have requested at least 2 reviews (If the PR is significant enough, use best judgement here)
- [ ] I have commented my code where relevant, particularly in hard-to-understand areas
- [ ] If package-lock.json has changes, it was intentional.
- [ ] The base of this PR is `master` if hotfix, `develop` if not
