### PR TITLE
Hotfix: Boosted APR scaling

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.81.9",
+  "version": "1.81.10",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@balancer-labs/frontend-v2",
-      "version": "1.81.9",
+      "version": "1.81.10",
       "license": "MIT",
       "devDependencies": {
         "@aave/protocol-js": "^4.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.81.9",
+  "version": "1.81.10",
   "engines": {
     "node": "14.x",
     "npm": ">=7"

--- a/src/composables/usePool.ts
+++ b/src/composables/usePool.ts
@@ -230,7 +230,7 @@ export function absMaxApr(aprs: AprBreakdown, boost?: string): string {
  */
 export function totalAprLabel(aprs: AprBreakdown, boost?: string): string {
   if (boost) {
-    return numF(absMaxApr(aprs, boost), FNumFormats.percent);
+    return numF(bpToDec(absMaxApr(aprs, boost)), FNumFormats.percent);
   } else if ((hasBalEmissions(aprs) && !isL2.value) || aprs.protocolApr > 0) {
     const minAPR = numF(bpToDec(aprs.min), FNumFormats.percent);
     const maxAPR = numF(bpToDec(aprs.max), FNumFormats.percent);


### PR DESCRIPTION
# Description

Fixes scaling of APR when boost is applied, we were missing the bpToDec function.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## How should this be tested?

- [ ] Check APRs in claims page where vebal boost is applied.

## Visual context

n/a

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have requested at least 1 review (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] If package-lock.json has changes, it was intentional.
- [x] The base of this PR is `master` if hotfix, `develop` if not
