### PR TITLE
Fix polygon and arbitrum hrefs in claim buttons

### DIFF
--- a/src/pages/claim.vue
+++ b/src/pages/claim.vue
@@ -330,7 +330,7 @@ onBeforeMount(async () => {
             v-for="network in networkBtns"
             :key="network.id"
             tag="a"
-            :href="`https://${network.subdomain}.balancer.fi/#/claim`"
+            :href="`https://app.balancer.fi/#/${network.subdomain}/claim`"
             color="white"
           >
             <img


### PR DESCRIPTION
# Description

"Claim on Polygon" and "Claim on Arbitrum" buttons were pointing to old urls. This fix updates to the new ones.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## How should this be tested?

Please provide instructions so we can test. Please also list any relevant details for your test configuration.

- [ ] Test A
- [ ] Test B

## Visual context

Please provide any relevant visual context for UI changes or additions. This could be static screenshots or a loom screencast.

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have requested at least 2 reviews (If the PR is significant enough, use best judgement here)
- [ ] I have commented my code where relevant, particularly in hard-to-understand areas
- [ ] If package-lock.json has changes, it was intentional.
- [ ] The base of this PR is `master` if hotfix, `develop` if not
