### PR TITLE
hotfix: pool redirect url

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.83.2",
+  "version": "1.83.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@balancer-labs/frontend-v2",
-      "version": "1.83.2",
+      "version": "1.83.3",
       "license": "MIT",
       "devDependencies": {
         "@aave/protocol-js": "^4.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.83.2",
+  "version": "1.83.3",
   "engines": {
     "node": "14.x",
     "npm": ">=7"

--- a/src/components/contextual/pages/vebal/LMVoting/GaugesTable.vue
+++ b/src/components/contextual/pages/vebal/LMVoting/GaugesTable.vue
@@ -141,7 +141,7 @@ function isInternalUrl(url: string): boolean {
 }
 
 function redirectToPool(gauge: VotingGaugeWithVotes, inNewTab) {
-  const redirectUrl = poolURLFor(gauge.pool.id, gauge.network);
+  const redirectUrl = poolURLFor(gauge.pool, gauge.network);
   if (!isInternalUrl(redirectUrl)) {
     window.location.href = redirectUrl;
   } else {
@@ -154,7 +154,7 @@ function redirectToPool(gauge: VotingGaugeWithVotes, inNewTab) {
 }
 
 function getPoolExternalUrl(gauge: VotingGaugeWithVotes) {
-  const poolUrl = poolURLFor(gauge.pool.id, gauge.network);
+  const poolUrl = poolURLFor(gauge.pool, gauge.network);
   return isInternalUrl(poolUrl) ? null : poolUrl;
 }
 

--- a/src/components/contextual/pages/vebal/LMVoting/LMVoting.vue
+++ b/src/components/contextual/pages/vebal/LMVoting/LMVoting.vue
@@ -187,9 +187,7 @@ function handleVoteSuccess() {
       v-if="!!activeVotingGauge"
       :gauge="activeVotingGauge"
       :logoURIs="orderedTokenURIs(activeVotingGauge)"
-      :poolURL="
-        poolURLFor(activeVotingGauge.pool.id, activeVotingGauge.network)
-      "
+      :poolURL="poolURLFor(activeVotingGauge.pool, activeVotingGauge.network)"
       :unallocatedVoteWeight="unallocatedVoteWeight"
       :veBalLockInfo="veBalLockInfoQuery.data.value"
       @success="handleVoteSuccess"

--- a/src/composables/usePool.ts
+++ b/src/composables/usePool.ts
@@ -201,21 +201,20 @@ export function orderedPoolTokens<TPoolTokens extends TokenProperties>(
  * @summary returns full URL for pool id, given network.
  */
 export function poolURLFor(
-  poolId: string,
-  network: Network,
-  poolType?: string | PoolType
+  pool: Pick<Pool, 'id' | 'poolType'>,
+  network: Network
 ): string {
   if (network === Network.OPTIMISM) {
-    return `https://op.beets.fi/#/pool/${poolId}`;
+    return `https://op.beets.fi/#/pool/${pool.id}`;
   }
-  if (poolType && poolType.toString() === 'Element') {
-    return `https://app.element.fi/pools/${addressFor(poolId)}`;
+  if (pool.poolType && pool.poolType.toString() === 'Element') {
+    return `https://app.element.fi/pools/${addressFor(pool.id)}`;
   }
-  if (poolType && poolType.toString() === 'FX') {
+  if (pool.poolType && pool.poolType.toString() === 'FX') {
     return `https://app.xave.finance/#/pool`;
   }
 
-  return `${appUrl()}/${getNetworkSlug(network)}/pool/${poolId}`;
+  return `${appUrl()}/${getNetworkSlug(network)}/pool/${pool.id}`;
 }
 
 /**


### PR DESCRIPTION
# Description

Pool redirecting on the veBAL page hasn't been working because `poolType` wasn't passed to `poolURLFor` function.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## How should this be tested?

Go to veBAL page and click on any Optimism pool and you should be redirected to Beets app.

## Visual context

Please provide any relevant visual context for UI changes or additions. This could be static screenshots or a loom screencast.

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have requested at least 1 review (If the PR is significant enough, use best judgement here)
- [ ] I have commented my code where relevant, particularly in hard-to-understand areas
- [ ] If package-lock.json has changes, it was intentional.
- [ ] The base of this PR is `master` if hotfix, `develop` if not
