### PR TITLE
Fix: Permanently dismiss pool creation alert if user closes it

### DIFF
--- a/src/components/navs/AppNav/AppNavAlert.vue
+++ b/src/components/navs/AppNav/AppNavAlert.vue
@@ -33,8 +33,6 @@ import { computed, defineComponent, PropType } from 'vue';
 import useAlerts, { Alert, AlertType } from '@/composables/useAlerts';
 
 export default defineComponent({
-  name: 'NavAlert',
-
   props: {
     alert: { type: Object as PropType<Alert>, required: true },
   },

--- a/src/composables/watchers/usePoolCreationWatcher.ts
+++ b/src/composables/watchers/usePoolCreationWatcher.ts
@@ -40,6 +40,7 @@ export default function usePoolCreationWatcher() {
         action: navigateToPoolCreation,
         actionLabel: t('returnToPoolCreation'),
         priority: AlertPriority.LOW,
+        rememberClose: true,
       });
     }
   });


### PR DESCRIPTION
# Description

Closes: #2591 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

1. Go to pool creation page
2. Add some new pool parameters and click continue to the 2nd step
3. Navigate back to front page
4. Refresh the page
5. Close the Pool Creation alert.
6. Refresh the page again, and the alert should stay hidden

## Visual context

<img width="1090" alt="Screenshot 2023-01-04 at 15 03 43" src="https://user-images.githubusercontent.com/28311328/210561330-da482c84-65fc-400e-a3a4-c4db07ed36d9.png">


## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have requested at least 1 review (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] If package-lock.json has changes, it was intentional.
- [x] The base of this PR is `master` if hotfix, `develop` if not
