### PR TITLE
Soft page transition animations

### DIFF
--- a/src/assets/css/global/animations.css
+++ b/src/assets/css/global/animations.css
@@ -94,3 +94,13 @@
   opacity: 0;
   transition: opacity 0.2s ease-in;
 }
+
+.appear-enter-active,
+.appear-leave-active {
+  @apply opacity-100 transition-opacity duration-500 ease-in-out;
+}
+
+.appear-enter-from,
+.appear-leave-to {
+  @apply opacity-0;
+}

--- a/src/components/contextual/pages/pool/invest/InvestPage.vue
+++ b/src/components/contextual/pages/pool/invest/InvestPage.vue
@@ -15,21 +15,23 @@ const { upToLargeBreakpoint } = useBreakpoints();
 </script>
 
 <template>
-  <div class="invest-page-layout-grid">
-    <div v-if="!upToLargeBreakpoint" class="col-span-5">
-      <InvestPageMyWallet />
-    </div>
+  <Transition appear name="appear">
+    <div class="invest-page-layout-grid">
+      <div v-if="!upToLargeBreakpoint" class="col-span-5">
+        <InvestPageMyWallet />
+      </div>
 
-    <div class="col-span-7">
-      <InvestPageInvestBlock />
-    </div>
+      <div class="col-span-7">
+        <InvestPageInvestBlock />
+      </div>
 
-    <InvestPageAccordion
-      v-if="upToLargeBreakpoint"
-      class="mt-4"
-      :isDeepPool="isDeepPool"
-    ></InvestPageAccordion>
-  </div>
+      <InvestPageAccordion
+        v-if="upToLargeBreakpoint"
+        class="mt-4"
+        :isDeepPool="isDeepPool"
+      ></InvestPageAccordion>
+    </div>
+  </Transition>
 </template>
 
 <style scoped>

--- a/src/components/contextual/pages/pool/invest/InvestPage.vue
+++ b/src/components/contextual/pages/pool/invest/InvestPage.vue
@@ -15,23 +15,25 @@ const { upToLargeBreakpoint } = useBreakpoints();
 </script>
 
 <template>
-  <Transition appear name="appear">
-    <div class="invest-page-layout-grid">
-      <div v-if="!upToLargeBreakpoint" class="col-span-5">
-        <InvestPageMyWallet />
-      </div>
+  <div>
+    <Transition appear name="appear">
+      <div class="invest-page-layout-grid">
+        <div v-if="!upToLargeBreakpoint" class="col-span-5">
+          <InvestPageMyWallet />
+        </div>
 
-      <div class="col-span-7">
-        <InvestPageInvestBlock />
-      </div>
+        <div class="col-span-7">
+          <InvestPageInvestBlock />
+        </div>
 
-      <InvestPageAccordion
-        v-if="upToLargeBreakpoint"
-        class="mt-4"
-        :isDeepPool="isDeepPool"
-      ></InvestPageAccordion>
-    </div>
-  </Transition>
+        <InvestPageAccordion
+          v-if="upToLargeBreakpoint"
+          class="mt-4"
+          :isDeepPool="isDeepPool"
+        ></InvestPageAccordion>
+      </div>
+    </Transition>
+  </div>
 </template>
 
 <style scoped>

