### PR TITLE
Fix portfolio staked pools list

### DIFF
--- a/src/components/tooltips/APRTooltip/components/StakingBreakdown.vue
+++ b/src/components/tooltips/APRTooltip/components/StakingBreakdown.vue
@@ -1,7 +1,7 @@
 <script lang="ts" setup>
 import { computed } from 'vue';
 
-import useNumbers, { FNumFormats, bpToDec } from '@/composables/useNumbers';
+import useNumbers, { FNumFormats } from '@/composables/useNumbers';
 import { bnum } from '@/lib/utils';
 import { Pool } from '@/services/pool/types';
 import { hasBalEmissions } from '@/services/staking/utils';
@@ -58,10 +58,10 @@ const boostedTotalAPR = computed((): string => {
       .plus(rewardTokensAPR.value)
       .toString();
 
-    return fNum2(bpToDec(boostedStakingAPR), FNumFormats.percent);
+    return fNum2(boostedStakingAPR, FNumFormats.bp);
   }
 
-  return fNum2(bpToDec(rewardTokensAPR.value), FNumFormats.percent);
+  return fNum2(rewardTokensAPR.value, FNumFormats.bp);
 });
 
 /**
@@ -122,7 +122,7 @@ const breakdownItems = computed((): Array<any> => {
         </template>
       </BalBreakdown>
       <div v-else-if="hasRewardTokens" class="flex items-center">
-        {{ fNum2(bpToDec(rewardTokensAPR), FNumFormats.percent) }}
+        {{ fNum2(rewardTokensAPR, FNumFormats.bp) }}
         <span class="ml-1 text-xs text-secondary">
           {{ $t('staking.stakingApr') }}
         </span>

--- a/src/composables/queries/usePoolsQuery.ts
+++ b/src/composables/queries/usePoolsQuery.ts
@@ -131,10 +131,10 @@ export default function usePoolsQuery(
         id: { not_in: POOLS.BlockList },
       },
     };
-    if (queryArgs.where && filterOptions?.poolIds?.value.length) {
+    if (queryArgs.where && filterOptions?.poolIds?.value) {
       queryArgs.where.id = { in: filterOptions.poolIds.value };
     }
-    if (queryArgs.where && filterOptions?.poolAddresses?.value.length) {
+    if (queryArgs.where && filterOptions?.poolAddresses?.value) {
       queryArgs.where.address = { in: filterOptions.poolAddresses.value };
     }
     if (options.first) {

--- a/src/composables/useNumbers.ts
+++ b/src/composables/useNumbers.ts
@@ -179,14 +179,6 @@ export function numF(
   return formattedNumber + postfixSymbol;
 }
 
-/**
- * @summary APR's are in basis points (100 = 1%), while percent formatting takes a decimal (0.01 = 1%)
- *          this helper should be run on each APR value before formatting as a percent
- */
-export function bpToDec(value: number | string): string {
-  return bnum(value).div(10000).toString();
-}
-
 export default function useNumbers() {
   const { currency } = useUserSettings();
   const { priceFor } = useTokens();

--- a/src/composables/usePool.ts
+++ b/src/composables/usePool.ts
@@ -239,7 +239,7 @@ export function absMaxApr(aprs: AprBreakdown, boost?: string): string {
  */
 export function totalAprLabel(aprs: AprBreakdown, boost?: string): string {
   if (boost) {
-    return numF(bpToDec(absMaxApr(aprs, boost)), FNumFormats.percent);
+    return numF(absMaxApr(aprs, boost), FNumFormats.bp);
   } else if ((hasBalEmissions(aprs) && !isL2.value) || aprs.protocolApr > 0) {
     const minAPR = numF(aprs.min, FNumFormats.bp);
     const maxAPR = numF(aprs.max, FNumFormats.bp);

--- a/src/services/balancer/api/entities/pools/index.ts
+++ b/src/services/balancer/api/entities/pools/index.ts
@@ -36,7 +36,7 @@ export default class Pools {
      *   and if not_in is also set then delete it (because it's set by default) */
     if (query.args.where?.id?.in) {
       if (query.args.where?.id?.in.length === 0) {
-        query.args.where.id.in = [''];
+        return [];
       }
       if (query.args.where?.id?.not_in) {
         delete query.args.where?.id.not_in;

--- a/src/services/balancer/api/entities/pools/index.ts
+++ b/src/services/balancer/api/entities/pools/index.ts
@@ -32,6 +32,17 @@ export default class Pools {
     delete query.args.skip; // not allowed for Balancer API
     delete query.args.first;
 
+    /* Some temporary hacks to make the API work with an empty in array (it should return no data)
+     *   and if not_in is also set then delete it (because it's set by default) */
+    if (query.args.where?.id?.in) {
+      if (query.args.where?.id?.in.length === 0) {
+        query.args.where.id.in = [''];
+      }
+      if (query.args.where?.id?.not_in) {
+        delete query.args.where?.id.not_in;
+      }
+    }
+
     if (!this.repository || !_.isEqual(query, this.lastQuery)) {
       this.lastQuery = _.cloneDeep(query);
       this.repository = new PoolsBalancerAPIRepository({


### PR DESCRIPTION


# Description

There were two bugs causing the staked pools list to show every single pool instead of only the ones the user had a stake in

- The first bug was there where the query wasn't being updated when poolIds was of length 0
- Second bug was the Balancer API doesn't accept an empty array for pool id in. So I've added a hack for it to just pass a single empty string instead. It also didn't like if both in and not_in were in the same query so I deleted the not_in. Will fix the API correctly soon.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

- Visit your portfolio page, it should show pools you are staking in, or an empty list if you're not staking in any pools. 

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have requested at least 1 review (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] If package-lock.json has changes, it was intentional.
- [x] The base of this PR is `master` if hotfix, `develop` if not
