### PR TITLE
Rename and refactor deep join/exit handlers

### DIFF
--- a/src/services/balancer/pools/exits/exit-pool.service.ts
+++ b/src/services/balancer/pools/exits/exit-pool.service.ts
@@ -5,7 +5,7 @@ import { Pool } from '@/services/pool/types';
 import { TransactionResponse } from '@ethersproject/abstract-provider';
 import { Ref } from 'vue';
 import { SwapExitHandler } from './handlers/swap-exit.handler';
-import { DeepExitHandler } from './handlers/deep-exit.handler';
+import { GeneralisedExitHandler } from './handlers/generalised-exit.handler';
 import {
   ExitParams,
   ExitPoolHandler,
@@ -48,7 +48,11 @@ export class ExitPoolService {
     if (swapJoin) {
       return (this.exitHandler = new SwapExitHandler(pool, sdk, gasPriceServ));
     } else if (isDeep(pool.value)) {
-      return (this.exitHandler = new DeepExitHandler(pool, sdk, gasPriceServ));
+      return (this.exitHandler = new GeneralisedExitHandler(
+        pool,
+        sdk,
+        gasPriceServ
+      ));
     } else {
       throw new Error(`Pool type not handled: ${pool.value.poolType}`);
     }

--- a/src/services/balancer/pools/joins/join-pool.service.ts
+++ b/src/services/balancer/pools/joins/join-pool.service.ts
@@ -10,7 +10,7 @@ import {
   JoinPoolHandler,
   QueryOutput,
 } from './handlers/join-pool.handler';
-import { DeepPoolJoinHandler } from './handlers/deep-pool-join.handler';
+import { GeneralisedJoinHandler } from './handlers/generalised-join.handler';
 
 /**
  * JoinPoolService acts as an adapter to underlying handlers based on the pool
@@ -48,7 +48,7 @@ export class JoinPoolService {
     if (swapJoin) {
       return (this.joinHandler = new SwapJoinHandler(pool, sdk, gasPriceServ));
     } else if (isDeep(pool.value)) {
-      return (this.joinHandler = new DeepPoolJoinHandler(
+      return (this.joinHandler = new GeneralisedJoinHandler(
         pool,
         sdk,
         gasPriceServ


### PR DESCRIPTION
# Description

- Refactors DeepExitHandler and DeepJoinHandler classes.
- Renames DeepExitHandler > GeneralisedExitHandler and DeepJoinHandler > GeneralisedJoinHandler because it better describes what the handler is handling. The fact that it's used for deep pools is just one use case, it may be used for other pool types at some point.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [x] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## How should this be tested?

- [ ] Test exits that use the generalised exit function, e.g. proportional exits from deep pools.
- [ ] Test joins that use the generalised join function, e.g. proportional joins for deep pools.

## Visual context

n/a

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have requested at least 1 review (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] If package-lock.json has changes, it was intentional.
- [x] The base of this PR is `master` if hotfix, `develop` if not
