### PR TITLE
Remove pools query enable condition

### DIFF
--- a/src/components/_global/shapes/BalCircle/BalCircle.vue
+++ b/src/components/_global/shapes/BalCircle/BalCircle.vue
@@ -26,5 +26,7 @@ const classes = computed(() => ({
 <style scoped>
 .bal-circle {
   @apply rounded-full flex items-center justify-center;
+
+  margin-bottom: 0;
 }
 </style>

--- a/src/components/cards/CreatePool/PreviewPool.vue
+++ b/src/components/cards/CreatePool/PreviewPool.vue
@@ -178,7 +178,7 @@ function getInitialWeightHighlightClass(tokenAddress: string) {
         }}</span>
       </BalStack>
       <BalStack vertical>
-        <div class="flex items-center">
+        <div class="flex items-center mt-2">
           <BalCircle
             v-if="poolCreated"
             size="8"
@@ -345,18 +345,7 @@ function getInitialWeightHighlightClass(tokenAddress: string) {
             {{ $t('createAPool.nativeAssetWarning') }}
           </BalAlert>
         </AnimatePresence>
-        <!-- <BalAlert
-          type="error"
-          class="mb-4"
-          :title="
-            t('createAPool.arbTitle', [
-              fNum2(arbitrageDelta.value, FNumFormats.fiat),
-              fNum2(arbitrageDelta.delta, FNumFormats.percent)
-            ])
-          "
-        >
-          {{ t('createAPool.arbReason') }}
-        </BalAlert> -->
+
         <CreateActions
           :createDisabled="hasMissingPoolNameOrSymbol"
           :tokenAddresses="tokenAddresses"

--- a/src/components/cards/PairPriceGraph/PairPriceGraph.vue
+++ b/src/components/cards/PairPriceGraph/PairPriceGraph.vue
@@ -12,7 +12,6 @@ import {
 import { computed, reactive, ref } from 'vue';
 import { useI18n } from 'vue-i18n';
 import { useQuery } from 'vue-query';
-import { useStore } from 'vuex';
 
 import { useTradeState } from '@/composables/trade/useTradeState';
 import useBreakpoints from '@/composables/useBreakpoints';
@@ -123,7 +122,6 @@ type Props = {
 const props = defineProps<Props>();
 const { upToLargeBreakpoint } = useBreakpoints();
 const { t } = useI18n();
-const store = useStore();
 const { getToken, wrappedNativeAsset, nativeAsset } = useTokens();
 const { tokenInAddress, tokenOutAddress, initialized } = useTradeState();
 const tailwind = useTailwind();
@@ -133,7 +131,6 @@ const chartHeight = ref(
   upToLargeBreakpoint ? (props.isModal ? 250 : 75) : props.isModal ? 250 : 100
 );
 const activeTimespan = ref(chartTimespans[0]);
-const appLoading = computed(() => store.state.app.loading);
 
 const inputSym = computed(() => {
   if (tokenInAddress.value === '') return 'Unknown';
@@ -274,17 +271,14 @@ const chartGrid = computed(() => {
     >
       <div class="relative p-4 h-full bg-transparent">
         <button
-          v-if="!failedToLoadPriceData && !(isLoadingPriceData || appLoading)"
+          v-if="!failedToLoadPriceData && !isLoadingPriceData"
           class="flex justify-center items-center p-2 m-4 rounded-full shadow-lg maximise"
           @click="toggle"
         >
           <BalIcon v-if="!isModal" name="maximize-2" class="text-secondary" />
           <BalIcon v-if="isModal" name="x" class="text-secondary" />
         </button>
-        <div
-          v-if="!failedToLoadPriceData && !(isLoadingPriceData || appLoading)"
-          class="flex"
-        >
+        <div v-if="!failedToLoadPriceData && !isLoadingPriceData" class="flex">
           <h6 class="font-medium">{{ outputSym }}/{{ inputSym }}</h6>
           <BalTooltip class="ml-2" :text="$t('coingeckoPricingTooltip')">
             <template #activator>

--- a/src/components/contextual/pages/pool/PoolChart.vue
+++ b/src/components/contextual/pages/pool/PoolChart.vue
@@ -3,7 +3,6 @@ import { format, addMinutes } from 'date-fns';
 import * as echarts from 'echarts/core';
 import { computed, ref } from 'vue';
 import { useI18n } from 'vue-i18n';
-import { useStore } from 'vuex';
 
 import { PRETTY_DATE_FORMAT } from '@/components/forms/lock_actions/constants';
 import PoolChartPeriodSelect from '@/components/pool/PoolChartPeriodSelect.vue';
@@ -67,7 +66,6 @@ const props = withDefaults(defineProps<Props>(), {
 /**
  * COMPOSABLES
  */
-const store = useStore();
 const { t } = useI18n();
 const tailwind = useTailwind();
 const { fNum2 } = useNumbers();
@@ -102,8 +100,6 @@ const isFocusedOnChart = ref(false);
 /**
  * COMPUTED
  */
-const appLoading = computed(() => store.state.app.loading);
-
 const snapshotValues = computed(() => Object.values(props.snapshots || []));
 
 const periodOptions = computed(() => [
@@ -427,7 +423,7 @@ function addLaggingTimestamps() {
 </script>
 
 <template>
-  <BalLoadingBlock v-if="loading || appLoading" class="chart-loading-block" />
+  <BalLoadingBlock v-if="loading" class="chart-loading-block" />
 
   <div v-else-if="snapshotValues.length >= MIN_CHART_VALUES" class="chart">
     <div

--- a/src/components/forms/pool_actions/MigrateForm/MigrateForm.vue
+++ b/src/components/forms/pool_actions/MigrateForm/MigrateForm.vue
@@ -13,7 +13,6 @@ import MigrateExplainer from './components/MigrateExplainer.vue';
 import PoolsInfo from './components/PoolsInfo/PoolsInfo.vue';
 import PoolStats from './components/PoolStats.vue';
 import { PoolMigrationInfo } from './types';
-import useApp from '@/composables/useApp';
 import usePoolsQuery from '@/composables/queries/usePoolsQuery';
 
 type Props = {
@@ -29,7 +28,6 @@ const props = defineProps<Props>();
  * COMPOSABLES
  */
 const { getToken } = useTokens();
-const { appLoading } = useApp();
 
 /**
  * QUERIES
@@ -83,8 +81,7 @@ const toPoolTokenInfo = computed(() =>
         !toPool ||
         fromPoolTokenInfo == null ||
         toPoolTokenInfo == null ||
-        batchRelayerApprovalLoading ||
-        appLoading
+        batchRelayerApprovalLoading
       "
       class="h-96"
     />

--- a/src/components/pool/PoolPageHeader.spec.ts
+++ b/src/components/pool/PoolPageHeader.spec.ts
@@ -28,13 +28,6 @@ jest.mock('@/components/contextual/stake/StakePreviewModal.vue', () => ({
 jest.mock('@/locales');
 jest.mock('@/composables/useNumbers');
 jest.mock('@/composables/useTokens');
-jest.mock('@/composables/useApp', () => {
-  return jest.fn().mockImplementation(() => {
-    return {
-      appLoading: false,
-    };
-  });
-});
 jest.mock('@/composables/staking/useStaking', () => {
   return jest.fn().mockImplementation(() => {
     return {

--- a/src/components/pool/PoolPageHeader.vue
+++ b/src/components/pool/PoolPageHeader.vue
@@ -6,7 +6,6 @@ import BalChipNew from '@/components/chips/BalChipNew.vue';
 import GauntletIcon from '@/components/images/icons/GauntletIcon.vue';
 import APRTooltip from '@/components/tooltips/APRTooltip/APRTooltip.vue';
 import StakePreviewModal from '@/components/contextual/stake/StakePreviewModal.vue';
-import useApp from '@/composables/useApp';
 import useNumbers from '@/composables/useNumbers';
 import { usePoolWarning } from '@/composables/usePoolWarning';
 import { usePool } from '@/composables/usePool';
@@ -48,7 +47,6 @@ const poolId = computed(() => toRef(props, 'pool').value.id);
 /**
  * COMPOSABLES
  */
-const { appLoading } = useApp();
 const { isAffected, warnings } = usePoolWarning(poolId);
 const { hasNonApprovedRateProviders } = usePool(toRef(props, 'pool'));
 const { fNum2 } = useNumbers();
@@ -219,14 +217,14 @@ const poolTypeLabel = computed(() => {
       block
     />
     <BalAlert
-      v-if="!appLoading && !loadingPool && missingPrices"
+      v-if="!loadingPool && missingPrices"
       type="warning"
       :title="$t('noPriceInfo')"
       class="mt-2"
       block
     />
     <BalAlert
-      v-if="!appLoading && !loadingPool && hasCustomToken"
+      v-if="!loadingPool && hasCustomToken"
       type="error"
       :title="$t('highRiskPool')"
       class="mt-2"
@@ -252,7 +250,7 @@ const poolTypeLabel = computed(() => {
         </div>
       </BalStack>
     </BalAlert>
-    <template v-if="!appLoading && !loadingPool && isAffected">
+    <template v-if="!loadingPool && isAffected">
       <BalAlert
         v-for="(warning, i) in warnings"
         :key="`warning-${i}`"
@@ -269,7 +267,7 @@ const poolTypeLabel = computed(() => {
       </BalAlert>
     </template>
     <BalAlert
-      v-if="!appLoading && noInitLiquidity"
+      v-if="noInitLiquidity"
       type="warning"
       :title="$t('noInitLiquidity')"
       :description="$t('noInitLiquidityDetail')"

--- a/src/composables/queries/usePoolQuery.ts
+++ b/src/composables/queries/usePoolQuery.ts
@@ -12,7 +12,6 @@ import useWeb3 from '@/services/web3/useWeb3';
 
 import PoolRepository from '@/services/pool/pool.repository';
 import { configService } from '@/services/config/config.service';
-import useApp from '../useApp';
 import { isBlocked, tokenTreeLeafs } from '../usePool';
 import useGaugesQuery from './useGaugesQuery';
 import { POOLS } from '@/constants/pools';
@@ -32,10 +31,8 @@ export default function usePoolQuery(
   /**
    * COMPOSABLES
    */
-  const { injectTokens, dynamicDataLoading } = useTokens();
-  const { appLoading } = useApp();
+  const { injectTokens, dynamicDataLoading, tokens } = useTokens();
   const { account } = useWeb3();
-  const { tokens } = useTokens();
   const { data: subgraphGauges } = useGaugesQuery();
   const gaugeAddresses = computed(() =>
     (subgraphGauges.value || []).map(gauge => gauge.id)
@@ -46,9 +43,7 @@ export default function usePoolQuery(
   /**
    * COMPUTED
    */
-  const enabled = computed(
-    () => !appLoading.value && !dynamicDataLoading.value && isEnabled.value
-  );
+  const enabled = computed(() => !dynamicDataLoading.value && isEnabled.value);
 
   /**
    * METHODS

--- a/src/composables/queries/usePoolsQuery.ts
+++ b/src/composables/queries/usePoolsQuery.ts
@@ -1,12 +1,11 @@
 import { UseInfiniteQueryOptions } from 'react-query/types';
-import { computed, reactive, Ref, ref, watch } from 'vue';
+import { reactive, Ref, ref, watch } from 'vue';
 import { useInfiniteQuery } from 'vue-query';
 
 import { POOLS } from '@/constants/pools';
 import QUERY_KEYS from '@/constants/queryKeys';
 import { Pool } from '@/services/pool/types';
 
-import useApp from '../useApp';
 import useNetwork from '../useNetwork';
 import useTokens from '../useTokens';
 import { configService } from '@/services/config/config.service';
@@ -44,17 +43,11 @@ export default function usePoolsQuery(
    * COMPOSABLES
    */
   const { injectTokens, tokens: tokenMeta, dynamicDataLoading } = useTokens();
-  const { appLoading } = useApp();
   const { networkId } = useNetwork();
 
   let balancerApiRepository = initializeDecoratedAPIRepository();
   let subgraphRepository = initializeDecoratedSubgraphRepository();
   let poolsRepository = initializePoolsRepository();
-
-  /**
-   * COMPUTED
-   */
-  const enabled = computed(() => !appLoading.value);
 
   /**
    * METHODS
@@ -208,7 +201,6 @@ export default function usePoolsQuery(
   const queryOptions = reactive({
     ...options,
     getNextPageParam: (lastPage: PoolsQueryResponse) => lastPage.skip,
-    enabled,
   });
 
   return useInfiniteQuery<PoolsQueryResponse>(queryKey, queryFn, queryOptions);

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,7 +2,7 @@ import '@/assets/css/tailwind.css';
 import '@/assets/css/index.css';
 import 'vue3-virtual-scroller/dist/vue3-virtual-scroller.css';
 
-import { BarChart, LineChart } from 'echarts/charts';
+import { BarChart, LineChart, PieChart } from 'echarts/charts';
 import {
   GridComponent,
   LegendComponent,
@@ -32,6 +32,7 @@ echarts.use([
   GridComponent,
   LegendComponent,
   BarChart,
+  PieChart,
 ]);
 
 const app = createApp(Root)

--- a/src/pages/trade.vue
+++ b/src/pages/trade.vue
@@ -1,6 +1,5 @@
 <script setup lang="ts">
-import { computed, onMounted, ref } from 'vue';
-import { useStore } from 'vuex';
+import { onMounted, ref } from 'vue';
 import MyWallet from '@/components/cards/MyWallet/MyWallet.vue';
 import PairPriceGraph from '@/components/cards/PairPriceGraph/PairPriceGraph.vue';
 import TradeCard from '@/components/cards/TradeCard/TradeCard.vue';
@@ -19,14 +18,8 @@ const showPriceGraphModal = ref(false);
 /**
  * COMPOSABLES
  */
-const store = useStore();
 const { setSelectedTokens } = usePoolFilters();
 const { upToLargeBreakpoint } = useBreakpoints();
-
-/**
- * COMPUTED
- */
-const appLoading = computed(() => store.state.app.loading);
 
 /**
  * METHODS
@@ -55,10 +48,7 @@ onMounted(() => {
       <TrendingPairs class="mt-4" />
     </template>
 
-    <BalLoadingBlock v-if="appLoading" class="h-96" />
-    <template v-else>
-      <TradeCard />
-    </template>
+    <TradeCard />
     <div class="p-4 sm:p-0 lg:p-0 mt-8">
       <BalAccordion
         v-if="upToLargeBreakpoint"

--- a/src/providers/app.provider.ts
+++ b/src/providers/app.provider.ts
@@ -1,7 +1,5 @@
-import { computed, ComputedRef, InjectionKey, provide } from 'vue';
-import { useStore } from 'vuex';
+import { InjectionKey, provide } from 'vue';
 
-import useTokens from '@/composables/useTokens';
 import symbolKeys from '@/constants/symbol.keys';
 
 import { version } from '../../package.json';
@@ -11,7 +9,6 @@ import { version } from '../../package.json';
  */
 export interface AppProviderResponse {
   version: string;
-  appLoading: ComputedRef<boolean>;
 }
 
 /**
@@ -29,17 +26,8 @@ export default {
   name: 'AppProvider',
 
   setup(props, { slots }) {
-    const store = useStore();
-    const { loading: loadingTokens } = useTokens();
-
-    const appLoading = computed(
-      () => store.state.app.loading || loadingTokens.value
-    );
-
     provide(AppProviderSymbol, {
       version,
-      // computed
-      appLoading,
     });
 
     return () => slots.default();

--- a/src/store/modules/app.ts
+++ b/src/store/modules/app.ts
@@ -3,26 +3,22 @@ import { lsGet, lsSet } from '@/lib/utils';
 import i18n from '@/plugins/i18n';
 
 export interface AppState {
-  loading: boolean;
   modalOpen: boolean;
   locale: string;
   transactionDeadline: number;
 }
 
 const state: AppState = {
-  loading: true,
   modalOpen: false,
   locale: lsGet(LS_KEYS.App.Locale, 'en-US'),
   transactionDeadline: lsGet(LS_KEYS.App.TradeDeadline, 100), // minutes
 };
 
 const actions = {
-  init: async ({ commit, dispatch }) => {
+  init: async ({ dispatch }) => {
     try {
       // Fetch initial trade tokens
       dispatch('trade/init', null, { root: true });
-
-      commit('setLoading', false);
     } catch (error) {
       console.error('Failed to initialize app', error);
     }
@@ -30,10 +26,6 @@ const actions = {
 };
 
 const mutations = {
-  setLoading(state: AppState, val: AppState['loading']) {
-    state.loading = val;
-  },
-
   toggleModal(state: AppState) {
     state.modalOpen = !state.modalOpen;
   },


### PR DESCRIPTION
# Description
Since we use api now, it seems that we don't need to wait until app is loaded (`appLoading === true`) in usePoolsQuery composable. Removing this `enabled` condition leads to faster rendering of pools table on main page

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [x] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## How should this be tested?

Please provide instructions so we can test. Please also list any relevant details for your test configuration.

- [ ] Test A
- [ ] Test B

## Visual context

Please provide any relevant visual context for UI changes or additions. This could be static screenshots or a loom screencast.

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have requested at least 1 review (If the PR is significant enough, use best judgement here)
- [ ] I have commented my code where relevant, particularly in hard-to-understand areas
- [ ] If package-lock.json has changes, it was intentional.
- [ ] The base of this PR is `master` if hotfix, `develop` if not
