### PR TITLE
Improve + simplify token yield breakdown in APR Tooltip

### DIFF
--- a/src/components/tooltips/APRTooltip/APRTooltip.spec.ts
+++ b/src/components/tooltips/APRTooltip/APRTooltip.spec.ts
@@ -174,7 +174,7 @@ describe('APRTooltip', () => {
   });
 
   describe('Token Aprs', () => {
-    it('Should show stETH staking reward APRs', () => {
+    it('Should show stETH token APRs', () => {
       const aprBreakdown: AprBreakdown = {
         ...EmptyAprBreakdownMock,
         tokenAprs: {
@@ -197,18 +197,16 @@ describe('APRTooltip', () => {
         },
       });
       expect(getByTestId('total-apr').textContent).toBe('Total APR1.66%');
-      expect(getByTestId('yield-apr').textContent).toBe(
-        '1.66% stETH staking rewards APR'
-      );
+      expect(getByTestId('yield-apr').textContent).toBe('1.66% wstETH APR');
     });
 
-    it('Should show stMATIC staking reward APRs', () => {
+    it('Should show stMATIC token APRs', () => {
       const aprBreakdown: AprBreakdown = {
         ...EmptyAprBreakdownMock,
         tokenAprs: {
           total: 153,
           breakdown: {
-            [configService.network.addresses.stMATIC]: 153,
+            '0x3a58a54c066fdc0f2d55fc9c89f0415c92ebf3c4': 153,
           },
         },
         min: 153,
@@ -225,12 +223,10 @@ describe('APRTooltip', () => {
         },
       });
       expect(getByTestId('total-apr').textContent).toBe('Total APR1.53%');
-      expect(getByTestId('yield-apr').textContent).toBe(
-        '1.53% stMATIC staking rewards APR'
-      );
+      expect(getByTestId('yield-apr').textContent).toBe('1.53% stMATIC APR');
     });
 
-    it('Should show rETH staking reward APRs', () => {
+    it('Should show rETH token APRs', () => {
       const aprBreakdown: AprBreakdown = {
         ...EmptyAprBreakdownMock,
         swapFees: 29,
@@ -254,8 +250,45 @@ describe('APRTooltip', () => {
         },
       });
       expect(getByTestId('total-apr').textContent).toBe('Total APR1.02%');
-      expect(getByTestId('yield-apr').textContent).toBe(
-        '0.73% rETH staking rewards APR'
+      expect(getByTestId('yield-apr').textContent).toBe('0.73% rETH APR');
+    });
+
+    it('Should show multiple token APRs with a generic header', () => {
+      const aprBreakdown: AprBreakdown = {
+        ...EmptyAprBreakdownMock,
+        swapFees: 48,
+        tokenAprs: {
+          total: 254,
+          breakdown: {
+            '0x7f39C581F595B53c5cb19bD0b3f8dA6c935E2Ca0': 118,
+            '0xac3E018457B222d93114458476f3E3416Abbe38F': 104,
+            '0xae78736Cd615f374D3085123A210448E74Fc6393': 32,
+          },
+        },
+        min: 102,
+        max: 102,
+      };
+      const poolMock: Pool = {
+        ...EmptyPoolMock,
+        tokensList: [configService.network.addresses.rETH],
+      };
+      const { getByTestId } = render(APRTooltip, {
+        props: {
+          pool: poolMock,
+          poolApr: aprBreakdown,
+        },
+      });
+      expect(getByTestId('total-apr').textContent).toBe('Total APR1.02%');
+      const yieldAprBreakdown = getByTestId('yield-apr').children[0];
+      expect(yieldAprBreakdown.children[0].textContent).toBe('2.54% Token APR');
+      expect(yieldAprBreakdown.children[1].children[0].textContent).toBe(
+        '1.18% wstETH APR'
+      );
+      expect(yieldAprBreakdown.children[1].children[1].textContent).toBe(
+        '1.04% sfrxETH APR'
+      );
+      expect(yieldAprBreakdown.children[1].children[2].textContent).toBe(
+        '0.32% rETH APR'
       );
     });
 

--- a/src/components/tooltips/APRTooltip/APRTooltip.spec.ts
+++ b/src/components/tooltips/APRTooltip/APRTooltip.spec.ts
@@ -197,7 +197,7 @@ describe('APRTooltip', () => {
         },
       });
       expect(getByTestId('total-apr').textContent).toBe('Total APR1.66%');
-      expect(getByTestId('yield-apr').textContent).toBe('1.66% wstETH APR');
+      expect(getByTestId('yield-apr').textContent).toBe('1.66% Token APR');
     });
 
     it('Should show stMATIC token APRs', () => {
@@ -250,7 +250,7 @@ describe('APRTooltip', () => {
         },
       });
       expect(getByTestId('total-apr').textContent).toBe('Total APR1.02%');
-      expect(getByTestId('yield-apr').textContent).toBe('0.73% rETH APR');
+      expect(getByTestId('yield-apr').textContent).toBe('0.73% Token APR');
     });
 
     it('Should show multiple token APRs with a generic header', () => {

--- a/src/composables/__mocks__/useTokens.ts
+++ b/src/composables/__mocks__/useTokens.ts
@@ -12,7 +12,7 @@ const mockTokens = {
     symbol: 'USDC',
     decimals: 6,
   },
-  '0x7f39c581f595b53c5cb19bd0b3f8da6c935e2ca0': {
+  '0x7f39C581F595B53c5cb19bD0b3f8dA6c935E2Ca0': {
     symbol: 'wstETH',
   },
   '0x2F4eb100552ef93840d5aDC30560E5513DFfFACb': {
@@ -23,6 +23,15 @@ const mockTokens = {
   },
   '0xae37D54Ae477268B9997d4161B96b8200755935c': {
     symbol: 'bb-a-DAI',
+  },
+  '0xae78736Cd615f374D3085123A210448E74Fc6393': {
+    symbol: 'rETH',
+  },
+  '0xac3E018457B222d93114458476f3E3416Abbe38F': {
+    symbol: 'sfrxETH',
+  },
+  '0x3A58a54C066FdC0f2D55FC9C89F0415C92eBf3C4': {
+    symbol: 'stMATIC',
   },
 };
 

--- a/src/locales/default.json
+++ b/src/locales/default.json
@@ -1158,16 +1158,12 @@
   "theme": "Theme",
   "yieldAprRewards": {
     "apr": {
-      "steth": "stETH staking rewards APR",
-      "reth": "rETH staking rewards APR",
-      "stmatic": "stMATIC staking rewards APR",
+      "token": "Token APR",
       "boosted": "Boosted APR",
       "veBAL": "veBAL APR"
     },
     "fiat": {
-      "steth": "stETH staking rewards",
-      "reth": "rETH staking rewards",
-      "stmatic": "stMATIC staking rewards",
+      "token": "Token rewards",
       "boosted": "Boosted rewards"
     }
   },


### PR DESCRIPTION
# Description

- When there is a single token giving yield show <symbol> APR
- When there are multiple tokens giving yield show a breakdown with a generic header of 'Token APR'
- Removes a bunch of 'is X token in this array' checks that were getting unruly and replaces them with the token symbol + APR

## Type of change

- [x] New feature (non-breaking change which adds functionality)


## How should this be tested?

- Look at the APR tooltips of pools with token yield, ensure they look correct, include all tokens, and make sense. 

## Visual context

### Before:

![2022-12-12-192554_310x251_scrot](https://user-images.githubusercontent.com/525534/207009813-cee423ce-6306-45b5-974e-2b62131573b5.png)


![2022-12-12-192719_288x306_scrot](https://user-images.githubusercontent.com/525534/207009857-6886127f-9a8b-44de-a138-c61c38f65e4d.png)

### After

![2022-12-12-192424_238x256_scrot](https://user-images.githubusercontent.com/525534/207009920-5e8a1786-3f55-4a63-88e9-e663db5a2fcc.png)

![2022-12-12-192656_262x331_scrot](https://user-images.githubusercontent.com/525534/207009945-acaa1e9e-dfca-4aaa-99f8-f9375ee130d5.png)



## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have requested at least 1 review (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] If package-lock.json has changes, it was intentional.
- [x] The base of this PR is `master` if hotfix, `develop` if not
