### PR TITLE
Re-add BridgeLink to trade page

### DIFF
--- a/src/components/links/BridgeLink.vue
+++ b/src/components/links/BridgeLink.vue
@@ -9,7 +9,7 @@ const { networkId } = useNetwork();
 const bridgeUrl = computed((): string => {
   switch (networkId.value) {
     case Network.POLYGON:
-      return 'https://wallet.polygon.technology/login?redirectTo=%2Fpolygon%2Fbridge';
+      return 'https://wallet.polygon.technology/polygon/bridge';
     case Network.ARBITRUM:
       return 'https://bridge.arbitrum.io/';
     default:

--- a/src/components/links/BridgeLink.vue
+++ b/src/components/links/BridgeLink.vue
@@ -9,7 +9,7 @@ const { networkId } = useNetwork();
 const bridgeUrl = computed((): string => {
   switch (networkId.value) {
     case Network.POLYGON:
-      return 'https://wallet.polygon.technology/bridge';
+      return 'https://wallet.polygon.technology/login?redirectTo=%2Fpolygon%2Fbridge';
     case Network.ARBITRUM:
       return 'https://bridge.arbitrum.io/';
     default:

--- a/src/pages/trade.vue
+++ b/src/pages/trade.vue
@@ -1,9 +1,6 @@
 <script setup lang="ts">
 import { computed, onMounted, ref } from 'vue';
-// Composables
 import { useStore } from 'vuex';
-
-// Components
 import MyWallet from '@/components/cards/MyWallet/MyWallet.vue';
 import PairPriceGraph from '@/components/cards/PairPriceGraph/PairPriceGraph.vue';
 import TradeCard from '@/components/cards/TradeCard/TradeCard.vue';
@@ -11,6 +8,8 @@ import TrendingPairs from '@/components/cards/TrendingPairs/TrendingPairs.vue';
 import Col3Layout from '@/components/layouts/Col3Layout.vue';
 import usePoolFilters from '@/composables/pools/usePoolFilters';
 import useBreakpoints from '@/composables/useBreakpoints';
+import BridgeLink from '@/components/links/BridgeLink.vue';
+import { isL2 } from '@/composables/useNetwork';
 
 /**
  * STATE
@@ -68,6 +67,7 @@ onMounted(() => {
           { title: 'My wallet', id: 'my-wallet' },
           { title: 'Trending pairs', id: 'trending-pairs' },
           { title: 'Price chart', id: 'price-chart' },
+          { title: 'Bridge assets', id: 'bridge' },
         ]"
       >
         <template #my-wallet>
@@ -79,11 +79,15 @@ onMounted(() => {
         <template #price-chart>
           <PairPriceGraph :toggleModal="togglePairPriceGraphModal" />
         </template>
+        <template #bridge>
+          <BridgeLink v-if="isL2" />
+        </template>
       </BalAccordion>
     </div>
 
     <template #gutterRight>
       <PairPriceGraph :toggleModal="togglePairPriceGraphModal" />
+      <BridgeLink v-if="isL2" class="mt-4" />
     </template>
   </Col3Layout>
 


### PR DESCRIPTION
# Description

Somehow this got reverted in the boosted pool work, re-adding functionality back in.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [x] Other

## How should this be tested?

- [ ] Test bridge links appear on L2 swap pages.

## Visual context

n/a

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have requested at least 2 reviews (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] If package-lock.json has changes, it was intentional.
- [x] The base of this PR is `master` if hotfix, `develop` if not
