### PR TITLE
prevent staking before current lp balance is loaded

### DIFF
--- a/src/components/contextual/stake/StakePreview.vue
+++ b/src/components/contextual/stake/StakePreview.vue
@@ -105,6 +105,11 @@ watch(
 /* COMPUTED */
 const assetRowWidth = computed(() => (props.pool.tokensList.length * 32) / 1.5);
 
+const isStakeAndZero = computed(
+  () =>
+    props.action === 'stake' && (currentShares === '0' || currentShares === '')
+);
+
 const fiatValueOfModifiedShares = ref(
   bnum(props.pool.totalLiquidity)
     .div(props.pool.totalShares)
@@ -249,6 +254,7 @@ function handleClose() {
       v-if="!isActionConfirmed"
       :actions="stakeActions"
       :isLoading="isLoadingApprovalsForGauge"
+      :disabled="isStakeAndZero"
       @success="handleSuccess"
     />
     <BalStack v-if="isActionConfirmed && confirmationReceipt" vertical>


### PR DESCRIPTION
# Description

Fixes #2244. I couldn't reproduce but tested that all the existing functionality still worked

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## How should this be tested?

Confirm staking and unstaking works as expected

## Visual context

Please provide any relevant visual context for UI changes or additions. This could be static screenshots or a loom screencast.

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have requested at least 1 review (If the PR is significant enough, use best judgement here)
- [ ] I have commented my code where relevant, particularly in hard-to-understand areas
- [ ] If package-lock.json has changes, it was intentional.
- [ ] The base of this PR is `master` if hotfix, `develop` if not
