### PR TITLE
fix: don't redirect after manual wallet switch if on correct page

### DIFF
--- a/src/components/navs/AppNav/AppNavNetworkSelect.vue
+++ b/src/components/navs/AppNav/AppNavNetworkSelect.vue
@@ -94,7 +94,7 @@ onMounted(async () => {
 
 // WATCHERS
 watch(
-  () => chainId.value,
+  chainId,
   (newVal, oldVal) => {
     if (newVal && oldVal && oldVal !== newVal && networkId.value !== newVal) {
       const newNetwork = allNetworks.value.find(n => Number(n.key) === newVal);

--- a/src/components/navs/AppNav/AppNavNetworkSelect.vue
+++ b/src/components/navs/AppNav/AppNavNetworkSelect.vue
@@ -95,12 +95,12 @@ onMounted(async () => {
 // WATCHERS
 watch(
   chainId,
-  (newVal, oldVal) => {
-    if (newVal && oldVal && oldVal !== newVal && networkId.value !== newVal) {
-      const newNetwork = allNetworks.value.find(n => Number(n.key) === newVal);
+  (newChainId, oldChainId) => {
+    if (newChainId && oldChainId && oldChainId !== newChainId && networkId.value !== newChainId) {
+      const newNetwork = allNetworks.value.find(n => Number(n.key) === newChainId);
       if (newNetwork) {
         document.body.style.display = 'none';
-        localStorage.setItem('networkId', newVal.toString());
+        localStorage.setItem('networkId', newChainId.toString());
         setWindowLocation(getNetworkChangeUrl(newNetwork));
       }
     }

--- a/src/components/navs/AppNav/AppNavNetworkSelect.vue
+++ b/src/components/navs/AppNav/AppNavNetworkSelect.vue
@@ -93,19 +93,23 @@ onMounted(async () => {
 });
 
 // WATCHERS
-watch(
-  chainId,
-  (newChainId, oldChainId) => {
-    if (newChainId && oldChainId && oldChainId !== newChainId && networkId.value !== newChainId) {
-      const newNetwork = allNetworks.value.find(n => Number(n.key) === newChainId);
-      if (newNetwork) {
-        document.body.style.display = 'none';
-        localStorage.setItem('networkId', newChainId.toString());
-        setWindowLocation(getNetworkChangeUrl(newNetwork));
-      }
+watch(chainId, (newChainId, oldChainId) => {
+  if (
+    newChainId &&
+    oldChainId &&
+    oldChainId !== newChainId &&
+    networkId.value !== newChainId
+  ) {
+    const newNetwork = allNetworks.value.find(
+      n => Number(n.key) === newChainId
+    );
+    if (newNetwork) {
+      document.body.style.display = 'none';
+      localStorage.setItem('networkId', newChainId.toString());
+      setWindowLocation(getNetworkChangeUrl(newNetwork));
     }
   }
-);
+});
 
 // METHODS
 function iconSrc(network: NetworkOption): string {

--- a/src/components/navs/AppNav/AppNavNetworkSelect.vue
+++ b/src/components/navs/AppNav/AppNavNetworkSelect.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, ref, onMounted, watchEffect, Ref } from 'vue';
+import { computed, ref, onMounted, watch } from 'vue';
 import { useRouter } from 'vue-router';
 
 import i18n from '@/plugins/i18n';
@@ -55,7 +55,6 @@ const networksDev = ref([
     key: '5',
   },
 ]);
-const previousNetwork: Ref<number | null> = ref(null);
 
 // COMPUTED
 const allNetworks = computed(() => {
@@ -94,23 +93,19 @@ onMounted(async () => {
 });
 
 // WATCHERS
-watchEffect(() => {
-  if (
-    chainId.value &&
-    previousNetwork.value &&
-    previousNetwork.value !== chainId.value
-  ) {
-    const newNetwork = allNetworks.value.find(
-      n => Number(n.key) === chainId.value
-    );
-    if (newNetwork) {
-      document.body.style.display = 'none';
-      localStorage.setItem('networkId', chainId.value.toString());
-      setWindowLocation(getNetworkChangeUrl(newNetwork));
+watch(
+  () => chainId.value,
+  (newVal, oldVal) => {
+    if (newVal && oldVal && oldVal !== newVal && networkId.value !== newVal) {
+      const newNetwork = allNetworks.value.find(n => Number(n.key) === newVal);
+      if (newNetwork) {
+        document.body.style.display = 'none';
+        localStorage.setItem('networkId', newVal.toString());
+        setWindowLocation(getNetworkChangeUrl(newNetwork));
+      }
     }
   }
-  previousNetwork.value = chainId.value;
-});
+);
 
 // METHODS
 function iconSrc(network: NetworkOption): string {


### PR DESCRIPTION
# Description

If the user is manually switches networks via wallet to a network the url points to, don't reload the page.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## How should this be tested?

Please provide instructions so we can test. Please also list any relevant details for your test configuration.

- [ ] Test A
- [ ] Test B

## Visual context

Please provide any relevant visual context for UI changes or additions. This could be static screenshots or a loom screencast.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have requested at least 1 review (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] If package-lock.json has changes, it was intentional.
- [x] The base of this PR is `master` if hotfix, `develop` if not
