### PR TITLE
Feature/vebal resubmit votes

### DIFF
--- a/src/components/_global/BalAlert/BalAlert.vue
+++ b/src/components/_global/BalAlert/BalAlert.vue
@@ -3,7 +3,8 @@
     <div :class="['bal-alert-container', containerClasses]">
       <div>
         <div :class="['bal-alert-icon', iconClasses]">
-          <BalIcon name="alert-circle" :size="iconSize" />
+          <LightBulbIcon v-if="type === 'tip'"></LightBulbIcon>
+          <BalIcon v-else name="alert-circle" :size="iconSize" />
         </div>
       </div>
       <div :class="['bal-alert-content', contentClasses]">
@@ -38,7 +39,7 @@ import { computed, defineComponent, PropType } from 'vue';
 import BalBtn from '../BalBtn/BalBtn.vue';
 import BalIcon from '../BalIcon/BalIcon.vue';
 
-type AlertType = 'warning' | 'error' | 'info';
+type AlertType = 'warning' | 'error' | 'info' | 'tip';
 
 export default defineComponent({
   name: 'BalAlert',
@@ -60,6 +61,7 @@ export default defineComponent({
     actionLabel: { type: String, default: '' },
     raised: { type: Boolean, default: false },
     block: { type: Boolean, default: false },
+    contentClass: { type: String, default: '' },
     square: { type: Boolean, default: false },
     noBorder: { type: Boolean, default: false },
   },
@@ -69,6 +71,8 @@ export default defineComponent({
   setup(props, { slots }) {
     const bgColorClass = computed(() => {
       switch (props.type) {
+        case 'tip':
+          return 'bg-blue-50 dark:bg-blue-500 dark:bg-opacity-10 border-blue-200 dark:border-blue-500 text-black dark:text-white';
         case 'warning':
           return 'bg-orange-50 dark:bg-orange-600 dark:bg-opacity-10 border-orange-200 dark:border-orange-700 text-black dark:text-white';
         case 'error':
@@ -113,10 +117,13 @@ export default defineComponent({
       'items-center': !props.description && !slots.default,
     }));
 
-    const contentClasses = computed(() => ({
-      'items-center': !props.description && !slots.default,
-      'flex-col': !!props.description || slots.default,
-    }));
+    const contentClasses = computed(() => [
+      props.contentClass,
+      {
+        'items-center': !props.description && !slots.default,
+        'flex-col': !!props.description || slots.default,
+      },
+    ]);
 
     const iconSizeClasses = computed(() => {
       switch (props.size) {
@@ -131,6 +138,8 @@ export default defineComponent({
 
     const iconColorClasses = computed(() => {
       switch (props.type) {
+        case 'tip':
+          return 'text-blue-700 dark:text-blue-400';
         case 'warning':
           return 'text-orange-500 dark:text-white bg-orange-500 dark:bg-white bg-opacity-10 dark:bg-opacity-10';
         case 'error':
@@ -152,8 +161,7 @@ export default defineComponent({
     }));
 
     const descriptionColor = computed(() => {
-      if (props.type === 'info')
-        return 'text-black dark:text-white text-opacity-70';
+      if (props.type === 'tip') return 'text-black dark:text-white';
       return 'text-black dark:text-white text-opacity-70';
     });
 

--- a/src/components/_global/BalAsset/BalAssetSet.vue
+++ b/src/components/_global/BalAsset/BalAssetSet.vue
@@ -5,6 +5,7 @@
   >
     <div
       :class="['addresses-row', assetRowClasses]"
+      v-bind="$attrs"
       :style="{
         width: `${width}px`,
         height: `${size}px`,

--- a/src/components/_global/BalTextInput/composables/useInputStyles.ts
+++ b/src/components/_global/BalTextInput/composables/useInputStyles.ts
@@ -54,6 +54,8 @@ export default function useInputStyles(
         return 'h-8';
       case 'lg':
         return 'h-12';
+      case 'auto':
+        return 'h-auto';
       default:
         return 'h-10';
     }

--- a/src/components/_global/BalTextInput/types.ts
+++ b/src/components/_global/BalTextInput/types.ts
@@ -3,5 +3,5 @@
  */
 export type InputValue = string | number;
 export type InputType = 'text' | 'number' | 'date' | 'email' | 'password';
-export type InputSize = 'xs' | 'sm' | 'md' | 'lg';
+export type InputSize = 'xs' | 'sm' | 'md' | 'lg' | 'auto';
 export type ValidationTrigger = 'input' | 'blur';

--- a/src/components/contextual/pages/pool/PoolContractDetails.vue
+++ b/src/components/contextual/pages/pool/PoolContractDetails.vue
@@ -84,7 +84,7 @@ const data = computed(() => {
     },
     {
       title: t('poolOwner'),
-      value: shortenLabel(owner),
+      value: shortenLabel(owner || ''),
       link: explorer.addressLink(owner || ''),
     },
     {

--- a/src/components/contextual/pages/vebal/LMVoting/GaugesTable.spec.ts
+++ b/src/components/contextual/pages/vebal/LMVoting/GaugesTable.spec.ts
@@ -7,6 +7,47 @@ GaugesTable.components = {
   BalAssetSet,
 };
 
+jest.mock('@/composables/queries/useExpiredGaugesQuery', () =>
+  jest.fn().mockImplementation(() => ({
+    data: {
+      value: [],
+    },
+  }))
+);
+
+jest.mock('@/composables/queries/useGraphQuery', () => {
+  return {
+    __esModule: true,
+    default: jest.fn(() => ({
+      data: {
+        value: {
+          votingEscrowLocks: [
+            {
+              votingEscrowID: {
+                id: 'asdf',
+              },
+              updatedAt: 123,
+            },
+          ],
+        },
+      },
+    })),
+    subgraphs: {
+      gauge: 'mockgauge',
+    },
+  };
+});
+
+jest.mock('@/composables/queries/useVeBalLockInfoQuery', () =>
+  jest.fn().mockImplementation(() => ({
+    data: {
+      value: {
+        lockedAmount: '123',
+      },
+    },
+  }))
+);
+jest.mock('@/composables/queries/useGaugeVotesQuery');
 // Global settings for component render.
 const global = {
   stubs: {
@@ -27,7 +68,7 @@ jest.mock('@/services/web3/useWeb3', () => {
           },
         }
       ),
-      account: '0x0000000000000000000000000000000000000000',
+      account: { value: '0x0000000000000000000000000000000000000000' },
     };
   });
 });

--- a/src/components/contextual/pages/vebal/LMVoting/GaugesTable.vue
+++ b/src/components/contextual/pages/vebal/LMVoting/GaugesTable.vue
@@ -1,6 +1,5 @@
 <script setup lang="ts">
 import { Network } from '@balancer-labs/sdk';
-import BigNumber from 'bignumber.js';
 import { computed, ref } from 'vue';
 import { useRouter } from 'vue-router';
 import { useI18n } from 'vue-i18n';
@@ -12,7 +11,6 @@ import BalChipExpired from '@/components/chips/BalChipExpired.vue';
 import TokenPills from '@/components/tables/PoolsTable/TokenPills/TokenPills.vue';
 import useBreakpoints from '@/composables/useBreakpoints';
 import { getNetworkSlug } from '@/composables/useNetwork';
-import useNumbers from '@/composables/useNumbers';
 import {
   isStableLike,
   isUnknownType,
@@ -20,18 +18,15 @@ import {
   poolURLFor,
 } from '@/composables/usePool';
 import { isSameAddress } from '@/lib/utils';
-import { scale } from '@/lib/utils';
 import { VotingGaugeWithVotes } from '@/services/balancer/gauges/gauge-controller.decorator';
 import useWeb3 from '@/services/web3/useWeb3';
 
 import GaugesTableVoteBtn from './GaugesTableVoteBtn.vue';
 import GaugeVoteInfo from './GaugeVoteInfo.vue';
+import GaugesTableMyVotes from './GaugesTableMyVotes.vue';
+import BalAssetSet from '@/components/_global/BalAsset/BalAssetSet.vue';
+import { orderedTokenURIs } from '@/composables/useVotingGauges';
 import IconLimit from '@/components/icons/IconLimit.vue';
-import {
-  isVotingTimeLocked,
-  remainingVoteLockTime,
-} from '@/composables/useVeBAL';
-import { Pool } from '@/services/pool/types';
 import { differenceInWeeks } from 'date-fns';
 import { oneSecondInMs } from '@/composables/useTime';
 
@@ -64,7 +59,6 @@ const emit = defineEmits<{
 /**
  * COMPOSABLES
  */
-const { fNum2 } = useNumbers();
 const router = useRouter();
 const { t } = useI18n();
 const { upToLargeBreakpoint } = useBreakpoints();
@@ -136,13 +130,6 @@ const dataKey = computed(() => JSON.stringify(props.data));
 /**
  * METHODS
  */
-function orderedTokenURIs(gauge: VotingGaugeWithVotes): string[] {
-  const sortedTokens = orderedPoolTokens(gauge.pool as Pool, gauge.pool.tokens);
-  return sortedTokens.map(
-    token => gauge.tokenLogoURIs[token?.address || ''] || ''
-  );
-}
-
 function networkSrc(network: Network) {
   return require(`@/assets/images/icons/networks/${getNetworkSlug(
     network
@@ -284,37 +271,8 @@ function getTableRowClass(gauge: VotingGaugeWithVotes): string {
         </div>
       </template>
       <template #myVotesCell="gauge">
-        <div class="flex justify-end px-4">
-          {{
-            fNum2(scale(new BigNumber(gauge.userVotes), -4).toString(), {
-              style: 'percent',
-              maximumFractionDigits: 2,
-            })
-          }}
-          <div class="flex justify-end w-6">
-            <BalTooltip v-if="isVotingTimeLocked(gauge.lastUserVoteTime)">
-              <template #activator>
-                <TimelockIcon />
-              </template>
-              <div>
-                <span class="font-semibold">
-                  {{
-                    $t(
-                      'veBAL.liquidityMining.popover.warnings.votedTooRecently.title'
-                    )
-                  }}
-                </span>
-                <p class="text-gray-500">
-                  {{
-                    $t(
-                      'veBAL.liquidityMining.popover.warnings.votedTooRecently.description',
-                      [remainingVoteLockTime(gauge.lastUserVoteTime)]
-                    )
-                  }}
-                </p>
-              </div>
-            </BalTooltip>
-          </div>
+        <div v-if="!isLoading" class="py-4 px-6 text-right">
+          <GaugesTableMyVotes :gauge="gauge"></GaugesTableMyVotes>
         </div>
       </template>
       <template #voteColumnCell="gauge">

--- a/src/components/contextual/pages/vebal/LMVoting/GaugesTableMyVotes.vue
+++ b/src/components/contextual/pages/vebal/LMVoting/GaugesTableMyVotes.vue
@@ -1,0 +1,103 @@
+
+<script setup lang="ts">
+import { computed } from 'vue';
+import { isSameAddress, scale } from '@/lib/utils';
+import { VotingGaugeWithVotes } from '@/services/balancer/gauges/gauge-controller.decorator';
+import BigNumber from 'bignumber.js';
+import useNumbers from '@/composables/useNumbers';
+import useVotingEscrowLocks from '@/composables/useVotingEscrowLocks';
+import { useI18n } from 'vue-i18n';
+import {
+  isVotingTimeLocked,
+  remainingVoteLockTime,
+} from '@/composables/useVeBAL';
+import TimelockIcon from '@/components/_global/icons/TimelockIcon.vue';
+import BalTooltip from '@/components/_global/BalTooltip/BalTooltip.vue';
+
+/**
+ * TYPES
+ */
+type Props = {
+  gauge: VotingGaugeWithVotes;
+};
+
+/**
+ * PROPS & EMITS
+ */
+const props = defineProps<Props>();
+
+/**
+ * COMPOSABLES
+ */
+const { t } = useI18n();
+const { fNum2 } = useNumbers();
+const { gaugesUsingUnderUtilizedVotingPower } = useVotingEscrowLocks();
+
+const myVotes = computed(() => {
+  const normalizedVotes = scale(new BigNumber(props.gauge.userVotes), -4);
+  return fNum2(normalizedVotes.toString(), {
+    style: 'percent',
+    maximumFractionDigits: 2,
+  });
+});
+
+const poolHasUnderUtilizedVotingPoewer = computed<boolean>(
+  () =>
+    !!gaugesUsingUnderUtilizedVotingPower.value.find(gauge =>
+      isSameAddress(gauge.address, props.gauge.address)
+    )
+);
+</script>
+
+<template>
+  <div
+    :class="{
+      'flex justify-end items-center': true,
+      'text-red-600': poolHasUnderUtilizedVotingPoewer,
+    }"
+  >
+    {{ myVotes }}
+    <BalTooltip
+      v-if="isVotingTimeLocked(gauge.lastUserVoteTime)"
+      textAlign="left"
+    >
+      <template #activator>
+        <TimelockIcon />
+      </template>
+      <div>
+        <span class="font-semibold">
+          {{
+            $t('veBAL.liquidityMining.popover.warnings.votedTooRecently.title')
+          }}
+        </span>
+        <p class="text-gray-500">
+          {{
+            $t(
+              'veBAL.liquidityMining.popover.warnings.votedTooRecently.description',
+              [remainingVoteLockTime(gauge.lastUserVoteTime)]
+            )
+          }}
+        </p>
+      </div>
+    </BalTooltip>
+    <BalTooltip
+      v-else-if="poolHasUnderUtilizedVotingPoewer"
+      template
+      textAlign="left"
+      width="60"
+    >
+      <template #activator>
+        <BalIcon class="ml-1" name="alert-triangle" size="sm" />
+      </template>
+      <div class="flex flex-col gap-1">
+        <span class="font-semibold"
+          >{{ t('veBAL.liquidityMining.resubmit.hint.title') }}
+        </span>
+        <span>
+          {{ t('veBAL.liquidityMining.resubmit.hint.description') }}
+        </span>
+      </div>
+    </BalTooltip>
+  </div>
+</template>
+

--- a/src/components/contextual/pages/vebal/LMVoting/LMVoting.vue
+++ b/src/components/contextual/pages/vebal/LMVoting/LMVoting.vue
@@ -3,15 +3,17 @@ import { computed, ref } from 'vue';
 
 import useExpiredGaugesQuery from '@/composables/queries/useExpiredGaugesQuery';
 import useVeBalLockInfoQuery from '@/composables/queries/useVeBalLockInfoQuery';
+import useVotingEscrowLocks from '@/composables/useVotingEscrowLocks';
 import useNumbers, { FNumFormats } from '@/composables/useNumbers';
-import { orderedPoolTokens, poolURLFor } from '@/composables/usePool';
+import { poolURLFor } from '@/composables/usePool';
 import useVotingGauges from '@/composables/useVotingGauges';
 import { bnum, scale } from '@/lib/utils';
 import { VotingGaugeWithVotes } from '@/services/balancer/gauges/gauge-controller.decorator';
 
 import GaugesTable from './GaugesTable.vue';
 import GaugeVoteModal from './GaugeVoteModal.vue';
-import { Pool } from '@/services/pool/types';
+import ResubmitVotesAlert from './ResubmitVotes/ResubmitVotesAlert.vue';
+import { orderedTokenURIs } from '@/composables/useVotingGauges';
 
 /**
  * DATA
@@ -32,10 +34,11 @@ const {
 const { fNum2 } = useNumbers();
 const veBalLockInfoQuery = useVeBalLockInfoQuery();
 
+const { shouldResubmitVotes } = useVotingEscrowLocks();
+
 const votingGaugeAddresses = computed<string[]>(
   () => votingGauges.value?.map(gauge => gauge.address) || []
 );
-
 const { data: expiredGauges } = useExpiredGaugesQuery(votingGaugeAddresses);
 
 /**
@@ -76,16 +79,6 @@ function setActiveGaugeVote(votingGauge: VotingGaugeWithVotes) {
   activeVotingGauge.value = votingGauge;
 }
 
-function orderedTokenURIs(gauge: VotingGaugeWithVotes): string[] {
-  const sortedTokens = orderedPoolTokens(
-    gauge.pool as unknown as Pool,
-    gauge.pool.tokens
-  );
-  return sortedTokens.map(
-    token => gauge.tokenLogoURIs[token?.address || ''] || ''
-  );
-}
-
 function handleModalClose() {
   activeVotingGauge.value = null;
   refetchVotingGauges.value();
@@ -97,87 +90,98 @@ function handleVoteSuccess() {
 </script>
 
 <template>
-  <div
-    class="flex flex-col lg:flex-row gap-4 lg:justify-between lg:items-end mb-2"
-  >
-    <div class="px-4 xl:px-0 max-w-3xl">
-      <h3 class="mb-2">
-        {{ $t('veBAL.liquidityMining.title') }}
-      </h3>
-      <p class="">
-        {{ $t('veBAL.liquidityMining.description') }}
-      </p>
-    </div>
-    <div class="flex gap-2 xs:gap-3 px-4 xl:px-0">
-      <BalCard shadow="none" class="md:w-48 min-w-max">
-        <div class="flex items-center">
-          <p class="inline mr-1 text-sm text-secondary">My unallocated votes</p>
-          <BalTooltip
-            :text="$t('veBAL.liquidityMining.myUnallocatedVotesTooltip')"
-            iconClass="text-gray-400 dark:text-gray-600"
-            iconSize="sm"
-            width="72"
-            class="mt-1"
-          />
-        </div>
-        <p
-          class="inline mr-1 text-lg font-semibold"
-          :class="{ 'text-red-500': hasExpiredLock }"
-        >
-          <span v-if="hasLock">
-            {{ unallocatedVotesFormatted }}
-          </span>
-          <span v-else class="mr-1">—</span>
+  <div class="flex flex-col">
+    <div
+      class="flex flex-col lg:flex-row gap-4 lg:justify-between lg:items-end mb-7"
+    >
+      <div class="px-4 xl:px-0 max-w-3xl">
+        <h3 class="mb-2">
+          {{ $t('veBAL.liquidityMining.title') }}
+        </h3>
+        <p class="">
+          {{ $t('veBAL.liquidityMining.description') }}
         </p>
-        <BalTooltip
-          v-if="hasExpiredLock"
-          :text="$t('veBAL.liquidityMining.votingPowerExpiredTooltip')"
-          iconSize="sm"
-          :iconName="'alert-triangle'"
-          :iconClass="'text-red-500 hover:text-red-700 dark:hover:text-red-400 transition-colors'"
-          width="72"
-          class="relative top-0.5"
-        />
-      </BalCard>
-      <BalCard shadow="none" class="md:w-48 min-w-max">
-        <div class="flex items-center">
+      </div>
+      <div class="flex gap-2 xs:gap-3 px-4 xl:px-0">
+        <BalCard shadow="none" class="md:w-48 min-w-max">
+          <div class="flex items-center">
+            <p class="inline mr-1 text-sm text-secondary">
+              My unallocated votes
+            </p>
+            <BalTooltip
+              :text="$t('veBAL.liquidityMining.myUnallocatedVotesTooltip')"
+              iconClass="text-gray-400 dark:text-gray-600"
+              iconSize="sm"
+              width="72"
+              class="mt-1"
+            />
+          </div>
           <p
-            :class="{ 'text-orange-500 font-medium': votingPeriodLastHour }"
-            class="inline mr-1 text-sm text-secondary"
+            class="inline mr-1 text-lg font-semibold"
+            :class="{ 'text-red-500': hasExpiredLock }"
           >
-            Voting period ends
+            <span v-if="hasLock">
+              {{ unallocatedVotesFormatted }}
+            </span>
+            <span v-else class="mr-1">—</span>
           </p>
           <BalTooltip
-            :text="$t('veBAL.liquidityMining.votingPeriodTooltip')"
+            v-if="hasExpiredLock"
+            :text="$t('veBAL.liquidityMining.votingPowerExpiredTooltip')"
             iconSize="sm"
-            iconClass="text-gray-400 dark:text-gray-600"
+            :iconName="'alert-triangle'"
+            :iconClass="'text-red-500 hover:text-red-700 dark:hover:text-red-400 transition-colors'"
             width="72"
-            class="mt-1"
+            class="relative top-0.5"
           />
-        </div>
-        <p class="text-lg font-semibold tabular-nums">
-          <span
-            v-if="votingPeriodEnd.length"
-            :class="{ 'text-orange-500': votingPeriodLastHour }"
-          >
-            {{
-              $t('veBAL.liquidityMining.votingPeriodCountdown', votingPeriodEnd)
-            }}
-          </span>
-        </p>
-      </BalCard>
+        </BalCard>
+        <BalCard shadow="none" class="md:w-48 min-w-max">
+          <div class="flex items-center">
+            <p
+              :class="{ 'text-orange-500 font-medium': votingPeriodLastHour }"
+              class="inline mr-1 text-sm text-secondary"
+            >
+              Voting period ends
+            </p>
+            <BalTooltip
+              :text="$t('veBAL.liquidityMining.votingPeriodTooltip')"
+              iconSize="sm"
+              iconClass="text-gray-400 dark:text-gray-600"
+              width="72"
+              class="mt-1"
+            />
+          </div>
+          <p class="text-lg font-semibold tabular-nums">
+            <span
+              v-if="votingPeriodEnd.length"
+              :class="{ 'text-orange-500': votingPeriodLastHour }"
+            >
+              {{
+                $t(
+                  'veBAL.liquidityMining.votingPeriodCountdown',
+                  votingPeriodEnd
+                )
+              }}
+            </span>
+          </p>
+        </BalCard>
+      </div>
     </div>
+    <ResubmitVotesAlert
+      v-if="shouldResubmitVotes"
+      class="mx-4 xl:mx-0 mb-7"
+    ></ResubmitVotesAlert>
+    <GaugesTable
+      :key="gaugesTableKey"
+      :expiredGauges="expiredGauges"
+      :isLoading="isLoading"
+      :data="votingGauges"
+      :noPoolsLabel="$t('noInvestments')"
+      showPoolShares
+      class="mb-8"
+      @clicked-vote="setActiveGaugeVote"
+    />
   </div>
-  <GaugesTable
-    :key="gaugesTableKey"
-    :expiredGauges="expiredGauges"
-    :isLoading="isLoading"
-    :data="votingGauges"
-    :noPoolsLabel="$t('noInvestments')"
-    showPoolShares
-    class="mb-8"
-    @clicked-vote="setActiveGaugeVote"
-  />
   <teleport to="#modal">
     <GaugeVoteModal
       v-if="!!activeVotingGauge"

--- a/src/components/contextual/pages/vebal/LMVoting/ResubmitVotes/GaugeVoteResubmitModal.vue
+++ b/src/components/contextual/pages/vebal/LMVoting/ResubmitVotes/GaugeVoteResubmitModal.vue
@@ -1,0 +1,280 @@
+<script lang="ts" setup>
+import { TransactionReceipt } from '@ethersproject/abstract-provider';
+import { BigNumber } from '@ethersproject/bignumber';
+import { computed, ref, watchEffect } from 'vue';
+import { useI18n } from 'vue-i18n';
+import useEthers from '@/composables/useEthers';
+import useNumbers, { FNumFormats } from '@/composables/useNumbers';
+import { dateTimeLabelFor } from '@/composables/useTime';
+import useTransactions from '@/composables/useTransactions';
+import { bnum, scale } from '@/lib/utils';
+import { gaugeControllerService } from '@/services/contracts/gauge-controller.service';
+import { Address, WalletError } from '@/types';
+import useVotingEscrowLocks from '@/composables/useVotingEscrowLocks';
+import useVotingGauges from '@/composables/useVotingGauges';
+import VoteInput from './VoteInput.vue';
+import SubmitVoteBtn from '../SubmitVoteBtn.vue';
+import { POOLS } from '@/constants/pools';
+import useActionState, { State } from '@/composables/useActionState';
+
+/**
+ * PROPS & EMITS
+ */
+const emit = defineEmits<{
+  (e: 'close'): void;
+}>();
+
+/**
+ * COMPOSABLES
+ */
+const { gaugesUsingUnderUtilizedVotingPower } = useVotingEscrowLocks();
+const { votingGauges, refetch: refetchVotingGauges } = useVotingGauges();
+const voteState = useActionState();
+const { t } = useI18n();
+const { addTransaction } = useTransactions();
+const { txListener, getTxConfirmedAt } = useEthers();
+const { fNum2 } = useNumbers();
+
+/**
+ * STATE
+ */
+const votes = ref<Record<Address, string>>({});
+
+/**
+ * COMPUTED
+ */
+
+//  Can vote max 8 gauges in one time
+const visibleVotingGauges = computed(() =>
+  gaugesUsingUnderUtilizedVotingPower.value.slice(0, 8)
+);
+
+// All other gauges using under-utilized voting power are grouped separately
+const hiddenVotingGauges = computed(() =>
+  gaugesUsingUnderUtilizedVotingPower.value.slice(7)
+);
+
+const allGaugesTotalAllocation = computed<number>(() => {
+  const underUtilizedAddresses = gaugesUsingUnderUtilizedVotingPower.value.map(
+    gauge => gauge.address
+  );
+
+  return votingGauges.value.reduce<number>((total, gauge) => {
+    return !underUtilizedAddresses.includes(gauge.address)
+      ? total + Number(bpsToPct(gauge.userVotes))
+      : total + Number(votes.value[gauge.address]);
+  }, 0);
+});
+
+const hasMoreThan8VotingGauges = computed(
+  () => gaugesUsingUnderUtilizedVotingPower.value.length > 8
+);
+
+const hiddenVotesTotalAllocation = computed<number>(() => {
+  const totalUnscaled = hiddenVotingGauges.value.reduce<number>(
+    (total, gauge) => total + Number(gauge.userVotes),
+    0
+  );
+  return Number(bpsToPct(totalUnscaled));
+});
+
+const voteButtonDisabled = computed<boolean>(
+  () => allGaugesTotalAllocation.value > 100
+);
+const transactionInProgress = computed(
+  (): boolean =>
+    voteState.state.value === State.TRANSACTION_INITIALIZED ||
+    voteState.state.value === State.CONFIRMING
+);
+const totalAllocationClass = computed(() => ({
+  'total-allocation-disabled': voteButtonDisabled.value,
+  'total-allocation mt-3 flex justify-between': true,
+}));
+
+/**
+ * METHODS
+ */
+function bpsToPct(weight: string | number): string {
+  return scale(bnum(weight || '0'), -2).toString();
+}
+
+async function submitVote() {
+  // Gauge Controller requires a fixed 8 Gauge Addresses
+  // We take the first 8 Voting Gauges
+  // If there's less than 8, fill the remaining with Zero Addresses
+  console.log({ otes: votes.value });
+  const gaugeAddresses: string[] = Object.keys(votes.value);
+  const weights: BigNumber[] = Object.values(votes.value).map(weight =>
+    BigNumber.from(scale(weight || '0', 2).toString())
+  );
+
+  const zeroAddresses: string[] = new Array(8 - gaugeAddresses.length).fill(
+    POOLS.ZeroAddress
+  );
+  const zeroWeights: BigNumber[] = new Array(8 - gaugeAddresses.length).fill(
+    BigNumber.from(0)
+  );
+  console.log({
+    zeroAddresses,
+    zeroWeights,
+  });
+  try {
+    voteState.setInit();
+    const tx = await gaugeControllerService.voteForManyGaugeWeights(
+      [...gaugeAddresses, ...zeroAddresses],
+      [...weights, ...zeroWeights]
+    );
+
+    voteState.setConfirming();
+    handleTransaction(tx);
+  } catch (e: any) {
+    const error = e as WalletError;
+    console.error({ error });
+    voteState.setError({
+      title: 'Vote failed',
+      description: error.message,
+    });
+  }
+}
+
+function getTransactionSummaryMsg(): string {
+  const gauges = visibleVotingGauges.value;
+  const message = gauges.reduce<string>((acc, gauge, i) => {
+    return (
+      acc +
+      t('veBAL.liquidityMining.popover.voteForGauge', [
+        fNum2(bpsToPct(votes.value[gauge.address]), FNumFormats.percent),
+        gauge.pool.symbol,
+      ]) +
+      (i < gauges.length - 1 ? ', ' : '')
+    );
+  }, '');
+  return message;
+}
+
+async function handleTransaction(tx) {
+  addTransaction({
+    id: tx.hash,
+    type: 'tx',
+    action: 'voteForGauge',
+    summary: getTransactionSummaryMsg(),
+  });
+
+  txListener(tx, {
+    onTxConfirmed: async (receipt: TransactionReceipt) => {
+      const confirmedAt = dateTimeLabelFor(await getTxConfirmedAt(receipt));
+
+      voteState.setSuccess({ receipt, confirmedAt });
+      refetchVotingGauges.value();
+    },
+    onTxFailed: () => {
+      console.error('Vote failed');
+      voteState.setError({
+        title: 'Vote Failed',
+        description: 'Vote failed for an unknown reason',
+      });
+    },
+  });
+}
+
+watchEffect(() => {
+  visibleVotingGauges.value.forEach(gauge => {
+    votes.value[gauge.address] = gauge.userVotes
+      ? bpsToPct(gauge.userVotes)
+      : '0';
+  });
+});
+</script>
+
+<template>
+  <BalModal show @close="emit('close')">
+    <template #header>
+      <div class="flex items-center">
+        <h4>
+          {{ t('veBAL.liquidityMining.resubmit.modal.title') }}
+        </h4>
+      </div>
+    </template>
+    <div>
+      <BalAlert
+        v-if="hasMoreThan8VotingGauges"
+        class="mb-4"
+        type="warning"
+        :title="t('veBAL.liquidityMining.resubmit.modal.warning.title')"
+        :description="
+          t('veBAL.liquidityMining.resubmit.modal.warning.description')
+        "
+      >
+      </BalAlert>
+      <BalAlert
+        v-if="voteState.error.value"
+        type="error"
+        :title="voteState.error.value.title"
+        :description="voteState.error.value.description"
+        block
+        class="mt-2 mb-4"
+      />
+      <VoteInput
+        v-for="gauge in visibleVotingGauges"
+        :key="gauge.address"
+        v-model="votes[gauge.address]"
+        :gauge="gauge"
+        :disabled="transactionInProgress"
+      ></VoteInput>
+
+      <div
+        v-if="hiddenVotesTotalAllocation"
+        class="flex justify-between p-4 mt-3 total-allocation"
+      >
+        <div>
+          {{
+            t(
+              'veBAL.liquidityMining.resubmit.modal.otherPools',
+              hiddenVotingGauges.length
+            )
+          }}
+        </div>
+        <div>{{ hiddenVotesTotalAllocation }}%</div>
+      </div>
+
+      <div :class="totalAllocationClass">
+        <div class="p-4">
+          {{ t('veBAL.liquidityMining.resubmit.modal.total') }}
+        </div>
+        <div class="p-4 border-l border-gray-200 dark:border-gray-900">
+          {{ allGaugesTotalAllocation }}%
+        </div>
+      </div>
+
+      <div v-if="voteButtonDisabled" class="mt-3 text-sm text-red-500">
+        {{ t('veBAL.liquidityMining.resubmit.modal.exceeding') }}
+      </div>
+
+      <SubmitVoteBtn
+        :disabled="voteButtonDisabled"
+        :loading="transactionInProgress"
+        class="mt-4"
+        :loadingLabel="
+          voteState.state.value === State.IDLE
+            ? $t('veBAL.liquidityMining.popover.actions.vote.loadingLabel')
+            : $t('veBAL.liquidityMining.popover.actions.vote.confirming')
+        "
+        @click:close="emit('close')"
+        @click:submit="submitVote"
+      >
+        {{ t('veBAL.liquidityMining.resubmit.modal.confirm') }}
+      </SubmitVoteBtn>
+    </div>
+  </BalModal>
+</template>
+  
+  <style lang="css" scoped>
+.total-allocation {
+  @apply bg-gray-50 dark:bg-gray-800  border border-gray-200 dark:border-0 rounded-lg;
+}
+
+.total-allocation-disabled {
+  @apply bg-red-600 dark:bg-red-600 text-white;
+}
+</style>
+  

--- a/src/components/contextual/pages/vebal/LMVoting/ResubmitVotes/ResubmitVotesAlert.vue
+++ b/src/components/contextual/pages/vebal/LMVoting/ResubmitVotes/ResubmitVotesAlert.vue
@@ -1,0 +1,39 @@
+  <script setup lang="ts">
+import { ref } from 'vue';
+import GaugeVoteResubmitModal from './GaugeVoteResubmitModal.vue';
+import { useI18n } from 'vue-i18n';
+
+const { t } = useI18n();
+const isModalOpen = ref<boolean>(false);
+</script>
+
+<template>
+  <BalAlert
+    v-bind="$attrs"
+    type="warning"
+    :title="t('veBAL.liquidityMining.resubmit.hint.title')"
+    contentClass="w-full"
+  >
+    <div
+      class="flex flex-col lg:flex-row gap-2 lg:gap-4 justify-between items-baseline lg:items-start pb-1 lg:pb-0"
+    >
+      <div class="mr-auto max-w-3xl">
+        {{ t('veBAL.liquidityMining.resubmit.resubmitWarning') }}
+      </div>
+
+      <BalBtn
+        color="gradient"
+        class="flex-shrink-0"
+        size="sm"
+        @click="isModalOpen = true"
+        >{{ t('veBAL.liquidityMining.resubmit.btn') }}</BalBtn
+      >
+    </div>
+  </BalAlert>
+  <teleport to="#modal">
+    <GaugeVoteResubmitModal v-if="isModalOpen" @close="isModalOpen = false" />
+  </teleport>
+</template>
+
+
+

--- a/src/components/contextual/pages/vebal/LMVoting/ResubmitVotes/VoteInput.vue
+++ b/src/components/contextual/pages/vebal/LMVoting/ResubmitVotes/VoteInput.vue
@@ -1,0 +1,84 @@
+<script lang="ts" setup>
+import BalTextInput from '@/components/_global/BalTextInput/BalTextInput.vue';
+import { VotingGaugeWithVotes } from '@/services/balancer/gauges/gauge-controller.decorator';
+import { orderedTokenURIs } from '@/composables/useVotingGauges';
+
+/**
+ * TYPES
+ */
+type Props = {
+  gauge: VotingGaugeWithVotes;
+  modelValue?: string;
+};
+/**
+ * PROPS & EMITS
+ */
+withDefaults(defineProps<Props>(), {
+  modelValue: '',
+});
+
+const emit = defineEmits<{
+  (e: 'update:modelValue', value: string): void;
+}>();
+</script>
+
+<template>
+  <div class="special-input">
+    <BalTextInput
+      :modelValue="modelValue"
+      v-bind="$attrs"
+      class="mb-3"
+      size="auto"
+      type="number"
+      name="poolName"
+      inputAlignRight
+      @input="val => emit('update:modelValue', val)"
+    >
+      <template #prepend>
+        <div class="flex gap-3">
+          <BalAssetSet
+            :logoURIs="orderedTokenURIs(gauge)"
+            class="flex-shrink-0"
+            :width="100"
+            :size="32"
+          />
+          <div class="flex flex-col">
+            <div class="flex flex-row flex-wrap">
+              <span
+                v-for="(token, i) in gauge.pool.tokens"
+                :key="token.address"
+                class="flex-shrink-0"
+              >
+                {{
+                  !!Number(token.weight)
+                    ? `${Number(token.weight) * 100}%`
+                    : '100%'
+                }}
+                {{ token.symbol
+                }}<template v-if="i !== gauge.pool.tokens.length - 1"
+                  >,&nbsp;</template
+                >
+              </span>
+            </div>
+            <div class="text-sm">
+              {{ gauge.pool.symbol }}
+            </div>
+          </div>
+        </div>
+      </template>
+      <template #append>
+        <div class="flex items-center px-2 h-full">
+          <span class="text-xl text-black dark:text-white">%</span>
+        </div>
+      </template>
+    </BalTextInput>
+  </div>
+</template>
+
+<style lang="css" scoped>
+.special-input :deep(input) {
+  @apply w-14 ml-auto;
+
+  min-width: 3.5rem;
+}
+</style>

--- a/src/components/contextual/pages/vebal/LMVoting/SubmitVoteBtn.vue
+++ b/src/components/contextual/pages/vebal/LMVoting/SubmitVoteBtn.vue
@@ -1,0 +1,57 @@
+<script lang="ts" setup>
+import ConfirmationIndicator from '@/components/web3/ConfirmationIndicator.vue';
+
+import { TransactionReceipt } from '@ethersproject/abstract-provider';
+
+/**
+ * TYPES
+ */
+type Props = {
+  disabled: boolean;
+  loading: boolean;
+  receipt?: TransactionReceipt;
+};
+
+/**
+ * PROPS & EMITS
+ */
+withDefaults(defineProps<Props>(), {
+  disabled: false,
+  loading: false,
+  receipt: undefined,
+});
+
+const emit = defineEmits<{
+  (e: 'click:close'): void;
+  (e: 'click:submit'): void;
+}>();
+</script>
+
+<template>
+  <div>
+    <template v-if="receipt">
+      <ConfirmationIndicator :txReceipt="receipt" class="mb-2" />
+      <BalBtn
+        v-if="receipt"
+        color="gray"
+        outline
+        v-bind="$attrs"
+        block
+        @click="emit('click:close')"
+      >
+        {{ $t('getVeBAL.previewModal.returnToVeBalPage') }}
+      </BalBtn>
+    </template>
+    <BalBtn
+      v-else
+      color="gradient"
+      block
+      :disabled="disabled"
+      :loading="loading"
+      v-bind="$attrs"
+      @click.prevent="emit('click:submit')"
+    >
+      <slot></slot>
+    </BalBtn>
+  </div>
+</template>

--- a/src/components/forms/lock_actions/LockForm/components/LockPreviewModal/LockPreviewModal.vue
+++ b/src/components/forms/lock_actions/LockForm/components/LockPreviewModal/LockPreviewModal.vue
@@ -118,9 +118,9 @@ function handleSuccess() {
       :lockType="lockType"
       :veBalLockInfo="veBalLockInfo"
     />
-
     <LockActions
-      :lockablePool="lockablePool"
+      :veBalLockInfo="veBalLockInfo"
+      :lockConfirmed="lockConfirmed"
       :lockAmount="lockAmount"
       :lockEndDate="lockEndDate"
       :lockType="lockType"

--- a/src/components/tables/PoolsTable/TokenPills/BalanceTooltip.vue
+++ b/src/components/tables/PoolsTable/TokenPills/BalanceTooltip.vue
@@ -29,12 +29,13 @@ const { balanceFor } = useTokens();
  * COMPUTED
  */
 const tokenBalance = computed(() => balanceFor(props.token.address));
+const shortenedAccount = computed(() => shortenLabel(account.value));
 </script>
 
 <template>
   <div>
     <div class="mb-2 text-secondary">
-      {{ $t('tokenPills.balanceTooltip.title', [shortenLabel(account)]) }}
+      {{ $t('tokenPills.balanceTooltip.title', [shortenedAccount]) }}
     </div>
     <div class="flex">
       <BalAsset :address="token.address" :size="36" class="mr-2" />

--- a/src/composables/queries/__mocks__/useGaugeVotesQuery.ts
+++ b/src/composables/queries/__mocks__/useGaugeVotesQuery.ts
@@ -2,6 +2,8 @@ export default function useGaugeVotesQuery() {
   return {
     data: [],
     isLoading: false,
+    isIdle: false,
+    error: false,
     refetch: jest.fn(),
   };
 }

--- a/src/composables/queries/useVeBalLockInfoQuery.ts
+++ b/src/composables/queries/useVeBalLockInfoQuery.ts
@@ -22,7 +22,6 @@ export default function useVeBalQuery(
    */
   const { account, isWalletReady } = useWeb3();
   const { networkId } = useNetwork();
-
   /**
    * COMPUTED
    */

--- a/src/composables/useActionState.ts
+++ b/src/composables/useActionState.ts
@@ -1,0 +1,61 @@
+import { TransactionError } from '@/types/transactions';
+import { TransactionReceipt } from '@ethersproject/abstract-provider';
+import { ref } from 'vue';
+
+export enum State {
+  IDLE = 'IDLE',
+  TRANSACTION_INITIALIZED = 'INIT',
+  CONFIRMING = 'CONFIRMING',
+  CONFIRMED = 'CONFIRMED',
+  ERROR = 'ERROR',
+}
+
+interface SuccessParams {
+  confirmedAt: string;
+  receipt: TransactionReceipt;
+}
+
+export default function useActionState() {
+  const state = ref<State>(State.IDLE);
+  const confirmedAt = ref<string>('');
+  const receipt = ref<TransactionReceipt | null>(null);
+  const error = ref<TransactionError | null>(null);
+
+  function setInit() {
+    state.value = State.TRANSACTION_INITIALIZED;
+    error.value = null;
+  }
+
+  function setConfirming() {
+    state.value = State.CONFIRMING;
+  }
+  function setSuccess(successParams: SuccessParams) {
+    state.value = State.CONFIRMED;
+    receipt.value = successParams.receipt;
+    confirmedAt.value = successParams.confirmedAt;
+  }
+  function setError({
+    title,
+    description,
+  }: {
+    title: string;
+    description: string;
+  }) {
+    state.value = State.ERROR;
+    error.value = {
+      title,
+      description,
+    };
+  }
+
+  return {
+    state,
+    confirmedAt,
+    receipt,
+    error,
+    setInit,
+    setConfirming,
+    setSuccess,
+    setError,
+  };
+}

--- a/src/composables/useVotingEscrowLocks.ts
+++ b/src/composables/useVotingEscrowLocks.ts
@@ -1,0 +1,114 @@
+import { computed, reactive } from 'vue';
+import useGraphQuery, { subgraphs } from '@/composables/queries/useGraphQuery';
+import useWeb3 from '@/services/web3/useWeb3';
+import useConfig from '@/composables/useConfig';
+import { bnum, isSameAddress } from '@/lib/utils';
+import useVeBalLockInfoQuery from '@/composables/queries/useVeBalLockInfoQuery';
+import useVotingGauges from '@/composables/useVotingGauges';
+import configs from '@/lib/config';
+import { networkId } from '@/composables/useNetwork';
+import useExpiredGaugesQuery from '@/composables/queries/useExpiredGaugesQuery';
+import { VotingGaugeWithVotes } from '@/services/balancer/gauges/gauge-controller.decorator';
+import useVeBal, { isVotingTimeLocked } from '@/composables/useVeBAL';
+import QUERY_KEYS from '@/constants/queryKeys';
+
+/**
+ * TYPES
+ */
+export type VotingEscrowLock = {
+  votingEscrowID: {
+    id: string;
+  };
+  updatedAt: number;
+};
+
+type VotingEscrowLockQueryResponse = {
+  votingEscrowLocks: VotingEscrowLock[];
+};
+
+export default function useVotingEscrowLocks() {
+  /**
+   * COMPOSABLES
+   */
+  const { account } = useWeb3();
+  const { networkConfig } = useConfig();
+  const veBalLockInfoQuery = useVeBalLockInfoQuery();
+  const { votingGauges: allVotingGauges } = useVotingGauges();
+  const { veBalBalance } = useVeBal();
+
+  const votingEscrowLocksQueryEnabled = computed(() => !!account.value);
+  const votingEscrowLocksQuery = useGraphQuery<VotingEscrowLockQueryResponse>(
+    subgraphs.gauge,
+    QUERY_KEYS.Gauges.VotingEscrowLocks(
+      veBalLockInfoQuery.data.value?.lockedAmount
+    ),
+    () => ({
+      votingEscrowLocks: {
+        __args: {
+          where: {
+            user: account.value.toLowerCase(),
+            votingEscrowID:
+              configs[networkId.value].addresses.veBAL.toLocaleLowerCase(),
+          },
+        },
+        votingEscrowID: {
+          id: true,
+        },
+        updatedAt: true,
+      },
+    }),
+    reactive({ enabled: votingEscrowLocksQueryEnabled })
+  );
+
+  /**
+   * COMPUTED
+   */
+  const votingEscrowLocks = computed(
+    () => votingEscrowLocksQuery.data.value?.votingEscrowLocks
+  );
+
+  const votingGaugeAddresses = computed<string[]>(
+    () => allVotingGauges.value?.map(gauge => gauge.address) || []
+  );
+
+  const { data: expiredGauges } = useExpiredGaugesQuery(votingGaugeAddresses);
+
+  //  If user has received more veBAL since they last voted, their voting power is under-utilized
+  const gaugesUsingUnderUtilizedVotingPower = computed<VotingGaugeWithVotes[]>(
+    () =>
+      allVotingGauges.value.filter(gauge => {
+        return (
+          // Does the gauge have user votes
+          bnum(gauge.userVotes).gt(0) &&
+          // Has user received veBAL since they last voted
+          gauge.lastUserVoteTime < lastReceivedVebal.value &&
+          // Is voting currently not locked
+          !isVotingTimeLocked(gauge.lastUserVoteTime) &&
+          // Is gauge not expired
+          !expiredGauges.value?.includes(gauge.address)
+        );
+      })
+  );
+
+  const shouldResubmitVotes = computed<boolean>(
+    () =>
+      // Does user have any veBAL
+      bnum(veBalBalance.value).gt(0) &&
+      !!gaugesUsingUnderUtilizedVotingPower.value.length
+  );
+
+  // Timestamp when user has last received veBAL
+  const lastReceivedVebal = computed(
+    () =>
+      votingEscrowLocks.value?.find(item =>
+        isSameAddress(item.votingEscrowID.id, networkConfig.addresses.veBAL)
+      )?.updatedAt || 0
+  );
+
+  return {
+    votingEscrowLocks,
+    lastReceivedVebal,
+    gaugesUsingUnderUtilizedVotingPower,
+    shouldResubmitVotes,
+  };
+}

--- a/src/composables/useVotingGauges.ts
+++ b/src/composables/useVotingGauges.ts
@@ -9,8 +9,20 @@ import {
 
 import useGaugeVotesQuery from './queries/useGaugeVotesQuery';
 import { isGoerli } from './useNetwork';
+import { orderedPoolTokens } from '@/composables/usePool';
+import { VotingGaugeWithVotes } from '@/services/balancer/gauges/gauge-controller.decorator';
+import { Pool } from '@/services/pool/types';
+
+export function orderedTokenURIs(gauge: VotingGaugeWithVotes): string[] {
+  const sortedTokens = orderedPoolTokens(gauge.pool as Pool, gauge.pool.tokens);
+  return sortedTokens.map(
+    token => gauge.tokenLogoURIs[token?.address || ''] || ''
+  );
+}
 
 export default function useVotingGauges() {
+  const totalVotes = 1e4;
+
   // Hard coded list of voting gauges
   const _votingGauges = computed((): VotingGauge[] => {
     if (isGoerli.value) {
@@ -33,7 +45,6 @@ export default function useVotingGauges() {
   const votingGauges = computed(() => gaugeVotesQuery.data.value || []);
 
   const unallocatedVotes = computed(() => {
-    const totalVotes = 1e4;
     if (isLoading.value || !votingGauges.value) return totalVotes;
     const votesRemaining = votingGauges.value.reduce(
       (remainingVotes, gauge) => {
@@ -88,6 +99,7 @@ export default function useVotingGauges() {
   }
 
   return {
+    totalVotes,
     isLoading,
     votingGauges,
     unallocatedVotes,

--- a/src/constants/queryKeys.ts
+++ b/src/constants/queryKeys.ts
@@ -200,6 +200,10 @@ const QUERY_KEYS = {
       'expired',
       { gauges, networkId },
     ],
+    VotingEscrowLocks: (lockedAmount?: string) => [
+      'votingEscrowLocks',
+      lockedAmount,
+    ],
     Voting: (account: Ref<string>) => ['gauges', 'voting', { account }],
   },
   Transaction: {

--- a/src/jest/jest.setup-suite.jsdom.ts
+++ b/src/jest/jest.setup-suite.jsdom.ts
@@ -7,9 +7,10 @@ import { createI18n } from 'vue-i18n';
 
 import BalBreakdown from '@/components/_global/BalBreakdown/BalBreakdown.vue';
 import BalBtn from '@/components/_global/BalBtn/BalBtn.vue';
+import BalIcon from '@/components/_global/BalIcon/BalIcon.vue';
+import BalAlert from '@/components/_global/BalAlert/BalAlert.vue';
 import BalCard from '@/components/_global/BalCard/BalCard.vue';
 import BalChip from '@/components/_global/BalChip/BalChip.vue';
-import BalIcon from '@/components/_global/BalIcon/BalIcon.vue';
 import BalLoadingBlock from '@/components/_global/BalLoadingBlock/BalLoadingBlock.vue';
 import BalTable from '@/components/_global/BalTable/BalTable.vue';
 import BalTooltip from '@/components/_global/BalTooltip/BalTooltip.vue';
@@ -46,6 +47,7 @@ config.global.components = {
   BalBreakdown,
   BalBtn,
   BalCard,
+  BalAlert,
   BalChip,
   BalIcon,
   BalLoadingBlock,

--- a/src/lib/utils/index.ts
+++ b/src/lib/utils/index.ts
@@ -89,7 +89,7 @@ export function scale(
   return unscaled.times(scaleMul);
 }
 
-export function shortenLabel(str, segLength = 4) {
+export function shortenLabel(str: string, segLength = 4) {
   const firstSegment = str.substring(0, segLength + 2);
   const lastSegment = str.substring(str.length, str.length - segLength);
   return `${firstSegment}...${lastSegment}`;

--- a/src/locales/default.json
+++ b/src/locales/default.json
@@ -967,6 +967,25 @@
         "errors": {
           "notEnoughVotes": "Not enough unallocated votes"
         }
+      },
+      "resubmit": {
+        "modal": {
+          "title": "Preview vote resubmission",
+          "warning": {
+            "title": "You can only resubmit up to 8 votes",
+            "description": "It’s only possible to update 8 pool gauge votes at a time. You’ll need to update your votes for the remaining ones manually."
+          },
+          "otherPools": "0 other pools | 1 other pool | {n} other pools",
+          "total": "Total vote allocation",
+          "exceeding": "Your votes can’t exceed 100%",
+          "confirm": "Confirm votes"
+        },
+        "hint": {
+          "title": "Resubmit your votes to utilize your full voting power",
+          "description": "Votes on pools are set at the time of your last vote. Since you’ve added new veBAL after your original vote, the additional voting power is not being used."
+        },
+        "resubmitWarning": "Votes on pools are set at the time of the vote. Since you’ve added new veBAL since your original vote, you have additional voting power which is not being used. To use your full voting power, resubmit your votes.",
+        "btn": "Resubmit votes"
       }
     },
     "notSupported": {
@@ -1084,7 +1103,11 @@
           "loadingLabel": "Confirm lock in wallet"
         }
       },
-      "returnToVeBalPage": "Return to veBAL page"
+      "returnToVeBalPage": "Return to veBAL page",
+      "firstVeBALReceived": {
+        "title": "Vote on pools to direct liquidity incentives",
+        "description": "Your voting weight is set at the time of the vote. If you acquire additional veBAL, resubmit your votes to utilize your newly acquired voting power. Voting per pool can only be done once every 10 days."
+      }
     },
     "notSupported": {
       "title": "Locking is unavailable on this network",

--- a/src/services/gas-price/gas-price.service.ts
+++ b/src/services/gas-price/gas-price.service.ts
@@ -69,7 +69,9 @@ export class GasPriceService {
     const gasLimit = await contractWithSigner.estimateGas[action](
       ...params,
       options
-    );
+    ).catch(err => {
+      return Promise.reject(err.error);
+    });
     gasSettings.gasLimit = this.formatGasLimit(gasLimit.toNumber());
 
     if (this.shouldSetGasPriceSettings(options)) {


### PR DESCRIPTION
# Description

## Original: #2191 

If user has received veBAL since they last voted, suggest them to resubmit their votes.

- Add a warning above the pool gauge table with a button to resubmit all votes
- Add a tooltip and icon for affected gauge's
 
![Screenshot 2022-11-24 at 21 14 42](https://user-images.githubusercontent.com/28311328/203852580-3a42ba2a-e866-4e20-9f9a-29e58c21f0c3.png)


- New modal screen interaction to resubmit multiple votes at once

| Total allocation within limits | Total allocation over 100% |
| --- | --- |
|    ![Screen Shot 2022-09-09 at 9 04 47](https://user-images.githubusercontent.com/28311328/189302239-b6ad4abd-a82f-4d3d-8935-0b3f1976aab7.png)  |    ![Screen Shot 2022-09-09 at 9 04 56](https://user-images.githubusercontent.com/28311328/189302205-9925111a-ce6d-4d4b-b50b-52ed0020939e.png)  |

- Tip for people acquiring their first veBAL

![Screenshot 2022-11-24 at 20 44 43](https://user-images.githubusercontent.com/28311328/203852445-c8728121-b5c1-41ce-96d1-73e6a9211ba8.png)


- Warning for people who’ve previously got veBAL and voted, and then acquire more veBAL

![Screenshot 2022-11-24 at 21 17 33](https://user-images.githubusercontent.com/28311328/203852851-dc0b6bd1-ae13-453c-b66a-65b778cd7873.png)


## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How should this be tested?

Please provide instructions so we can test. Please also list any relevant details for your test configuration.

1. If you have previously voted, and your votes are not locked (10 days since voting). Get some more veBAL and you should see the warning above the pool gauge table with a button to resubmit votes. And an icon and a tooltip in Gauges table "My votes" column.
2. Create new Metamask account and lock your first veBAL. When lock is confirmed, you should see the info alert suggesting you to vote


## Visual context

Please provide any relevant visual context for UI changes or additions. This could be static screenshots or a loom screencast.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have requested at least 2 reviews (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] If package-lock.json has changes, it was intentional.
- [x] The base of this PR is `master` if hotfix, `develop` if not