--- a/src/components/navs/AppNav/AppNav.vue
+++ b/src/components/navs/AppNav/AppNav.vue
@@ -52,23 +52,25 @@ onUnmounted(() => {
 
 <template>
   <AppNavAlert v-if="currentAlert" :alert="currentAlert" />
-  <nav id="app-nav" ref="appNav" class="sticky top-0 lg:px-6 pr-1 pl-4 h-20">
-    <div class="flex justify-between items-center h-full">
-      <div class="flex items-center h-full">
-        <router-link
-          :to="{ name: 'home', params: { networkSlug } }"
-          @click="trackGoal(Goals.ClickNavLogo)"
-        >
-          <AppIcon v-if="['xs', 'sm'].includes(bp)" />
-          <AppLogo v-else />
-        </router-link>
+  <Transition appear name="appear">
+    <nav id="app-nav" ref="appNav" class="sticky top-0 lg:px-6 pr-1 pl-4 h-20">
+      <div class="flex justify-between items-center h-full">
+        <div class="flex items-center h-full">
+          <router-link
+            :to="{ name: 'home', params: { networkSlug } }"
+            @click="trackGoal(Goals.ClickNavLogo)"
+          >
+            <AppIcon v-if="['xs', 'sm'].includes(bp)" />
+            <AppLogo v-else />
+          </router-link>
 
-        <DesktopLinks v-if="isDesktop" class="ml-8 font-medium" />
+          <DesktopLinks v-if="isDesktop" class="ml-8 font-medium" />
+        </div>
+
+        <AppNavActions />
       </div>
-
-      <AppNavActions />
-    </div>
-  </nav>
+    </nav>
+  </Transition>
 </template>
 
 <style scoped>

--- a/src/pages/_layouts/DefaultLayout.vue
+++ b/src/pages/_layouts/DefaultLayout.vue
@@ -4,18 +4,15 @@ import AppNav from '@/components/navs/AppNav/AppNav.vue';
 </script>
 
 <template>
-  <Transition appear name="appear">
-    <div>
-      <div class="app-body">
-        <AppNav />
-
-        <div class="pb-16">
-          <router-view :key="$route.path" />
-        </div>
+  <div>
+    <div class="app-body">
+      <AppNav />
+      <div class="pb-16">
+        <router-view :key="$route.path" />
       </div>
-      <Footer />
     </div>
-  </Transition>
+    <Footer />
+  </div>
 </template>
 
 <style>

--- a/src/pages/_layouts/DefaultLayout.vue
+++ b/src/pages/_layouts/DefaultLayout.vue
@@ -4,15 +4,18 @@ import AppNav from '@/components/navs/AppNav/AppNav.vue';
 </script>
 
 <template>
-  <div>
-    <div class="app-body">
-      <AppNav />
-      <div class="pb-16">
-        <router-view :key="$route.path" />
+  <Transition appear name="appear">
+    <div>
+      <div class="app-body">
+        <AppNav />
+
+        <div class="pb-16">
+          <router-view :key="$route.path" />
+        </div>
       </div>
+      <Footer />
     </div>
-    <Footer />
-  </div>
+  </Transition>
 </template>
 
 <style>

--- a/src/pages/claim.vue
+++ b/src/pages/claim.vue
@@ -226,20 +226,43 @@ onBeforeMount(async () => {
 </script>
 
 <template>
-  <HeroClaim />
-  <div>
-    <div class="xl:container py-12 xl:px-4 xl:mx-auto">
-      <h2 class="px-4 xl:px-0 font-body text-2xl font-semibold">
-        {{ configService.network.chainName }} {{ $t('liquidityIncentives') }}
-      </h2>
+  <Transition appear name="appear">
+    <div>
+      <HeroClaim />
+      <div>
+        <div class="xl:container py-12 xl:px-4 xl:mx-auto">
+          <h2 class="px-4 xl:px-0 font-body text-2xl font-semibold">
+            {{ configService.network.chainName }}
+            {{ $t('liquidityIncentives') }}
+          </h2>
 
-      <template v-if="!isL2">
-        <div class="mb-16">
-          <div class="px-4 xl:px-0">
-            <BalLoadingBlock v-if="appLoading" class="mt-6 mb-2 w-64 h-8" />
-            <div v-else class="flex items-center mt-6 mb-2">
-              <h3 class="inline-block mr-1.5 text-xl">
-                BAL {{ $t('incentives') }}
+          <template v-if="!isL2">
+            <div class="mb-16">
+              <div class="px-4 xl:px-0">
+                <BalLoadingBlock v-if="appLoading" class="mt-6 mb-2 w-64 h-8" />
+                <div v-else class="flex items-center mt-6 mb-2">
+                  <h3 class="inline-block mr-1.5 text-xl">
+                    BAL {{ $t('incentives') }}
+                  </h3>
+                  <BalTooltip
+                    iconSize="xs"
+                    textAlign="left"
+                    class="relative top-px"
+                    iconClass="text-secondary"
+                    width="60"
+                  >
+                    {{ $t('claimPage.tips.BalIncentives') }}
+                  </BalTooltip>
+                </div>
+              </div>
+              <BalClaimsTable
+                :rewardsData="balRewardsData"
+                :isLoading="loading"
+              />
+            </div>
+            <div class="mb-16">
+              <h3 class="inline-block xl:px-0 pl-4 mt-8 mr-1.5 mb-3 text-xl">
+                {{ $t('protocolIncentives') }}
               </h3>
               <BalTooltip
                 iconSize="xs"
@@ -248,109 +271,96 @@ onBeforeMount(async () => {
                 iconClass="text-secondary"
                 width="60"
               >
-                {{ $t('claimPage.tips.BalIncentives') }}
+                {{ $t('claimPage.tips.ProtocolAndVebal') }}
               </BalTooltip>
+              <ProtocolRewardsTable
+                :rewardsData="protocolRewardsData"
+                :isLoading="loading"
+              />
+              <ProtocolRewardsTable
+                v-if="!loading"
+                :rewardsData="protocolRewardsDataDeprecated"
+                :isLoading="loading"
+                deprecated
+              />
             </div>
+          </template>
+          <div v-if="!isL2">
+            <h3 class="inline-block px-4 xl:px-0 mt-8 mr-1.5 text-xl">
+              {{ $t('otherTokenIncentives') }}
+            </h3>
+            <BalTooltip
+              iconSize="xs"
+              textAlign="left"
+              class="relative top-px"
+              iconClass="text-secondary"
+              width="60"
+            >
+              {{ $t('claimPage.tips.OtherIncentives') }}
+            </BalTooltip>
           </div>
-          <BalClaimsTable :rewardsData="balRewardsData" :isLoading="loading" />
-        </div>
-        <div class="mb-16">
-          <h3 class="inline-block xl:px-0 pl-4 mt-8 mr-1.5 mb-3 text-xl">
-            {{ $t('protocolIncentives') }}
-          </h3>
-          <BalTooltip
-            iconSize="xs"
-            textAlign="left"
-            class="relative top-px"
-            iconClass="text-secondary"
-            width="60"
+          <BalLoadingBlock v-if="loading" class="mt-6 mb-2 h-56" />
+          <template
+            v-if="!isClaimsLoading && !appLoading && gaugeTables.length > 0"
           >
-            {{ $t('claimPage.tips.ProtocolAndVebal') }}
-          </BalTooltip>
-          <ProtocolRewardsTable
-            :rewardsData="protocolRewardsData"
-            :isLoading="loading"
-          />
-          <ProtocolRewardsTable
-            v-if="!loading"
-            :rewardsData="protocolRewardsDataDeprecated"
-            :isLoading="loading"
-            deprecated
-          />
-        </div>
-      </template>
-      <div v-if="!isL2">
-        <h3 class="inline-block px-4 xl:px-0 mt-8 mr-1.5 text-xl">
-          {{ $t('otherTokenIncentives') }}
-        </h3>
-        <BalTooltip
-          iconSize="xs"
-          textAlign="left"
-          class="relative top-px"
-          iconClass="text-secondary"
-          width="60"
-        >
-          {{ $t('claimPage.tips.OtherIncentives') }}
-        </BalTooltip>
-      </div>
-      <BalLoadingBlock v-if="loading" class="mt-6 mb-2 h-56" />
-      <template
-        v-if="!isClaimsLoading && !appLoading && gaugeTables.length > 0"
-      >
-        <div v-for="{ gauge, pool } in gaugeTables" :key="gauge.id">
-          <div class="mb-16">
-            <div class="flex px-4 xl:px-0 mt-4">
-              <h4 class="mb-2 text-base">
-                {{ gaugeTitle(pool) }}
-              </h4>
+            <div v-for="{ gauge, pool } in gaugeTables" :key="gauge.id">
+              <div class="mb-16">
+                <div class="flex px-4 xl:px-0 mt-4">
+                  <h4 class="mb-2 text-base">
+                    {{ gaugeTitle(pool) }}
+                  </h4>
+                </div>
+                <GaugeRewardsTable
+                  :gauge="gauge"
+                  :isLoading="isClaimsLoading || appLoading"
+                />
+              </div>
             </div>
-            <GaugeRewardsTable
-              :gauge="gauge"
-              :isLoading="isClaimsLoading || appLoading"
-            />
-          </div>
-        </div>
-      </template>
+          </template>
 
-      <BalBlankSlate
-        v-else-if="
-          (!isClaimsLoading && !appLoading && gaugeTables.length === 0) ||
-          !isWalletReady
-        "
-        class="px-4 xl:px-0 mt-4 mb-16"
-      >
-        {{ $t('noClaimableIncentives') }}
-      </BalBlankSlate>
-      <div class="px-4 xl:px-0 mb-16">
-        <h2 class="mt-8 font-body text-2xl font-semibold">
-          {{ $t('pages.claim.titles.incentivesOnOtherNetworks') }}
-        </h2>
-        <BalFlexGrid class="mt-4" flexWrap>
-          <BalBtn
-            v-for="network in networkBtns"
-            :key="network.id"
-            tag="a"
-            :href="`https://app.balancer.fi/#/${network.subdomain}/claim`"
-            color="white"
+          <BalBlankSlate
+            v-else-if="
+              (!isClaimsLoading && !appLoading && gaugeTables.length === 0) ||
+              !isWalletReady
+            "
+            class="px-4 xl:px-0 mt-4 mb-16"
           >
-            <img
-              :src="require(`@/assets/images/icons/networks/${network.id}.svg`)"
-              :alt="network.id"
-              class="mr-2 w-6 h-6 rounded-full shadow-sm"
-            />
-            {{ $t('pages.claim.btns.claimOn') }} {{ network.name }}
-          </BalBtn>
-        </BalFlexGrid>
-      </div>
+            {{ $t('noClaimableIncentives') }}
+          </BalBlankSlate>
+          <div class="px-4 xl:px-0 mb-16">
+            <h2 class="mt-8 font-body text-2xl font-semibold">
+              {{ $t('pages.claim.titles.incentivesOnOtherNetworks') }}
+            </h2>
+            <BalFlexGrid class="mt-4" flexWrap>
+              <BalBtn
+                v-for="network in networkBtns"
+                :key="network.id"
+                tag="a"
+                :href="`https://app.balancer.fi/#/${network.subdomain}/claim`"
+                color="white"
+              >
+                <img
+                  :src="
+                    require(`@/assets/images/icons/networks/${network.id}.svg`)
+                  "
+                  :alt="network.id"
+                  class="mr-2 w-6 h-6 rounded-full shadow-sm"
+                />
+                {{ $t('pages.claim.btns.claimOn') }} {{ network.name }}
+              </BalBtn>
+            </BalFlexGrid>
+          </div>
 
-      <template v-if="isWalletReady">
-        <div class="px-4 xl:px-0">
-          <h2 :class="['font-body font-semibold text-2xl mt-8']">
-            {{ $t('pages.claim.titles.legacyIncentives') }}
-          </h2>
-          <LegacyClaims />
+          <template v-if="isWalletReady">
+            <div class="px-4 xl:px-0">
+              <h2 :class="['font-body font-semibold text-2xl mt-8']">
+                {{ $t('pages.claim.titles.legacyIncentives') }}
+              </h2>
+              <LegacyClaims />
+            </div>
+          </template>
         </div>
-      </template>
+      </div>
     </div>
-  </div>
+  </Transition>
 </template>

--- a/src/pages/cookies-policy.vue
+++ b/src/pages/cookies-policy.vue
@@ -1,106 +1,108 @@
 <template>
-  <div class="pb-4">
-    <div class="subsection">
-      <h1>Balancer Cookies&nbsp;Policy</h1>
-      <p><em>Last Updated: June 2022</em></p>
-    </div>
-    <div class="subsection">
-      <h2>Introduction and Scope of Policy</h2>
-      <p>
-        This Cookies Policy (“Policy”) applies to your interaction with the
-        Balancer Foundation, its subsidiary, Balancer OpCo Limited, and material
-        service providers operating under a legal agreement (“Balancer
-        Foundation,” “Balancer,” “we,” “our,” or “us”).
-      </p>
-    </div>
+  <Transition appear name="appear">
+    <div class="pb-4">
+      <div class="subsection">
+        <h1>Balancer Cookies&nbsp;Policy</h1>
+        <p><em>Last Updated: June 2022</em></p>
+      </div>
+      <div class="subsection">
+        <h2>Introduction and Scope of Policy</h2>
+        <p>
+          This Cookies Policy (“Policy”) applies to your interaction with the
+          Balancer Foundation, its subsidiary, Balancer OpCo Limited, and
+          material service providers operating under a legal agreement
+          (“Balancer Foundation,” “Balancer,” “we,” “our,” or “us”).
+        </p>
+      </div>
 
-    <div class="subsection">
-      <h2>About Cookies</h2>
-      <p>
-        Cookies are pieces of data stored on your device. Browser cookies are
-        assigned by a web server to the browser on your device. When you return
-        to a site you have visited before, your browser gives this data back to
-        the server. Mobile applications may also use cookies.
-      </p>
+      <div class="subsection">
+        <h2>About Cookies</h2>
+        <p>
+          Cookies are pieces of data stored on your device. Browser cookies are
+          assigned by a web server to the browser on your device. When you
+          return to a site you have visited before, your browser gives this data
+          back to the server. Mobile applications may also use cookies.
+        </p>
 
-      <p>
-        We do not generally use cookies. We do not intentionally collect
-        information to customize your experience on the website or the
-        Balancer.fi user interface (UI) to the Balancer Protocol. (“Sites” or
-        “Site”).
-      </p>
-      <p>
-        Industry standards are currently evolving, and we may not separately
-        respond to or take any action with respect to a “do not track”
-        configuration set in your internet browser.
-      </p>
-      <p>
-        Other parties that may collect information about your web browsing
-        behavior when you use our Site are generally limited to service
-        providers who may only use any information collected to provide services
-        for us and not to provide services or advertising for any other party.
-        Note, however, that we also provide certain widgets or tools on our
-        sites that allow you to interact with third parties who provide these
-        features, such as tools that allow web surfers to easily share
-        information on another platform. At other times, information from a
-        third party may be embedded on our Site, such as a map. These widgets,
-        tools, and informational items often function through the use of
-        third-party cookies utilized by the third party site. As a result, these
-        third parties may have access to information about your web browsing on
-        the pages of our Site where these widgets, tools, or information are
-        placed. You may wish to review information at third party sites, where
-        you have an account, to determine how these third parties treat data
-        that they obtain through the use of cookies.
-      </p>
-    </div>
+        <p>
+          We do not generally use cookies. We do not intentionally collect
+          information to customize your experience on the website or the
+          Balancer.fi user interface (UI) to the Balancer Protocol. (“Sites” or
+          “Site”).
+        </p>
+        <p>
+          Industry standards are currently evolving, and we may not separately
+          respond to or take any action with respect to a “do not track”
+          configuration set in your internet browser.
+        </p>
+        <p>
+          Other parties that may collect information about your web browsing
+          behavior when you use our Site are generally limited to service
+          providers who may only use any information collected to provide
+          services for us and not to provide services or advertising for any
+          other party. Note, however, that we also provide certain widgets or
+          tools on our sites that allow you to interact with third parties who
+          provide these features, such as tools that allow web surfers to easily
+          share information on another platform. At other times, information
+          from a third party may be embedded on our Site, such as a map. These
+          widgets, tools, and informational items often function through the use
+          of third-party cookies utilized by the third party site. As a result,
+          these third parties may have access to information about your web
+          browsing on the pages of our Site where these widgets, tools, or
+          information are placed. You may wish to review information at third
+          party sites, where you have an account, to determine how these third
+          parties treat data that they obtain through the use of cookies.
+        </p>
+      </div>
 
-    <div class="subsection">
-      <h2>Do You Have to Accept Cookies?</h2>
+      <div class="subsection">
+        <h2>Do You Have to Accept Cookies?</h2>
 
-      <p>
-        You may be able to set your browser to reject cookies. If you set your
-        browser options to disallow cookies, you may limit the functionality we
-        can provide when you visit our Site. The latest versions of internet
-        browsers provide cookie management tools, such as the ability to delete
-        or reject cookies. We recommend that you refer to information supplied
-        by browser providers for more specific information, including how to use
-        these tools.
-      </p>
+        <p>
+          You may be able to set your browser to reject cookies. If you set your
+          browser options to disallow cookies, you may limit the functionality
+          we can provide when you visit our Site. The latest versions of
+          internet browsers provide cookie management tools, such as the ability
+          to delete or reject cookies. We recommend that you refer to
+          information supplied by browser providers for more specific
+          information, including how to use these tools.
+        </p>
+      </div>
+      <div class="subsection">
+        <h2>Additional Technologies</h2>
+        <p>
+          We do not typically use additional technologies such as pixel tags,
+          web beacons, and clear GIFs. We may permit third-party service
+          providers to use these technologies. They may use these technologies
+          for purposes such as determining viewing and response rates.
+        </p>
+      </div>
+      <div class="subsection">
+        <h2>Using Information</h2>
+        <p>
+          In addition to the uses described above, we may use information for
+          purposes as allowed by law such as: servicing; communicating with you;
+          improving our Site, products, or services; legal compliance; risk
+          control; information security; anti-fraud purposes; tracking website
+          usage, such as number of hits, pages visited, and the length of user
+          sessions in order to evaluate the usefulness of our sites.
+        </p>
+      </div>
+      <div>
+        <h2>Sharing</h2>
+        <p>
+          We may share information with service providers with whom we work,
+          such as service providers and companies that help us service you
+          better. When permitted or required by law, we may share information
+          with additional third parties for purposes including response to legal
+          process. As applicable, please see our
+          <router-link :to="{ name: 'privacy-policy' }">
+            <span className="link">Privacy Policy</span>
+          </router-link>
+          for more information on how we may share information with affiliates
+          and third parties.
+        </p>
+      </div>
     </div>
-    <div class="subsection">
-      <h2>Additional Technologies</h2>
-      <p>
-        We do not typically use additional technologies such as pixel tags, web
-        beacons, and clear GIFs. We may permit third-party service providers to
-        use these technologies. They may use these technologies for purposes
-        such as determining viewing and response rates.
-      </p>
-    </div>
-    <div class="subsection">
-      <h2>Using Information</h2>
-      <p>
-        In addition to the uses described above, we may use information for
-        purposes as allowed by law such as: servicing; communicating with you;
-        improving our Site, products, or services; legal compliance; risk
-        control; information security; anti-fraud purposes; tracking website
-        usage, such as number of hits, pages visited, and the length of user
-        sessions in order to evaluate the usefulness of our sites.
-      </p>
-    </div>
-    <div>
-      <h2>Sharing</h2>
-      <p>
-        We may share information with service providers with whom we work, such
-        as service providers and companies that help us service you better. When
-        permitted or required by law, we may share information with additional
-        third parties for purposes including response to legal process. As
-        applicable, please see our
-        <router-link :to="{ name: 'privacy-policy' }">
-          <span className="link">Privacy Policy</span>
-        </router-link>
-        for more information on how we may share information with affiliates and
-        third parties.
-      </p>
-    </div>
-  </div>
+  </Transition>
 </template>

--- a/src/pages/index.vue
+++ b/src/pages/index.vue
@@ -35,65 +35,71 @@ function navigateToCreatePool() {
 </script>
 
 <template>
-  <HomePageHero />
-  <div class="xl:container xl:px-4 pt-10 md:pt-12 xl:mx-auto">
-    <BalStack vertical>
-      <div class="px-4 xl:px-0">
-        <div class="flex justify-between items-end mb-8">
-          <h3>
-            {{ networkConfig.chainName }}
-            <span class="lowercase">{{ $t('pools') }}</span>
-          </h3>
-          <BalBtn
-            v-if="upToMediumBreakpoint"
-            color="blue"
-            size="sm"
-            outline
-            :class="{ 'mt-4': upToMediumBreakpoint }"
-            @click="navigateToCreatePool"
-          >
-            {{ $t('createAPool.title') }}
-          </BalBtn>
-        </div>
+  <div>
+    <Transition appear name="appear">
+      <HomePageHero />
+    </Transition>
+    <Transition appear name="appear">
+      <div class="xl:container xl:px-4 pt-10 md:pt-12 xl:mx-auto">
+        <BalStack vertical>
+          <div class="px-4 xl:px-0">
+            <div class="flex justify-between items-end mb-8">
+              <h3>
+                {{ networkConfig.chainName }}
+                <span class="lowercase">{{ $t('pools') }}</span>
+              </h3>
+              <BalBtn
+                v-if="upToMediumBreakpoint"
+                color="blue"
+                size="sm"
+                outline
+                :class="{ 'mt-4': upToMediumBreakpoint }"
+                @click="navigateToCreatePool"
+              >
+                {{ $t('createAPool.title') }}
+              </BalBtn>
+            </div>
 
-        <div
-          class="flex flex-col md:flex-row justify-between items-end lg:items-center w-full"
-        >
-          <TokenSearchInput
-            v-model="selectedTokens"
-            class="w-full md:w-2/3"
-            @add="addSelectedToken"
-            @remove="removeSelectedToken"
+            <div
+              class="flex flex-col md:flex-row justify-between items-end lg:items-center w-full"
+            >
+              <TokenSearchInput
+                v-model="selectedTokens"
+                class="w-full md:w-2/3"
+                @add="addSelectedToken"
+                @remove="removeSelectedToken"
+              />
+              <BalBtn
+                v-if="!upToMediumBreakpoint"
+                color="blue"
+                size="sm"
+                outline
+                :class="{ 'mt-4': upToMediumBreakpoint }"
+                :block="upToMediumBreakpoint"
+                @click="navigateToCreatePool"
+              >
+                {{ $t('createAPool.title') }}
+              </BalBtn>
+            </div>
+          </div>
+          <PoolsTable
+            :data="pools"
+            :noPoolsLabel="$t('noPoolsFound')"
+            :isLoading="isLoading"
+            :selectedTokens="selectedTokens"
+            class="mb-8"
+            :hiddenColumns="['migrate', 'actions', 'lockEndDate']"
+            :isLoadingMore="poolsIsFetchingNextPage"
+            :isPaginated="isPaginated"
+            skeletonClass="pools-table-loading-height"
+            @load-more="loadMorePools"
           />
-          <BalBtn
-            v-if="!upToMediumBreakpoint"
-            color="blue"
-            size="sm"
-            outline
-            :class="{ 'mt-4': upToMediumBreakpoint }"
-            :block="upToMediumBreakpoint"
-            @click="navigateToCreatePool"
-          >
-            {{ $t('createAPool.title') }}
-          </BalBtn>
-        </div>
+          <div v-if="isElementSupported" class="p-4 xl:p-0 mt-16">
+            <FeaturedProtocols />
+          </div>
+        </BalStack>
       </div>
-      <PoolsTable
-        :data="pools"
-        :noPoolsLabel="$t('noPoolsFound')"
-        :isLoading="isLoading"
-        :selectedTokens="selectedTokens"
-        class="mb-8"
-        :hiddenColumns="['migrate', 'actions', 'lockEndDate']"
-        :isLoadingMore="poolsIsFetchingNextPage"
-        :isPaginated="isPaginated"
-        skeletonClass="pools-table-loading-height"
-        @load-more="loadMorePools"
-      />
-      <div v-if="isElementSupported" class="p-4 xl:p-0 mt-16">
-        <FeaturedProtocols />
-      </div>
-    </BalStack>
+    </Transition>
   </div>
 </template>
 

--- a/src/pages/pool/_id.vue
+++ b/src/pages/pool/_id.vue
@@ -193,99 +193,101 @@ watch(poolQuery.error, () => {
 </script>
 
 <template>
-  <div class="xl:container lg:px-4 pt-8 xl:mx-auto">
-    <StakingProvider :poolAddress="getAddressFromPoolId(poolId)">
-      <div
-        class="grid grid-cols-1 lg:grid-cols-3 gap-x-0 lg:gap-x-4 xl:gap-x-8 gap-y-8"
-      >
-        <PoolPageHeader
-          :loadingPool="loadingPool"
-          :loadingApr="loadingApr"
-          :pool="pool"
-          :poolApr="poolApr"
-          :isStableLikePool="isStableLikePool"
-          :noInitLiquidity="noInitLiquidity"
-          :titleTokens="titleTokens"
-          :missingPrices="missingPrices"
-          :isLiquidityBootstrappingPool="isLiquidityBootstrappingPool"
-          :isComposableStableLikePool="isComposableStableLikePool"
-        />
-        <div class="hidden lg:block" />
-        <div class="order-2 lg:order-1 col-span-2">
-          <div class="grid grid-cols-1 gap-y-8">
-            <div class="px-4 lg:px-0">
-              <PoolChart
-                :historicalPrices="historicalPrices"
-                :snapshots="snapshots"
-                :loading="isLoadingSnapshots"
-                :totalLiquidity="pool?.totalLiquidity"
-                :tokensList="pool?.tokensList"
-                :poolType="pool?.poolType"
-                :poolPremintedBptIndex="poolPremintedBptIndex"
-              />
-            </div>
-            <div class="px-4 lg:px-0 mb-4">
-              <PoolStatCards
-                :pool="pool"
-                :poolApr="poolApr"
-                :loading="loadingPool"
-                :loadingApr="loadingApr"
-              />
-              <ApyVisionPoolLink
-                v-if="!loadingPool && pool"
-                :poolId="pool.id"
-                :tokens="titleTokens"
-              />
-            </div>
-            <div class="mb-4">
-              <h4 class="px-4 lg:px-0 mb-4" v-text="$t('poolComposition')" />
-              <BalLoadingBlock v-if="loadingPool" class="h-64" />
-              <PoolCompositionCard v-else-if="pool" :pool="pool" />
-            </div>
+  <Transition appear name="appear">
+    <div class="xl:container lg:px-4 pt-8 xl:mx-auto">
+      <StakingProvider :poolAddress="getAddressFromPoolId(poolId)">
+        <div
+          class="grid grid-cols-1 lg:grid-cols-3 gap-x-0 lg:gap-x-4 xl:gap-x-8 gap-y-8"
+        >
+          <PoolPageHeader
+            :loadingPool="loadingPool"
+            :loadingApr="loadingApr"
+            :pool="pool"
+            :poolApr="poolApr"
+            :isStableLikePool="isStableLikePool"
+            :noInitLiquidity="noInitLiquidity"
+            :titleTokens="titleTokens"
+            :missingPrices="missingPrices"
+            :isLiquidityBootstrappingPool="isLiquidityBootstrappingPool"
+            :isComposableStableLikePool="isComposableStableLikePool"
+          />
+          <div class="hidden lg:block" />
+          <div class="order-2 lg:order-1 col-span-2">
+            <div class="grid grid-cols-1 gap-y-8">
+              <div class="px-4 lg:px-0">
+                <PoolChart
+                  :historicalPrices="historicalPrices"
+                  :snapshots="snapshots"
+                  :loading="isLoadingSnapshots"
+                  :totalLiquidity="pool?.totalLiquidity"
+                  :tokensList="pool?.tokensList"
+                  :poolType="pool?.poolType"
+                  :poolPremintedBptIndex="poolPremintedBptIndex"
+                />
+              </div>
+              <div class="px-4 lg:px-0 mb-4">
+                <PoolStatCards
+                  :pool="pool"
+                  :poolApr="poolApr"
+                  :loading="loadingPool"
+                  :loadingApr="loadingApr"
+                />
+                <ApyVisionPoolLink
+                  v-if="!loadingPool && pool"
+                  :poolId="pool.id"
+                  :tokens="titleTokens"
+                />
+              </div>
+              <div class="mb-4">
+                <h4 class="px-4 lg:px-0 mb-4" v-text="$t('poolComposition')" />
+                <BalLoadingBlock v-if="loadingPool" class="h-64" />
+                <PoolCompositionCard v-else-if="pool" :pool="pool" />
+              </div>
 
-            <div ref="intersectionSentinel" />
-            <template v-if="isSentinelIntersected && pool">
-              <PoolTransactionsCard :pool="pool" :loading="loadingPool" />
-              <PoolContractDetails :pool="pool" />
-            </template>
+              <div ref="intersectionSentinel" />
+              <template v-if="isSentinelIntersected && pool">
+                <PoolTransactionsCard :pool="pool" :loading="loadingPool" />
+                <PoolContractDetails :pool="pool" />
+              </template>
+            </div>
+          </div>
+
+          <div
+            v-if="!isLiquidityBootstrappingPool"
+            class="order-1 lg:order-2 px-4 lg:px-0"
+          >
+            <BalStack vertical>
+              <BalLoadingBlock
+                v-if="loadingPool || !pool"
+                class="mb-4 h-60 pool-actions-card"
+              />
+              <MyPoolBalancesCard
+                v-else-if="!noInitLiquidity"
+                :pool="pool"
+                :missingPrices="missingPrices"
+                class="mb-4"
+              />
+
+              <BalLoadingBlock
+                v-if="loadingPool"
+                class="h-40 pool-actions-card"
+              />
+              <StakingIncentivesCard
+                v-if="isStakablePool && !loadingPool && pool"
+                :pool="pool"
+                class="staking-incentives"
+              />
+              <PoolLockingCard
+                v-if="_isVeBalPool && !loadingPool && pool"
+                :pool="pool"
+                class="pool-locking"
+              />
+            </BalStack>
           </div>
         </div>
-
-        <div
-          v-if="!isLiquidityBootstrappingPool"
-          class="order-1 lg:order-2 px-4 lg:px-0"
-        >
-          <BalStack vertical>
-            <BalLoadingBlock
-              v-if="loadingPool || !pool"
-              class="mb-4 h-60 pool-actions-card"
-            />
-            <MyPoolBalancesCard
-              v-else-if="!noInitLiquidity"
-              :pool="pool"
-              :missingPrices="missingPrices"
-              class="mb-4"
-            />
-
-            <BalLoadingBlock
-              v-if="loadingPool"
-              class="h-40 pool-actions-card"
-            />
-            <StakingIncentivesCard
-              v-if="isStakablePool && !loadingPool && pool"
-              :pool="pool"
-              class="staking-incentives"
-            />
-            <PoolLockingCard
-              v-if="_isVeBalPool && !loadingPool && pool"
-              :pool="pool"
-              class="pool-locking"
-            />
-          </BalStack>
-        </div>
-      </div>
-    </StakingProvider>
-  </div>
+      </StakingProvider>
+    </div>
+  </Transition>
 </template>
 
 <style scoped>

--- a/src/pages/pool/migrate.vue
+++ b/src/pages/pool/migrate.vue
@@ -22,14 +22,17 @@ const poolMigrationInfo = POOL_MIGRATIONS.find(
 </script>
 
 <template>
-  <MigrateForm
-    v-if="poolMigrationInfo"
-    :poolMigrationInfo="poolMigrationInfo"
-  />
-  <div v-else class="text-center">
-    <div class="text-lg font-semibold">
-      {{ $t('migratePool.errorLoadingMigration.title') }}
+  <Transition appear name="appear">
+    <MigrateForm
+      v-if="poolMigrationInfo"
+      :poolMigrationInfo="poolMigrationInfo"
+    />
+
+    <div v-else class="text-center">
+      <div class="text-lg font-semibold">
+        {{ $t('migratePool.errorLoadingMigration.title') }}
+      </div>
+      <div>{{ $t('migratePool.errorLoadingMigration.description') }}</div>
     </div>
-    <div>{{ $t('migratePool.errorLoadingMigration.description') }}</div>
-  </div>
+  </Transition>
 </template>

--- a/src/pages/pool/withdraw.vue
+++ b/src/pages/pool/withdraw.vue
@@ -48,35 +48,37 @@ onMounted(() => resetTabs());
 </script>
 
 <template>
-  <div class="px-4 sm:px-0 mx-auto max-w-md">
-    <BalLoadingBlock v-if="isLoading || !pool" class="h-96" />
-    <BalCard v-else shadow="xl" exposeOverflow noBorder>
-      <template #header>
-        <div class="w-full">
-          <div class="text-xs leading-none text-secondary">
-            {{ network.chainName }}
+  <Transition appear name="appear">
+    <div class="px-4 sm:px-0 mx-auto max-w-md">
+      <BalLoadingBlock v-if="isLoading || !pool" class="h-96" />
+      <BalCard v-else shadow="xl" exposeOverflow noBorder>
+        <template #header>
+          <div class="w-full">
+            <div class="text-xs leading-none text-secondary">
+              {{ network.chainName }}
+            </div>
+            <div class="flex justify-between items-center">
+              <h4>{{ $t('withdrawFromPool') }}</h4>
+              <TradeSettingsPopover :context="TradeSettingsContext.invest" />
+            </div>
+            <BalTabs
+              v-if="isDeepPool && isPreMintedBptPool"
+              v-model="activeTab"
+              :tabs="tabs"
+              class="p-0 m-0 -mb-px whitespace-nowrap"
+              noPad
+            />
           </div>
-          <div class="flex justify-between items-center">
-            <h4>{{ $t('withdrawFromPool') }}</h4>
-            <TradeSettingsPopover :context="TradeSettingsContext.invest" />
-          </div>
-          <BalTabs
-            v-if="isDeepPool && isPreMintedBptPool"
-            v-model="activeTab"
-            :tabs="tabs"
-            class="p-0 m-0 -mb-px whitespace-nowrap"
-            noPad
-          />
-        </div>
-      </template>
-      <ExitPoolProvider
-        v-if="isDeepPool"
-        :isSingleAssetExit="activeTab === Tab.SingleToken"
-        :pool="pool"
-      >
-        <WithdrawFormV2 />
-      </ExitPoolProvider>
-      <WithdrawForm v-else :pool="pool" />
-    </BalCard>
-  </div>
+        </template>
+        <ExitPoolProvider
+          v-if="isDeepPool"
+          :isSingleAssetExit="activeTab === Tab.SingleToken"
+          :pool="pool"
+        >
+          <WithdrawFormV2 />
+        </ExitPoolProvider>
+        <WithdrawForm v-else :pool="pool" />
+      </BalCard>
+    </div>
+  </Transition>
 </template>

--- a/src/pages/portfolio.vue
+++ b/src/pages/portfolio.vue
@@ -12,25 +12,27 @@ const { lockPool, lock } = useLock();
 </script>
 
 <template>
-  <StakingProvider>
-    <PortfolioPageHero />
-    <div class="xl:container xl:px-4 pt-10 md:pt-12 xl:mx-auto">
-      <BalStack vertical>
-        <div class="px-4 xl:px-0">
-          <BalStack horizontal justify="between" align="center">
-            <h3>{{ $t('myLiquidityInBalancerPools') }}</h3>
+  <Transition appear name="appear">
+    <StakingProvider>
+      <PortfolioPageHero />
+      <div class="xl:container xl:px-4 pt-10 md:pt-12 xl:mx-auto">
+        <BalStack vertical>
+          <div class="px-4 xl:px-0">
+            <BalStack horizontal justify="between" align="center">
+              <h3>{{ $t('myLiquidityInBalancerPools') }}</h3>
+            </BalStack>
+          </div>
+          <BalStack vertical spacing="2xl">
+            <UnstakedPoolsTable />
+            <StakedPoolsTable />
+            <VeBalPoolTable
+              v-if="lockPool && Number(lock?.lockedAmount) > 0"
+              :lock="lock"
+              :lockPool="lockPool"
+            />
           </BalStack>
-        </div>
-        <BalStack vertical spacing="2xl">
-          <UnstakedPoolsTable />
-          <StakedPoolsTable />
-          <VeBalPoolTable
-            v-if="lockPool && Number(lock?.lockedAmount) > 0"
-            :lock="lock"
-            :lockPool="lockPool"
-          />
         </BalStack>
-      </BalStack>
-    </div>
-  </StakingProvider>
+      </div>
+    </StakingProvider>
+  </Transition>
 </template>

--- a/src/pages/privacy-policy.vue
+++ b/src/pages/privacy-policy.vue
@@ -1,431 +1,439 @@
 <template>
-  <div class="pb-4">
-    <div class="subsection">
-      <h1>Balancer Privacy&nbsp;Policy</h1>
-      <p><em>Last Updated: August 2022</em></p>
-      <p>
-        <em class="font-medium">
-          This Privacy Policy explains how the Balancer Foundation, its
-          subsidiary, Balancer OpCo Limited (“Balancer Foundation,” “Balancer,”
-          “we,” “our,” or “us”) collects, uses, and discloses information about
-          you. This Privacy Policy applies when you use our website, Balancer
-          Protocol user-interface or application and other online products
-          (collectively, our “UI”), engage with us on social media, or otherwise
-          interact with us.
-        </em>
-      </p>
-      <p>
-        <em class="font-medium">
-          We may change this Privacy Policy from time to time. If we make
-          changes, we will notify you by revising the date at the top of this
-          policy and, when material, we will provide you with additional notice
-          by adding a statement to our website and consent as required under
-          applicable law. Your continued use of this UI after we make changes is
-          deemed to be acceptance of those changes when permissible. We
-          encourage you to review this Privacy Policy regularly to stay informed
-          about our information practices and the choices available to you.</em
-        >
-      </p>
-    </div>
-    <div class="subsection">
-      <h2>Summary</h2>
-      <ul>
-        <li>
-          Balancer does not typically request, collect or use personal
-          information. With the exception of your wallet address, there is no
-          reason for you to provide personal information when you use the UI.
-        </li>
-        <li>
-          Balancer does not and has not stored personal information from users
-          of the UI. However, Balancer uses third party services including,
-          without limitation, Cloudflare and Fathom Analytics who may collect
-          and store certain user information only for use in the provision of
-          their services.
-        </li>
-        <li>
-          Balancer does not set any cookies. However, it’s possible we may use
-          third party service providers in the future that set cookies.
-        </li>
-      </ul>
-    </div>
-    <div class="subsection">
-      <h2>Collection of Information</h2>
-      <h3>Information You Provide to Us</h3>
-
-      <p>
-        We do not typically request, collect or use personal information from
-        you except under limited circumstances as described herein. With the
-        exception of your wallet address, there is no reason for you to provide
-        personal information when you use the UI. Your use of the UI will not be
-        customized and this policy reflects that practice.
-      </p>
-      <p>
-        Balancer is not directed to children under the age of 16. If a parent or
-        guardian becomes aware that his or her child has provided us with
-        personal information without your consent, please contact us at
-        <a class="link" href="mailto:privacypolicy@balancer.finance"
-          >privacypolicy@balancer.finance</a
-        >. If we become aware that a child under the age of 16 has provided us
-        with personal information, we will take reasonable efforts to delete
-        such personal information.
-      </p>
-
-      <h3>
-        Information We Collect Automatically When You Interact With&nbsp;Us
-      </h3>
-      <p>
-        When you access or use our UI, we may automatically collect certain
-        information, including:
-      </p>
-      <ul>
-        <li>
-          <em class="font-semibold"> Device and Usage Information:</em> We (and
-          our service providers) collect information about how you access the
-          UI, including data about the device and network you use, such as your
-          hardware model, operating system version, mobile network, browser
-          type, IP address and app version. We do not typically, but we may,
-          also collect information about your activity on the UI, such as access
-          times, pages viewed, links clicked, and the page you visited before
-          navigating to the UI.
-        </li>
-        <li>
-          <em class="font-semibold"
-            >Information Collected by Cookies and Similar Tracking
-            Technologies:</em
+  <Transition appear name="appear">
+    <div class="pb-4">
+      <div class="subsection">
+        <h1>Balancer Privacy&nbsp;Policy</h1>
+        <p><em>Last Updated: August 2022</em></p>
+        <p>
+          <em class="font-medium">
+            This Privacy Policy explains how the Balancer Foundation, its
+            subsidiary, Balancer OpCo Limited (“Balancer Foundation,”
+            “Balancer,” “we,” “our,” or “us”) collects, uses, and discloses
+            information about you. This Privacy Policy applies when you use our
+            website, Balancer Protocol user-interface or application and other
+            online products (collectively, our “UI”), engage with us on social
+            media, or otherwise interact with us.
+          </em>
+        </p>
+        <p>
+          <em class="font-medium">
+            We may change this Privacy Policy from time to time. If we make
+            changes, we will notify you by revising the date at the top of this
+            policy and, when material, we will provide you with additional
+            notice by adding a statement to our website and consent as required
+            under applicable law. Your continued use of this UI after we make
+            changes is deemed to be acceptance of those changes when
+            permissible. We encourage you to review this Privacy Policy
+            regularly to stay informed about our information practices and the
+            choices available to you.</em
           >
-          We do not typically use tracking technologies, such as cookies and web
-          beacons, to collect information about you. Cookies are small data
-          files stored on your hard drive or in device memory that help us
-          improve the UI and your experience, see which areas and features of
-          the UI are popular, and count visits. Web beacons (also known as
-          “pixel tags” or “clear GIFs”) are electronic images that we use on the
-          UI to help deliver cookies, count visits, and understand usage and
-          campaign effectiveness. For more information about cookies and how to
-          disable them, see our
+        </p>
+      </div>
+      <div class="subsection">
+        <h2>Summary</h2>
+        <ul>
+          <li>
+            Balancer does not typically request, collect or use personal
+            information. With the exception of your wallet address, there is no
+            reason for you to provide personal information when you use the UI.
+          </li>
+          <li>
+            Balancer does not and has not stored personal information from users
+            of the UI. However, Balancer uses third party services including,
+            without limitation, Cloudflare and Fathom Analytics who may collect
+            and store certain user information only for use in the provision of
+            their services.
+          </li>
+          <li>
+            Balancer does not set any cookies. However, it’s possible we may use
+            third party service providers in the future that set cookies.
+          </li>
+        </ul>
+      </div>
+      <div class="subsection">
+        <h2>Collection of Information</h2>
+        <h3>Information You Provide to Us</h3>
+
+        <p>
+          We do not typically request, collect or use personal information from
+          you except under limited circumstances as described herein. With the
+          exception of your wallet address, there is no reason for you to
+          provide personal information when you use the UI. Your use of the UI
+          will not be customized and this policy reflects that practice.
+        </p>
+        <p>
+          Balancer is not directed to children under the age of 16. If a parent
+          or guardian becomes aware that his or her child has provided us with
+          personal information without your consent, please contact us at
+          <a class="link" href="mailto:privacypolicy@balancer.finance"
+            >privacypolicy@balancer.finance</a
+          >. If we become aware that a child under the age of 16 has provided us
+          with personal information, we will take reasonable efforts to delete
+          such personal information.
+        </p>
+
+        <h3>
+          Information We Collect Automatically When You Interact With&nbsp;Us
+        </h3>
+        <p>
+          When you access or use our UI, we may automatically collect certain
+          information, including:
+        </p>
+        <ul>
+          <li>
+            <em class="font-semibold"> Device and Usage Information:</em> We
+            (and our service providers) collect information about how you access
+            the UI, including data about the device and network you use, such as
+            your hardware model, operating system version, mobile network,
+            browser type, IP address and app version. We do not typically, but
+            we may, also collect information about your activity on the UI, such
+            as access times, pages viewed, links clicked, and the page you
+            visited before navigating to the UI.
+          </li>
+          <li>
+            <em class="font-semibold"
+              >Information Collected by Cookies and Similar Tracking
+              Technologies:</em
+            >
+            We do not typically use tracking technologies, such as cookies and
+            web beacons, to collect information about you. Cookies are small
+            data files stored on your hard drive or in device memory that help
+            us improve the UI and your experience, see which areas and features
+            of the UI are popular, and count visits. Web beacons (also known as
+            “pixel tags” or “clear GIFs”) are electronic images that we use on
+            the UI to help deliver cookies, count visits, and understand usage
+            and campaign effectiveness. For more information about cookies and
+            how to disable them, see our
+            <router-link :to="{ name: 'cookies-policy' }">
+              <span className="link">Cookies Policy</span>
+            </router-link>
+            and the Your Choices section below.
+          </li>
+        </ul>
+
+        <h3>Information We Collect from Other&nbsp;Sources</h3>
+
+        <p>
+          We do not typically obtain information from third-party sources in
+          order to provide business services. We do not sell information we
+          collect.
+        </p>
+
+        <h3>Information We Derive</h3>
+
+        <p>
+          We may derive limited information or draw inferences about you based
+          on the information we have access to or receive, most importantly,
+          from our service providers. Your wallet and IP address is accessible
+          to Balancer and its vendor(s). We may make inferences about you based
+          on your wallet or IP address.
+        </p>
+      </div>
+      <div class="subsection">
+        <h2>Use of Information</h2>
+
+        <p>
+          We do not collect your personal information, other than wallet
+          address, to customize the UI for your use. However, we reserve the
+          ability to use information we collect to provide, maintain, administer
+          and/or improve the UI. We may also use the information we collect to:
+        </p>
+        <ul>
+          <li>Ensure proper functioning of Balancer and the UI;</li>
+          <li>
+            Provide services, content, material and other information on the UI;
+          </li>
+          <li>Identify and/or diagnose problems on or related to the UI;</li>
+          <li>
+            Send technical notices, security alerts, and support and
+            administrative messages;
+          </li>
+          <li>
+            Provide requested information, technical support and/or integrations
+            such as an application programming interface or API;
+          </li>
+          <li>Respond to comments and questions;</li>
+          <li>
+            Analyze trends, usage, and activities in connection with the UI;
+          </li>
+          <li>
+            Detect, investigate, and prevent security incidents and other
+            malicious, deceptive, fraudulent, or illegal activity and protect
+            the rights and property of Balancer and others;
+          </li>
+          <li>Debug to identify and repair errors in the UI;</li>
+          <li>Comply with legal, regulatory and financial obligations;</li>
+          <li>
+            Carry out any other purpose described to you at the time the
+            information was collected; and
+          </li>
+          <li>
+            For other reasonable internal use or uses aligned with your
+            relationship with us and the context in which we collected the
+            information.
+          </li>
+        </ul>
+      </div>
+      <div class="subsection">
+        <h2>Sharing of Information</h2>
+
+        <p>
+          We do not have access to or share personally identifiable information,
+          other than as described herein, in the normal course of Balancer
+          business. However, when Balancer has access to personal information,
+          such as your wallet and certain IP addresses, it may share that
+          information in the following circumstances or as otherwise described
+          in this policy:
+        </p>
+        <ul>
+          <li>
+            We share personal information with vendors, service providers, and
+            consultants that need access to personal information in order to
+            perform services for us, such as transaction monitoring, data
+            management, fraud prevention, customer service and support,
+            marketing and/or advertising.
+          </li>
+          <li>
+            If you choose to use integrations, we may share certain information
+            with the integration partners.
+          </li>
+          <li>
+            We may disclose personal information if we believe that disclosure
+            is in accordance with, or required by, any applicable law or legal
+            process, including lawful requests by public authorities to meet
+            national security or law enforcement requirements.
+          </li>
+          <li>
+            We may share personal information if we believe that your actions
+            are inconsistent with our user agreements or policies, if we believe
+            that you have violated the law, or if we believe it is necessary to
+            protect the rights, property, and safety of Balancer, the Balancer
+            ecosystem, the public, or others.
+          </li>
+          <li>
+            We share personal information with our lawyers and other
+            professional advisors where necessary to obtain advice or otherwise
+            protect and manage our business interests.
+          </li>
+          <li>
+            We may share personal information in connection with, or during
+            negotiations concerning, merger, sale of company assets, financing,
+            bankruptcy, business closure, or acquisition of all or a portion of
+            our assets. Additionally, as part of such an event, we may transfer
+            or sell personal information to a third party. We will provide
+            notice to you on our UI of any such sharing to a third party and any
+            choices you may have regarding the sharing of your personal
+            information.
+          </li>
+          <li>
+            Personal information may be shared between and among Balancer and
+            our current and future parents, affiliates, and subsidiaries and
+            other companies under common control and ownership (“corporate
+            affiliates”). This information may be used to provide you with
+            offers, services, or products that may be of interest to you and
+            provide you with their products and services. Any such corporate
+            affiliate may use your personal information only according to the
+            terms of this Policy. If you are located in a jurisdiction where
+            such sharing requires your permission, we will only share such
+            information with your consent. If you decide you no longer wish to
+            receive these promotional communications, please follow the
+            instructions provided in Your Choices section below.
+          </li>
+          <li>
+            We share personal information with your consent or at your
+            direction.
+          </li>
+          <li>
+            We also share aggregated or de-identified information that cannot
+            reasonably be used to identify you.
+          </li>
+        </ul>
+      </div>
+      <div class="subsection">
+        <h2>Advertising and Analytics</h2>
+
+        <p>
+          We do not work with third parties to serve ads to you as part of
+          customized campaigns on the UI or third-party UIs.
+        </p>
+      </div>
+      <div class="subsection">
+        <h2>
+          Transfer of information to the United States and Other&nbsp;Countries
+        </h2>
+
+        <p>
+          Balancer Foundation is headquartered in the Cayman Islands with a
+          subsidiary in the British Virgin Islands (BVI). Therefore, we and our
+          service providers may transfer your personal information to, or store
+          or access it in, jurisdictions that may not provide levels of data
+          protection that are equivalent to those of your home jurisdiction. We
+          will take steps to ensure that your personal information receives an
+          adequate level of protection in the jurisdictions in which we process
+          it.
+        </p>
+      </div>
+      <div class="subsection">
+        <h2>Your Choices</h2>
+        <h3>Cookies</h3>
+        <p>
+          Balancer does not typically use any cookies. It reserves the ability
+          to use them to affect the availability and functionality of the UI.
+          For more information about cookies and how to disable them, see our
           <router-link :to="{ name: 'cookies-policy' }">
-            <span className="link">Cookies Policy</span>
-          </router-link>
-          and the Your Choices section below.
-        </li>
-      </ul>
+            <span
+              className="text-blue-500 hover:text-blue-800 transition-colors"
+              >Cookies Policy</span
+            > </router-link
+          >.
+        </p>
+      </div>
+      <div class="subsection">
+        <h2>Additional Considerations</h2>
 
-      <h3>Information We Collect from Other&nbsp;Sources</h3>
+        <p>
+          In the preceding 12 months, we or our vendors may have collected the
+          following categories of personal information: identifiers, internet or
+          other electronic network activity information and inferences. For
+          details about the data points we collect and the categories of sources
+          of such collection, please see the Collection of Information section
+          above. We collect personal information for the purposes described in
+          the Use of Information section above. In the preceding 12 months, we
+          have disclosed the following categories of personal information for
+          business purposes to the following categories of recipients:
+        </p>
 
-      <p>
-        We do not typically obtain information from third-party sources in order
-        to provide business services. We do not sell information we collect.
-      </p>
+        <table border="1" cellpadding="0" cellspacing="0" style="width: 100%">
+          <tr>
+            <th>Category of Personal Information</th>
+            <th>Type of Information &amp; Categories of Recipients</th>
+          </tr>
+          <tr>
+            <td>Identifiers</td>
+            <td>
+              <p>
+                We share with vendors, such CloudFlare and Fathom Analytics:
+                certain IP addresses, device identifiers or other similar
+                identifiers.
+              </p>
 
-      <h3>Information We Derive</h3>
+              <p>
+                With our compliance partner, TRM Labs, we only share wallet
+                addresses used to connect a wallet to our UI (all other user
+                information like IP addresses, device identifiers and location
+                are not shared). The code for the UI is open source, and can be
+                reviewed by anyone at any time.
+              </p>
+            </td>
+          </tr>
+          <tr>
+            <td>Internet or other electronic network activity information</td>
+            <td>
+              We share with vendors: information regarding an interaction with
+              an UI/website
+            </td>
+          </tr>
+        </table>
 
-      <p>
-        We may derive limited information or draw inferences about you based on
-        the information we have access to or receive, most importantly, from our
-        service providers. Your wallet and IP address is accessible to Balancer
-        and its vendor(s). We may make inferences about you based on your wallet
-        or IP address.
-      </p>
+        <p>
+          Balancer does not “sell” personal information to advertise our
+          products to you or otherwise.
+        </p>
+
+        <p>
+          Subject to certain limitations, you have the right to (1) request to
+          know more about the categories and specific pieces of personal
+          information we collect, use, and disclose, and sell, (2) request
+          deletion of your personal information, (3) opt out of any “sales” of
+          your personal information that may be occurring, and (4) not be
+          discriminated against for exercising these rights. You may make these
+          requests by emailing us at
+          <a class="link" href="mailto:privacypolicy@balancer.finance"
+            >privacypolicy@balancer.finance</a
+          >. If we receive your request from an authorized agent, we may ask for
+          evidence that you have provided such agent with a power of attorney or
+          that the agent otherwise has valid written authority to submit
+          requests to exercise rights on your behalf. If you are an authorized
+          agent seeking to make a request, please contact us.
+        </p>
+
+        <h3>Shine the Light</h3>
+
+        <p>
+          Balancer does not share such information with third parties for direct
+          marketing purposes.
+        </p>
+
+        <h3>Do Not Track Signals</h3>
+
+        <p>
+          Our Services do not respond to “Do Not Track” signals communicated by
+          your browser. We do not knowingly retain or sell tracking information
+          collected about your online activity. For more information about Do
+          Not Track, please visit
+          <a class="link" target="_blank" href="https://allaboutdnt.com/"
+            >www.allaboutdnt.com</a
+          >.
+        </p>
+      </div>
+      <div class="subsection">
+        <h2>Additional Disclousures for Individuals in Europe</h2>
+
+        <p>
+          If you are located in the European Economic Area (EEA), the United
+          Kingdom, or Switzerland, you have certain rights and protections under
+          the law regarding the processing of your personal data, and this
+          section applies to you.
+        </p>
+        <h3>Legal Basis for Processing</h3>
+
+        <p>
+          Balancer does not typically process user personal data. If Balancer
+          processes data, such as a wallet address and certain IP addresses, it
+          will do so in reliance on the following lawful bases:
+        </p>
+        <ul>
+          <li>
+            To perform our responsibilities under our contract with you (e.g.,
+            providing access to the UI you requested).
+          </li>
+          <li>
+            When we have a legitimate interest in processing your personal data
+            to operate the UI or protect our interests (e.g., to adhere with
+            applicable laws, rules and regulations, provide, maintain, and
+            improve our products and UI, conduct data analytics, and communicate
+            with you).
+          </li>
+          <li>To comply with our legal obligations.</li>
+        </ul>
+        <h3>Data Retention</h3>
+
+        <p>
+          We do not maintain customer accounts or store personal data. Our
+          vendor will store your wallet address in order to provide requested
+          services.
+        </p>
+        <h3>Data Subject Requests</h3>
+        <p>
+          Subject to certain limitations, you have the right to request access
+          to the personal data we hold about you and to receive your data in a
+          portable format, the right to ask that your personal data be corrected
+          or erased, and the right to object to, or request that we restrict,
+          certain processing. Balancer does not typically hold or store such
+          personal data.
+        </p>
+      </div>
+      <div>
+        <h2>Contact Us</h2>
+
+        <p>
+          If you have any questions about this Privacy Policy, please contact us
+          at
+          <a class="link" href="mailto:privacypolicy@balancer.finance"
+            >privacypolicy@balancer.finance</a
+          >.
+        </p>
+      </div>
     </div>
-    <div class="subsection">
-      <h2>Use of Information</h2>
-
-      <p>
-        We do not collect your personal information, other than wallet address,
-        to customize the UI for your use. However, we reserve the ability to use
-        information we collect to provide, maintain, administer and/or improve
-        the UI. We may also use the information we collect to:
-      </p>
-      <ul>
-        <li>Ensure proper functioning of Balancer and the UI;</li>
-        <li>
-          Provide services, content, material and other information on the UI;
-        </li>
-        <li>Identify and/or diagnose problems on or related to the UI;</li>
-        <li>
-          Send technical notices, security alerts, and support and
-          administrative messages;
-        </li>
-        <li>
-          Provide requested information, technical support and/or integrations
-          such as an application programming interface or API;
-        </li>
-        <li>Respond to comments and questions;</li>
-        <li>
-          Analyze trends, usage, and activities in connection with the UI;
-        </li>
-        <li>
-          Detect, investigate, and prevent security incidents and other
-          malicious, deceptive, fraudulent, or illegal activity and protect the
-          rights and property of Balancer and others;
-        </li>
-        <li>Debug to identify and repair errors in the UI;</li>
-        <li>Comply with legal, regulatory and financial obligations;</li>
-        <li>
-          Carry out any other purpose described to you at the time the
-          information was collected; and
-        </li>
-        <li>
-          For other reasonable internal use or uses aligned with your
-          relationship with us and the context in which we collected the
-          information.
-        </li>
-      </ul>
-    </div>
-    <div class="subsection">
-      <h2>Sharing of Information</h2>
-
-      <p>
-        We do not have access to or share personally identifiable information,
-        other than as described herein, in the normal course of Balancer
-        business. However, when Balancer has access to personal information,
-        such as your wallet and certain IP addresses, it may share that
-        information in the following circumstances or as otherwise described in
-        this policy:
-      </p>
-      <ul>
-        <li>
-          We share personal information with vendors, service providers, and
-          consultants that need access to personal information in order to
-          perform services for us, such as transaction monitoring, data
-          management, fraud prevention, customer service and support, marketing
-          and/or advertising.
-        </li>
-        <li>
-          If you choose to use integrations, we may share certain information
-          with the integration partners.
-        </li>
-        <li>
-          We may disclose personal information if we believe that disclosure is
-          in accordance with, or required by, any applicable law or legal
-          process, including lawful requests by public authorities to meet
-          national security or law enforcement requirements.
-        </li>
-        <li>
-          We may share personal information if we believe that your actions are
-          inconsistent with our user agreements or policies, if we believe that
-          you have violated the law, or if we believe it is necessary to protect
-          the rights, property, and safety of Balancer, the Balancer ecosystem,
-          the public, or others.
-        </li>
-        <li>
-          We share personal information with our lawyers and other professional
-          advisors where necessary to obtain advice or otherwise protect and
-          manage our business interests.
-        </li>
-        <li>
-          We may share personal information in connection with, or during
-          negotiations concerning, merger, sale of company assets, financing,
-          bankruptcy, business closure, or acquisition of all or a portion of
-          our assets. Additionally, as part of such an event, we may transfer or
-          sell personal information to a third party. We will provide notice to
-          you on our UI of any such sharing to a third party and any choices you
-          may have regarding the sharing of your personal information.
-        </li>
-        <li>
-          Personal information may be shared between and among Balancer and our
-          current and future parents, affiliates, and subsidiaries and other
-          companies under common control and ownership (“corporate affiliates”).
-          This information may be used to provide you with offers, services, or
-          products that may be of interest to you and provide you with their
-          products and services. Any such corporate affiliate may use your
-          personal information only according to the terms of this Policy. If
-          you are located in a jurisdiction where such sharing requires your
-          permission, we will only share such information with your consent. If
-          you decide you no longer wish to receive these promotional
-          communications, please follow the instructions provided in Your
-          Choices section below.
-        </li>
-        <li>
-          We share personal information with your consent or at your direction.
-        </li>
-        <li>
-          We also share aggregated or de-identified information that cannot
-          reasonably be used to identify you.
-        </li>
-      </ul>
-    </div>
-    <div class="subsection">
-      <h2>Advertising and Analytics</h2>
-
-      <p>
-        We do not work with third parties to serve ads to you as part of
-        customized campaigns on the UI or third-party UIs.
-      </p>
-    </div>
-    <div class="subsection">
-      <h2>
-        Transfer of information to the United States and Other&nbsp;Countries
-      </h2>
-
-      <p>
-        Balancer Foundation is headquartered in the Cayman Islands with a
-        subsidiary in the British Virgin Islands (BVI). Therefore, we and our
-        service providers may transfer your personal information to, or store or
-        access it in, jurisdictions that may not provide levels of data
-        protection that are equivalent to those of your home jurisdiction. We
-        will take steps to ensure that your personal information receives an
-        adequate level of protection in the jurisdictions in which we process
-        it.
-      </p>
-    </div>
-    <div class="subsection">
-      <h2>Your Choices</h2>
-      <h3>Cookies</h3>
-      <p>
-        Balancer does not typically use any cookies. It reserves the ability to
-        use them to affect the availability and functionality of the UI. For
-        more information about cookies and how to disable them, see our
-        <router-link :to="{ name: 'cookies-policy' }">
-          <span className="text-blue-500 hover:text-blue-800 transition-colors"
-            >Cookies Policy</span
-          > </router-link
-        >.
-      </p>
-    </div>
-    <div class="subsection">
-      <h2>Additional Considerations</h2>
-
-      <p>
-        In the preceding 12 months, we or our vendors may have collected the
-        following categories of personal information: identifiers, internet or
-        other electronic network activity information and inferences. For
-        details about the data points we collect and the categories of sources
-        of such collection, please see the Collection of Information section
-        above. We collect personal information for the purposes described in the
-        Use of Information section above. In the preceding 12 months, we have
-        disclosed the following categories of personal information for business
-        purposes to the following categories of recipients:
-      </p>
-
-      <table border="1" cellpadding="0" cellspacing="0" style="width: 100%">
-        <tr>
-          <th>Category of Personal Information</th>
-          <th>Type of Information &amp; Categories of Recipients</th>
-        </tr>
-        <tr>
-          <td>Identifiers</td>
-          <td>
-            <p>
-              We share with vendors, such CloudFlare and Fathom Analytics:
-              certain IP addresses, device identifiers or other similar
-              identifiers.
-            </p>
-
-            <p>
-              With our compliance partner, TRM Labs, we only share wallet
-              addresses used to connect a wallet to our UI (all other user
-              information like IP addresses, device identifiers and location are
-              not shared). The code for the UI is open source, and can be
-              reviewed by anyone at any time.
-            </p>
-          </td>
-        </tr>
-        <tr>
-          <td>Internet or other electronic network activity information</td>
-          <td>
-            We share with vendors: information regarding an interaction with an
-            UI/website
-          </td>
-        </tr>
-      </table>
-
-      <p>
-        Balancer does not “sell” personal information to advertise our products
-        to you or otherwise.
-      </p>
-
-      <p>
-        Subject to certain limitations, you have the right to (1) request to
-        know more about the categories and specific pieces of personal
-        information we collect, use, and disclose, and sell, (2) request
-        deletion of your personal information, (3) opt out of any “sales” of
-        your personal information that may be occurring, and (4) not be
-        discriminated against for exercising these rights. You may make these
-        requests by emailing us at
-        <a class="link" href="mailto:privacypolicy@balancer.finance"
-          >privacypolicy@balancer.finance</a
-        >. If we receive your request from an authorized agent, we may ask for
-        evidence that you have provided such agent with a power of attorney or
-        that the agent otherwise has valid written authority to submit requests
-        to exercise rights on your behalf. If you are an authorized agent
-        seeking to make a request, please contact us.
-      </p>
-
-      <h3>Shine the Light</h3>
-
-      <p>
-        Balancer does not share such information with third parties for direct
-        marketing purposes.
-      </p>
-
-      <h3>Do Not Track Signals</h3>
-
-      <p>
-        Our Services do not respond to “Do Not Track” signals communicated by
-        your browser. We do not knowingly retain or sell tracking information
-        collected about your online activity. For more information about Do Not
-        Track, please visit
-        <a class="link" target="_blank" href="https://allaboutdnt.com/"
-          >www.allaboutdnt.com</a
-        >.
-      </p>
-    </div>
-    <div class="subsection">
-      <h2>Additional Disclousures for Individuals in Europe</h2>
-
-      <p>
-        If you are located in the European Economic Area (EEA), the United
-        Kingdom, or Switzerland, you have certain rights and protections under
-        the law regarding the processing of your personal data, and this section
-        applies to you.
-      </p>
-      <h3>Legal Basis for Processing</h3>
-
-      <p>
-        Balancer does not typically process user personal data. If Balancer
-        processes data, such as a wallet address and certain IP addresses, it
-        will do so in reliance on the following lawful bases:
-      </p>
-      <ul>
-        <li>
-          To perform our responsibilities under our contract with you (e.g.,
-          providing access to the UI you requested).
-        </li>
-        <li>
-          When we have a legitimate interest in processing your personal data to
-          operate the UI or protect our interests (e.g., to adhere with
-          applicable laws, rules and regulations, provide, maintain, and improve
-          our products and UI, conduct data analytics, and communicate with
-          you).
-        </li>
-        <li>To comply with our legal obligations.</li>
-      </ul>
-      <h3>Data Retention</h3>
-
-      <p>
-        We do not maintain customer accounts or store personal data. Our vendor
-        will store your wallet address in order to provide requested services.
-      </p>
-      <h3>Data Subject Requests</h3>
-      <p>
-        Subject to certain limitations, you have the right to request access to
-        the personal data we hold about you and to receive your data in a
-        portable format, the right to ask that your personal data be corrected
-        or erased, and the right to object to, or request that we restrict,
-        certain processing. Balancer does not typically hold or store such
-        personal data.
-      </p>
-    </div>
-    <div>
-      <h2>Contact Us</h2>
-
-      <p>
-        If you have any questions about this Privacy Policy, please contact us
-        at
-        <a class="link" href="mailto:privacypolicy@balancer.finance"
-          >privacypolicy@balancer.finance</a
-        >.
-      </p>
-    </div>
-  </div>
+  </Transition>
 </template>

--- a/src/pages/terms-of-use.vue
+++ b/src/pages/terms-of-use.vue
@@ -1,617 +1,628 @@
 <template>
-  <div class="pb-4">
-    <div class="subsection">
-      <h1>Balancer Terms of Use</h1>
-      <p><em>Last updated: November 2022</em></p>
-      <p>
-        <em class="font-semibold">
-          Do not access this site where such access is prohibited by applicable
-          law. Please carefully read these terms of use before using the site.
-          These terms apply to any person or entity accessing the site and by
-          using the site you agree to be bound by them. The terms of use contain
-          a mandatory individual arbitration and class action/jury trial waiver
-          provision that requires the use of arbitration on an individual basis
-          to resolve disputes, rather than jury trials or class actions. If you
-          do not want to be bound by these terms of use, you should not access
-          the site. By using the site in any capacity, you agree that you have
-          read, understood, and agree to be subject to these terms of use.</em
-        >
-      </p>
-    </div>
-    <div class="subsection">
-      <h2>1. Overview</h2>
-      <p>
-        This Balancer Terms of Use document (“Terms” or “agreement”) (“Balancer
-        ”, “we” and “us” refers to the Balancer Foundation and its subsidiary
-        Balancer OpCo Limited) covers the website, Balancer Protocol
-        user-interface and free application (collectively “the Site”) we own and
-        administer, at times in conjunction with others, which provides the
-        ability to access the decentralized Balancer Protocol. Additionally, you
-        can access the Balancer Protocol through third-party web or mobile
-        interfaces. These Terms apply to you (“You” or “you”) as a user of our
-        Site including all the products, services, tools and information,
-        without limitation, made available on the Site.
-      </p>
-      <p>
-        You must be able to form a legally binding contract online either as an
-        individual or on behalf of a legal entity. You represent that, if you
-        are agreeing to these Terms on behalf of a legal entity, you have the
-        legal authority to bind that entity to these Terms and you are not
-        indirectly or directly included on any sanctions list and at least 18
-        years old or the age of majority where you reside, (whichever is older)
-        can form a legally binding contract online, and have the full, right,
-        power and authority to enter into and to comply with the obligations
-        under these Terms.
-      </p>
-      <p>
-        You are advised to periodically review these Terms so you understand any
-        changes to the Terms. Balancer in its sole discretion, reserves the
-        right to make changes to our Terms. Changes are binding on users of the
-        Site and will take effect immediately upon posting. As a user, you agree
-        to be bound by any changes, variations, or modifications to our Terms
-        and your continued use of the Site shall constitute acceptance of any
-        such changes, revisions, variations, or modifications. When we make
-        changes, we will make the updated Terms available on the interface and
-        update the “Last Updated” date at the beginning of the Terms
-        accordingly.
-      </p>
-      <p>
-        You accept such changes, by continuing to use the Site and by doing so
-        you agree that we have provided you with sufficient notice of such
-        change. Our
-        <router-link :to="{ name: 'privacy-policy' }">
-          <span className="link">Privacy Policy</span>
-        </router-link>
-        and
-        <router-link :to="{ name: 'cookies-policy' }">
-          <span className="link">Cookies Policy</span>
-        </router-link>
-        also apply to your access and use of the Site. You are entering into a
-        binding Agreement. Any failure by us to exercise any rights or
-        provisions of the Agreement shall not constitute a waiver of such right
-        or provision.
-      </p>
-    </div>
-    <div class="subsection">
-      <h2>2. Site</h2>
-      <p>
-        As part of the Site, Balancer provides access to a decentralized finance
-        application (“Application” or “Balancer Protocol app”) on the Ethereum
-        blockchain, that allows swappers or liquidity providers of Ethereum
-        assets (“Cryptocurrency Assets”) to transact using smart contracts
-        (“Smart Contracts”). Use of the Balancer Protocol may require that you
-        pay a fee, such as gas charges on the Ethereum network to perform a
-        transaction. You acknowledge and agree that Balancer has no control over
-        any activities, transactions, the method of payment of any transactions,
-        or any actual processing of payments of transactions. You must ensure
-        that you have a sufficient balance to complete any transaction on the
-        Balancer Protocol before initiating such transaction. You should not
-        take or refrain from taking any action based on any information
-        contained on the Site or any other available information at any time.
-        Before you make any legal, technical, or financial decisions involving
-        the Services, you should seek independent professional advice from a
-        licensed and qualified individual in the area for which such advice
-        would be appropriate.
-      </p>
-      <p>
-        You acknowledge and agree that Balancer has no control over any
-        transactions conducted through the Balancer Protocol, the method of
-        payment of any transactions or any actual payments of transactions
-        including use of any third-party services such as Metamask, or other
-        wallet services. Likewise, you must ensure that you have a sufficient
-        balance of the applicable cryptocurrency tokens stored at your Balancer
-        Protocol-compatible wallet address (“Cryptocurrency Wallet”) to complete
-        any transaction on the Balancer Protocol or the Ethereum network before
-        initiating such transaction.
-      </p>
-    </div>
-    <div class="subsection">
-      <h2>3. Access / Disclaimer of Warranties</h2>
-      <p>
-        ACCESS TO THIS SITE AND THE PRODUCTS HEREIN ARE PROVIDED ON AN 'AS IS'
-        AND 'AS AVAILABLE' BASIS WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS
-        OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
-        MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT.
-        NO WARRANTY IS PROVIDED THAT THE SITE OR ANY PRODUCT WILL BE FREE FROM
-        DEFECTS OR VIRUSES OR THAT OPERATION OF THE PRODUCT WILL BE
-        UNINTERRUPTED. YOUR USE OF THE SITE AND ANY PRODUCT AND ANY MATERIAL OR
-        SERVICES OBTAINED OR ACCESSED VIA THE SITE IS AT YOUR OWN DISCRETION AND
-        RISK, AND YOU ARE SOLELY RESPONSIBLE FOR ANY DAMAGE RESULTING FROM THEIR
-        USE. SOME JURISDICTIONS DO NOT ALLOW THE EXCLUSION OF CERTAIN
-        WARRANTIES, SO SOME OF THE ABOVE LIMITATIONS MAY NOT APPLY TO YOU.
-        TRANSACTIONS THAT ARE RECORDED VIA THE SITE MUST BE TREATED AS PERMANENT
-        AND CANNOT BE UNDONE BY US OR BY ANYONE.
-      </p>
-      <p>
-        We do not guarantee or promise that the Site, or any content on it, will
-        always be available, functional, usable or uninterrupted. From time to
-        time, access may be interrupted, suspended or restricted, including
-        because of a fault, error or unforeseen circumstances or because we are
-        carrying out planned maintenance or changes. You acknowledge and agree
-        that you will access and use the site at your own risk. By using the
-        Site, you will be solely responsible for conducting your own due
-        diligence into the risks of a transaction.
-      </p>
-      <p>
-        We reserve the right to limit the availability of the site to any
-        person, geographic area or jurisdiction in our sole discretion and/or to
-        terminate your access to and use of the site, at any time and in our
-        sole discretion. We may suspend or disable your access to the Site for
-        any reason and in our sole discretion, including for any intentional or
-        unintentional breaches of these Terms. We may remove or amend the
-        content of the Site at any time. Some of the content may be out of date
-        at any given time and we are under no obligation to update or revise it.
-        We do not promise or guarantee that the Site, or any content on it, will
-        be free from errors or omissions.
-      </p>
-      <p>
-        We will not be liable to you for any issue, loss or damage you may or
-        have suffered as a result of the Site being unavailable at any time for
-        any reason. You will comply with all applicable domestic and
-        international laws, statutes, ordinances, rules and regulations
-        applicable to your use of the site (“Applicable Laws”). Likewise, we are
-        not liable for any third-party services and are not responsible for the
-        content or services of these party’s.
-      </p>
-      <p>
-        As a condition to accessing or using the Site, you agree and represent
-        that you will:
-      </p>
-      <ul>
-        <li>
-          Only use the Services and the Site for lawful purposes and in
-          adherence with these Terms;
-        </li>
-        <li>
-          Ensure that all information that you provide on the Site is current,
-          complete, and accurate; and
-        </li>
-        <li>
-          Maintain the security, privacy and confidentiality of access to your
-          cryptocurrency wallet address.
-        </li>
-      </ul>
-      <p>
-        As a condition to accessing or using the Site or the Services, you will
-        not:
-      </p>
-      <ul>
-        <li>
-          Violate any Applicable Law, including, without limitation, any
-          relevant and applicable anti-money laundering and anti-terrorist
-          financing and sanctions laws and any relevant and applicable privacy,
-          secrecy and data protection laws.
-        </li>
-        <li>
-          Use the Site for any purpose or conduct that is directly or indirectly
-          unlawful;
-        </li>
-        <li>
-          Export, reexport, or transfer, directly or indirectly, any Balancer
-          technology in violation of applicable export laws or regulations;
-        </li>
-        <li>
-          Infringe on or misappropriate any contract, intellectual property or
-          other third-party right, or commit a tort while using the Site;
-        </li>
-        <li>
-          Misrepresent, with omission or otherwise, the truthfulness, sourcing
-          or reliability of any content on the Site;
-        </li>
-        <li>
-          Use the Site in any manner that could interfere with, disrupt,
-          negatively affect, redirect or inhibit other users from fully enjoying
-          the Site or the Balancer Protocol, or that could damage, disable,
-          overburden, or impair the functioning of the Site or the Balancer
-          Protocol in any manner;
-        </li>
-        <li>
-          Attempt to circumvent or disable any content filtering techniques or
-          security measures that Balancer employs on the Site, or attempt to
-          access any service or area of the Site that you are not authorized to
-          access;
-        </li>
-        <li>
-          Use any robot, spider, crawler, scraper, or other automated means or
-          interface not provided by us, to access the Site to extract data;
-        </li>
-        <li>
-          Introduce or use any malware, virus, Trojan horse, worm, logic bomb,
-          drop-dead device, backdoor, shutdown mechanism or other harmful
-          material into the Site;
-        </li>
-        <li>
-          Post content or communications on the Site that are, in our sole
-          discretion, libelous, defamatory, profane, obscene, pornographic,
-          sexually explicit, indecent, lewd, vulgar, suggestive, harassing,
-          hateful, threatening, offensive, discriminatory, bigoted, abusive,
-          inflammatory, fraudulent, deceptive or otherwise objectionable;
-        </li>
-        <li>
-          To the extent applicable, post content on the Site containing
-          unsolicited promotions, commercial messages or any chain messages or
-          user content designed to deceive, induce or trick the user of the
-          Site; or
-        </li>
-        <li>
-          Encourage or induce any third party to engage in any of the activities
-          prohibited under these Terms.
-        </li>
-      </ul>
-    </div>
-    <div class="subsection">
-      <h3>
-        3(a). You acknowledge that the Site and your use of the Site present
-        certain risks, including without limitation the following risks:
-      </h3>
-      <ul>
-        <li>
-          Losses while digital assets are being supplied to the Balancer
-          Protocol and losses due to the fluctuation of prices of tokens in a
-          trading pair or liquidity pool. Prices of digital currencies, tokens
-          and/or other digital assets fluctuate day by day or even minute by
-          minute. The value of your available balance could surge or drop
-          suddenly. Please note that there is a possibility that the price of
-          tokens could decrease to zero. Prices of tokens are prone to
-          significant fluctuations, for example, due to announced proposed
-          legislative acts, governmental restrictions, news related to cyber
-          crimes or other factors causing potentially excessive market
-          enthusiasm, disproportionate loss in confidence, or manipulation by
-          others in the market.
-        </li>
-        <li>
-          Risks associated with accessing the Balancer Protocol through third
-          party web or mobile interfaces. You are responsible for doing your own
-          diligence on those interfaces to understand and accept the risks that
-          use entails. You are also responsible for doing your own diligence on
-          those interfaces to understand and accept any fees that those
-          interfaces may charge.
-        </li>
-        <li>
-          Risks associated with any Smart Contracts with which you interact.
-        </li>
-        <li>
-          Although Balancer does not have access to your assets, you are
-          reminded and acknowledge that at any time, your access to your
-          Cryptocurrency Assets through third party wallet services, unrelated
-          to Balancer or the Balancer.Fi website, may be suspended or terminated
-          or there may be a delay in your access or use of your Cryptocurrency
-          Assets, which may result in the Cryptocurrency Assets diminishing in
-          value or you being unable to complete a Smart Contract.
-        </li>
-        <li>
-          You are reminded of the inherent risks with digital assets and
-          decentralized finance including the fact that tokens are not legal
-          tender and are not backed by any government. Unlike fiat currencies,
-          which are regulated and backed by local governments and central banks,
-          tokens are based only on technology and user consensus, which means
-          that in cases of manipulations or market panic, central governments
-          will not take any corrective actions or measures to achieve stability,
-          maintain liquidity or protect their value. There is a possibility that
-          certain transactions cannot be settled or may be difficult to settle,
-          or can be completed only at significantly adverse prices depending on
-          the market situation and/or market volume. Transactions may be
-          irreversible, and, accordingly, potential losses due to fraudulent or
-          accidental transactions are not recoverable. Some blockchain
-          transactions are deemed to be completed when recorded on a public
-          ledger, which is not necessarily the date or time when you or another
-          party initiated the transaction.
-        </li>
-        <li>
-          The regulatory frameworks applicable to blockchain transactions in
-          connection with tokens are still developing and evolving. It is
-          possible that your transactions or funds are, or may be in the future,
-          subject to various reporting, tax or other liabilities and
-          obligations. Legislative and regulatory changes or actions at the
-          country or international level may materially and adversely affect the
-          use, transfer, exchange, and value of your tokens.
-        </li>
-        <li>
-          The site and/or application may be wholly or partially suspended or
-          terminated for any or no reason, which may limit your access to your
-          Cryptocurrency Assets.
-        </li>
-        <li>
-          You are solely responsible for understanding and complying with any
-          and all Applicable Laws in connection with your acceptance of these
-          Terms and your use of any part of the Site, including but not limited
-          to those related to taxes as well as reporting and disclosure
-          obligations.
-        </li>
-        <li>
-          This list of risk factors is non-exhaustive, and other risks, arising
-          either now or in the future, could additionally be relevant and
-          applicable to you in making an informed judgment to accept, or
-          continue to accept, these Terms and/or use, or continue to use the
-          Site.
-        </li>
-      </ul>
+  <Transition appear name="appear">
+    <div class="pb-4">
+      <div class="subsection">
+        <h1>Balancer Terms of Use</h1>
+        <p><em>Last updated: November 2022</em></p>
+        <p>
+          <em class="font-semibold">
+            Do not access this site where such access is prohibited by
+            applicable law. Please carefully read these terms of use before
+            using the site. These terms apply to any person or entity accessing
+            the site and by using the site you agree to be bound by them. The
+            terms of use contain a mandatory individual arbitration and class
+            action/jury trial waiver provision that requires the use of
+            arbitration on an individual basis to resolve disputes, rather than
+            jury trials or class actions. If you do not want to be bound by
+            these terms of use, you should not access the site. By using the
+            site in any capacity, you agree that you have read, understood, and
+            agree to be subject to these terms of use.</em
+          >
+        </p>
+      </div>
+      <div class="subsection">
+        <h2>1. Overview</h2>
+        <p>
+          This Balancer Terms of Use document (“Terms” or “agreement”)
+          (“Balancer ”, “we” and “us” refers to the Balancer Foundation and its
+          subsidiary Balancer OpCo Limited) covers the website, Balancer
+          Protocol user-interface and free application (collectively “the Site”)
+          we own and administer, at times in conjunction with others, which
+          provides the ability to access the decentralized Balancer Protocol.
+          Additionally, you can access the Balancer Protocol through third-party
+          web or mobile interfaces. These Terms apply to you (“You” or “you”) as
+          a user of our Site including all the products, services, tools and
+          information, without limitation, made available on the Site.
+        </p>
+        <p>
+          You must be able to form a legally binding contract online either as
+          an individual or on behalf of a legal entity. You represent that, if
+          you are agreeing to these Terms on behalf of a legal entity, you have
+          the legal authority to bind that entity to these Terms and you are not
+          indirectly or directly included on any sanctions list and at least 18
+          years old or the age of majority where you reside, (whichever is
+          older) can form a legally binding contract online, and have the full,
+          right, power and authority to enter into and to comply with the
+          obligations under these Terms.
+        </p>
+        <p>
+          You are advised to periodically review these Terms so you understand
+          any changes to the Terms. Balancer in its sole discretion, reserves
+          the right to make changes to our Terms. Changes are binding on users
+          of the Site and will take effect immediately upon posting. As a user,
+          you agree to be bound by any changes, variations, or modifications to
+          our Terms and your continued use of the Site shall constitute
+          acceptance of any such changes, revisions, variations, or
+          modifications. When we make changes, we will make the updated Terms
+          available on the interface and update the “Last Updated” date at the
+          beginning of the Terms accordingly.
+        </p>
+        <p>
+          You accept such changes, by continuing to use the Site and by doing so
+          you agree that we have provided you with sufficient notice of such
+          change. Our
+          <router-link :to="{ name: 'privacy-policy' }">
+            <span className="link">Privacy Policy</span>
+          </router-link>
+          and
+          <router-link :to="{ name: 'cookies-policy' }">
+            <span className="link">Cookies Policy</span>
+          </router-link>
+          also apply to your access and use of the Site. You are entering into a
+          binding Agreement. Any failure by us to exercise any rights or
+          provisions of the Agreement shall not constitute a waiver of such
+          right or provision.
+        </p>
+      </div>
+      <div class="subsection">
+        <h2>2. Site</h2>
+        <p>
+          As part of the Site, Balancer provides access to a decentralized
+          finance application (“Application” or “Balancer Protocol app”) on the
+          Ethereum blockchain, that allows swappers or liquidity providers of
+          Ethereum assets (“Cryptocurrency Assets”) to transact using smart
+          contracts (“Smart Contracts”). Use of the Balancer Protocol may
+          require that you pay a fee, such as gas charges on the Ethereum
+          network to perform a transaction. You acknowledge and agree that
+          Balancer has no control over any activities, transactions, the method
+          of payment of any transactions, or any actual processing of payments
+          of transactions. You must ensure that you have a sufficient balance to
+          complete any transaction on the Balancer Protocol before initiating
+          such transaction. You should not take or refrain from taking any
+          action based on any information contained on the Site or any other
+          available information at any time. Before you make any legal,
+          technical, or financial decisions involving the Services, you should
+          seek independent professional advice from a licensed and qualified
+          individual in the area for which such advice would be appropriate.
+        </p>
+        <p>
+          You acknowledge and agree that Balancer has no control over any
+          transactions conducted through the Balancer Protocol, the method of
+          payment of any transactions or any actual payments of transactions
+          including use of any third-party services such as Metamask, or other
+          wallet services. Likewise, you must ensure that you have a sufficient
+          balance of the applicable cryptocurrency tokens stored at your
+          Balancer Protocol-compatible wallet address (“Cryptocurrency Wallet”)
+          to complete any transaction on the Balancer Protocol or the Ethereum
+          network before initiating such transaction.
+        </p>
+      </div>
+      <div class="subsection">
+        <h2>3. Access / Disclaimer of Warranties</h2>
+        <p>
+          ACCESS TO THIS SITE AND THE PRODUCTS HEREIN ARE PROVIDED ON AN 'AS IS'
+          AND 'AS AVAILABLE' BASIS WITHOUT WARRANTIES OF ANY KIND, EITHER
+          EXPRESS OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+          WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+          NON-INFRINGEMENT. NO WARRANTY IS PROVIDED THAT THE SITE OR ANY PRODUCT
+          WILL BE FREE FROM DEFECTS OR VIRUSES OR THAT OPERATION OF THE PRODUCT
+          WILL BE UNINTERRUPTED. YOUR USE OF THE SITE AND ANY PRODUCT AND ANY
+          MATERIAL OR SERVICES OBTAINED OR ACCESSED VIA THE SITE IS AT YOUR OWN
+          DISCRETION AND RISK, AND YOU ARE SOLELY RESPONSIBLE FOR ANY DAMAGE
+          RESULTING FROM THEIR USE. SOME JURISDICTIONS DO NOT ALLOW THE
+          EXCLUSION OF CERTAIN WARRANTIES, SO SOME OF THE ABOVE LIMITATIONS MAY
+          NOT APPLY TO YOU. TRANSACTIONS THAT ARE RECORDED VIA THE SITE MUST BE
+          TREATED AS PERMANENT AND CANNOT BE UNDONE BY US OR BY ANYONE.
+        </p>
+        <p>
+          We do not guarantee or promise that the Site, or any content on it,
+          will always be available, functional, usable or uninterrupted. From
+          time to time, access may be interrupted, suspended or restricted,
+          including because of a fault, error or unforeseen circumstances or
+          because we are carrying out planned maintenance or changes. You
+          acknowledge and agree that you will access and use the site at your
+          own risk. By using the Site, you will be solely responsible for
+          conducting your own due diligence into the risks of a transaction.
+        </p>
+        <p>
+          We reserve the right to limit the availability of the site to any
+          person, geographic area or jurisdiction in our sole discretion and/or
+          to terminate your access to and use of the site, at any time and in
+          our sole discretion. We may suspend or disable your access to the Site
+          for any reason and in our sole discretion, including for any
+          intentional or unintentional breaches of these Terms. We may remove or
+          amend the content of the Site at any time. Some of the content may be
+          out of date at any given time and we are under no obligation to update
+          or revise it. We do not promise or guarantee that the Site, or any
+          content on it, will be free from errors or omissions.
+        </p>
+        <p>
+          We will not be liable to you for any issue, loss or damage you may or
+          have suffered as a result of the Site being unavailable at any time
+          for any reason. You will comply with all applicable domestic and
+          international laws, statutes, ordinances, rules and regulations
+          applicable to your use of the site (“Applicable Laws”). Likewise, we
+          are not liable for any third-party services and are not responsible
+          for the content or services of these party’s.
+        </p>
+        <p>
+          As a condition to accessing or using the Site, you agree and represent
+          that you will:
+        </p>
+        <ul>
+          <li>
+            Only use the Services and the Site for lawful purposes and in
+            adherence with these Terms;
+          </li>
+          <li>
+            Ensure that all information that you provide on the Site is current,
+            complete, and accurate; and
+          </li>
+          <li>
+            Maintain the security, privacy and confidentiality of access to your
+            cryptocurrency wallet address.
+          </li>
+        </ul>
+        <p>
+          As a condition to accessing or using the Site or the Services, you
+          will not:
+        </p>
+        <ul>
+          <li>
+            Violate any Applicable Law, including, without limitation, any
+            relevant and applicable anti-money laundering and anti-terrorist
+            financing and sanctions laws and any relevant and applicable
+            privacy, secrecy and data protection laws.
+          </li>
+          <li>
+            Use the Site for any purpose or conduct that is directly or
+            indirectly unlawful;
+          </li>
+          <li>
+            Export, reexport, or transfer, directly or indirectly, any Balancer
+            technology in violation of applicable export laws or regulations;
+          </li>
+          <li>
+            Infringe on or misappropriate any contract, intellectual property or
+            other third-party right, or commit a tort while using the Site;
+          </li>
+          <li>
+            Misrepresent, with omission or otherwise, the truthfulness, sourcing
+            or reliability of any content on the Site;
+          </li>
+          <li>
+            Use the Site in any manner that could interfere with, disrupt,
+            negatively affect, redirect or inhibit other users from fully
+            enjoying the Site or the Balancer Protocol, or that could damage,
+            disable, overburden, or impair the functioning of the Site or the
+            Balancer Protocol in any manner;
+          </li>
+          <li>
+            Attempt to circumvent or disable any content filtering techniques or
+            security measures that Balancer employs on the Site, or attempt to
+            access any service or area of the Site that you are not authorized
+            to access;
+          </li>
+          <li>
+            Use any robot, spider, crawler, scraper, or other automated means or
+            interface not provided by us, to access the Site to extract data;
+          </li>
+          <li>
+            Introduce or use any malware, virus, Trojan horse, worm, logic bomb,
+            drop-dead device, backdoor, shutdown mechanism or other harmful
+            material into the Site;
+          </li>
+          <li>
+            Post content or communications on the Site that are, in our sole
+            discretion, libelous, defamatory, profane, obscene, pornographic,
+            sexually explicit, indecent, lewd, vulgar, suggestive, harassing,
+            hateful, threatening, offensive, discriminatory, bigoted, abusive,
+            inflammatory, fraudulent, deceptive or otherwise objectionable;
+          </li>
+          <li>
+            To the extent applicable, post content on the Site containing
+            unsolicited promotions, commercial messages or any chain messages or
+            user content designed to deceive, induce or trick the user of the
+            Site; or
+          </li>
+          <li>
+            Encourage or induce any third party to engage in any of the
+            activities prohibited under these Terms.
+          </li>
+        </ul>
+      </div>
+      <div class="subsection">
+        <h3>
+          3(a). You acknowledge that the Site and your use of the Site present
+          certain risks, including without limitation the following risks:
+        </h3>
+        <ul>
+          <li>
+            Losses while digital assets are being supplied to the Balancer
+            Protocol and losses due to the fluctuation of prices of tokens in a
+            trading pair or liquidity pool. Prices of digital currencies, tokens
+            and/or other digital assets fluctuate day by day or even minute by
+            minute. The value of your available balance could surge or drop
+            suddenly. Please note that there is a possibility that the price of
+            tokens could decrease to zero. Prices of tokens are prone to
+            significant fluctuations, for example, due to announced proposed
+            legislative acts, governmental restrictions, news related to cyber
+            crimes or other factors causing potentially excessive market
+            enthusiasm, disproportionate loss in confidence, or manipulation by
+            others in the market.
+          </li>
+          <li>
+            Risks associated with accessing the Balancer Protocol through third
+            party web or mobile interfaces. You are responsible for doing your
+            own diligence on those interfaces to understand and accept the risks
+            that use entails. You are also responsible for doing your own
+            diligence on those interfaces to understand and accept any fees that
+            those interfaces may charge.
+          </li>
+          <li>
+            Risks associated with any Smart Contracts with which you interact.
+          </li>
+          <li>
+            Although Balancer does not have access to your assets, you are
+            reminded and acknowledge that at any time, your access to your
+            Cryptocurrency Assets through third party wallet services, unrelated
+            to Balancer or the Balancer.Fi website, may be suspended or
+            terminated or there may be a delay in your access or use of your
+            Cryptocurrency Assets, which may result in the Cryptocurrency Assets
+            diminishing in value or you being unable to complete a Smart
+            Contract.
+          </li>
+          <li>
+            You are reminded of the inherent risks with digital assets and
+            decentralized finance including the fact that tokens are not legal
+            tender and are not backed by any government. Unlike fiat currencies,
+            which are regulated and backed by local governments and central
+            banks, tokens are based only on technology and user consensus, which
+            means that in cases of manipulations or market panic, central
+            governments will not take any corrective actions or measures to
+            achieve stability, maintain liquidity or protect their value. There
+            is a possibility that certain transactions cannot be settled or may
+            be difficult to settle, or can be completed only at significantly
+            adverse prices depending on the market situation and/or market
+            volume. Transactions may be irreversible, and, accordingly,
+            potential losses due to fraudulent or accidental transactions are
+            not recoverable. Some blockchain transactions are deemed to be
+            completed when recorded on a public ledger, which is not necessarily
+            the date or time when you or another party initiated the
+            transaction.
+          </li>
+          <li>
+            The regulatory frameworks applicable to blockchain transactions in
+            connection with tokens are still developing and evolving. It is
+            possible that your transactions or funds are, or may be in the
+            future, subject to various reporting, tax or other liabilities and
+            obligations. Legislative and regulatory changes or actions at the
+            country or international level may materially and adversely affect
+            the use, transfer, exchange, and value of your tokens.
+          </li>
+          <li>
+            The site and/or application may be wholly or partially suspended or
+            terminated for any or no reason, which may limit your access to your
+            Cryptocurrency Assets.
+          </li>
+          <li>
+            You are solely responsible for understanding and complying with any
+            and all Applicable Laws in connection with your acceptance of these
+            Terms and your use of any part of the Site, including but not
+            limited to those related to taxes as well as reporting and
+            disclosure obligations.
+          </li>
+          <li>
+            This list of risk factors is non-exhaustive, and other risks,
+            arising either now or in the future, could additionally be relevant
+            and applicable to you in making an informed judgment to accept, or
+            continue to accept, these Terms and/or use, or continue to use the
+            Site.
+          </li>
+        </ul>
 
-      <h3>Violating our rules may result in our intervention.</h3>
-      <p>
-        You agree and acknowledge that if you use the Site and its Services to
-        engage in conduct prohibited by applicable law, we reserve the right to
-        completely or partially restrict or revoke your access to the Services
-        at our sole discretion. We reserve the right to investigate violations
-        and prosecute any suspected breaches of this Agreement, including the
-        Terms. Any information may be disclosed to satisfy any new regulation,
-        law, government request, or legal process.
-      </p>
+        <h3>Violating our rules may result in our intervention.</h3>
+        <p>
+          You agree and acknowledge that if you use the Site and its Services to
+          engage in conduct prohibited by applicable law, we reserve the right
+          to completely or partially restrict or revoke your access to the
+          Services at our sole discretion. We reserve the right to investigate
+          violations and prosecute any suspected breaches of this Agreement,
+          including the Terms. Any information may be disclosed to satisfy any
+          new regulation, law, government request, or legal process.
+        </p>
 
-      <p>Accordingly, you expressly agree that:</p>
-      <ol>
-        <li>
-          you assume all risk in connection with the specific risks identified
-          above in 3(a);
-        </li>
-        <li>
-          you assume all risk in connection with your access to and use of the
-          Site, the Application and the Smart Contracts;
-        </li>
-        <li>
-          that you expressly waive and release Balancer from any and all
-          liability, claims, causes of action, responsibility or damages arising
-          from or in any way related to your use of the Site, the Application or
-          the Smart Contracts.
-        </li>
-        <li>
-          upgrades and modifications to the protocol are managed in a
-          community-driven way by holders of the Balancer Protocol governance
-          token. No developer or entity involved in creating the Balancer
-          Protocol will be liable for any claims or damages whatsoever
-          associated with your use, inability to use, or your interaction with
-          other users of, the Balancer Protocol, including any direct, indirect,
-          incidental, special, exemplary, punitive or consequential damages, or
-          loss of profits, cryptocurrencies, tokens, or anything else of value.
-        </li>
-      </ol>
+        <p>Accordingly, you expressly agree that:</p>
+        <ol>
+          <li>
+            you assume all risk in connection with the specific risks identified
+            above in 3(a);
+          </li>
+          <li>
+            you assume all risk in connection with your access to and use of the
+            Site, the Application and the Smart Contracts;
+          </li>
+          <li>
+            that you expressly waive and release Balancer from any and all
+            liability, claims, causes of action, responsibility or damages
+            arising from or in any way related to your use of the Site, the
+            Application or the Smart Contracts.
+          </li>
+          <li>
+            upgrades and modifications to the protocol are managed in a
+            community-driven way by holders of the Balancer Protocol governance
+            token. No developer or entity involved in creating the Balancer
+            Protocol will be liable for any claims or damages whatsoever
+            associated with your use, inability to use, or your interaction with
+            other users of, the Balancer Protocol, including any direct,
+            indirect, incidental, special, exemplary, punitive or consequential
+            damages, or loss of profits, cryptocurrencies, tokens, or anything
+            else of value.
+          </li>
+        </ol>
+      </div>
+      <div class="subsection">
+        <h2>4. Third-Party Content</h2>
+        <p>
+          The Site may contain hyperlinks or references to third party websites
+          or content. Any such hyperlinks or references are provided for your
+          information and convenience only. We have no control over third party
+          websites and accept no legal responsibility for any content, material
+          or information contained in them. The display of any hyperlink and
+          reference to any third-party website does not mean that we endorse
+          that third party's website, products or services or opine on the
+          accuracy or reliability of such information. Your use of a third-party
+          site may be governed by the terms and conditions of that third-party
+          site.
+        </p>
+      </div>
+      <div class="subsection">
+        <h2>5. Our Privacy Policy and Cookies Policy</h2>
+        <p>
+          Certain areas of our website may record and collect information about
+          you. You can find more information about how we will process your
+          personal information in our
+          <router-link :to="{ name: 'privacy-policy' }">
+            <span className="link">Privacy Policy</span> </router-link
+          >.
+        </p>
+        <p>
+          When you use the Site, we may collect information about your computer
+          and your interaction with the Site. See our
+          <router-link :to="{ name: 'cookies-policy' }">
+            <span className="link">Cookies Policy</span>
+          </router-link>
+          for more information.
+        </p>
+      </div>
+      <div class="subsection">
+        <h2>6. Intellectual Property Rights</h2>
+        <p>
+          Balancer is the owner of all intellectual property rights in the Site
+          and the material published on them. To the extent practical, these
+          works are protected by copyright laws and all such rights are
+          reserved. www.Balancer.fi is the uniform resource locator (‘URL’) of
+          Balancer. You will not make use of this URL (or any other URL owned by
+          us) on another website or digital platform without our prior written
+          consent. Any unauthorized use or reproduction may be prosecuted. You
+          will retain ownership of all copyright in data you upload or submit
+          by, through or to the Site. You grant us a worldwide, royalty-free,
+          irrevocable license to use, copy, distribute or publish and send this
+          data in any manner.
+        </p>
+      </div>
+      <div class="subsection">
+        <h2>7. Limitation of Liability</h2>
+        <p>
+          <em class="font-semibold">
+            Under no circumstances shall we or any of our officers, directors,
+            employees, contractors, agents, affiliates, or subsidiaries be
+            liable to you for any indirect, punitive, incidental, special,
+            consequential, or exemplary damages, including (but not limited to)
+            damages for loss of profits, goodwill, use, data, or other
+            intangible property, arising out of or relating to any access or use
+            of the Site including the user-interface, nor will we be responsible
+            for any damage, loss, or injury resulting from hacking, tampering,
+            or other unauthorized access or use of the Site including the
+            user-interface or the information contained within it.</em
+          >
+        </p>
+        <p>
+          <em class="font-semibold">
+            We assume no liability or responsibility for any: (a) errors,
+            mistakes, or inaccuracies of content; (b) personal injury or
+            property damage, of any nature whatsoever, resulting from any access
+            or use of the Site including the user-interface; (c) unauthorized
+            access or use of any secure server or database in our control, or
+            the use of any information or data stored therein; (d) interruption
+            or cessation of function related to the Site; (e) bugs, viruses,
+            trojan horses, or the like that may be transmitted to or through the
+            Site; (f) errors or omissions in, or loss or damage incurred as a
+            result of the use of, any content made available through the Site;
+            and (g) the defamatory, offensive, or illegal conduct of any third
+            party.</em
+          >
+        </p>
+        <p>
+          <em class="font-semibold">
+            Under no circumstances shall we or any of our officers, directors,
+            employees, contractors, agents, affiliates, or subsidiaries be
+            liable to you for any claims, proceedings, liabilities, obligations,
+            damages, losses, or costs in an amount exceeding $100.00. This
+            limitation of liability applies regardless of whether the alleged
+            liability is based on contract, tort, negligence, strict liability,
+            or any other basis, and even if we have been advised of the
+            possibility of such liability. Some jurisdictions do not allow the
+            exclusion of certain warranties or the limitation or exclusion of
+            certain liabilities, but your acceptance of these Terms constitutes
+            an agreement to limit the liability of Balancer and our officers,
+            directors, employees, contractors, agents, affiliates, or
+            subsidiaries to the maximum extent possible under any applicable
+            laws.</em
+          >
+        </p>
+      </div>
+      <div class="subsection">
+        <h2>8. Disclaimers</h2>
+        <p>
+          We do not guarantee that the Site will be secure or free from bugs or
+          viruses.
+        </p>
+        <p>
+          You are responsible for configuring your information technology,
+          computer programs and/or platform in order to access the Site. You
+          should use and deploy your own virus protection and security software.
+          We cannot promise that the use of the Site, or any content taken from
+          the Site, will not infringe the rights of any third party.
+        </p>
+        <p>
+          The content and materials available on the Site are for informational
+          purposes only and are not intended to address your particular
+          requirements or needs. In particular, the content and materials
+          available on the Site do not constitute any form of advice, referral
+          or recommendation by us, should not be regarded as an offer,
+          solicitation, invitation or recommendation to buy or sell tokens or
+          any other financial services and is not intended to be relied upon by
+          you in making any specific decision to buy or sell a token.
+          <em class="font-semibold"
+            >We recommend that you seek independent advice from financial, legal
+            and tax advisors before making any such decision particularly in
+            light of the risks associated with digital assets.</em
+          >
+        </p>
+        <p>
+          Nothing included in the site constitutes an offer or solicitation to
+          sell, or distribution of, investments and related services to anyone
+          in any jurisdiction.
+        </p>
+        <p>
+          From time to time, reference may be made to data we have gathered.
+          These references may be selective or, may be partial. As markets
+          change continuously, previously published information and data may not
+          be current and should not be relied upon.
+        </p>
+      </div>
+      <div class="subsection">
+        <h2>9. Indemnification</h2>
+        <p>
+          You agree to indemnify and hold Balancer and our officers, directors,
+          employees, contractors, agents, affiliates, or subsidiaries harmless
+          from any claim or demand, including attorneys’ fees and costs, made by
+          any third-party due to or arising out of 1) your use of the site or 2)
+          this agreement.
+        </p>
+      </div>
+      <div class="subsection">
+        <h2>10. General</h2>
+        <p>
+          We may perform any of our obligations, and exercise any of the rights
+          granted to us under these Terms, through an affiliated or unaffiliated
+          third-party. We may assign any or all our rights and obligations under
+          these Terms to any third-party.
+        </p>
+        <p>
+          If any clause or part of any clause of these Terms is found to be
+          void, unenforceable or invalid, then it will be severed from these
+          Terms, leaving the remainder in full force and effect, provided that
+          the severance has not altered the basic nature of these Terms.
+        </p>
+        <p>
+          No single or partial exercise, or failure or delay in exercising any
+          right, power or remedy by us shall constitute a waiver by us of, or
+          impair or preclude any further exercise of, that or any right, power
+          or remedy arising under these terms and conditions or otherwise. If
+          any of the provisions in these Terms are found to be illegal, invalid
+          or unenforceable by any court of competent jurisdiction, the remainder
+          shall continue in full force and effect.
+        </p>
+        <p>
+          All disclaimers, indemnities and exclusions in these Terms shall
+          survive termination of the Terms and shall continue to apply during
+          any suspension or any period during which the Site is not available
+          for you to use for any reason whatsoever.
+        </p>
+        <p>
+          These Terms and the documents referred to in them set out the entire
+          agreement between you and us with respect to your use of the site,
+          Balancer and the services provided via the site and supersede any and
+          all prior or contemporaneous representations, communications or
+          agreements (written or oral) made between you or us.
+        </p>
+        <p>
+          <em class="font-semibold"
+            >Any dispute, controversy, or claim arising out of or in relation to
+            these Terms, including the validity, invalidity, breach or
+            termination thereof, shall be settled by arbitration in accordance
+            with the Cayman Islands Arbitration Law, 2012. There shall be one
+            arbitrator; the appointing authority may be based on mutual
+            agreement, be chosen by the parties or in the absence of such
+            agreement, the court may designate an appointing authority. The seat
+            of the arbitration shall be the Cayman Islands and the language of
+            the arbitration shall be English. The applicable law shall be Cayman
+            Islands law or another choice of law determined in Balancer’s sole
+            discretion.</em
+          >
+        </p>
+        <p>
+          <em class="font-semibold">
+            With respect to all persons and entities, regardless of whether they
+            have obtained or used the site for personal, commercial or other
+            purposes, all disputes, controversies or claims must be brought in
+            the parties’ individual capacity, and not as a plaintiff or class
+            member in any purported class action, collective action or other
+            representative proceeding. This waiver applies to class arbitration,
+            and, unless we agree otherwise, the arbitrator may not consolidate
+            more than one person’s claims. You agree that, by entering into this
+            agreement, you and Balancer are each waiving the right to a trial by
+            jury or to participate in a class action, collective action, or
+            other representative proceeding of any kind.
+          </em>
+        </p>
+        <p>
+          <em class="font-semibold">
+            There is a Cayman Island International Arbitration Centre expected
+            in the near term, but in the meantime there is the modern
+            Arbitration Act, 2012.
+          </em>
+        </p>
+      </div>
+      <div class="subsection">
+        <h2>11. Force Majeure</h2>
+        <p>
+          There is a risk that transactions effected through the Site may be
+          affected by system failures resulting from adverse events, natural
+          disasters, pandemics and other emergencies, as well as unforeseen
+          significant changes in the external environment. With regards to
+          opportunity loss (e.g., loss of opportunity to place a payment
+          instruction, resulting in loss of profits which could have been
+          obtained) due to occurrences such as emergency situations and force
+          majeure events, Balancer is under no obligation to take any corrective
+          action or measure and shall no under circumstances be liable for any
+          lost profits or other trading losses.
+        </p>
+      </div>
+      <div>
+        <h2>12. Contact Us</h2>
+        <p>
+          Balancer is a foundation company organized in the Cayman Islands with
+          an operating company organized in the British Virgin Islands (BVI).
+          Please contact us if you have any questions about these Terms or other
+          topics, by sending an email to
+          <a class="link" href="mailto:termsofuse@balancer.finance"
+            >termsofuse@balancer.finance</a
+          >.
+        </p>
+      </div>
     </div>
-    <div class="subsection">
-      <h2>4. Third-Party Content</h2>
-      <p>
-        The Site may contain hyperlinks or references to third party websites or
-        content. Any such hyperlinks or references are provided for your
-        information and convenience only. We have no control over third party
-        websites and accept no legal responsibility for any content, material or
-        information contained in them. The display of any hyperlink and
-        reference to any third-party website does not mean that we endorse that
-        third party's website, products or services or opine on the accuracy or
-        reliability of such information. Your use of a third-party site may be
-        governed by the terms and conditions of that third-party site.
-      </p>
-    </div>
-    <div class="subsection">
-      <h2>5. Our Privacy Policy and Cookies Policy</h2>
-      <p>
-        Certain areas of our website may record and collect information about
-        you. You can find more information about how we will process your
-        personal information in our
-        <router-link :to="{ name: 'privacy-policy' }">
-          <span className="link">Privacy Policy</span> </router-link
-        >.
-      </p>
-      <p>
-        When you use the Site, we may collect information about your computer
-        and your interaction with the Site. See our
-        <router-link :to="{ name: 'cookies-policy' }">
-          <span className="link">Cookies Policy</span>
-        </router-link>
-        for more information.
-      </p>
-    </div>
-    <div class="subsection">
-      <h2>6. Intellectual Property Rights</h2>
-      <p>
-        Balancer is the owner of all intellectual property rights in the Site
-        and the material published on them. To the extent practical, these works
-        are protected by copyright laws and all such rights are reserved.
-        www.Balancer.fi is the uniform resource locator (‘URL’) of Balancer. You
-        will not make use of this URL (or any other URL owned by us) on another
-        website or digital platform without our prior written consent. Any
-        unauthorized use or reproduction may be prosecuted. You will retain
-        ownership of all copyright in data you upload or submit by, through or
-        to the Site. You grant us a worldwide, royalty-free, irrevocable license
-        to use, copy, distribute or publish and send this data in any manner.
-      </p>
-    </div>
-    <div class="subsection">
-      <h2>7. Limitation of Liability</h2>
-      <p>
-        <em class="font-semibold">
-          Under no circumstances shall we or any of our officers, directors,
-          employees, contractors, agents, affiliates, or subsidiaries be liable
-          to you for any indirect, punitive, incidental, special, consequential,
-          or exemplary damages, including (but not limited to) damages for loss
-          of profits, goodwill, use, data, or other intangible property, arising
-          out of or relating to any access or use of the Site including the
-          user-interface, nor will we be responsible for any damage, loss, or
-          injury resulting from hacking, tampering, or other unauthorized access
-          or use of the Site including the user-interface or the information
-          contained within it.</em
-        >
-      </p>
-      <p>
-        <em class="font-semibold">
-          We assume no liability or responsibility for any: (a) errors,
-          mistakes, or inaccuracies of content; (b) personal injury or property
-          damage, of any nature whatsoever, resulting from any access or use of
-          the Site including the user-interface; (c) unauthorized access or use
-          of any secure server or database in our control, or the use of any
-          information or data stored therein; (d) interruption or cessation of
-          function related to the Site; (e) bugs, viruses, trojan horses, or the
-          like that may be transmitted to or through the Site; (f) errors or
-          omissions in, or loss or damage incurred as a result of the use of,
-          any content made available through the Site; and (g) the defamatory,
-          offensive, or illegal conduct of any third party.</em
-        >
-      </p>
-      <p>
-        <em class="font-semibold">
-          Under no circumstances shall we or any of our officers, directors,
-          employees, contractors, agents, affiliates, or subsidiaries be liable
-          to you for any claims, proceedings, liabilities, obligations, damages,
-          losses, or costs in an amount exceeding $100.00. This limitation of
-          liability applies regardless of whether the alleged liability is based
-          on contract, tort, negligence, strict liability, or any other basis,
-          and even if we have been advised of the possibility of such liability.
-          Some jurisdictions do not allow the exclusion of certain warranties or
-          the limitation or exclusion of certain liabilities, but your
-          acceptance of these Terms constitutes an agreement to limit the
-          liability of Balancer and our officers, directors, employees,
-          contractors, agents, affiliates, or subsidiaries to the maximum extent
-          possible under any applicable laws.</em
-        >
-      </p>
-    </div>
-    <div class="subsection">
-      <h2>8. Disclaimers</h2>
-      <p>
-        We do not guarantee that the Site will be secure or free from bugs or
-        viruses.
-      </p>
-      <p>
-        You are responsible for configuring your information technology,
-        computer programs and/or platform in order to access the Site. You
-        should use and deploy your own virus protection and security software.
-        We cannot promise that the use of the Site, or any content taken from
-        the Site, will not infringe the rights of any third party.
-      </p>
-      <p>
-        The content and materials available on the Site are for informational
-        purposes only and are not intended to address your particular
-        requirements or needs. In particular, the content and materials
-        available on the Site do not constitute any form of advice, referral or
-        recommendation by us, should not be regarded as an offer, solicitation,
-        invitation or recommendation to buy or sell tokens or any other
-        financial services and is not intended to be relied upon by you in
-        making any specific decision to buy or sell a token.
-        <em class="font-semibold"
-          >We recommend that you seek independent advice from financial, legal
-          and tax advisors before making any such decision particularly in light
-          of the risks associated with digital assets.</em
-        >
-      </p>
-      <p>
-        Nothing included in the site constitutes an offer or solicitation to
-        sell, or distribution of, investments and related services to anyone in
-        any jurisdiction.
-      </p>
-      <p>
-        From time to time, reference may be made to data we have gathered. These
-        references may be selective or, may be partial. As markets change
-        continuously, previously published information and data may not be
-        current and should not be relied upon.
-      </p>
-    </div>
-    <div class="subsection">
-      <h2>9. Indemnification</h2>
-      <p>
-        You agree to indemnify and hold Balancer and our officers, directors,
-        employees, contractors, agents, affiliates, or subsidiaries harmless
-        from any claim or demand, including attorneys’ fees and costs, made by
-        any third-party due to or arising out of 1) your use of the site or 2)
-        this agreement.
-      </p>
-    </div>
-    <div class="subsection">
-      <h2>10. General</h2>
-      <p>
-        We may perform any of our obligations, and exercise any of the rights
-        granted to us under these Terms, through an affiliated or unaffiliated
-        third-party. We may assign any or all our rights and obligations under
-        these Terms to any third-party.
-      </p>
-      <p>
-        If any clause or part of any clause of these Terms is found to be void,
-        unenforceable or invalid, then it will be severed from these Terms,
-        leaving the remainder in full force and effect, provided that the
-        severance has not altered the basic nature of these Terms.
-      </p>
-      <p>
-        No single or partial exercise, or failure or delay in exercising any
-        right, power or remedy by us shall constitute a waiver by us of, or
-        impair or preclude any further exercise of, that or any right, power or
-        remedy arising under these terms and conditions or otherwise. If any of
-        the provisions in these Terms are found to be illegal, invalid or
-        unenforceable by any court of competent jurisdiction, the remainder
-        shall continue in full force and effect.
-      </p>
-      <p>
-        All disclaimers, indemnities and exclusions in these Terms shall survive
-        termination of the Terms and shall continue to apply during any
-        suspension or any period during which the Site is not available for you
-        to use for any reason whatsoever.
-      </p>
-      <p>
-        These Terms and the documents referred to in them set out the entire
-        agreement between you and us with respect to your use of the site,
-        Balancer and the services provided via the site and supersede any and
-        all prior or contemporaneous representations, communications or
-        agreements (written or oral) made between you or us.
-      </p>
-      <p>
-        <em class="font-semibold"
-          >Any dispute, controversy, or claim arising out of or in relation to
-          these Terms, including the validity, invalidity, breach or termination
-          thereof, shall be settled by arbitration in accordance with the Cayman
-          Islands Arbitration Law, 2012. There shall be one arbitrator; the
-          appointing authority may be based on mutual agreement, be chosen by
-          the parties or in the absence of such agreement, the court may
-          designate an appointing authority. The seat of the arbitration shall
-          be the Cayman Islands and the language of the arbitration shall be
-          English. The applicable law shall be Cayman Islands law or another
-          choice of law determined in Balancer’s sole discretion.</em
-        >
-      </p>
-      <p>
-        <em class="font-semibold">
-          With respect to all persons and entities, regardless of whether they
-          have obtained or used the site for personal, commercial or other
-          purposes, all disputes, controversies or claims must be brought in the
-          parties’ individual capacity, and not as a plaintiff or class member
-          in any purported class action, collective action or other
-          representative proceeding. This waiver applies to class arbitration,
-          and, unless we agree otherwise, the arbitrator may not consolidate
-          more than one person’s claims. You agree that, by entering into this
-          agreement, you and Balancer are each waiving the right to a trial by
-          jury or to participate in a class action, collective action, or other
-          representative proceeding of any kind.
-        </em>
-      </p>
-      <p>
-        <em class="font-semibold">
-          There is a Cayman Island International Arbitration Centre expected in
-          the near term, but in the meantime there is the modern Arbitration
-          Act, 2012.
-        </em>
-      </p>
-    </div>
-    <div class="subsection">
-      <h2>11. Force Majeure</h2>
-      <p>
-        There is a risk that transactions effected through the Site may be
-        affected by system failures resulting from adverse events, natural
-        disasters, pandemics and other emergencies, as well as unforeseen
-        significant changes in the external environment. With regards to
-        opportunity loss (e.g., loss of opportunity to place a payment
-        instruction, resulting in loss of profits which could have been
-        obtained) due to occurrences such as emergency situations and force
-        majeure events, Balancer is under no obligation to take any corrective
-        action or measure and shall no under circumstances be liable for any
-        lost profits or other trading losses.
-      </p>
-    </div>
-    <div>
-      <h2>12. Contact Us</h2>
-      <p>
-        Balancer is a foundation company organized in the Cayman Islands with an
-        operating company organized in the British Virgin Islands (BVI). Please
-        contact us if you have any questions about these Terms or other topics,
-        by sending an email to
-        <a class="link" href="mailto:termsofuse@balancer.finance"
-          >termsofuse@balancer.finance</a
-        >.
-      </p>
-    </div>
-  </div>
+  </Transition>
 </template>

--- a/src/pages/trade.vue
+++ b/src/pages/trade.vue
@@ -49,47 +49,49 @@ onMounted(() => {
 </script>
 
 <template>
-  <Col3Layout offsetGutters mobileHideGutters class="mt-8">
-    <template #gutterLeft>
-      <MyWallet />
-      <TrendingPairs class="mt-4" />
-    </template>
+  <Transition appear name="appear">
+    <Col3Layout offsetGutters mobileHideGutters class="mt-8">
+      <template #gutterLeft>
+        <MyWallet />
+        <TrendingPairs class="mt-4" />
+      </template>
 
-    <BalLoadingBlock v-if="appLoading" class="h-96" />
-    <template v-else>
-      <TradeCard />
-    </template>
-    <div class="p-4 sm:p-0 lg:p-0 mt-8">
-      <BalAccordion
-        v-if="upToLargeBreakpoint"
-        class="w-full"
-        :sections="[
-          { title: 'My wallet', id: 'my-wallet' },
-          { title: 'Trending pairs', id: 'trending-pairs' },
-          { title: 'Price chart', id: 'price-chart' },
-          { title: 'Bridge assets', id: 'bridge' },
-        ]"
-      >
-        <template #my-wallet>
-          <MyWallet />
-        </template>
-        <template #trending-pairs>
-          <TrendingPairs />
-        </template>
-        <template #price-chart>
-          <PairPriceGraph :toggleModal="togglePairPriceGraphModal" />
-        </template>
-        <template #bridge>
-          <BridgeLink v-if="isL2" />
-        </template>
-      </BalAccordion>
-    </div>
+      <BalLoadingBlock v-if="appLoading" class="h-96" />
+      <template v-else>
+        <TradeCard />
+      </template>
+      <div class="p-4 sm:p-0 lg:p-0 mt-8">
+        <BalAccordion
+          v-if="upToLargeBreakpoint"
+          class="w-full"
+          :sections="[
+            { title: 'My wallet', id: 'my-wallet' },
+            { title: 'Trending pairs', id: 'trending-pairs' },
+            { title: 'Price chart', id: 'price-chart' },
+            { title: 'Bridge assets', id: 'bridge' },
+          ]"
+        >
+          <template #my-wallet>
+            <MyWallet />
+          </template>
+          <template #trending-pairs>
+            <TrendingPairs />
+          </template>
+          <template #price-chart>
+            <PairPriceGraph :toggleModal="togglePairPriceGraphModal" />
+          </template>
+          <template #bridge>
+            <BridgeLink v-if="isL2" />
+          </template>
+        </BalAccordion>
+      </div>
 
-    <template #gutterRight>
-      <PairPriceGraph :toggleModal="togglePairPriceGraphModal" />
-      <BridgeLink v-if="isL2" class="mt-4" />
-    </template>
-  </Col3Layout>
+      <template #gutterRight>
+        <PairPriceGraph :toggleModal="togglePairPriceGraphModal" />
+        <BridgeLink v-if="isL2" class="mt-4" />
+      </template>
+    </Col3Layout>
+  </Transition>
 
   <teleport to="#modal">
     <BalModal :show="showPriceGraphModal" @close="onPriceGraphModalClose">

--- a/src/pages/vebal.vue
+++ b/src/pages/vebal.vue
@@ -9,30 +9,34 @@ import { isVeBalSupported } from '@/composables/useVeBAL';
 </script>
 
 <template>
-  <div v-if="isVeBalSupported" class="">
+  <Transition appear name="appear">
     <div>
-      <Hero />
-    </div>
-  </div>
-  <div class="py-16 xl:py-20 bg-gray-50 dark:bg-gray-900">
-    <div v-if="isVeBalSupported" class="lg:container lg:mx-auto">
-      <div class="px-4">
-        <MyVeBAL />
+      <div v-if="isVeBalSupported">
+        <div>
+          <Hero />
+        </div>
+      </div>
+      <div class="py-16 xl:py-20 bg-gray-50 dark:bg-gray-900">
+        <div v-if="isVeBalSupported" class="lg:container lg:mx-auto">
+          <div class="px-4">
+            <MyVeBAL />
+          </div>
+        </div>
+      </div>
+      <div
+        v-if="isVeBalSupported"
+        class="xl:container xl:px-4 pt-16 xl:pt-20 xl:mx-auto"
+      >
+        <div class="xl:px-0 mb-16">
+          <LMVoting />
+        </div>
+      </div>
+      <div v-else class="text-center">
+        <div class="text-lg font-semibold">
+          {{ $t('veBAL.notSupported.title') }}
+        </div>
+        <div>{{ $t('veBAL.notSupported.description') }}</div>
       </div>
     </div>
-  </div>
-  <div
-    v-if="isVeBalSupported"
-    class="xl:container xl:px-4 pt-16 xl:pt-20 xl:mx-auto"
-  >
-    <div class="xl:px-0 mb-16">
-      <LMVoting />
-    </div>
-  </div>
-  <div v-else class="text-center">
-    <div class="text-lg font-semibold">
-      {{ $t('veBAL.notSupported.title') }}
-    </div>
-    <div>{{ $t('veBAL.notSupported.description') }}</div>
-  </div>
+  </Transition>
 </template>


### PR DESCRIPTION
# Description

This PR adds page transitions using opacity to soften the appearance as content fades in between pages. This includes the following pages:
- Home page
- Swap page
- Claims page
- Portfolio page
- veBAL page
- Invest flow modal
- Withdraw flow modal
- Migrate flow modal
- Terms of Service
- Privacy Policy
- Cookies Policy

The main change was wrapping content in vue transition tags:
`<Transition appear name="appear"> </Transition>`


## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [x] Other: Softer page transition animations

## How should this be tested?

Make sure no pages have broken with the changes. Page content should appear with a soft fade in from opacity: 0 to opacity: 1. 

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have requested at least 1 review (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] If package-lock.json has changes, it was intentional.
- [x] The base of this PR is `master` if hotfix, `develop` if not
