### PR TITLE
Hotfix: revert token input changes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.81.3",
+  "version": "1.81.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@balancer-labs/frontend-v2",
-      "version": "1.81.3",
+      "version": "1.81.4",
       "license": "MIT",
       "devDependencies": {
         "@aave/protocol-js": "^4.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.81.3",
+  "version": "1.81.4",
   "engines": {
     "node": "14.x",
     "npm": ">=7"

--- a/src/components/inputs/TokenInput/TokenInput.vue
+++ b/src/components/inputs/TokenInput/TokenInput.vue
@@ -203,9 +203,8 @@ const decimalLimit = computed<number>(() => token.value?.decimals || 18);
 /**
  * METHODS
  */
-function changeAmount(amount: InputValue) {
+function handleAmountChange(amount: InputValue) {
   const safeAmount = overflowProtected(amount, decimalLimit.value);
-  _amount.value = safeAmount;
   emit('update:amount', safeAmount);
 }
 
@@ -216,7 +215,7 @@ const setMax = () => {
     ? props.customBalance
     : getMaxBalanceFor(_address.value, props.disableNativeAssetBuffer);
 
-  changeAmount(maxAmount);
+  handleAmountChange(maxAmount);
 };
 
 /**
@@ -232,7 +231,7 @@ watch(_address, async (newAddress, oldAddress) => {
   if (!isSameAddress(newAddress, oldAddress)) {
     // wait for the token's decimals to be updated
     await nextTick();
-    changeAmount(_amount.value);
+    handleAmountChange(_amount.value);
   }
 });
 </script>

--- a/src/components/inputs/TokenInput/TokenInput.vue
+++ b/src/components/inputs/TokenInput/TokenInput.vue
@@ -254,7 +254,7 @@ watch(_address, async (newAddress, oldAddress) => {
     inputAlignRight
     @blur="emit('blur', $event)"
     @input="emit('input', $event)"
-    @update:model-value="emit('update:amount', $event)"
+    @update:model-value="handleAmountChange($event)"
     @update:is-valid="emit('update:isValid', $event)"
     @keydown="emit('keydown', $event)"
   >

--- a/src/components/inputs/TokenInput/TokenInput.vue
+++ b/src/components/inputs/TokenInput/TokenInput.vue
@@ -304,7 +304,7 @@ watch(_address, async (newAddress, oldAddress) => {
               </span>
             </template>
           </button>
-          <div>
+          <div class="pl-2 truncate">
             <template v-if="hasAmount && hasToken">
               <span v-if="!hideFiatValue">
                 {{ fNum2(tokenValue, FNumFormats.fiat) }}

--- a/src/components/inputs/TokenInput/TokenInput.vue
+++ b/src/components/inputs/TokenInput/TokenInput.vue
@@ -1,12 +1,12 @@
 <script setup lang="ts">
-import { computed, nextTick, watch } from 'vue';
+import { computed, nextTick, ref, watch, watchEffect } from 'vue';
 import { useI18n } from 'vue-i18n';
 import { overflowProtected } from '@/components/_global/BalTextInput/helpers';
 import { Rules } from '@/types';
 import TokenSelectInput from '@/components/inputs/TokenSelectInput/TokenSelectInput.vue';
 import useNumbers, { FNumFormats } from '@/composables/useNumbers';
 import useTokens from '@/composables/useTokens';
-import { bnum } from '@/lib/utils';
+import { bnum, isSameAddress } from '@/lib/utils';
 import { isLessThanOrEqualTo, isPositive } from '@/lib/utils/validations';
 import useWeb3 from '@/services/web3/useWeb3';
 import { TokenInfo } from '@/types/TokenList';
@@ -93,6 +93,12 @@ const emit = defineEmits<{
 }>();
 
 /**
+ * STATE
+ */
+const _amount = ref<InputValue>('');
+const _address = ref<string>('');
+
+/**
  * COMPOSABLES
  */
 const { getToken, balanceFor, nativeAsset, getMaxBalanceFor } = useTokens();
@@ -103,13 +109,14 @@ const { isWalletReady } = useWeb3();
 /**
  * COMPUTED
  */
-const hasToken = computed(() => !!props.address);
-const amountBN = computed(() => bnum(props.amount));
+const hasToken = computed(() => !!_address.value);
+const amountBN = computed(() => bnum(_amount.value));
 const tokenBalanceBN = computed(() => bnum(tokenBalance.value));
 const hasAmount = computed(() => amountBN.value.gt(0));
 const hasBalance = computed(() => tokenBalanceBN.value.gt(0));
 const shouldUseTxBuffer = computed(
-  () => props.address === nativeAsset.address && !props.disableNativeAssetBuffer
+  () =>
+    _address.value === nativeAsset.address && !props.disableNativeAssetBuffer
 );
 const amountExceedsTokenBalance = computed(() =>
   amountBN.value.gt(tokenBalance.value)
@@ -132,26 +139,26 @@ const shouldShowTxBufferMessage = computed(() => {
 const isMaxed = computed(() => {
   if (shouldUseTxBuffer.value) {
     return (
-      props.amount ===
+      _amount.value ===
       tokenBalanceBN.value.minus(nativeAsset.minTransactionBuffer).toString()
     );
   } else {
-    return props.amount === tokenBalance.value;
+    return _amount.value === tokenBalance.value;
   }
 });
 
 const tokenBalance = computed(() => {
   if (props.customBalance) return props.customBalance;
-  return balanceFor(props.address);
+  return balanceFor(_address.value);
 });
 
 const token = computed((): TokenInfo | undefined => {
   if (!hasToken.value) return undefined;
-  return getToken(props.address);
+  return getToken(_address.value);
 });
 
 const tokenValue = computed(() => {
-  return props.tokenValue ?? toFiat(props.amount, props.address);
+  return props.tokenValue ?? toFiat(props.amount, _address.value);
 });
 
 const inputRules = computed(() => {
@@ -193,27 +200,12 @@ const priceImpactClass = computed(() =>
 
 const decimalLimit = computed<number>(() => token.value?.decimals || 18);
 
-watch(
-  () => props.address,
-  async (newVal, oldVal) => {
-    // If token address changes, we have to calculate new safe value based on new token's decimals
-    if (newVal !== oldVal) {
-      // wait for the token's decimals to be updated
-      await nextTick();
-      handleAmountChange(props.amount);
-    }
-  }
-);
-
 /**
  * METHODS
  */
-function getSafeAmount(amount: InputValue, decimalLimit: number) {
-  return overflowProtected(amount, decimalLimit);
-}
-
-function handleAmountChange(amount: InputValue) {
-  const safeAmount = getSafeAmount(amount, decimalLimit.value);
+function changeAmount(amount: InputValue) {
+  const safeAmount = overflowProtected(amount, decimalLimit.value);
+  _amount.value = safeAmount;
   emit('update:amount', safeAmount);
 }
 
@@ -222,15 +214,32 @@ const setMax = () => {
 
   const maxAmount = props.customBalance
     ? props.customBalance
-    : getMaxBalanceFor(props.address, props.disableNativeAssetBuffer);
+    : getMaxBalanceFor(_address.value, props.disableNativeAssetBuffer);
 
-  handleAmountChange(maxAmount);
+  changeAmount(maxAmount);
 };
+
+/**
+ * WATCHERS
+ */
+watchEffect(() => {
+  _amount.value = props.amount;
+  _address.value = props.address;
+});
+
+watch(_address, async (newAddress, oldAddress) => {
+  // If token address changes, we have to calculate new safe value based on new token's decimals
+  if (!isSameAddress(newAddress, oldAddress)) {
+    // wait for the token's decimals to be updated
+    await nextTick();
+    changeAmount(_amount.value);
+  }
+});
 </script>
 
 <template>
   <BalTextInput
-    :modelValue="amount"
+    :modelValue="_amount"
     :name="name"
     :placeholder="placeholder || '0.0'"
     type="number"
@@ -246,14 +255,14 @@ const setMax = () => {
     inputAlignRight
     @blur="emit('blur', $event)"
     @input="emit('input', $event)"
-    @update:model-value="handleAmountChange($event)"
+    @update:model-value="emit('update:amount', $event)"
     @update:is-valid="emit('update:isValid', $event)"
     @keydown="emit('keydown', $event)"
   >
     <template #prepend>
       <slot name="tokenSelect">
         <TokenSelectInput
-          :modelValue="props.address"
+          :modelValue="_address"
           v-bind="tokenSelectProps"
           :weight="weight"
           :fixed="fixedToken"

--- a/src/composables/trade/useSor.ts
+++ b/src/composables/trade/useSor.ts
@@ -22,7 +22,7 @@ import { useI18n } from 'vue-i18n';
 
 import { NATIVE_ASSET_ADDRESS } from '@/constants/tokens';
 import { balancer } from '@/lib/balancer.sdk';
-import { bnum, isSameAddress, scale } from '@/lib/utils';
+import { bnum, isSameAddress } from '@/lib/utils';
 import {
   SorManager,
   SorReturn,
@@ -345,8 +345,8 @@ export default function useSor({
       );
 
       const tokenInAmountNormalised = new OldBigNumber(amount); // Normalized value
-      const tokenInAmountScaled = scale(
-        tokenInAmountNormalised,
+      const tokenInAmountScaled = parseUnits(
+        tokenInAmountNormalised.toString(),
         tokenInDecimals
       );
 
@@ -400,7 +400,10 @@ export default function useSor({
       await setSwapCost(tokenInAddressInput.value, tokenInDecimals, sorManager);
 
       let tokenOutAmountNormalised = new OldBigNumber(amount);
-      const tokenOutAmount = scale(tokenOutAmountNormalised, tokenOutDecimals);
+      const tokenOutAmount = parseUnits(
+        tokenOutAmountNormalised.toString(),
+        tokenOutDecimals
+      );
 
       console.log('[SOR Manager] swapExactOut');
 

--- a/src/lib/utils/balancer/helpers/sor/sorManager.ts
+++ b/src/lib/utils/balancer/helpers/sor/sorManager.ts
@@ -10,7 +10,6 @@ import { Pool } from '@balancer-labs/sor/dist/types';
 import { BigNumber } from '@ethersproject/bignumber';
 import { AddressZero } from '@ethersproject/constants';
 import { Provider } from '@ethersproject/providers';
-import OldBigNumber from 'bignumber.js';
 
 import { NATIVE_ASSET_ADDRESS } from '@/constants/tokens';
 import { balancer } from '@/lib/balancer.sdk';
@@ -125,7 +124,7 @@ export class SorManager {
     tokenInDecimals: number,
     tokenOutDecimals: number,
     swapType: SwapTypes,
-    amountScaled: OldBigNumber
+    amountScaled: BigNumber
   ): Promise<SorReturn> {
     const v2TokenIn = tokenIn === NATIVE_ASSET_ADDRESS ? AddressZero : tokenIn;
     const v2TokenOut =
@@ -147,7 +146,7 @@ export class SorManager {
       v2TokenIn.toLowerCase(),
       v2TokenOut.toLowerCase(),
       swapType,
-      BigNumber.from(amountScaled.toString()),
+      amountScaled,
       swapOptions
     );
 


### PR DESCRIPTION
# Description

TokenInput used to have this internal state for amount/address. I know it seems like we can just use prop values here but I seem to remember a specific reason it was like this. I believe this might be causing a lot of the exceptions we are seeing in the swap UI after merging the boosted pool work. The changes to the TokenInput seem to be the only thing that could cause this after looking through the diff. So this PR reverts to using internal state for this component.

We should deploy this and see if the exceptions are fixed in Sentry. If not we can investigate further.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## How should this be tested?

- [ ] Test TokenInputs in swap UI and join/exit UIs.

## Visual context

n/a

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have requested at least 2 reviews (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] If package-lock.json has changes, it was intentional.
- [x] The base of this PR is `master` if hotfix, `develop` if not
