### PR TITLE
remove bignumber.js from sor logic

### DIFF
--- a/src/lib/utils/balancer/helpers/sor/sorManager.ts
+++ b/src/lib/utils/balancer/helpers/sor/sorManager.ts
@@ -10,7 +10,6 @@ import { Pool } from '@balancer-labs/sor/dist/types';
 import { BigNumber } from '@ethersproject/bignumber';
 import { AddressZero } from '@ethersproject/constants';
 import { Provider } from '@ethersproject/providers';
-import OldBigNumber from 'bignumber.js';
 
 import { NATIVE_ASSET_ADDRESS } from '@/constants/tokens';
 import { balancer } from '@/lib/balancer.sdk';
@@ -125,7 +124,7 @@ export class SorManager {
     tokenInDecimals: number,
     tokenOutDecimals: number,
     swapType: SwapTypes,
-    amountScaled: OldBigNumber
+    amountScaled: BigNumber
   ): Promise<SorReturn> {
     const v2TokenIn = tokenIn === NATIVE_ASSET_ADDRESS ? AddressZero : tokenIn;
     const v2TokenOut =
@@ -147,7 +146,7 @@ export class SorManager {
       v2TokenIn.toLowerCase(),
       v2TokenOut.toLowerCase(),
       swapType,
-      BigNumber.from(amountScaled.toString()),
+      amountScaled,
       swapOptions
     );
 


### PR DESCRIPTION
# Description

Lots of numerical issues due to the mess of bignumber libraries. This removes bignumber.js from the SOR logic. Unfortunately the SOR is still returning numbers like `marketSp` in normalized form so it's still far from an ideal setup until that gets updated

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## How should this be tested?

Test swaps with tokens of different decimals and wrappers and confirm amounts make sense including outputs and price impact numbers

## Visual context

Please provide any relevant visual context for UI changes or additions. This could be static screenshots or a loom screencast.

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have requested at least 2 reviews (If the PR is significant enough, use best judgement here)
- [ ] I have commented my code where relevant, particularly in hard-to-understand areas
- [ ] If package-lock.json has changes, it was intentional.
- [ ] The base of this PR is `master` if hotfix, `develop` if not
