### PR TITLE
Limit single asset tokens to high level tokens

### DIFF
--- a/src/components/forms/pool_actions/WithdrawForm/composables/useWithdrawMath.ts
+++ b/src/components/forms/pool_actions/WithdrawForm/composables/useWithdrawMath.ts
@@ -267,6 +267,7 @@ export default function useWithdrawMath(
   /**
    * The BPT value to be used for the withdrawal transaction without accounting for slippage.
    */
+  // Called when input amount is changed
   const fullBPTIn = computed((): string => {
     if (isProportional.value) {
       const _bpt = bnum(propBptIn.value)
@@ -286,6 +287,17 @@ export default function useWithdrawMath(
       return batchSwap.value?.returnAmounts?.[0]?.toString() || '0';
     } else if (isShallowComposableStablePool.value) return queryBptIn.value;
 
+    // This returns
+    console.log(
+      {
+        tokenOutAmount: tokenOutAmount.value,
+        tokenOutIndex: tokenOutIndex.value,
+      },
+      'fullBPTIn',
+      poolCalculator
+        .bptInForExactTokenOut(tokenOutAmount.value, tokenOutIndex.value)
+        .toString()
+    );
     return poolCalculator
       .bptInForExactTokenOut(tokenOutAmount.value, tokenOutIndex.value)
       .toString();
@@ -314,6 +326,7 @@ export default function useWithdrawMath(
     fullAmounts.value.some(amount => bnum(amount).gt(0))
   );
 
+  // Runs when changing token
   const singleAssetMaxes = computed((): string[] => {
     if (isDeepPool.value || isShallowComposableStablePool.value)
       return fetchedSingleAssetMaxes.value;
@@ -663,7 +676,9 @@ export default function useWithdrawMath(
    * High level function that uses withdrawal state to
    * decide what swap should be fetched and sets it.
    */
+  // Runs when shitching tokens
   async function fetchExitData(): Promise<void> {
+    // Returns here when selecting single asset
     if (!isDeepPool.value && !isShallowComposableStablePool.value) return;
 
     if (isShallowComposableStablePool.value) {

--- a/src/components/forms/pool_actions/WithdrawForm/composables/useWithdrawMath.ts
+++ b/src/components/forms/pool_actions/WithdrawForm/composables/useWithdrawMath.ts
@@ -267,7 +267,6 @@ export default function useWithdrawMath(
   /**
    * The BPT value to be used for the withdrawal transaction without accounting for slippage.
    */
-  // Called when input amount is changed
   const fullBPTIn = computed((): string => {
     if (isProportional.value) {
       const _bpt = bnum(propBptIn.value)
@@ -287,17 +286,6 @@ export default function useWithdrawMath(
       return batchSwap.value?.returnAmounts?.[0]?.toString() || '0';
     } else if (isShallowComposableStablePool.value) return queryBptIn.value;
 
-    // This returns
-    console.log(
-      {
-        tokenOutAmount: tokenOutAmount.value,
-        tokenOutIndex: tokenOutIndex.value,
-      },
-      'fullBPTIn',
-      poolCalculator
-        .bptInForExactTokenOut(tokenOutAmount.value, tokenOutIndex.value)
-        .toString()
-    );
     return poolCalculator
       .bptInForExactTokenOut(tokenOutAmount.value, tokenOutIndex.value)
       .toString();
@@ -326,7 +314,6 @@ export default function useWithdrawMath(
     fullAmounts.value.some(amount => bnum(amount).gt(0))
   );
 
-  // Runs when changing token
   const singleAssetMaxes = computed((): string[] => {
     if (isDeepPool.value || isShallowComposableStablePool.value)
       return fetchedSingleAssetMaxes.value;
@@ -676,9 +663,7 @@ export default function useWithdrawMath(
    * High level function that uses withdrawal state to
    * decide what swap should be fetched and sets it.
    */
-  // Runs when shitching tokens
   async function fetchExitData(): Promise<void> {
-    // Returns here when selecting single asset
     if (!isDeepPool.value && !isShallowComposableStablePool.value) return;
 
     if (isShallowComposableStablePool.value) {

--- a/src/composables/useSlippage.ts
+++ b/src/composables/useSlippage.ts
@@ -1,32 +1,42 @@
 import { formatUnits, parseUnits } from '@ethersproject/units';
 import BigNumber from 'bignumber.js';
-import { computed } from 'vue';
 
 import { bnum } from '@/lib/utils';
 
 import { useUserSettings } from '@/providers/user-settings.provider';
 
-export default function useSlippage() {
-  const { slippage } = useUserSettings();
+export function getMinusSlippage(
+  _amount: string,
+  decimals: number,
+  slippageBasisPoints: string | number
+): string {
+  let amount = parseUnits(_amount, decimals).toString();
+  amount = getMinusSlippageScaled(amount, slippageBasisPoints);
 
-  const slippageBasisPoints = computed((): string => {
-    return bnum(slippage.value).times(10000).toString();
-  });
+  return formatUnits(amount, decimals);
+}
+
+export function getMinusSlippageScaled(
+  amount: string,
+  slippageBasisPoints: string | number
+): string {
+  const delta = bnum(amount)
+    .times(slippageBasisPoints)
+    .div(10000)
+    .dp(0, BigNumber.ROUND_UP);
+
+  return bnum(amount).minus(delta).toString();
+}
+
+export default function useSlippage() {
+  const { slippageBsp } = useUserSettings();
 
   function minusSlippage(_amount: string, decimals: number): string {
-    let amount = parseUnits(_amount, decimals).toString();
-    amount = minusSlippageScaled(amount);
-
-    return formatUnits(amount, decimals);
+    return getMinusSlippage(_amount, decimals, slippageBsp.value);
   }
 
   function minusSlippageScaled(amount: string): string {
-    const delta = bnum(amount)
-      .times(slippageBasisPoints.value)
-      .div(10000)
-      .dp(0, BigNumber.ROUND_UP);
-
-    return bnum(amount).minus(delta).toString();
+    return getMinusSlippageScaled(amount, slippageBsp.value);
   }
 
   function addSlippage(_amount: string, decimals: number): string {
@@ -38,7 +48,7 @@ export default function useSlippage() {
 
   function addSlippageScaled(amount: string): string {
     const delta = bnum(amount)
-      .times(slippageBasisPoints.value)
+      .times(slippageBsp.value)
       .div(10000)
       .dp(0, BigNumber.ROUND_DOWN);
 

--- a/src/pages/pool/withdraw.vue
+++ b/src/pages/pool/withdraw.vue
@@ -22,7 +22,7 @@ import { hasFetchedPoolsForSor } from '@/lib/balancer.sdk';
  */
 const { network } = configService;
 const { pool, poolQuery, loadingPool, transfersAllowed } = usePoolTransfers();
-const { isDeepPool, isPreMintedBptPool } = usePool(pool);
+const { isDeepPool } = usePool(pool);
 const { activeTab, resetTabs } = useWithdrawPageTabs();
 
 // Instead of refetching pool data on every block, we refetch every minute to prevent
@@ -61,7 +61,7 @@ onMounted(() => resetTabs());
             <TradeSettingsPopover :context="TradeSettingsContext.invest" />
           </div>
           <BalTabs
-            v-if="isDeepPool && isPreMintedBptPool"
+            v-if="isDeepPool"
             v-model="activeTab"
             :tabs="tabs"
             class="p-0 m-0 -mb-px whitespace-nowrap"

--- a/src/providers/local/exit-pool.provider.ts
+++ b/src/providers/local/exit-pool.provider.ts
@@ -53,6 +53,7 @@ import { useQuery, useQueryClient } from 'vue-query';
 import debounce from 'debounce-promise';
 import { captureException } from '@sentry/browser';
 import PoolCalculator from '@/services/pool/calculator/calculator.sevice';
+import PoolExchange from '@/services/pool/exchange/exchange.service';
 
 /**
  * TYPES
@@ -150,6 +151,7 @@ const provider = (props: Props) => {
    */
   const exitPoolService = new ExitPoolService(pool);
   const poolCalculator = new PoolCalculator(pool, allTokens, balances, 'exit');
+  const poolExchange = new PoolExchange(pool);
 
   /**
    * COMPUTED
@@ -346,6 +348,7 @@ const provider = (props: Props) => {
         tokenInfo: exitTokenInfo.value,
         prices: prices.value,
         poolCalculator,
+        poolExchange,
       });
 
       priceImpact.value = output.priceImpact;
@@ -385,6 +388,7 @@ const provider = (props: Props) => {
         prices: prices.value,
         relayerSignature: '',
         poolCalculator,
+        poolExchange,
       });
 
       singleAmountOut.max =
@@ -410,6 +414,7 @@ const provider = (props: Props) => {
         prices: prices.value,
         relayerSignature: relayerSignature.value,
         poolCalculator,
+        poolExchange,
       });
     } catch (error) {
       txError.value = (error as Error).message;

--- a/src/providers/local/exit-pool.provider.ts
+++ b/src/providers/local/exit-pool.provider.ts
@@ -388,13 +388,13 @@ const provider = (props: Props) => {
     if (!hasFetchedPoolsForSor.value) return;
     if (!isSingleAssetExit.value) return;
 
-    const exitHandler = exitPoolService.setExitHandler(exitHandlerType.value);
+    exitPoolService.setExitHandler(exitHandlerType.value);
     singleAmountOut.max = '';
 
     try {
       let output;
       if (exitHandlerType.value === ExitHandlerType.LegacySwapExit) {
-        output = await exitHandler.queryExit({
+        output = await exitPoolService.queryExit({
           exitType: ExitType.LegacySwapGivenIn,
           bptIn: bptBalance.value,
           amountsOut: [singleAmountOut],
@@ -405,7 +405,7 @@ const provider = (props: Props) => {
           poolExchange,
         });
       } else {
-        output = await exitHandler.queryExit({
+        output = await exitPoolService.queryExit({
           exitType: ExitType.SwapGivenIn,
           bptIn: bptBalance.value,
           amountsOut: [singleAmountOut],

--- a/src/services/balancer/pools/exits/exit-pool.service.ts
+++ b/src/services/balancer/pools/exits/exit-pool.service.ts
@@ -11,6 +11,7 @@ import {
   ExitPoolHandler,
   QueryOutput,
 } from './handlers/exit-pool.handler';
+import { LegacySwapExitHandler } from './handlers/legacy-swap-exit.handler';
 
 /**
  * ExitPoolService acts as an adapter to underlying handlers based on the pool
@@ -42,10 +43,19 @@ export class ExitPoolService {
    * @param {boolean} [swapExit=false] - Flag to ensure SwapExitHandler is used for exiting.
    * @returns {ExitPoolHandler} The ExitPoolHandler class to be used.
    */
-  setExitHandler(swapJoin = false): ExitPoolHandler {
+  setExitHandler(swapExit = false, hasPremintedBPT = true): ExitPoolHandler {
     const { pool, sdk, gasPriceServ } = this;
-
-    if (swapJoin) {
+    console.log({
+      swapExit,
+      hasPremintedBPT,
+    });
+    if (swapExit && !hasPremintedBPT) {
+      return (this.exitHandler = new LegacySwapExitHandler(
+        pool,
+        sdk,
+        gasPriceServ
+      ));
+    } else if (swapExit) {
       return (this.exitHandler = new SwapExitHandler(pool, sdk, gasPriceServ));
     } else if (isDeep(pool.value)) {
       return (this.exitHandler = new GeneralisedExitHandler(

--- a/src/services/balancer/pools/exits/handlers/exit-pool.handler.ts
+++ b/src/services/balancer/pools/exits/handlers/exit-pool.handler.ts
@@ -5,7 +5,7 @@ import { TransactionResponse } from '@ethersproject/abstract-provider';
 import { Ref } from 'vue';
 import { SwapExitParams } from './swap-exit.handler';
 import { LegacySwapExitParams } from './legacy-swap-exit.handler';
-import { DeepExitParams } from './deep-exit.handler';
+import { GeneralisedExitParams } from './generalised-exit.handler';
 
 export type AmountsOut = Record<Address, string>;
 
@@ -17,7 +17,10 @@ export enum ExitType {
   DeepGivenIn, // When BPT in is specified.
 }
 
-export type ExitParams = LegacySwapExitParams | SwapExitParams | DeepExitParams;
+export type ExitParams =
+  | LegacySwapExitParams
+  | SwapExitParams
+  | GeneralisedExitParams;
 
 export type QueryOutput = {
   priceImpact: number;

--- a/src/services/balancer/pools/exits/handlers/exit-pool.handler.ts
+++ b/src/services/balancer/pools/exits/handlers/exit-pool.handler.ts
@@ -7,6 +7,7 @@ import { TokenInfoMap } from '@/types/TokenList';
 import { TransactionResponse } from '@ethersproject/abstract-provider';
 import { Ref } from 'vue';
 import { JsonRpcSigner } from '@ethersproject/providers';
+import PoolCalculator from '@/services/pool/calculator/calculator.sevice';
 
 export type AmountsOut = Record<Address, string>;
 
@@ -24,6 +25,7 @@ export type ExitParams = {
   signer: JsonRpcSigner;
   slippageBsp: number;
   relayerSignature?: string;
+  poolCalculator: PoolCalculator;
 };
 
 export type QueryOutput = {

--- a/src/services/balancer/pools/exits/handlers/exit-pool.handler.ts
+++ b/src/services/balancer/pools/exits/handlers/exit-pool.handler.ts
@@ -8,6 +8,7 @@ import { TransactionResponse } from '@ethersproject/abstract-provider';
 import { Ref } from 'vue';
 import { JsonRpcSigner } from '@ethersproject/providers';
 import PoolCalculator from '@/services/pool/calculator/calculator.sevice';
+import PoolExchange from '@/services/pool/exchange/exchange.service';
 
 export type AmountsOut = Record<Address, string>;
 
@@ -26,6 +27,7 @@ export type ExitParams = {
   slippageBsp: number;
   relayerSignature?: string;
   poolCalculator: PoolCalculator;
+  poolExchange: PoolExchange;
 };
 
 export type QueryOutput = {

--- a/src/services/balancer/pools/exits/handlers/exit-pool.handler.ts
+++ b/src/services/balancer/pools/exits/handlers/exit-pool.handler.ts
@@ -1,34 +1,23 @@
 import { Address, BalancerSDK } from '@balancer-labs/sdk';
-import { AmountOut } from '@/providers/local/exit-pool.provider';
-import { TokenPrices } from '@/services/coingecko/api/price.service';
 import { GasPriceService } from '@/services/gas-price/gas-price.service';
 import { Pool } from '@/services/pool/types';
-import { TokenInfoMap } from '@/types/TokenList';
 import { TransactionResponse } from '@ethersproject/abstract-provider';
 import { Ref } from 'vue';
-import { JsonRpcSigner } from '@ethersproject/providers';
-import PoolCalculator from '@/services/pool/calculator/calculator.sevice';
-import PoolExchange from '@/services/pool/exchange/exchange.service';
+import { SwapExitParams } from './swap-exit.handler';
+import { LegacySwapExitParams } from './legacy-swap-exit.handler';
+import { DeepExitParams } from './deep-exit.handler';
 
 export type AmountsOut = Record<Address, string>;
 
 export enum ExitType {
-  GivenIn, // When BPT in is specified.
-  GivenOut, // When an amount out is specified.
+  SwapGivenIn, // When BPT in is specified.
+  SwapGivenOut, // When an amount out is specified.
+  LegacySwapGivenIn, // When BPT in is specified.
+  LegacySwapGivenOut, // When an amount out is specified.
+  DeepGivenIn, // When BPT in is specified.
 }
 
-export type ExitParams = {
-  exitType: ExitType;
-  bptIn: string;
-  amountsOut: AmountOut[];
-  tokenInfo: TokenInfoMap;
-  prices: TokenPrices;
-  signer: JsonRpcSigner;
-  slippageBsp: number;
-  relayerSignature?: string;
-  poolCalculator: PoolCalculator;
-  poolExchange: PoolExchange;
-};
+export type ExitParams = LegacySwapExitParams | SwapExitParams | DeepExitParams;
 
 export type QueryOutput = {
   priceImpact: number;

--- a/src/services/balancer/pools/exits/handlers/generalised-exit.handler.ts
+++ b/src/services/balancer/pools/exits/handlers/generalised-exit.handler.ts
@@ -19,7 +19,7 @@ import { JsonRpcSigner } from '@ethersproject/providers';
 
 type ExitResponse = Awaited<ReturnType<typeof balancer.pools.generalisedExit>>;
 
-export type DeepExitParams = {
+export type GeneralisedExitParams = {
   exitType: ExitType.DeepGivenIn;
   bptIn: string;
   signer: JsonRpcSigner;
@@ -39,7 +39,7 @@ export class GeneralisedExitHandler implements ExitPoolHandler {
     public readonly gasPriceService: GasPriceService
   ) {}
 
-  async exit(params: DeepExitParams): Promise<TransactionResponse> {
+  async exit(params: GeneralisedExitParams): Promise<TransactionResponse> {
     await this.queryExit(params);
 
     if (!this.lastExitRes) {
@@ -57,7 +57,7 @@ export class GeneralisedExitHandler implements ExitPoolHandler {
     signer,
     slippageBsp,
     relayerSignature,
-  }: DeepExitParams): Promise<QueryOutput> {
+  }: GeneralisedExitParams): Promise<QueryOutput> {
     const evmAmountIn = parseFixed(
       bptIn || '0',
       this.pool.value.onchain?.decimals ?? 18

--- a/src/services/balancer/pools/exits/handlers/legacy-swap-exit.handler.ts
+++ b/src/services/balancer/pools/exits/handlers/legacy-swap-exit.handler.ts
@@ -1,0 +1,214 @@
+import { overflowProtected } from '@/components/_global/BalTextInput/helpers';
+import { getTimestampSecondsFromNow } from '@/composables/useTime';
+import { POOLS } from '@/constants/pools';
+import { NATIVE_ASSET_ADDRESS } from '@/constants/tokens';
+
+import { bnum, isSameAddress, selectByAddress } from '@/lib/utils';
+import { vaultService } from '@/services/contracts/vault.service';
+import { GasPriceService } from '@/services/gas-price/gas-price.service';
+import { Pool } from '@/services/pool/types';
+import { BalancerSDK, BatchSwap, SwapInfo, SwapType } from '@balancer-labs/sdk';
+import { TransactionResponse } from '@ethersproject/abstract-provider';
+import { BigNumber } from '@ethersproject/bignumber';
+import { JsonRpcSigner } from '@ethersproject/providers';
+import { formatUnits, parseUnits } from '@ethersproject/units';
+import { Ref } from 'vue';
+
+import {
+  ExitParams,
+  ExitPoolHandler,
+  ExitType,
+  QueryOutput,
+} from './exit-pool.handler';
+
+/**
+ * Handles exits for single asset flows where we need to use a BatchSwap to exit
+ * the pool.
+ */
+export class LegacySwapExitHandler implements ExitPoolHandler {
+  private lastSwapRoute?: SwapInfo;
+
+  constructor(
+    public readonly pool: Ref<Pool>,
+    public readonly sdk: BalancerSDK,
+    public readonly gasPriceService: GasPriceService
+  ) {}
+
+  async exit(params: ExitParams): Promise<TransactionResponse> {
+    const userAddress = await params.signer.getAddress();
+    await this.queryExit(params);
+    if (!this.lastSwapRoute)
+      throw new Error('Could not fetch swap route for join.');
+
+    const swap = this.getSwapAttributes(
+      params.exitType,
+      this.lastSwapRoute,
+      params.slippageBsp,
+      userAddress
+    );
+
+    const { kind, swaps, assets, funds, limits } = swap.attributes as BatchSwap;
+    return vaultService.batchSwap(
+      kind,
+      swaps,
+      assets,
+      funds,
+      limits as string[]
+    );
+  }
+
+  async queryExit(params: ExitParams): Promise<QueryOutput> {
+    if (params.exitType === ExitType.GivenIn) {
+      return this.queryOutGivenIn(params);
+    } else {
+      return this.queryInGivenOut(params);
+    }
+  }
+
+  /**
+   * PRIVATE
+   */
+
+  /**
+   * Get swap given bptIn, this only used in exits when the user clicks to
+   * maximize their withdrawal, i.e. we have to send their full BPT balance.
+   */
+  private async queryOutGivenIn({
+    bptIn,
+    tokenInfo,
+    amountsOut,
+    // signer,
+    poolCalculator,
+  }: ExitParams): Promise<QueryOutput> {
+    const bptBalanceScaled = parseUnits(
+      bptIn,
+      this.pool.value.onchain?.decimals || 18
+    ).toString();
+    const tokenOut = selectByAddress(tokenInfo, amountsOut[0].address);
+    if (!tokenOut)
+      throw new Error('Could not find exit token in pool tokens list.');
+    const tokenIndex = this.pool.value.tokensList.findIndex(address =>
+      isSameAddress(address, tokenOut.address)
+    );
+    try {
+      const maxOut = formatUnits(
+        poolCalculator
+          .exactBPTInForTokenOut(bptBalanceScaled, tokenIndex)
+          .toString(),
+        tokenOut.decimals
+      );
+
+      const result = {
+        amountsOut: { [tokenOut.address]: maxOut },
+        priceImpact: 0,
+      };
+      console.log({ queryOutGivenIn: result });
+      return result;
+    } catch (error) {
+      throw new Error('SINGLE_ASSET_WITHDRAWAL_MIN_BPT_LIMIT');
+      // TODO: Handle this error
+      // if ((error as Error).message.includes('MIN_BPT_IN_FOR_TOKEN_OUT')) {
+      //   setError(WithdrawalError.SINGLE_ASSET_WITHDRAWAL_MIN_BPT_LIMIT);
+      //   return poolTokens.value.map((token, tokenIndex) => {
+      //     return formatUnits(
+      //       poolCalculator
+      //         .exactBPTInForTokenOut(
+      //           parseUnits(absMaxBpt.value, poolDecimals.value).toString(),
+      //           tokenIndex
+      //         )
+      //         .toString(),
+      //       token.decimals
+      //     );
+      //   });
+      // }
+    }
+  }
+
+  /**
+   * Get swap given specified amount out.
+   */
+  private async queryInGivenOut({
+    // bptIn,
+    tokenInfo,
+    amountsOut,
+    // signer,
+    poolCalculator,
+  }: ExitParams): Promise<QueryOutput> {
+    const tokenOut = selectByAddress(tokenInfo, amountsOut[0].address);
+    if (!tokenOut)
+      throw new Error('Could not find exit token in pool tokens list.');
+    const tokenOutIndex = this.pool.value.tokensList.findIndex(address =>
+      isSameAddress(address, tokenOut.address)
+    );
+
+    const safeAmountOut = overflowProtected(
+      amountsOut[0].value,
+      tokenOut.decimals
+    );
+
+    const amountOut = poolCalculator
+      .bptInForExactTokenOut(safeAmountOut, tokenOutIndex)
+      .toString();
+
+    const result = {
+      amountsOut: { [tokenOut.address]: amountOut },
+      priceImpact: 0,
+    };
+    console.log({ queryInGivenOut: result });
+    return result;
+  }
+
+  private async getGasPrice(signer: JsonRpcSigner): Promise<BigNumber> {
+    let price: number;
+
+    const gasPriceParams = await this.gasPriceService.getGasPrice();
+    if (gasPriceParams) {
+      price = gasPriceParams.price;
+    } else {
+      price = (await signer.getGasPrice()).toNumber();
+    }
+
+    if (!price) throw new Error('Failed to fetch gas price.');
+
+    return BigNumber.from(price);
+  }
+
+  private calcPriceImpact(
+    amountIn: string,
+    amountOut: string,
+    marketSp: string
+  ): number {
+    const effectivePrice = bnum(amountIn).div(amountOut);
+    const priceImpact = effectivePrice.div(marketSp).minus(1) || 1; // If fails to calculate return error value of 100%
+
+    // Don't return negative price impact
+    return Math.max(0, priceImpact.toNumber());
+  }
+
+  private getSwapAttributes(
+    exitType: ExitType,
+    swapInfo: SwapInfo,
+    maxSlippage: number,
+    userAddress: string
+  ) {
+    const deadline = BigNumber.from(getTimestampSecondsFromNow(60)); // 60 seconds from now
+    const kind =
+      exitType === ExitType.GivenIn
+        ? SwapType.SwapExactIn
+        : SwapType.SwapExactOut;
+
+    return this.sdk.swaps.buildSwap({
+      userAddress,
+      swapInfo,
+      kind,
+      deadline,
+      maxSlippage,
+    });
+  }
+
+  private formatAddressForSor(address: string): string {
+    return isSameAddress(address, NATIVE_ASSET_ADDRESS)
+      ? POOLS.ZeroAddress
+      : address;
+  }
+}

--- a/src/services/balancer/pools/exits/handlers/swap-exit.handler.ts
+++ b/src/services/balancer/pools/exits/handlers/swap-exit.handler.ts
@@ -112,7 +112,7 @@ export class SwapExitHandler implements ExitPoolHandler {
       amountOut,
       this.lastSwapRoute.marketSp
     );
-
+    console.log({ amountsOut: { [tokenOut.address]: amountOut }, priceImpact });
     return { amountsOut: { [tokenOut.address]: amountOut }, priceImpact };
   }
 
@@ -165,7 +165,7 @@ export class SwapExitHandler implements ExitPoolHandler {
       amountOut,
       this.lastSwapRoute.marketSp
     );
-
+    console.log({ amountsOut: { [tokenOut.address]: amountOut }, priceImpact });
     return { amountsOut: { [tokenOut.address]: amountOut }, priceImpact };
   }
 

--- a/src/services/balancer/pools/exits/handlers/swap-exit.handler.ts
+++ b/src/services/balancer/pools/exits/handlers/swap-exit.handler.ts
@@ -36,7 +36,7 @@ export class SwapExitHandler implements ExitPoolHandler {
     const userAddress = await params.signer.getAddress();
     await this.queryExit(params);
     if (!this.lastSwapRoute)
-      throw new Error('Could not fetch swap route for join.');
+      throw new Error('Could not fetch swap route for exit.');
 
     const swap = this.getSwapAttributes(
       params.exitType,

--- a/src/services/balancer/pools/exits/handlers/swap-exit.handler.ts
+++ b/src/services/balancer/pools/exits/handlers/swap-exit.handler.ts
@@ -80,7 +80,7 @@ export class SwapExitHandler implements ExitPoolHandler {
     const amountIn = bptIn;
     const tokenIn = selectByAddress(tokenInfo, this.pool.value.address);
 
-    const tokenOut = tokenInfo[amountsOut[0].address];
+    const tokenOut = selectByAddress(tokenInfo, amountsOut[0].address);
 
     if (!tokenIn || !tokenOut)
       throw new Error('Missing critical token metadata.');
@@ -134,6 +134,10 @@ export class SwapExitHandler implements ExitPoolHandler {
       return { amountsOut: {}, priceImpact: 0 };
 
     if (!hasFetchedPoolsForSor.value) await fetchPoolsForSor();
+    console.log({
+      tokenIn: tokenIn.address,
+      tokenOut: tokenOut.address,
+    });
 
     const safeAmountOut = overflowProtected(
       amountsOut[0].value,
@@ -149,7 +153,7 @@ export class SwapExitHandler implements ExitPoolHandler {
       gasPrice,
       maxPools: 4,
     });
-
+    console.log({ lastSwapRoute: this.lastSwapRoute });
     const amountIn = formatFixed(
       this.lastSwapRoute.returnAmount,
       tokenIn.decimals


### PR DESCRIPTION
# Description

- When exiting deep Weighted pool, limit single asset tokens to high level tokens.
- Added new Exit Pool handler: `LegacySwapExitHandler`

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How should this be tested?

Please provide instructions so we can test. Please also list any relevant details for your test configuration.

- Go to Deep Weighted Pool's withdraw page `http://localhost:8080/#/ethereum/pool/0x25accb7943fd73dda5e23ba6329085a3c24bfb6a000200000000000000000387/withdraw`
- Select "Single token" tab
- Select any pool token to exit to and try inputting different amounts

## Visual context
<img width="681" alt="Screenshot 2023-01-04 at 12 25 17" src="https://user-images.githubusercontent.com/28311328/210535019-079eb9a7-a39d-405d-84e0-c2ef818eb140.png">



## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have requested at least 1 review (If the PR is significant enough, use best judgement here)
- [ ] I have commented my code where relevant, particularly in hard-to-understand areas
- [ ] If package-lock.json has changes, it was intentional.
- [ ] The base of this PR is `master` if hotfix, `develop` if not
