### PR TITLE
Hotfix: Scale staking APR's correctly

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.81.7",
+  "version": "1.81.8",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@balancer-labs/frontend-v2",
-      "version": "1.81.7",
+      "version": "1.81.8",
       "license": "MIT",
       "devDependencies": {
         "@aave/protocol-js": "^4.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.81.7",
+  "version": "1.81.8",
   "engines": {
     "node": "14.x",
     "npm": ">=7"

--- a/src/components/tooltips/APRTooltip/components/StakingBreakdown.vue
+++ b/src/components/tooltips/APRTooltip/components/StakingBreakdown.vue
@@ -58,10 +58,10 @@ const boostedTotalAPR = computed((): string => {
       .plus(rewardTokensAPR.value)
       .toString();
 
-    return fNum2(boostedStakingAPR, FNumFormats.percent);
+    return fNum2(bpToDec(boostedStakingAPR), FNumFormats.percent);
   }
 
-  return fNum2(rewardTokensAPR.value, FNumFormats.percent);
+  return fNum2(bpToDec(rewardTokensAPR.value), FNumFormats.percent);
 });
 
 /**
@@ -122,7 +122,7 @@ const breakdownItems = computed((): Array<any> => {
         </template>
       </BalBreakdown>
       <div v-else-if="hasRewardTokens" class="flex items-center">
-        {{ fNum2(rewardTokensAPR, FNumFormats.percent) }}
+        {{ fNum2(bpToDec(rewardTokensAPR), FNumFormats.percent) }}
         <span class="ml-1 text-xs text-secondary">
           {{ $t('staking.stakingApr') }}
         </span>


### PR DESCRIPTION
# Description

Some Staking APR's weren't being converted from basis points to decimals correctly

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

- Check APR Tooltips on Polygon / Arbitrum and ensure they look sane without any 10,000x values. 

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have requested at least 2 reviews (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] If package-lock.json has changes, it was intentional.
- [x] The base of this PR is `master` if hotfix, `develop` if not
