### PR TITLE
Use Balancer REST API for fetching individual pools

### DIFF
--- a/src/lib/config/arbitrum.json
+++ b/src/lib/config/arbitrum.json
@@ -14,7 +14,7 @@
   "explorer": "https://arbiscan.io",
   "explorerName": "Arbiscan",
   "subgraph": "https://api.thegraph.com/subgraphs/name/balancer-labs/balancer-arbitrum-v2",
-  "balancerApi": "https://48gc39o77a.execute-api.ap-southeast-2.amazonaws.com/prod",
+  "balancerApi": "https://api.balancer.fi",
   "poolsUrlV1": "",
   "poolsUrlV2": "",
   "subgraphs": {

--- a/src/lib/config/arbitrum.json
+++ b/src/lib/config/arbitrum.json
@@ -14,7 +14,7 @@
   "explorer": "https://arbiscan.io",
   "explorerName": "Arbiscan",
   "subgraph": "https://api.thegraph.com/subgraphs/name/balancer-labs/balancer-arbitrum-v2",
-  "balancerApi": "https://berfqtb52bc4hetoouojoshqem.appsync-api.eu-west-2.amazonaws.com/graphql",
+  "balancerApi": "https://48gc39o77a.execute-api.ap-southeast-2.amazonaws.com/prod",
   "poolsUrlV1": "",
   "poolsUrlV2": "",
   "subgraphs": {

--- a/src/lib/config/homestead.json
+++ b/src/lib/config/homestead.json
@@ -13,7 +13,7 @@
   "explorer": "https://etherscan.io",
   "explorerName": "Etherscan",
   "subgraph": "https://api.thegraph.com/subgraphs/name/balancer-labs/balancer-v2",
-  "balancerApi": "https://berfqtb52bc4hetoouojoshqem.appsync-api.eu-west-2.amazonaws.com/graphql",
+  "balancerApi": "https://48gc39o77a.execute-api.ap-southeast-2.amazonaws.com/prod",
   "poolsUrlV2": "https://storageapi.fleek.co/johngrantuk-team-bucket/poolsV2.json",
   "subgraphs": {
     "main": [

--- a/src/lib/config/homestead.json
+++ b/src/lib/config/homestead.json
@@ -13,7 +13,7 @@
   "explorer": "https://etherscan.io",
   "explorerName": "Etherscan",
   "subgraph": "https://api.thegraph.com/subgraphs/name/balancer-labs/balancer-v2",
-  "balancerApi": "https://48gc39o77a.execute-api.ap-southeast-2.amazonaws.com/prod",
+  "balancerApi": "https://api.balancer.fi",
   "poolsUrlV2": "https://storageapi.fleek.co/johngrantuk-team-bucket/poolsV2.json",
   "subgraphs": {
     "main": [

--- a/src/lib/config/polygon.json
+++ b/src/lib/config/polygon.json
@@ -13,8 +13,8 @@
   "publicRpc": "https://polygon-rpc.com",
   "explorer": "https://polygonscan.com",
   "explorerName": "Polygonscan",
-  "subgraph": "https://api.thegraph.com/subgraphs/name/balancer-labs/balancer-polygon-prune-v2",
-  "balancerApi": "https://berfqtb52bc4hetoouojoshqem.appsync-api.eu-west-2.amazonaws.com/graphql",
+  "subgraph": "https://api.thegraph.com/subgraphs/name/balancer-labs/balancer-polygon-v2",
+  "balancerApi": "https://48gc39o77a.execute-api.ap-southeast-2.amazonaws.com/prod",
   "poolsUrlV2": "",
   "subgraphs": {
     "main": [

--- a/src/lib/config/polygon.json
+++ b/src/lib/config/polygon.json
@@ -14,7 +14,7 @@
   "explorer": "https://polygonscan.com",
   "explorerName": "Polygonscan",
   "subgraph": "https://api.thegraph.com/subgraphs/name/balancer-labs/balancer-polygon-v2",
-  "balancerApi": "https://48gc39o77a.execute-api.ap-southeast-2.amazonaws.com/prod",
+  "balancerApi": "https://api.balancer.fi",
   "poolsUrlV2": "",
   "subgraphs": {
     "main": [

--- a/src/services/balancer/api/entities/pool/index.ts
+++ b/src/services/balancer/api/entities/pool/index.ts
@@ -1,11 +1,8 @@
 import { configService } from '@/services/config/config.service';
 import { Pool } from '@/services/pool/types';
 import { PoolsQueryBuilder } from '@/types/subgraph';
-import {
-  GraphQLArgs,
-  GraphQLQuery,
-  PoolsBalancerAPIRepository,
-} from '@balancer-labs/sdk';
+import { GraphQLArgs, GraphQLQuery } from '@balancer-labs/sdk';
+import axios from 'axios';
 
 import Service from '../../balancer-api.service';
 import queryBuilder from './query';
@@ -23,17 +20,20 @@ export default class SinglePool {
     this.queryBuilder = _queryBuilder;
   }
 
-  public async get(args: GraphQLArgs = {}, attrs: any = {}): Promise<Pool[]> {
+  public async get(args: GraphQLArgs = {}, attrs: any = {}): Promise<Pool> {
     const query = this.queryBuilder(args, attrs);
+    if (!query.args.chainId) {
+      throw new Error('Invalid query - missing chainId');
+    }
+    if (!query.args.where?.id?.eq) {
+      throw new Error('Invalid query - missing pool id');
+    }
 
-    const repository = new PoolsBalancerAPIRepository({
-      url: configService.network.balancerApi || '',
-      apiKey: configService.network.keys.balancerApi || '',
-      query: query,
-    });
+    const chainId: number = query.args.chainId;
+    const poolId: string = query.args.where.id.eq;
+    const url = `${configService.network.balancerApi}/pools/${chainId}/${poolId}`;
 
-    const pools = await repository.fetch();
-
-    return pools as Pool[];
+    const { data } = await axios.get(url);
+    return data;
   }
 }

--- a/src/services/balancer/api/entities/pool/index.ts
+++ b/src/services/balancer/api/entities/pool/index.ts
@@ -20,7 +20,10 @@ export default class SinglePool {
     this.queryBuilder = _queryBuilder;
   }
 
-  public async get(args: GraphQLArgs = {}, attrs: any = {}): Promise<Pool> {
+  public async get(
+    args: GraphQLArgs = {},
+    attrs: any = {}
+  ): Promise<Pool | undefined> {
     const query = this.queryBuilder(args, attrs);
     if (!query.args.chainId) {
       throw new Error('Invalid query - missing chainId');

--- a/src/services/balancer/api/entities/pools/index.ts
+++ b/src/services/balancer/api/entities/pools/index.ts
@@ -45,8 +45,9 @@ export default class Pools {
 
     if (!this.repository || !_.isEqual(query, this.lastQuery)) {
       this.lastQuery = _.cloneDeep(query);
+      const graphQLUrl = `${configService.network.balancerApi}/graphql`;
       this.repository = new PoolsBalancerAPIRepository({
-        url: configService.network.balancerApi || '',
+        url: graphQLUrl,
         apiKey: configService.network.keys.balancerApi || '',
         query: query,
       });

--- a/src/services/pool/pool.repository.ts
+++ b/src/services/pool/pool.repository.ts
@@ -31,9 +31,10 @@ export default class PoolRepository {
   private initializeDecoratedAPIRepository() {
     return {
       fetch: async (): Promise<Pool[]> => {
-        const pools = await balancerAPIService.pool.get(this.queryArgs);
-        if (!pools.length) throw new Error('Cannot find pool via Balancer API');
-        return pools;
+        const pool = await balancerAPIService.pool.get(this.queryArgs);
+        if (!pool) throw new Error('Cannot find pool via Balancer API');
+
+        return [pool];
       },
       get skip(): number {
         return 0;


### PR DESCRIPTION
# Description

- Fetch individual pools using the Balancer API REST endpoint rather than doing a GraphQL call. This mitigates some issues we've had requesting just one item from GraphQL.
- Use https://api.balancer.fi/graphql for GraphQL queries now that this endpoint has been implemented. This is just an API Gateway route that forwards to Appsync. 

- [x] Requires: https://github.com/balancer-labs/balancer-api/pull/145 to be merged for some CORS and Caching changes. 

I'd been debugging an issue where the Balancer GraphQL API wasn't returning certain pools that were in the database. Turns out it was caused by two things:
- Fetching an individual pool by ID was doing a full table scan for that ID instead of using an index. 
- Appsync can only scan a max of 1MB of DynamoDB data for the information it needs. 

So pools that were beyond that initial 1MB weren't returning. 

This can be fixed by using another index on the API when the where query contains where.id.eq but this would be pretty hacky to implement in the VTL files. It's far easier to just use the REST endpoint for fetching a single pool, and with that above API update it now has 30s caching on this endpoint which makes things even faster. 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

- Test that the overall pools list on each network is working
- Test that individual pool pages on each network are working. 
- Test that the following pool loads from the API: /#/polygon/pool/0x2a60ec04577e0025d177a251d12d39af593e95ae0002000000000000000008cb - this one is currently broken in prod. 

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have requested at least 1 review (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] If package-lock.json has changes, it was intentional.
- [x] The base of this PR is `master` if hotfix, `develop` if not
