### PR TITLE
Avoid ethers/lib/* imports to avoid vite build issues

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -55,6 +55,19 @@ module.exports = {
     ],
     // Typescript forces to check optional props for "undefined" values anyway, so this rule is not needed
     'vue/require-default-prop': 'off',
+    'no-restricted-imports': [
+      'error',
+      {
+        patterns: [
+          {
+            // Avoid imports using 'ethers/lib/*' because they lead to compilation issues in vite rollup builds
+            group: ['ethers/lib/*'],
+            message:
+              "Please import from '@ethersproject/*' instead to avoid vite rollup build issues",
+          },
+        ],
+      },
+    ],
   },
 
   overrides: [

--- a/src/components/cards/CreatePool/PoolFees.vue
+++ b/src/components/cards/CreatePool/PoolFees.vue
@@ -1,5 +1,5 @@
 <script lang="ts" setup>
-import { isAddress } from 'ethers/lib/utils';
+import { isAddress } from '@ethersproject/address';
 import { computed, nextTick, ref } from 'vue';
 
 import usePoolCreation from '@/composables/pools/usePoolCreation';

--- a/src/components/contextual/pages/claim/LegacyClaims.vue
+++ b/src/components/contextual/pages/claim/LegacyClaims.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { useIntervalFn } from '@vueuse/core';
 import { differenceInSeconds } from 'date-fns';
-import { getAddress } from 'ethers/lib/utils';
+import { getAddress } from '@ethersproject/address';
 import { computed, ref, watch } from 'vue';
 import { useI18n } from 'vue-i18n';
 

--- a/src/components/contextual/pages/pool/StakingIncentivesCard/StakingIncentivesCard.vue
+++ b/src/components/contextual/pages/pool/StakingIncentivesCard/StakingIncentivesCard.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { getAddress } from 'ethers/lib/utils';
+import { getAddress } from '@ethersproject/address';
 import { computed, ref } from 'vue';
 
 import BalLoadingBlock from '@/components/_global/BalLoadingBlock/BalLoadingBlock.vue';

--- a/src/components/contextual/stake/StakePreview.vue
+++ b/src/components/contextual/stake/StakePreview.vue
@@ -3,7 +3,7 @@ import {
   TransactionReceipt,
   TransactionResponse,
 } from '@ethersproject/abstract-provider';
-import { getAddress } from 'ethers/lib/utils';
+import { getAddress } from '@ethersproject/address';
 import { computed, onBeforeMount, ref, toRef, watch } from 'vue';
 import { useI18n } from 'vue-i18n';
 import { useQueryClient } from 'vue-query';

--- a/src/components/tables/GaugeRewardsTable.vue
+++ b/src/components/tables/GaugeRewardsTable.vue
@@ -1,5 +1,5 @@
 <script lang="ts" setup>
-import { formatUnits } from 'ethers/lib/utils';
+import { formatUnits } from '@ethersproject/units';
 import { computed, ref } from 'vue';
 import { useI18n } from 'vue-i18n';
 

--- a/src/composables/pools/usePoolMigration.ts
+++ b/src/composables/pools/usePoolMigration.ts
@@ -17,7 +17,7 @@ import { TransactionActionInfo } from '@/types/transactions';
 
 import useEthers from '../useEthers';
 import useTransactions from '../useTransactions';
-import { parseUnits } from 'ethers/lib/utils';
+import { parseUnits } from '@ethersproject/units';
 import useTime, { dateTimeLabelFor } from '../useTime';
 import { TokenInfo } from '@/types/TokenList';
 import { fiatValueOf } from '../usePool';

--- a/src/composables/queries/useExpiredGaugesQuery.ts
+++ b/src/composables/queries/useExpiredGaugesQuery.ts
@@ -1,4 +1,4 @@
-import { getAddress } from 'ethers/lib/utils';
+import { getAddress } from '@ethersproject/address';
 import { UseQueryOptions } from 'react-query/types';
 import { computed, reactive, Ref } from 'vue';
 import { useQuery } from 'vue-query';

--- a/src/composables/queries/useRelayerApprovalQuery.ts
+++ b/src/composables/queries/useRelayerApprovalQuery.ts
@@ -1,5 +1,5 @@
 import { Vault__factory } from '@balancer-labs/typechain';
-import { Contract } from 'ethers/lib/ethers';
+import { Contract } from '@ethersproject/contracts';
 import { UseQueryOptions } from 'react-query/types';
 import { computed, reactive, Ref } from 'vue';
 import { useQuery } from 'vue-query';

--- a/src/composables/trade/useSor.ts
+++ b/src/composables/trade/useSor.ts
@@ -7,7 +7,7 @@ import {
   Zero,
 } from '@ethersproject/constants';
 import { TransactionResponse } from '@ethersproject/providers';
-import { formatUnits, parseUnits } from 'ethers/lib/utils';
+import { formatUnits, parseUnits } from '@ethersproject/units';
 import {
   computed,
   ComputedRef,

--- a/src/composables/usePool.ts
+++ b/src/composables/usePool.ts
@@ -1,6 +1,5 @@
 import { Network, AprBreakdown, PoolType } from '@balancer-labs/sdk';
-import { isAddress } from '@ethersproject/address';
-import { getAddress } from 'ethers/lib/utils';
+import { isAddress, getAddress } from '@ethersproject/address';
 import { computed, Ref } from 'vue';
 
 import { POOL_MIGRATIONS } from '@/components/forms/pool_actions/MigrateForm/constants';

--- a/src/lib/scripts/voting-gauge.generator.ts
+++ b/src/lib/scripts/voting-gauge.generator.ts
@@ -15,7 +15,7 @@ import hardcodedGauges from '../../../public/data/hardcoded-gauges.json';
 import config from '../config';
 import { isSameAddress } from '../utils';
 import { Multicaller } from '../utils/balancer/contract';
-import { formatUnits } from 'ethers/lib/utils';
+import { formatUnits } from '@ethersproject/units';
 import { JsonRpcProvider } from '@ethersproject/providers';
 import template from '../utils/template';
 import { mapValues } from 'lodash';

--- a/src/lib/utils/apr.helper.ts
+++ b/src/lib/utils/apr.helper.ts
@@ -1,5 +1,5 @@
 import axios from 'axios';
-import { formatUnits } from 'ethers/lib/utils';
+import { formatUnits } from '@ethersproject/units';
 
 import { FiatCurrency } from '@/constants/currency';
 import { TokenPrices } from '@/services/coingecko/api/price.service';

--- a/src/lib/utils/balancer/pool.ts
+++ b/src/lib/utils/balancer/pool.ts
@@ -1,4 +1,4 @@
-import { getAddress } from 'ethers/lib/utils';
+import { getAddress } from '@ethersproject/address';
 
 import { AnyPool, Pool } from '@/services/pool/types';
 

--- a/src/pages/claim.vue
+++ b/src/pages/claim.vue
@@ -1,6 +1,6 @@
 <script lang="ts" setup>
 import { getAddress } from '@ethersproject/address';
-import { formatUnits } from 'ethers/lib/utils';
+import { formatUnits } from '@ethersproject/units';
 import { computed, onBeforeMount, watch } from 'vue';
 
 import HeroClaim from '@/components/contextual/pages/claim/HeroClaim.vue';

--- a/src/providers/local/staking/staking.provider.ts
+++ b/src/providers/local/staking/staking.provider.ts
@@ -1,7 +1,7 @@
 import { TransactionResponse } from '@ethersproject/abstract-provider';
 import { getAddress } from '@ethersproject/address';
 import { fromUnixTime, isAfter } from 'date-fns';
-import { parseUnits } from 'ethers/lib/utils';
+import { parseUnits } from '@ethersproject/units';
 import {
   computed,
   defineComponent,

--- a/src/providers/local/staking/userUserStakingData.ts
+++ b/src/providers/local/staking/userUserStakingData.ts
@@ -1,4 +1,4 @@
-import { formatUnits } from 'ethers/lib/utils';
+import { formatUnits } from '@ethersproject/units';
 import { intersection } from 'lodash';
 import { QueryObserverResult, RefetchOptions } from 'react-query';
 import { computed, ComputedRef, reactive, Ref, ref } from 'vue';

--- a/src/services/balancer/contracts/contracts/gauge-controller.ts
+++ b/src/services/balancer/contracts/contracts/gauge-controller.ts
@@ -1,5 +1,6 @@
 import { getUnixTime } from 'date-fns';
-import { formatUnits, getAddress } from 'ethers/lib/utils';
+import { getAddress } from '@ethersproject/address';
+import { formatUnits } from '@ethersproject/units';
 import { mapValues } from 'lodash';
 
 import GaugeControllerAbi from '@/lib/abi/GaugeController.json';

--- a/src/services/balancer/contracts/contracts/liquidity-gauge.ts
+++ b/src/services/balancer/contracts/contracts/liquidity-gauge.ts
@@ -2,7 +2,8 @@ import { BigNumber } from '@ethersproject/bignumber';
 import { AddressZero } from '@ethersproject/constants';
 import { Contract } from '@ethersproject/contracts';
 import { JsonRpcProvider, TransactionResponse } from '@ethersproject/providers';
-import { formatUnits, getAddress } from 'ethers/lib/utils';
+import { getAddress } from '@ethersproject/address';
+import { formatUnits } from '@ethersproject/units';
 import { mapValues } from 'lodash';
 
 import LiquidityGaugeAbi from '@/lib/abi/LiquidityGaugeV5.json';

--- a/src/services/balancer/contracts/contracts/token-admin.ts
+++ b/src/services/balancer/contracts/contracts/token-admin.ts
@@ -1,6 +1,5 @@
 import { Contract } from '@ethersproject/contracts';
-import { formatUnits } from 'ethers/lib/utils';
-
+import { formatUnits } from '@ethersproject/units';
 import TokenAdminAbi from '@/lib/abi/TokenAdmin.json';
 import { Multicaller } from '@/lib/utils/balancer/contract';
 import { configService } from '@/services/config/config.service';

--- a/src/services/balancer/contracts/contracts/vebal-helpers.ts
+++ b/src/services/balancer/contracts/contracts/vebal-helpers.ts
@@ -1,4 +1,5 @@
-import { formatUnits, getAddress } from 'ethers/lib/utils';
+import { getAddress } from '@ethersproject/address';
+import { formatUnits } from '@ethersproject/units';
 import { mapValues } from 'lodash';
 
 import VEBalHelpersABI from '@/lib/abi/VEBalHelpers.json';

--- a/src/services/balancer/contracts/contracts/vebal-proxy.ts
+++ b/src/services/balancer/contracts/contracts/vebal-proxy.ts
@@ -1,5 +1,6 @@
 import { Contract } from '@ethersproject/contracts';
-import { formatUnits, getAddress } from 'ethers/lib/utils';
+import { getAddress } from '@ethersproject/address';
+import { formatUnits } from '@ethersproject/units';
 import { mapValues } from 'lodash';
 
 import veBalProxyABI from '@/lib/abi/veDelegationProxy.json';

--- a/src/services/balancer/pools/joins/handlers/swap-join.handler.ts
+++ b/src/services/balancer/pools/joins/handlers/swap-join.handler.ts
@@ -15,7 +15,7 @@ import {
 } from '@ethersproject/abstract-provider';
 import { BigNumber, formatFixed, parseFixed } from '@ethersproject/bignumber';
 import { JsonRpcSigner } from '@ethersproject/providers';
-import { parseUnits } from 'ethers/lib/utils';
+import { parseUnits } from '@ethersproject/units';
 import { Ref } from 'vue';
 import { JoinParams, JoinPoolHandler, QueryOutput } from './join-pool.handler';
 

--- a/src/services/balancer/pools/weighted-pool.service.ts
+++ b/src/services/balancer/pools/weighted-pool.service.ts
@@ -13,7 +13,7 @@ import {
   Web3Provider,
 } from '@ethersproject/providers';
 import BigNumber from 'bignumber.js';
-import { formatUnits } from 'ethers/lib/utils';
+import { formatUnits } from '@ethersproject/units';
 
 import { PoolSeedToken } from '@/composables/pools/usePoolCreation';
 import { isSameAddress, scale } from '@/lib/utils';

--- a/src/services/staking/staking-rewards.service.ts
+++ b/src/services/staking/staking-rewards.service.ts
@@ -1,6 +1,7 @@
 import { Network } from '@balancer-labs/sdk';
 import { getUnixTime } from 'date-fns';
-import { formatUnits, getAddress } from 'ethers/lib/utils';
+import { getAddress } from '@ethersproject/address';
+import { formatUnits } from '@ethersproject/units';
 import { isNil, mapValues } from 'lodash';
 
 import { isL2 } from '@/composables/useNetwork';

--- a/src/services/staking/utils.ts
+++ b/src/services/staking/utils.ts
@@ -1,6 +1,6 @@
 import BigNumber from 'bignumber.js';
-import { formatUnits, getAddress } from 'ethers/lib/utils';
-
+import { getAddress } from '@ethersproject/address';
+import { formatUnits } from '@ethersproject/units';
 import { bnum } from '@/lib/utils';
 import { TokenInfoMap } from '@/types/TokenList';
 


### PR DESCRIPTION
# Description

Importing from 'ethers/lib' was causing issues when building with vite (that uses rollup underneath).

This PR adds a new eslint rule to avoid introducing this kind of imports again. 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [x] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## How should this be tested?

Please provide instructions so we can test. Please also list any relevant details for your test configuration.

- [ ] Test A
- [ ] Test B

## Visual context

Please provide any relevant visual context for UI changes or additions. This could be static screenshots or a loom screencast.

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have requested at least 2 reviews (If the PR is significant enough, use best judgement here)
- [ ] I have commented my code where relevant, particularly in hard-to-understand areas
- [ ] If package-lock.json has changes, it was intentional.
- [ ] The base of this PR is `master` if hotfix, `develop` if not
