### PR TITLE
Fix: after clicking on token icon on swap page, use it as tokenIn

### DIFF
--- a/src/components/cards/MyWallet/MyWallet.vue
+++ b/src/components/cards/MyWallet/MyWallet.vue
@@ -11,6 +11,7 @@ import MyWalletSubheader from './MyWalletSubheader.vue';
 import useNativeBalance from '@/composables/useNativeBalance';
 import { usePool } from '@/composables/usePool';
 import useMyWalletTokens from '@/composables/useMyWalletTokens';
+import { useTradeState } from '@/composables/trade/useTradeState';
 
 type Props = {
   excludedTokens?: string[];
@@ -28,7 +29,7 @@ const props = withDefaults(defineProps<Props>(), {
 
 const { isWalletReady, startConnectWithInjectedProvider } = useWeb3();
 const { upToLargeBreakpoint } = useBreakpoints();
-const { explorerLinks } = useWeb3();
+const { setTokenInAddress } = useTradeState();
 
 const networkName = configService.network.name;
 const { t } = useI18n();
@@ -57,7 +58,7 @@ const noTokensMessage = computed(() => {
 const { hasNativeBalance, nativeBalance, nativeCurrency } = useNativeBalance();
 
 function handleAssetClick(tokenAddress) {
-  window.open(explorerLinks.addressLink(tokenAddress));
+  setTokenInAddress(tokenAddress);
 }
 </script>
 

--- a/src/components/cards/MyWallet/MyWallet.vue
+++ b/src/components/cards/MyWallet/MyWallet.vue
@@ -4,10 +4,8 @@ import { useI18n } from 'vue-i18n';
 
 import useBreakpoints from '@/composables/useBreakpoints';
 import { isMainnet } from '@/composables/useNetwork';
-import { includesAddress } from '@/lib/utils';
 import { configService } from '@/services/config/config.service';
 import useWeb3 from '@/services/web3/useWeb3';
-import { Address } from '@/types';
 import { AnyPool } from '@/services/pool/types';
 import MyWalletSubheader from './MyWalletSubheader.vue';
 import useNativeBalance from '@/composables/useNativeBalance';
@@ -30,6 +28,7 @@ const props = withDefaults(defineProps<Props>(), {
 
 const { isWalletReady, startConnectWithInjectedProvider } = useWeb3();
 const { upToLargeBreakpoint } = useBreakpoints();
+const { explorerLinks } = useWeb3();
 
 const networkName = configService.network.name;
 const { t } = useI18n();
@@ -37,7 +36,6 @@ const { isDeepPool, isPreMintedBptPool } = usePool(toRef(props, 'pool'));
 
 const {
   tokensWithBalance,
-  poolTokenAddresses,
   poolTokensWithBalance,
   poolTokensWithoutBalance,
   notPoolTokensWithBalance,
@@ -59,13 +57,8 @@ const noTokensMessage = computed(() => {
 const { hasNativeBalance, nativeBalance, nativeCurrency } = useNativeBalance();
 
 function handleAssetClick(tokenAddress) {
-  const isPoolToken = includesAddress(poolTokenAddresses.value, tokenAddress);
-  emit('click:asset', tokenAddress, isPoolToken);
+  window.open(explorerLinks.addressLink(tokenAddress));
 }
-
-const emit = defineEmits<{
-  (e: 'click:asset', tokenAddress: Address, isPoolToken: boolean): void;
-}>();
 </script>
 
 <template>


### PR DESCRIPTION
# Description

On swap page there is a section called "My wallet". After clicking on token icon in this section, the token clicked with be used as tokenIn.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## How should this be tested?

Please provide instructions so we can test. Please also list any relevant details for your test configuration.

- [ ] Test A
- [ ] Test B

## Visual context

Please provide any relevant visual context for UI changes or additions. This could be static screenshots or a loom screencast.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have requested at least 1 review (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] If package-lock.json has changes, it was intentional.
- [x] The base of this PR is `master` if hotfix, `develop` if not
