### PR TITLE
Add single asset exits for Weighted pools in generalised flow

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@babel/core": "^7.13.8",
         "@babel/plugin-proposal-numeric-separator": "^7.14.5",
         "@balancer-labs/assets": "github:balancer-labs/assets#master",
-        "@balancer-labs/sdk": "^0.1.44",
+        "@balancer-labs/sdk": "^0.1.45-beta.6",
         "@balancer-labs/typechain": "^1.0.0",
         "@cowprotocol/contracts": "^1.3.1",
         "@ensdomains/content-hash": "^2.5.3",
@@ -1806,9 +1806,9 @@
       }
     },
     "node_modules/@balancer-labs/sdk": {
-      "version": "0.1.44",
-      "resolved": "https://registry.npmjs.org/@balancer-labs/sdk/-/sdk-0.1.44.tgz",
-      "integrity": "sha512-gbSZibcMPvJoPk5qzQzYbwgSHTdAslJHKp/bEYj96gN+lm3uXA/LRCxnKhdEUklCfzUEBALvEKrisr/gS0Z0Mw==",
+      "version": "0.1.45-beta.6",
+      "resolved": "https://registry.npmjs.org/@balancer-labs/sdk/-/sdk-0.1.45-beta.6.tgz",
+      "integrity": "sha512-A1feNhSc6wd7zUAb6r3CBPT0Eq//07cQYV5coAhCA7EdadZBSqHH0EBscUahmnOc35nD2jB+X7WwKJX6WAVlDg==",
       "dev": true,
       "dependencies": {
         "@balancer-labs/sor": "^4.0.1-beta.18",
@@ -37529,9 +37529,9 @@
       }
     },
     "@balancer-labs/sdk": {
-      "version": "0.1.44",
-      "resolved": "https://registry.npmjs.org/@balancer-labs/sdk/-/sdk-0.1.44.tgz",
-      "integrity": "sha512-gbSZibcMPvJoPk5qzQzYbwgSHTdAslJHKp/bEYj96gN+lm3uXA/LRCxnKhdEUklCfzUEBALvEKrisr/gS0Z0Mw==",
+      "version": "0.1.45-beta.6",
+      "resolved": "https://registry.npmjs.org/@balancer-labs/sdk/-/sdk-0.1.45-beta.6.tgz",
+      "integrity": "sha512-A1feNhSc6wd7zUAb6r3CBPT0Eq//07cQYV5coAhCA7EdadZBSqHH0EBscUahmnOc35nD2jB+X7WwKJX6WAVlDg==",
       "dev": true,
       "requires": {
         "@balancer-labs/sor": "^4.0.1-beta.18",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "@babel/core": "^7.13.8",
     "@babel/plugin-proposal-numeric-separator": "^7.14.5",
     "@balancer-labs/assets": "github:balancer-labs/assets#master",
-    "@balancer-labs/sdk": "^0.1.44",
+    "@balancer-labs/sdk": "^0.1.45-beta.6",
     "@balancer-labs/typechain": "^1.0.0",
     "@cowprotocol/contracts": "^1.3.1",
     "@ensdomains/content-hash": "^2.5.3",

--- a/src/__mocks__/boosted-pool.ts
+++ b/src/__mocks__/boosted-pool.ts
@@ -1,6 +1,7 @@
 import { Pool, PoolType } from '@/services/pool/types';
 
 export const BoostedPoolMock: Pool = {
+  protocolSwapFeeCache: '',
   id: '0xa13a9247ea42d743238089903570127dda72fe4400000000000000000000035d',
   address: '0xa13a9247ea42d743238089903570127dda72fe44',
   poolType: PoolType.ComposableStable,

--- a/src/__mocks__/pool.ts
+++ b/src/__mocks__/pool.ts
@@ -3,6 +3,7 @@ import { BoostedPoolMock } from './boosted-pool';
 import { Pool, PoolType } from '@/services/pool/types';
 
 export const EmptyPoolMock: Pool = {
+  protocolSwapFeeCache: '',
   id: '',
   address: '',
   name: '',

--- a/src/__mocks__/weighted-pool.ts
+++ b/src/__mocks__/weighted-pool.ts
@@ -1,6 +1,7 @@
 import { Pool, PoolType } from '@/services/pool/types';
 
 export const PoolMock: Pool = {
+  protocolSwapFeeCache: '',
   onchain: {
     tokens: {
       '0x3Ec8798B81485A254928B70CDA1cf0A2BB0B74D7': {

--- a/src/components/forms/pool_actions/InvestForm/InvestFormV2.vue
+++ b/src/components/forms/pool_actions/InvestForm/InvestFormV2.vue
@@ -42,7 +42,8 @@ const showStakeModal = ref(false);
 /**
  * COMPOSABLES
  */
-const { managedPoolWithTradingHalted } = usePool(toRef(props, 'pool'));
+const { managedPoolWithTradingHalted, isDeepPool, isPreMintedBptPool } =
+  usePool(toRef(props, 'pool'));
 const { veBalTokenInfo } = useVeBal();
 const { isWalletReady, startConnectWithInjectedProvider, isMismatchedNetwork } =
   useWeb3();
@@ -139,6 +140,7 @@ watch([isSingleAssetJoin, poolTokensWithBalance], ([isSingleAsset]) => {
 
     <MissingPoolTokensAlert
       v-if="!isSingleAssetJoin"
+      :showSingleTokenSuggestion="isDeepPool && isPreMintedBptPool"
       :poolTokensWithBalance="poolTokensWithBalance"
       :poolTokensWithoutBalance="poolTokensWithoutBalance"
     />

--- a/src/components/forms/pool_actions/InvestForm/components/MissingPoolTokensAlert.vue
+++ b/src/components/forms/pool_actions/InvestForm/components/MissingPoolTokensAlert.vue
@@ -10,6 +10,7 @@ import { useTokens } from '@/providers/tokens.provider';
 type Props = {
   poolTokensWithoutBalance: string[];
   poolTokensWithBalance: string[];
+  showSingleTokenSuggestion: boolean;
 };
 
 /**
@@ -33,6 +34,15 @@ const tokenSymbolsWithoutBalance = computed(() => {
 const tokenSymbolsWithoutBalanceMsg = computed(() => {
   return formatWordListAsSentence(tokenSymbolsWithoutBalance.value, t);
 });
+
+const description = computed(() => {
+  const singleTokenHint = props.showSingleTokenSuggestion
+    ? ` \n\n${t('investment.warning.noPoolTokensToJoinWith.paragraph2')}`
+    : '';
+  return (
+    t('investment.warning.noPoolTokensToJoinWith.paragraph1') + singleTokenHint
+  );
+});
 </script>
 
 <template>
@@ -41,7 +51,7 @@ const tokenSymbolsWithoutBalanceMsg = computed(() => {
     class="mb-4"
     :type="'warning'"
     :title="t('investment.warning.noPoolTokensToJoinWith.title')"
-    :description="t('investment.warning.noPoolTokensToJoinWith.description')"
+    :description="description"
   ></BalAlert>
   <div v-else-if="tokenSymbolsWithoutBalance.length" class="italic-warning">
     {{ t('investment.warning.noBalanceSomeTokens') }}:

--- a/src/components/forms/pool_actions/WithdrawForm/components/WithdrawTotalsV2.vue
+++ b/src/components/forms/pool_actions/WithdrawForm/components/WithdrawTotalsV2.vue
@@ -16,13 +16,14 @@ const { priceImpact, highPriceImpact, isLoadingQuery } = useExitPool();
  * COMPUTED
  */
 const priceImpactClasses = computed(() => ({
-  'bg-red-500 text-white divide-red-400 border-none': highPriceImpact.value,
+  'bg-red-500 dark:bg-red-500 text-white divide-red-400 border-none':
+    highPriceImpact.value,
 }));
 </script>
 
 <template>
   <div class="data-table">
-    <div :class="['data-table-row', priceImpactClasses]">
+    <div :class="['data-table-row', priceImpactClasses, 'dark:bg-gray-800']">
       <div class="p-2">
         {{ $t('priceImpact') }}
       </div>
@@ -62,7 +63,6 @@ const priceImpactClasses = computed(() => ({
   @apply flex;
   @apply rounded-lg;
   @apply divide-x dark:divide-gray-900 border dark:border-gray-900;
-  @apply dark:bg-gray-800;
 }
 
 .data-table-number-col {

--- a/src/composables/useNumbers.spec.ts
+++ b/src/composables/useNumbers.spec.ts
@@ -1,6 +1,6 @@
 import BigNumber from 'bignumber.js';
 import { mountComposable } from '@/tests/mount-helpers';
-import useNumbers, { FNumFormats } from './useNumbers';
+import useNumbers, { bspToDec, FNumFormats } from './useNumbers';
 
 jest.mock('@/providers/tokens.provider');
 
@@ -291,6 +291,13 @@ describe('useNumbers', () => {
       const expectedValue = (amount * priceFor).toString();
       const value = toFiat(amount, 'any token address');
       expect(value).toEqual(expectedValue);
+    });
+  });
+
+  describe('bspToDec', () => {
+    it('Returns correct decimal value', () => {
+      const val = bspToDec(500); // 5%
+      expect(val).toEqual(0.05);
     });
   });
 });

--- a/src/composables/useNumbers.ts
+++ b/src/composables/useNumbers.ts
@@ -179,6 +179,17 @@ export function numF(
   return formattedNumber + postfixSymbol;
 }
 
+/**
+ * Convert number in basis points scale to percentage decimal.
+ * e.g. 500 bps = 0.05 (5%)
+ *
+ * @param {number | string} bspValue - Value in basis points.
+ * @returns percent value in decimals.
+ */
+export function bspToDec(bspValue: number | string): number {
+  return bnum(bspValue).div(10_000).toNumber();
+}
+
 export default function useNumbers() {
   const { currency } = useUserSettings();
   const { priceFor } = useTokens();

--- a/src/locales/default.json
+++ b/src/locales/default.json
@@ -470,7 +470,8 @@
       },
       "noPoolTokensToJoinWith": {
         "title": "You have no pool tokens to join with",
-        "description": "This option would usually allow you to add pool tokens in any combination or proportionally to reduce price impact. \n\nHowever, since your connected wallet doesn’t have any pool tokens, go to the ‘Single token’ tab above to add liquidity to this pool with non-pool tokens. "
+        "paragraph1": "This option would usually allow you to add pool tokens in any combination or proportionally to reduce price impact.",
+        "paragraph2": "However, since your connected wallet doesn’t have any pool tokens, go to the ‘Single token’ tab above to add liquidity to this pool with non-pool tokens."
       }
     },
     "error": {

--- a/src/pages/pool/withdraw.vue
+++ b/src/pages/pool/withdraw.vue
@@ -61,7 +61,7 @@ onMounted(() => resetTabs());
             <TradeSettingsPopover :context="TradeSettingsContext.invest" />
           </div>
           <BalTabs
-            v-if="isDeepPool && isPreMintedBptPool"
+            v-if="isDeepPool"
             v-model="activeTab"
             :tabs="tabs"
             class="p-0 m-0 -mb-px whitespace-nowrap"

--- a/src/pages/pool/withdraw.vue
+++ b/src/pages/pool/withdraw.vue
@@ -22,7 +22,7 @@ import { hasFetchedPoolsForSor } from '@/lib/balancer.sdk';
  */
 const { network } = configService;
 const { pool, poolQuery, loadingPool, transfersAllowed } = usePoolTransfers();
-const { isDeepPool, isPreMintedBptPool } = usePool(pool);
+const { isDeepPool } = usePool(pool);
 const { activeTab, resetTabs } = useWithdrawPageTabs();
 
 // Instead of refetching pool data on every block, we refetch every minute to prevent

--- a/src/providers/local/exit-pool.provider.ts
+++ b/src/providers/local/exit-pool.provider.ts
@@ -194,8 +194,10 @@ const provider = (props: Props) => {
 
   const exitHandlerType = computed((): ExitHandler => {
     if (shouldUseSwapExit.value) return ExitHandler.Swap;
-    if (isWeightedPool.value && isSingleAssetExit.value)
+    if (isWeightedPool.value && isSingleAssetExit.value) {
+      if (singleAssetMaxed.value) return ExitHandler.ExactIn;
       return ExitHandler.ExactOut;
+    }
 
     return ExitHandler.Generalised;
   });
@@ -341,7 +343,7 @@ const provider = (props: Props) => {
 
     // Invalidate previous query in order to prevent stale data
     queryClient.invalidateQueries(QUERY_EXIT_ROOT_KEY);
-
+    console.log('hello');
     try {
       const output = await exitPoolService.queryExit({
         exitType: exitType.value,
@@ -372,6 +374,9 @@ const provider = (props: Props) => {
   async function getSingleAssetMax() {
     if (!hasFetchedPoolsForSor.value) return;
     if (!isSingleAssetExit.value) return;
+
+    // If the user has not BPT, there is no maximum amount out.
+    if (!hasBpt.value) return;
 
     const singleAssetMaxedExitHandler = shouldUseSwapExit.value
       ? ExitHandler.Swap

--- a/src/providers/local/exit-pool.provider.ts
+++ b/src/providers/local/exit-pool.provider.ts
@@ -343,7 +343,7 @@ const provider = (props: Props) => {
 
     // Invalidate previous query in order to prevent stale data
     queryClient.invalidateQueries(QUERY_EXIT_ROOT_KEY);
-    console.log('hello');
+
     try {
       const output = await exitPoolService.queryExit({
         exitType: exitType.value,

--- a/src/providers/local/exit-pool.provider.ts
+++ b/src/providers/local/exit-pool.provider.ts
@@ -4,8 +4,10 @@ import {
   fiatValueOf,
   flatTokenTree,
   isDeep,
+  isPreMintedBptType,
   tokenTreeLeafs,
   tokenTreeNodes,
+  usePool,
 } from '@/composables/usePool';
 import useRelayerApproval, {
   RelayerType,
@@ -21,7 +23,10 @@ import QUERY_KEYS, { QUERY_EXIT_ROOT_KEY } from '@/constants/queryKeys';
 import symbolKeys from '@/constants/symbol.keys';
 import { hasFetchedPoolsForSor } from '@/lib/balancer.sdk';
 import { bnSum, bnum, isSameAddress, removeAddress } from '@/lib/utils';
-import { ExitPoolService } from '@/services/balancer/pools/exits/exit-pool.service';
+import {
+  ExitHandler,
+  ExitPoolService,
+} from '@/services/balancer/pools/exits/exit-pool.service';
 import { ExitType } from '@/services/balancer/pools/exits/handlers/exit-pool.handler';
 import { Pool, PoolToken } from '@/services/pool/types';
 import useWeb3 from '@/services/web3/useWeb3';
@@ -103,6 +108,8 @@ const provider = (props: Props) => {
   const { relayerSignature, relayerApprovalAction } = useRelayerApproval(
     RelayerType.BATCH_V4
   );
+  const { isWeightedPool } = usePool(pool);
+
   const queryClient = useQueryClient();
 
   const debounceQueryExit = debounce(queryExit, 1000, { leading: true });
@@ -171,6 +178,24 @@ const provider = (props: Props) => {
   const approvalActions = computed((): TransactionActionInfo[] =>
     shouldSignRelayer.value ? [relayerApprovalAction.value] : []
   );
+
+  const shouldUseSwapExit = computed(
+    (): boolean =>
+      isSingleAssetExit.value &&
+      isDeep(pool.value) &&
+      isPreMintedBptType(pool.value.poolType)
+  );
+
+  const exitHandlerType = computed((): ExitHandler => {
+    if (shouldUseSwapExit.value) return ExitHandler.Swap;
+    if (isWeightedPool.value && isSingleAssetExit.value) {
+      if (singleAssetMaxed.value) return ExitHandler.ExactIn;
+
+      return ExitHandler.ExactOut;
+    }
+
+    return ExitHandler.Generalised;
+  });
 
   // All token addresses (excl. pre-minted BPT) in the pool token tree that can be used in exit functions.
   const exitTokenAddresses = computed((): string[] => {
@@ -309,7 +334,7 @@ const provider = (props: Props) => {
     // Proportional exit, and BPT in is 0 or less
     if (!isSingleAssetExit.value && !hasBptIn.value) return;
 
-    exitPoolService.setExitHandler(isSingleAssetExit.value);
+    exitPoolService.setExitHandler(exitHandlerType.value);
 
     // Invalidate previous query in order to prevent stale data
     queryClient.invalidateQueries(QUERY_EXIT_ROOT_KEY);
@@ -345,7 +370,7 @@ const provider = (props: Props) => {
     if (!hasFetchedPoolsForSor.value) return;
     if (!isSingleAssetExit.value) return;
 
-    exitPoolService.setExitHandler(isSingleAssetExit.value);
+    exitPoolService.setExitHandler(exitHandlerType.value);
     singleAmountOut.max = '';
 
     try {
@@ -403,7 +428,7 @@ const provider = (props: Props) => {
    */
   watch(isSingleAssetExit, _isSingleAssetExit => {
     bptIn.value = '';
-    exitPoolService.setExitHandler(_isSingleAssetExit);
+    exitPoolService.setExitHandler(exitHandlerType.value);
     if (!_isSingleAssetExit) {
       setInitialPropAmountsOut();
     }
@@ -417,7 +442,7 @@ const provider = (props: Props) => {
     // refactoted probably won't be required.
     injectTokens([...exitTokenAddresses.value, pool.value.address]);
 
-    exitPoolService.setExitHandler(isSingleAssetExit.value);
+    exitPoolService.setExitHandler(exitHandlerType.value);
 
     if (!props.isSingleAssetExit) {
       setInitialPropAmountsOut();

--- a/src/providers/local/exit-pool.provider.ts
+++ b/src/providers/local/exit-pool.provider.ts
@@ -410,6 +410,9 @@ const provider = (props: Props) => {
    */
   async function exit(): Promise<TransactionResponse> {
     try {
+      txError.value = '';
+      exitPoolService.setExitHandler(exitHandlerType.value);
+
       return exitPoolService.exit({
         exitType: exitType.value,
         bptIn: _bptIn.value,

--- a/src/providers/local/exit-pool.provider.ts
+++ b/src/providers/local/exit-pool.provider.ts
@@ -373,11 +373,11 @@ const provider = (props: Props) => {
     if (!hasFetchedPoolsForSor.value) return;
     if (!isSingleAssetExit.value) return;
 
-    const exitHandler = shouldUseSwapExit.value
+    const singleAssetMaxedExitHandler = shouldUseSwapExit.value
       ? ExitHandler.Swap
       : ExitHandler.ExactIn;
 
-    exitPoolService.setExitHandler(exitHandler);
+    exitPoolService.setExitHandler(singleAssetMaxedExitHandler);
     singleAmountOut.max = '';
 
     try {
@@ -391,10 +391,9 @@ const provider = (props: Props) => {
         prices: prices.value,
         relayerSignature: '',
       });
-      console.log({ output, address: singleAmountOut.address });
+
       singleAmountOut.max =
         selectByAddress(output.amountsOut, singleAmountOut.address) || '0';
-      console.log(singleAmountOut.max);
     } catch (error) {
       captureException(error);
       throw new Error('Failed to calculate max.', { cause: error });

--- a/src/services/balancer/pools/exits/handlers/exact-in-exit.handler.ts
+++ b/src/services/balancer/pools/exits/handlers/exact-in-exit.handler.ts
@@ -1,0 +1,59 @@
+import { bspToDec } from '@/composables/useNumbers';
+import { balancer } from '@/lib/balancer.sdk';
+import { GasPriceService } from '@/services/gas-price/gas-price.service';
+import { Pool } from '@/services/pool/types';
+import { BalancerSDK, PoolWithMethods } from '@balancer-labs/sdk';
+import { TransactionResponse } from '@ethersproject/abstract-provider';
+import { Ref } from 'vue';
+import { ExitParams, ExitPoolHandler, QueryOutput } from './exit-pool.handler';
+
+/**
+ * Handles cases where BPT in is set for the exit using SDK's
+ * buildExitExactBPTIn function.
+ */
+export class ExactInExitHandler implements ExitPoolHandler {
+  exitRes?: ReturnType<PoolWithMethods['buildExitExactBPTIn']>;
+
+  constructor(
+    public readonly pool: Ref<Pool>,
+    public readonly sdk: BalancerSDK,
+    public readonly gasPriceService: GasPriceService
+  ) {}
+
+  async exit(params: ExitParams): Promise<TransactionResponse> {}
+
+  async queryExit(params: ExitParams): Promise<QueryOutput> {
+    const { signer, bptIn, slippageBsp, amountsOut } = params;
+    const sdkPool = await balancer.pools.find(this.pool.value.id);
+
+    const exiter = await signer.getAddress();
+    const slippage = bspToDec(slippageBsp).toString();
+    const shouldUnwrapNativeAsset = false;
+    const singleTokenMaxOut =
+      amountsOut.length === 1 ? amountsOut[0].address : undefined;
+
+    this.exitRes = await sdkPool?.buildExitExactBPTIn(
+      exiter,
+      bptIn,
+      slippage,
+      shouldUnwrapNativeAsset,
+      singleTokenMaxOut
+    );
+    if (!this.exitRes) throw new Error('Failed to construct exit.');
+
+    // Because this is an exit we need to pass amountsOut as the amountsIn and
+    // bptIn as the minBptOut to this calcPriceImpact function.
+    const isJoin = false;
+    const minAmountsOut = this.exitRes.minAmountsOut;
+    const priceImpact = await sdkPool?.calcPriceImpact(
+      minAmountsOut,
+      bptIn,
+      isJoin
+    );
+
+    return {
+      amountsOut: minAmountsOut,
+      priceImpact,
+    };
+  }
+}

--- a/src/services/balancer/pools/exits/handlers/exact-in-exit.handler.ts
+++ b/src/services/balancer/pools/exits/handlers/exact-in-exit.handler.ts
@@ -6,6 +6,8 @@ import { BalancerSDK, PoolWithMethods } from '@balancer-labs/sdk';
 import { TransactionResponse } from '@ethersproject/abstract-provider';
 import { Ref } from 'vue';
 import { ExitParams, ExitPoolHandler, QueryOutput } from './exit-pool.handler';
+import { BigNumber, formatFixed, parseFixed } from '@ethersproject/bignumber';
+import { indexOfAddress, selectByAddress } from '@/lib/utils';
 
 /**
  * Handles cases where BPT in is set for the exit using SDK's
@@ -13,47 +15,74 @@ import { ExitParams, ExitPoolHandler, QueryOutput } from './exit-pool.handler';
  */
 export class ExactInExitHandler implements ExitPoolHandler {
   exitRes?: ReturnType<PoolWithMethods['buildExitExactBPTIn']>;
+  private allPoolTokens: string[];
 
   constructor(
     public readonly pool: Ref<Pool>,
     public readonly sdk: BalancerSDK,
     public readonly gasPriceService: GasPriceService
-  ) {}
+  ) {
+    this.allPoolTokens = this.pool.value.tokens.map(token => token.address);
+  }
 
-  async exit(params: ExitParams): Promise<TransactionResponse> {}
+  async exit(params: ExitParams): Promise<any> {
+    // async exit(params: ExitParams): Promise<TransactionResponse> {
+    return;
+  }
 
   async queryExit(params: ExitParams): Promise<QueryOutput> {
-    const { signer, bptIn, slippageBsp, amountsOut } = params;
+    const { signer, tokenInfo, bptIn, slippageBsp, amountsOut } = params;
     const sdkPool = await balancer.pools.find(this.pool.value.id);
+    if (!sdkPool) throw new Error('Failed to find pool: ' + this.pool.value.id);
+
+    const tokenOut = selectByAddress(tokenInfo, amountsOut[0].address);
+    if (!tokenOut)
+      throw new Error('Could not find exit token in pool tokens list.');
+
+    const tokenOutAddress = tokenOut.address;
+    const tokenOutIndex = indexOfAddress(this.allPoolTokens, tokenOutAddress);
 
     const exiter = await signer.getAddress();
-    const slippage = bspToDec(slippageBsp).toString();
+    const slippage = slippageBsp.toString();
     const shouldUnwrapNativeAsset = false;
     const singleTokenMaxOut =
-      amountsOut.length === 1 ? amountsOut[0].address : undefined;
+      amountsOut.length === 1
+        ? // TODO: Have to use lowercase address? Fix this in the SDK
+          tokenOutAddress.toLowerCase()
+        : undefined;
+
+    const evmBptIn = parseFixed(bptIn, 18).toString();
 
     this.exitRes = await sdkPool?.buildExitExactBPTIn(
       exiter,
-      bptIn,
+      evmBptIn,
       slippage,
       shouldUnwrapNativeAsset,
       singleTokenMaxOut
     );
     if (!this.exitRes) throw new Error('Failed to construct exit.');
 
+    // TODO: Amounts out is minAmountsOut, but how to get token addresses out (use tokenlist from the pool)
+    // These handler work for other pool types too? Weighted, linear, etc. (works with weighted and stable pools)
+
     // Because this is an exit we need to pass amountsOut as the amountsIn and
     // bptIn as the minBptOut to this calcPriceImpact function.
-    const isJoin = false;
     const minAmountsOut = this.exitRes.minAmountsOut;
+    const minAmountOut = minAmountsOut[tokenOutIndex];
+    const minAmountScaled = formatFixed(
+      minAmountOut,
+      tokenOut.decimals
+    ).toString();
     const priceImpact = await sdkPool?.calcPriceImpact(
       minAmountsOut,
-      bptIn,
-      isJoin
+      evmBptIn,
+      false
     );
+    const scaledPriceImpact = formatFixed(priceImpact, 18);
 
     return {
-      amountsOut: minAmountsOut,
-      priceImpact,
+      amountsOut: { [tokenOutAddress]: minAmountScaled },
+      priceImpact: Number(scaledPriceImpact),
     };
   }
 }

--- a/src/services/balancer/pools/exits/handlers/exact-in-exit.handler.ts
+++ b/src/services/balancer/pools/exits/handlers/exact-in-exit.handler.ts
@@ -16,15 +16,12 @@ import { TokenInfo } from '@/types/TokenList';
  */
 export class ExactInExitHandler implements ExitPoolHandler {
   private lastExitRes?: ReturnType<PoolWithMethods['buildExitExactBPTIn']>;
-  private allPoolTokens: string[];
 
   constructor(
     public readonly pool: Ref<Pool>,
     public readonly sdk: BalancerSDK,
     public readonly gasPriceService: GasPriceService
-  ) {
-    this.allPoolTokens = this.pool.value.tokens.map(token => token.address);
-  }
+  ) {}
 
   async exit(params: ExitParams): Promise<TransactionResponse> {
     await this.queryExit(params);
@@ -50,7 +47,10 @@ export class ExactInExitHandler implements ExitPoolHandler {
       throw new Error('Could not find exit token in pool tokens list.');
 
     const tokenOutAddress = tokenOut.address;
-    const tokenOutIndex = indexOfAddress(this.allPoolTokens, tokenOutAddress);
+    const tokenOutIndex = indexOfAddress(
+      this.pool.value.tokensList,
+      tokenOutAddress
+    );
 
     const evmBptIn = parseFixed(bptIn, 18).toString();
     const singleTokenMaxOut =

--- a/src/services/balancer/pools/exits/handlers/exact-in-exit.handler.ts
+++ b/src/services/balancer/pools/exits/handlers/exact-in-exit.handler.ts
@@ -72,26 +72,26 @@ export class ExactInExitHandler implements ExitPoolHandler {
 
     // Because this is an exit we need to pass amountsOut as the amountsIn and
     // bptIn as the minBptOut to this calcPriceImpact function.
-    const priceImpact = await sdkPool.calcPriceImpact(
+    const evmPriceImpact = await sdkPool.calcPriceImpact(
       expectedAmountsOut,
       evmBptIn,
       false
     );
 
-    const scaledPriceImpact = formatFixed(priceImpact, 18);
-    const scaledAmountOut = this.getScaledAmountOut(
+    const priceImpact = Number(formatFixed(evmPriceImpact, 18));
+    const normalizedAmountOut = this.normalizeAmountOut(
       expectedAmountsOut,
       tokenOutIndex,
       tokenOut
     );
 
     return {
-      amountsOut: { [tokenOutAddress]: scaledAmountOut },
-      priceImpact: Number(scaledPriceImpact),
+      amountsOut: { [tokenOutAddress]: normalizedAmountOut },
+      priceImpact,
     };
   }
 
-  private getScaledAmountOut(
+  private normalizeAmountOut(
     amountsOut: string[],
     tokenOutIndex: number,
     tokenOut: TokenInfo

--- a/src/services/balancer/pools/exits/handlers/exact-in-exit.handler.ts
+++ b/src/services/balancer/pools/exits/handlers/exact-in-exit.handler.ts
@@ -68,35 +68,35 @@ export class ExactInExitHandler implements ExitPoolHandler {
     );
     if (!this.lastExitRes) throw new Error('Failed to construct exit.');
 
-    const minAmountsOut = this.lastExitRes.minAmountsOut;
+    const expectedAmountsOut = this.lastExitRes.expectedAmountsOut;
 
     // Because this is an exit we need to pass amountsOut as the amountsIn and
     // bptIn as the minBptOut to this calcPriceImpact function.
     const priceImpact = await sdkPool.calcPriceImpact(
-      minAmountsOut,
+      expectedAmountsOut,
       evmBptIn,
       false
     );
 
     const scaledPriceImpact = formatFixed(priceImpact, 18);
-    const scaledMinAmountOut = this.getScaledMinAmountOut(
-      minAmountsOut,
+    const scaledAmountOut = this.getScaledAmountOut(
+      expectedAmountsOut,
       tokenOutIndex,
       tokenOut
     );
 
     return {
-      amountsOut: { [tokenOutAddress]: scaledMinAmountOut },
+      amountsOut: { [tokenOutAddress]: scaledAmountOut },
       priceImpact: Number(scaledPriceImpact),
     };
   }
 
-  private getScaledMinAmountOut(
-    minAmountsOut: string[],
+  private getScaledAmountOut(
+    amountsOut: string[],
     tokenOutIndex: number,
     tokenOut: TokenInfo
   ) {
-    const minAmountOut = minAmountsOut[tokenOutIndex];
-    return formatFixed(minAmountOut, tokenOut.decimals).toString();
+    const amountOut = amountsOut[tokenOutIndex];
+    return formatFixed(amountOut, tokenOut.decimals).toString();
   }
 }

--- a/src/services/balancer/pools/exits/handlers/exact-out-exit.handler.ts
+++ b/src/services/balancer/pools/exits/handlers/exact-out-exit.handler.ts
@@ -1,0 +1,57 @@
+import { bspToDec } from '@/composables/useNumbers';
+import { balancer } from '@/lib/balancer.sdk';
+import { GasPriceService } from '@/services/gas-price/gas-price.service';
+import { Pool } from '@/services/pool/types';
+import { BalancerSDK, PoolWithMethods } from '@balancer-labs/sdk';
+import { TransactionResponse } from '@ethersproject/abstract-provider';
+import { Ref } from 'vue';
+import { ExitParams, ExitPoolHandler, QueryOutput } from './exit-pool.handler';
+
+/**
+ * Handles cases where tokens out are specified for the exit using SDK's
+ * buildExitExactTokensOut function.
+ */
+export class ExactOutExitHandler implements ExitPoolHandler {
+  exitRes?: ReturnType<PoolWithMethods['buildExitExactTokensOut']>;
+
+  constructor(
+    public readonly pool: Ref<Pool>,
+    public readonly sdk: BalancerSDK,
+    public readonly gasPriceService: GasPriceService
+  ) {}
+
+  async exit(params: ExitParams): Promise<TransactionResponse> {}
+
+  async queryExit(params: ExitParams): Promise<QueryOutput> {
+    const { signer, slippageBsp, amountsOut, bptIn } = params;
+    const sdkPool = await balancer.pools.find(this.pool.value.id);
+
+    const exiter = await signer.getAddress();
+    const slippage = bspToDec(slippageBsp).toString();
+    const tokensOut = []; // TODO
+    const _amountsOut = []; // TODO
+
+    this.exitRes = await sdkPool?.buildExitExactTokensOut(
+      exiter,
+      tokensOut,
+      _amountsOut,
+      slippage
+    );
+    if (!this.exitRes) throw new Error('Failed to construct exit.');
+
+    // Because this is an exit we need to pass amountsOut as the amountsIn and
+    // bptIn as the minBptOut to this calcPriceImpact function.
+    const isJoin = false;
+    const minAmountsOut = this.exitRes.minAmountsOut;
+    const priceImpact = await sdkPool?.calcPriceImpact(
+      minAmountsOut,
+      bptIn,
+      isJoin
+    );
+
+    return {
+      amountsOut: minAmountsOut,
+      priceImpact,
+    };
+  }
+}

--- a/src/services/balancer/pools/exits/handlers/exact-out-exit.handler.ts
+++ b/src/services/balancer/pools/exits/handlers/exact-out-exit.handler.ts
@@ -16,15 +16,12 @@ import { ExitParams, ExitPoolHandler, QueryOutput } from './exit-pool.handler';
  */
 export class ExactOutExitHandler implements ExitPoolHandler {
   private lastExitRes?: ReturnType<PoolWithMethods['buildExitExactTokensOut']>;
-  private allPoolTokens: string[];
 
   constructor(
     public readonly pool: Ref<Pool>,
     public readonly sdk: BalancerSDK,
     public readonly gasPriceService: GasPriceService
-  ) {
-    this.allPoolTokens = this.pool.value.tokens.map(token => token.address);
-  }
+  ) {}
 
   async exit(params: ExitParams): Promise<TransactionResponse> {
     await this.queryExit(params);
@@ -49,21 +46,24 @@ export class ExactOutExitHandler implements ExitPoolHandler {
       throw new Error('Could not find exit token in pool tokens list.');
 
     const tokenOutAddress = tokenOut.address;
-    const tokenOutIndex = indexOfAddress(this.allPoolTokens, tokenOutAddress);
+    const tokenOutIndex = indexOfAddress(
+      this.pool.value.tokensList,
+      tokenOutAddress
+    );
     const evmAmountOut = parseFixed(
       amountsOut[0].value,
       tokenOut.decimals
     ).toString();
 
     const fullAmountsOut = this.getFullAmounts(
-      this.allPoolTokens,
+      this.pool.value.tokensList,
       tokenOutIndex,
       evmAmountOut
     );
 
     this.lastExitRes = await sdkPool.buildExitExactTokensOut(
       exiter,
-      this.allPoolTokens,
+      this.pool.value.tokensList,
       fullAmountsOut,
       slippage
     );

--- a/src/services/balancer/pools/exits/handlers/exact-out-exit.handler.ts
+++ b/src/services/balancer/pools/exits/handlers/exact-out-exit.handler.ts
@@ -1,9 +1,11 @@
 import { bspToDec } from '@/composables/useNumbers';
 import { balancer } from '@/lib/balancer.sdk';
+import { indexOfAddress, selectByAddress } from '@/lib/utils';
 import { GasPriceService } from '@/services/gas-price/gas-price.service';
 import { Pool } from '@/services/pool/types';
 import { BalancerSDK, PoolWithMethods } from '@balancer-labs/sdk';
 import { TransactionResponse } from '@ethersproject/abstract-provider';
+import { BigNumber, formatFixed, parseFixed } from '@ethersproject/bignumber';
 import { Ref } from 'vue';
 import { ExitParams, ExitPoolHandler, QueryOutput } from './exit-pool.handler';
 
@@ -13,28 +15,51 @@ import { ExitParams, ExitPoolHandler, QueryOutput } from './exit-pool.handler';
  */
 export class ExactOutExitHandler implements ExitPoolHandler {
   exitRes?: ReturnType<PoolWithMethods['buildExitExactTokensOut']>;
+  private allPoolTokens: string[];
 
   constructor(
     public readonly pool: Ref<Pool>,
     public readonly sdk: BalancerSDK,
     public readonly gasPriceService: GasPriceService
-  ) {}
+  ) {
+    this.allPoolTokens = this.pool.value.tokens.map(token => token.address);
+  }
 
-  async exit(params: ExitParams): Promise<TransactionResponse> {}
+  async exit(params: ExitParams): Promise<any> {
+    // async exit(params: ExitParams): Promise<TransactionResponse> {
+    return;
+  }
 
   async queryExit(params: ExitParams): Promise<QueryOutput> {
-    const { signer, slippageBsp, amountsOut, bptIn } = params;
+    const { signer, tokenInfo, slippageBsp, amountsOut, bptIn } = params;
     const sdkPool = await balancer.pools.find(this.pool.value.id);
+    if (!sdkPool) throw new Error('Failed to find pool: ' + this.pool.value.id);
+
+    const tokenOut = selectByAddress(tokenInfo, amountsOut[0].address);
+    if (!tokenOut)
+      throw new Error('Could not find exit token in pool tokens list.');
+
+    const tokenOutAddress = tokenOut.address;
+    const evmAmountOut = parseFixed(
+      amountsOut[0].value,
+      tokenOut.decimals
+    ).toString();
+
+    const tokenOutIndex = indexOfAddress(this.allPoolTokens, tokenOutAddress);
+
+    const fullAmountsOut = this.getFullAmounts(
+      this.allPoolTokens,
+      tokenOutIndex,
+      evmAmountOut
+    );
 
     const exiter = await signer.getAddress();
-    const slippage = bspToDec(slippageBsp).toString();
-    const tokensOut = []; // TODO
-    const _amountsOut = []; // TODO
+    const slippage = slippageBsp.toString();
 
-    this.exitRes = await sdkPool?.buildExitExactTokensOut(
+    this.exitRes = await sdkPool.buildExitExactTokensOut(
       exiter,
-      tokensOut,
-      _amountsOut,
+      this.allPoolTokens,
+      fullAmountsOut,
       slippage
     );
     if (!this.exitRes) throw new Error('Failed to construct exit.');
@@ -43,15 +68,30 @@ export class ExactOutExitHandler implements ExitPoolHandler {
     // bptIn as the minBptOut to this calcPriceImpact function.
     const isJoin = false;
     const minAmountsOut = this.exitRes.minAmountsOut;
-    const priceImpact = await sdkPool?.calcPriceImpact(
+
+    const priceImpact = await sdkPool.calcPriceImpact(
       minAmountsOut,
-      bptIn,
+      this.exitRes.maxBPTIn,
       isJoin
     );
 
+    const scaledPriceImpact = formatFixed(priceImpact, 18);
+
     return {
-      amountsOut: minAmountsOut,
-      priceImpact,
+      amountsOut: { [tokenOutAddress]: minAmountsOut[0] },
+      priceImpact: Number(scaledPriceImpact),
     };
+  }
+
+  private getFullAmounts(
+    poolTokens: string[],
+    tokenOutIndex: number,
+    tokenOutAmount: string
+  ): string[] {
+    // Set token amounts to 0
+    const allPoolTokensAmounts = poolTokens.map(() => '0');
+    // Set the exit token amount to tokenOutAmount
+    allPoolTokensAmounts[tokenOutIndex] = tokenOutAmount || '0';
+    return allPoolTokensAmounts;
   }
 }

--- a/src/services/balancer/pools/exits/handlers/exact-out-exit.handler.ts
+++ b/src/services/balancer/pools/exits/handlers/exact-out-exit.handler.ts
@@ -3,7 +3,6 @@ import { indexOfAddress, selectByAddress } from '@/lib/utils';
 import { GasPriceService } from '@/services/gas-price/gas-price.service';
 import { Pool } from '@/services/pool/types';
 import { TransactionBuilder } from '@/services/web3/transactions/transaction.builder';
-import { TokenInfo } from '@/types/TokenList';
 import { BalancerSDK, PoolWithMethods } from '@balancer-labs/sdk';
 import { TransactionResponse } from '@ethersproject/abstract-provider';
 import { formatFixed, parseFixed } from '@ethersproject/bignumber';
@@ -50,10 +49,9 @@ export class ExactOutExitHandler implements ExitPoolHandler {
       this.pool.value.tokensList,
       tokenOutAddress
     );
-    const evmAmountOut = parseFixed(
-      amountsOut[0].value,
-      tokenOut.decimals
-    ).toString();
+
+    const amountOut = amountsOut[0].value;
+    const evmAmountOut = parseFixed(amountOut, tokenOut.decimals).toString();
 
     const fullAmountsOut = this.getFullAmounts(
       this.pool.value.tokensList,
@@ -78,25 +76,11 @@ export class ExactOutExitHandler implements ExitPoolHandler {
     );
 
     const scaledPriceImpact = formatFixed(priceImpact, 18);
-    const scaledAmountOut = this.getScaledAmountOut(
-      fullAmountsOut,
-      tokenOutIndex,
-      tokenOut
-    );
 
     return {
-      amountsOut: { [tokenOutAddress]: scaledAmountOut },
+      amountsOut: { [tokenOutAddress]: amountOut },
       priceImpact: Number(scaledPriceImpact),
     };
-  }
-
-  private getScaledAmountOut(
-    amountsOut: string[],
-    tokenOutIndex: number,
-    tokenOut: TokenInfo
-  ) {
-    const amountOut = amountsOut[tokenOutIndex];
-    return formatFixed(amountOut, tokenOut.decimals).toString();
   }
 
   private getFullAmounts(

--- a/src/services/balancer/pools/exits/handlers/exact-out-exit.handler.ts
+++ b/src/services/balancer/pools/exits/handlers/exact-out-exit.handler.ts
@@ -69,36 +69,34 @@ export class ExactOutExitHandler implements ExitPoolHandler {
     );
     if (!this.lastExitRes) throw new Error('Failed to construct exit.');
 
-    const minAmountsOut = this.lastExitRes.minAmountsOut;
-
     // Because this is an exit we need to pass amountsOut as the amountsIn and
     // bptIn as the minBptOut to this calcPriceImpact function.
     const priceImpact = await sdkPool.calcPriceImpact(
-      minAmountsOut,
-      this.lastExitRes.maxBPTIn,
+      fullAmountsOut,
+      this.lastExitRes.expectedBPTIn,
       false
     );
 
     const scaledPriceImpact = formatFixed(priceImpact, 18);
-    const scaledMinAmountOut = this.getScaledMinAmountOut(
-      minAmountsOut,
+    const scaledAmountOut = this.getScaledAmountOut(
+      fullAmountsOut,
       tokenOutIndex,
       tokenOut
     );
 
     return {
-      amountsOut: { [tokenOutAddress]: scaledMinAmountOut },
+      amountsOut: { [tokenOutAddress]: scaledAmountOut },
       priceImpact: Number(scaledPriceImpact),
     };
   }
 
-  private getScaledMinAmountOut(
-    minAmountsOut: string[],
+  private getScaledAmountOut(
+    amountsOut: string[],
     tokenOutIndex: number,
     tokenOut: TokenInfo
   ) {
-    const minAmountOut = minAmountsOut[tokenOutIndex];
-    return formatFixed(minAmountOut, tokenOut.decimals).toString();
+    const amountOut = amountsOut[tokenOutIndex];
+    return formatFixed(amountOut, tokenOut.decimals).toString();
   }
 
   private getFullAmounts(

--- a/src/services/balancer/pools/exits/handlers/exact-out-exit.handler.ts
+++ b/src/services/balancer/pools/exits/handlers/exact-out-exit.handler.ts
@@ -69,17 +69,17 @@ export class ExactOutExitHandler implements ExitPoolHandler {
 
     // Because this is an exit we need to pass amountsOut as the amountsIn and
     // bptIn as the minBptOut to this calcPriceImpact function.
-    const priceImpact = await sdkPool.calcPriceImpact(
+    const evmPriceImpact = await sdkPool.calcPriceImpact(
       fullAmountsOut,
       this.lastExitRes.expectedBPTIn,
       false
     );
 
-    const scaledPriceImpact = formatFixed(priceImpact, 18);
+    const priceImpact = Number(formatFixed(evmPriceImpact, 18));
 
     return {
       amountsOut: { [tokenOutAddress]: amountOut },
-      priceImpact: Number(scaledPriceImpact),
+      priceImpact,
     };
   }
 

--- a/src/types/global-components.d.ts
+++ b/src/types/global-components.d.ts
@@ -24,6 +24,7 @@ import BalHorizSteps from '@/components/_global/BalHorizSteps/BalHorizSteps.vue'
 import BalIcon from '@/components/_global/BalIcon/BalIcon.vue';
 import BalImage from '@/components/_global/BalImage/BalImage.vue';
 import BalInlineInput from '@/components/_global/BalInlineInput/BalInlineInput.vue';
+import BalLazy from '@/components/_global/BalLazy/BalLazy.vue';
 import BalLink from '@/components/_global/BalLink/BalLink.vue';
 import BalLoadingBlock from '@/components/_global/BalLoadingBlock/BalLoadingBlock.vue';
 import BalLoadingIcon from '@/components/_global/BalLoadingIcon/BalLoadingIcon.vue';
@@ -66,7 +67,6 @@ import MediumIcon from '@/components/_global/icons/brands/MediumIcon.vue';
 import TwitterIcon from '@/components/_global/icons/brands/TwitterIcon.vue';
 import YoutubeIcon from '@/components/_global/icons/brands/YoutubeIcon.vue';
 import BalCircle from '@/components/_global/shapes/BalCircle/BalCircle.vue';
-import BalLazy from '@/components/_global/BalLazy/BalLazy.vue';
 
 declare module '@vue/runtime-core' {
   export interface GlobalComponents {
@@ -94,6 +94,7 @@ declare module '@vue/runtime-core' {
     BalIcon: typeof BalIcon;
     BalImage: typeof BalImage;
     BalInlineInput: typeof BalInlineInput;
+    BalLazy: typeof BalLazy;
     BalLink: typeof BalLink;
     BalLoadingBlock: typeof BalLoadingBlock;
     BalLoadingIcon: typeof BalLoadingIcon;
@@ -136,6 +137,5 @@ declare module '@vue/runtime-core' {
     TwitterIcon: typeof TwitterIcon;
     YoutubeIcon: typeof YoutubeIcon;
     BalCircle: typeof BalCircle;
-    BalLazy: typeof BalLazy;
   }
 }


### PR DESCRIPTION
# Description

**When exiting deep Weighted pool, limit single asset tokens to high level tokens.**

For details on the functions that are be used for exits see:
- https://github.com/balancer-labs/balancer-sdk/blob/develop/balancer-js/README.md#buildexitexactbptin
- https://github.com/balancer-labs/balancer-sdk/blob/develop/balancer-js/README.md#buildexitexacttokensout
And for price impact:
- https://github.com/balancer-labs/balancer-sdk/blob/develop/balancer-js/examples/priceImpact.ts

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How should this be tested?

- Go to Deep Weighted Pool's withdraw page `http://localhost:8080/#/ethereum/pool/0x25accb7943fd73dda5e23ba6329085a3c24bfb6a000200000000000000000387/withdraw`
- Select "Single token" tab
- Select any pool token to exit to and try inputting different amounts

## Visual context
<img width="681" alt="Screenshot 2023-01-04 at 12 25 17" src="https://user-images.githubusercontent.com/28311328/210535019-079eb9a7-a39d-405d-84e0-c2ef818eb140.png">

## Visual context

Please provide any relevant visual context for UI changes or additions. This could be static screenshots or a loom screencast.

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have requested at least 1 review (If the PR is significant enough, use best judgement here)
- [ ] I have commented my code where relevant, particularly in hard-to-understand areas
- [ ] If package-lock.json has changes, it was intentional.
- [ ] The base of this PR is `master` if hotfix, `develop` if not
