### PR TITLE
Skip balancer api repository when url is not defined

### DIFF
--- a/src/composables/queries/usePoolsQuery.ts
+++ b/src/composables/queries/usePoolsQuery.ts
@@ -13,6 +13,7 @@ import {
   GraphQLArgs,
   PoolsFallbackRepository,
   PoolsRepositoryFetchOptions,
+  PoolRepository as SDKPoolRepository,
 } from '@balancer-labs/sdk';
 import { PoolDecorator } from '@/services/pool/decorators/pool.decorator';
 import { flatten } from 'lodash';
@@ -21,6 +22,7 @@ import { tokenTreeLeafs } from '../usePool';
 import { balancerSubgraphService } from '@/services/balancer/subgraph/balancer-subgraph.service';
 import { balancerAPIService } from '@/services/balancer/api/balancer-api.service';
 import { poolsStoreService } from '@/services/pool/pools-store.service';
+import { isBalancerApiDefined } from '@/lib/utils/balancer/api';
 
 type PoolsQueryResponse = {
   pools: Pool[];
@@ -45,8 +47,6 @@ export default function usePoolsQuery(
   const { injectTokens, tokens: tokenMeta, dynamicDataLoading } = useTokens();
   const { networkId } = useNetwork();
 
-  let balancerApiRepository = initializeDecoratedAPIRepository();
-  let subgraphRepository = initializeDecoratedSubgraphRepository();
   let poolsRepository = initializePoolsRepository();
 
   /**
@@ -54,12 +54,9 @@ export default function usePoolsQuery(
    */
 
   function initializePoolsRepository(): PoolsFallbackRepository {
-    const fallbackRepository = new PoolsFallbackRepository(
-      [balancerApiRepository, subgraphRepository],
-      {
-        timeout: 30 * 1000,
-      }
-    );
+    const fallbackRepository = new PoolsFallbackRepository(buildProviders(), {
+      timeout: 30 * 1000,
+    });
     return fallbackRepository;
   }
 
@@ -102,6 +99,18 @@ export default function usePoolsQuery(
         return balancerSubgraphService.pools.skip;
       },
     };
+  }
+
+  function buildProviders() {
+    const providers: SDKPoolRepository[] = [];
+    if (isBalancerApiDefined()) {
+      const balancerApiRepository = initializeDecoratedAPIRepository();
+      providers.push(balancerApiRepository);
+    }
+    const subgraphRepository = initializeDecoratedSubgraphRepository();
+    providers.push(subgraphRepository);
+
+    return providers;
   }
 
   function getQueryArgs(options: PoolsRepositoryFetchOptions): GraphQLArgs {
@@ -161,8 +170,6 @@ export default function usePoolsQuery(
   watch(
     filterTokens,
     () => {
-      balancerApiRepository = initializeDecoratedAPIRepository();
-      subgraphRepository = initializeDecoratedSubgraphRepository();
       poolsRepository = initializePoolsRepository();
     },
     { deep: true }

--- a/src/composables/queries/usePoolsQuery.ts
+++ b/src/composables/queries/usePoolsQuery.ts
@@ -54,9 +54,12 @@ export default function usePoolsQuery(
    */
 
   function initializePoolsRepository(): PoolsFallbackRepository {
-    const fallbackRepository = new PoolsFallbackRepository(buildProviders(), {
-      timeout: 30 * 1000,
-    });
+    const fallbackRepository = new PoolsFallbackRepository(
+      buildRepositories(),
+      {
+        timeout: 30 * 1000,
+      }
+    );
     return fallbackRepository;
   }
 
@@ -101,16 +104,16 @@ export default function usePoolsQuery(
     };
   }
 
-  function buildProviders() {
-    const providers: SDKPoolRepository[] = [];
-    if (isBalancerApiDefined()) {
+  function buildRepositories() {
+    const repositories: SDKPoolRepository[] = [];
+    if (isBalancerApiDefined) {
       const balancerApiRepository = initializeDecoratedAPIRepository();
-      providers.push(balancerApiRepository);
+      repositories.push(balancerApiRepository);
     }
     const subgraphRepository = initializeDecoratedSubgraphRepository();
-    providers.push(subgraphRepository);
+    repositories.push(subgraphRepository);
 
-    return providers;
+    return repositories;
   }
 
   function getQueryArgs(options: PoolsRepositoryFetchOptions): GraphQLArgs {

--- a/src/lib/utils/balancer/api.ts
+++ b/src/lib/utils/balancer/api.ts
@@ -1,0 +1,10 @@
+import { configService } from '@/services/config/config.service';
+
+export function isBalancerApiDefined() {
+  const defined = configService.network.balancerApi;
+  if (!defined)
+    console.log(
+      `Skipping balancer api provider in your current network (${configService.network.chainName})`
+    );
+  return defined;
+}

--- a/src/lib/utils/balancer/api.ts
+++ b/src/lib/utils/balancer/api.ts
@@ -1,10 +1,3 @@
 import { configService } from '@/services/config/config.service';
 
-export function isBalancerApiDefined() {
-  const defined = configService.network.balancerApi;
-  if (!defined)
-    console.log(
-      `Skipping balancer api provider in your current network (${configService.network.chainName})`
-    );
-  return defined;
-}
+export const isBalancerApiDefined = !!configService.network.balancerApi;

--- a/src/services/pool/pool.repository.spec.ts
+++ b/src/services/pool/pool.repository.spec.ts
@@ -1,0 +1,14 @@
+import PoolRepository from '@/services/pool/pool.repository';
+import { TokenInfoMap } from '@/types/TokenList';
+import { computed } from 'vue';
+
+describe('Building a pool repository', () => {
+  it('Logs when balancer api provider is skipped', () => {
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
+    const log = vi.spyOn(console, 'log').mockImplementationOnce(() => {});
+    new PoolRepository(computed(() => ({} as TokenInfoMap)));
+    expect(log).toBeCalledWith(
+      'Skipping balancer api provider in your current network (Goerli)'
+    );
+  });
+});

--- a/src/services/pool/pool.repository.spec.ts
+++ b/src/services/pool/pool.repository.spec.ts
@@ -2,6 +2,8 @@ import PoolRepository from '@/services/pool/pool.repository';
 import { TokenInfoMap } from '@/types/TokenList';
 import { computed } from 'vue';
 
+jest.mock('@/services/web3/useWeb3');
+
 describe('Building a pool repository', () => {
   it('Logs when balancer api provider is skipped', () => {
     // eslint-disable-next-line @typescript-eslint/no-empty-function

--- a/src/services/pool/pool.repository.spec.ts
+++ b/src/services/pool/pool.repository.spec.ts
@@ -5,12 +5,11 @@ import { computed } from 'vue';
 jest.mock('@/services/web3/useWeb3');
 
 describe('Building a pool repository', () => {
-  it('Logs when balancer api provider is skipped', () => {
-    // eslint-disable-next-line @typescript-eslint/no-empty-function
-    const log = jest.spyOn(console, 'log').mockImplementationOnce(() => {});
-    new PoolRepository(computed(() => ({} as TokenInfoMap)));
-    expect(log).toBeCalledWith(
-      'Skipping balancer api provider in your current network (Goerli)'
+  it('avoids balancer Api as a repository when it is not defined', () => {
+    const poolRepository = new PoolRepository(
+      computed(() => ({} as TokenInfoMap))
     );
+    // @ts-ignore
+    expect(poolRepository.repository.providers).toHaveLength(1);
   });
 });

--- a/src/services/pool/pool.repository.spec.ts
+++ b/src/services/pool/pool.repository.spec.ts
@@ -5,7 +5,7 @@ import { computed } from 'vue';
 describe('Building a pool repository', () => {
   it('Logs when balancer api provider is skipped', () => {
     // eslint-disable-next-line @typescript-eslint/no-empty-function
-    const log = vi.spyOn(console, 'log').mockImplementationOnce(() => {});
+    const log = jest.spyOn(console, 'log').mockImplementationOnce(() => {});
     new PoolRepository(computed(() => ({} as TokenInfoMap)));
     expect(log).toBeCalledWith(
       'Skipping balancer api provider in your current network (Goerli)'

--- a/src/services/pool/pool.repository.ts
+++ b/src/services/pool/pool.repository.ts
@@ -16,7 +16,7 @@ export default class PoolRepository {
   queryArgs: GraphQLArgs;
 
   constructor(private tokens: ComputedRef<TokenInfoMap>) {
-    this.repository = new PoolsFallbackRepository(this.buildProviders(), {
+    this.repository = new PoolsFallbackRepository(this.buildRepositories(), {
       timeout: 30 * 1000,
     });
     this.queryArgs = {};
@@ -58,15 +58,15 @@ export default class PoolRepository {
     };
   }
 
-  private buildProviders() {
-    const providers: SDKPoolRepository[] = [];
-    if (isBalancerApiDefined()) {
+  private buildRepositories() {
+    const repositories: SDKPoolRepository[] = [];
+    if (isBalancerApiDefined) {
       const balancerApiRepository = this.initializeDecoratedAPIRepository();
-      providers.push(balancerApiRepository);
+      repositories.push(balancerApiRepository);
     }
     const subgraphRepository = this.initializeDecoratedSubgraphRepository();
-    providers.push(subgraphRepository);
+    repositories.push(subgraphRepository);
 
-    return providers;
+    return repositories;
   }
 }

--- a/src/services/pool/pool.repository.ts
+++ b/src/services/pool/pool.repository.ts
@@ -1,4 +1,3 @@
-import { configService } from '@/services/config/config.service';
 import { ComputedRef } from 'vue';
 import { balancerSubgraphService } from '@/services/balancer/subgraph/balancer-subgraph.service';
 import { PoolDecorator } from '@/services/pool/decorators/pool.decorator';
@@ -10,6 +9,8 @@ import {
 import { balancerAPIService } from '@/services/balancer/api/balancer-api.service';
 import { Pool } from '@/services/pool/types';
 import { TokenInfoMap } from '@/types/TokenList';
+import { isBalancerApiDefined } from '@/lib/utils/balancer/api';
+
 export default class PoolRepository {
   repository: PoolsFallbackRepository;
   queryArgs: GraphQLArgs;
@@ -59,7 +60,7 @@ export default class PoolRepository {
 
   private buildProviders() {
     const providers: SDKPoolRepository[] = [];
-    if (checkBalancerApiIsDefined()) {
+    if (isBalancerApiDefined()) {
       const balancerApiRepository = this.initializeDecoratedAPIRepository();
       providers.push(balancerApiRepository);
     }
@@ -68,13 +69,4 @@ export default class PoolRepository {
 
     return providers;
   }
-}
-
-function checkBalancerApiIsDefined() {
-  const defined = configService.network.balancerApi;
-  if (!defined)
-    console.log(
-      `Skipping balancer api provider in your current network (${configService.network.chainName})`
-    );
-  return defined;
 }


### PR DESCRIPTION
# Description

When connected to Goerli, you can see the attached error when loading the index page.

The problem is that [goerli.json](https://github.com/balancer-labs/frontend-v2/blob/870d008f7062e3082cb446c895a8df61f4bab8ba/src/lib/config/goerli.json) does not have an attribute for balancerApi so that the SDK.

This solution will also work for `docker.json`.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [x] Other

## How should this be tested?

Please provide instructions so we can test. Please also list any relevant details for your test configuration.

- [ ] Test A
- [ ] Test B

## Visual context

Please provide any relevant visual context for UI changes or additions. This could be static screenshots or a loom screencast.

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have requested at least 1 review (If the PR is significant enough, use best judgement here)
- [ ] I have commented my code where relevant, particularly in hard-to-understand areas
- [ ] If package-lock.json has changes, it was intentional.
- [ ] The base of this PR is `master` if hotfix, `develop` if not
