### PR TITLE
Update SDK to 0.1.44. Fixes PI for BoostedPools.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@babel/core": "^7.13.8",
         "@babel/plugin-proposal-numeric-separator": "^7.14.5",
         "@balancer-labs/assets": "github:balancer-labs/assets#master",
-        "@balancer-labs/sdk": "^0.1.43",
+        "@balancer-labs/sdk": "^0.1.44",
         "@balancer-labs/typechain": "^1.0.0",
         "@cowprotocol/contracts": "^1.3.1",
         "@ensdomains/content-hash": "^2.5.3",
@@ -1806,20 +1806,13 @@
       }
     },
     "node_modules/@balancer-labs/sdk": {
-      "version": "0.1.43",
-      "resolved": "https://registry.npmjs.org/@balancer-labs/sdk/-/sdk-0.1.43.tgz",
-      "integrity": "sha512-eHnF8ljjx9aanq4AoQdC+fKIM/kUn66dkR64J0Y244zj628ZLmlWT2NShfdamLcf4uoKMNqpk//gt/DFZICL4g==",
+      "version": "0.1.44",
+      "resolved": "https://registry.npmjs.org/@balancer-labs/sdk/-/sdk-0.1.44.tgz",
+      "integrity": "sha512-gbSZibcMPvJoPk5qzQzYbwgSHTdAslJHKp/bEYj96gN+lm3uXA/LRCxnKhdEUklCfzUEBALvEKrisr/gS0Z0Mw==",
       "dev": true,
       "dependencies": {
-        "@balancer-labs/sor": "^4.0.1-beta.16",
+        "@balancer-labs/sor": "^4.0.1-beta.18",
         "@balancer-labs/typechain": "^1.0.0",
-        "axios": "^0.24.0",
-        "graphql": "^15.6.1",
-        "graphql-request": "^3.5.0",
-        "json-to-graphql-query": "^2.2.4",
-        "lodash": "^4.17.21"
-      },
-      "peerDependencies": {
         "@ethersproject/abi": "^5.4.0",
         "@ethersproject/abstract-signer": "^5.4.0",
         "@ethersproject/address": "^5.4.0",
@@ -1827,13 +1820,27 @@
         "@ethersproject/bytes": "^5.4.0",
         "@ethersproject/constants": "^5.4.0",
         "@ethersproject/contracts": "^5.4.0",
-        "@ethersproject/providers": "^5.4.5"
+        "@ethersproject/providers": "^5.4.5",
+        "axios": "^0.24.0",
+        "graphql": "^15.6.1",
+        "graphql-request": "^3.5.0",
+        "json-to-graphql-query": "^2.2.4",
+        "lodash": "^4.17.21"
       }
     },
-    "node_modules/@balancer-labs/sdk/node_modules/@balancer-labs/sor": {
-      "version": "4.0.1-beta.16",
-      "resolved": "https://registry.npmjs.org/@balancer-labs/sor/-/sor-4.0.1-beta.16.tgz",
-      "integrity": "sha512-Yi7eUTKq0x3/WSB0JeLiTzgF/Um0j9JpWI/yizM68Kh6eBlMU0kEpdAsCrMOO3tR1gdARRa/TWeTgkcU+Qi8mw==",
+    "node_modules/@balancer-labs/sdk/node_modules/axios": {
+      "version": "0.24.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.24.0.tgz",
+      "integrity": "sha512-Q6cWsys88HoPgAaFAVUb0WpPk0O8iTeisR9IMqy9G8AbO4NlpVknrnQS03zzF9PGAWgO3cgletO3VjV/P7VztA==",
+      "dev": true,
+      "dependencies": {
+        "follow-redirects": "^1.14.4"
+      }
+    },
+    "node_modules/@balancer-labs/sor": {
+      "version": "4.0.1-beta.18",
+      "resolved": "https://registry.npmjs.org/@balancer-labs/sor/-/sor-4.0.1-beta.18.tgz",
+      "integrity": "sha512-tNY9OIptCVCysSYY6QKBIpJleM66DMKRK78t1WOG1boJbay3kCm+x9R4+6LN5n05gDYM0PE2QwCPytOxzkrCfA==",
       "dev": true,
       "dependencies": {
         "isomorphic-fetch": "^2.2.1"
@@ -1847,16 +1854,7 @@
         "@ethersproject/providers": "^5.4.4"
       }
     },
-    "node_modules/@balancer-labs/sdk/node_modules/axios": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.24.0.tgz",
-      "integrity": "sha512-Q6cWsys88HoPgAaFAVUb0WpPk0O8iTeisR9IMqy9G8AbO4NlpVknrnQS03zzF9PGAWgO3cgletO3VjV/P7VztA==",
-      "dev": true,
-      "dependencies": {
-        "follow-redirects": "^1.14.4"
-      }
-    },
-    "node_modules/@balancer-labs/sdk/node_modules/isomorphic-fetch": {
+    "node_modules/@balancer-labs/sor/node_modules/isomorphic-fetch": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
       "integrity": "sha512-9c4TNAKYXM5PRyVcwUZrF3W09nQ+sO7+jydgs4ZGW9dhsLG2VOlISJABombdQqQRXCwuYG3sYV/puGf5rp0qmA==",
@@ -1866,7 +1864,7 @@
         "whatwg-fetch": ">=0.10.0"
       }
     },
-    "node_modules/@balancer-labs/sdk/node_modules/node-fetch": {
+    "node_modules/@balancer-labs/sor/node_modules/node-fetch": {
       "version": "1.7.3",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
       "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
@@ -37531,13 +37529,21 @@
       }
     },
     "@balancer-labs/sdk": {
-      "version": "0.1.43",
-      "resolved": "https://registry.npmjs.org/@balancer-labs/sdk/-/sdk-0.1.43.tgz",
-      "integrity": "sha512-eHnF8ljjx9aanq4AoQdC+fKIM/kUn66dkR64J0Y244zj628ZLmlWT2NShfdamLcf4uoKMNqpk//gt/DFZICL4g==",
+      "version": "0.1.44",
+      "resolved": "https://registry.npmjs.org/@balancer-labs/sdk/-/sdk-0.1.44.tgz",
+      "integrity": "sha512-gbSZibcMPvJoPk5qzQzYbwgSHTdAslJHKp/bEYj96gN+lm3uXA/LRCxnKhdEUklCfzUEBALvEKrisr/gS0Z0Mw==",
       "dev": true,
       "requires": {
-        "@balancer-labs/sor": "^4.0.1-beta.16",
+        "@balancer-labs/sor": "^4.0.1-beta.18",
         "@balancer-labs/typechain": "^1.0.0",
+        "@ethersproject/abi": "^5.4.0",
+        "@ethersproject/abstract-signer": "^5.4.0",
+        "@ethersproject/address": "^5.4.0",
+        "@ethersproject/bignumber": "^5.4.0",
+        "@ethersproject/bytes": "^5.4.0",
+        "@ethersproject/constants": "^5.4.0",
+        "@ethersproject/contracts": "^5.4.0",
+        "@ethersproject/providers": "^5.4.5",
         "axios": "^0.24.0",
         "graphql": "^15.6.1",
         "graphql-request": "^3.5.0",
@@ -37545,15 +37551,6 @@
         "lodash": "^4.17.21"
       },
       "dependencies": {
-        "@balancer-labs/sor": {
-          "version": "4.0.1-beta.16",
-          "resolved": "https://registry.npmjs.org/@balancer-labs/sor/-/sor-4.0.1-beta.16.tgz",
-          "integrity": "sha512-Yi7eUTKq0x3/WSB0JeLiTzgF/Um0j9JpWI/yizM68Kh6eBlMU0kEpdAsCrMOO3tR1gdARRa/TWeTgkcU+Qi8mw==",
-          "dev": true,
-          "requires": {
-            "isomorphic-fetch": "^2.2.1"
-          }
-        },
         "axios": {
           "version": "0.24.0",
           "resolved": "https://registry.npmjs.org/axios/-/axios-0.24.0.tgz",
@@ -37562,7 +37559,18 @@
           "requires": {
             "follow-redirects": "^1.14.4"
           }
-        },
+        }
+      }
+    },
+    "@balancer-labs/sor": {
+      "version": "4.0.1-beta.18",
+      "resolved": "https://registry.npmjs.org/@balancer-labs/sor/-/sor-4.0.1-beta.18.tgz",
+      "integrity": "sha512-tNY9OIptCVCysSYY6QKBIpJleM66DMKRK78t1WOG1boJbay3kCm+x9R4+6LN5n05gDYM0PE2QwCPytOxzkrCfA==",
+      "dev": true,
+      "requires": {
+        "isomorphic-fetch": "^2.2.1"
+      },
+      "dependencies": {
         "isomorphic-fetch": {
           "version": "2.2.1",
           "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "@babel/core": "^7.13.8",
     "@babel/plugin-proposal-numeric-separator": "^7.14.5",
     "@balancer-labs/assets": "github:balancer-labs/assets#master",
-    "@balancer-labs/sdk": "^0.1.43",
+    "@balancer-labs/sdk": "^0.1.44",
     "@balancer-labs/typechain": "^1.0.0",
     "@cowprotocol/contracts": "^1.3.1",
     "@ensdomains/content-hash": "^2.5.3",


### PR DESCRIPTION
# Description

Update SDK to [0.1.44](https://github.com/balancer-labs/balancer-sdk/releases/tag/v0.1.44)

Fixes Price Impact in Boosted Pools. Price Impact for BoostedPools is currently innacurate and displaying too high. This is a combination of
- incorrect stable maths for invariant
- PriceRates from SG are innacurate and don't exist for Linear Pool wrapped token - these need to be fetched using onchain calls.
Fixed by:
- Update SOR to 4.0.1-beta.17 - Has fixes for stable maths
- Add PoolsSubgraphOnChainRepository. Retrieves pools from SG and updates with onchain values. Important for correct priceRates.
- Join/Exit services use onchain pool data.
- Add subgraphQuery option to help filtering during tests that use onchain data.
- Removes default SpotPrice option as was previously a fix for linear pool issue.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## How should this be tested?

Boosted Pools PI should be more accurate (lower). Opened against develop so it goes through full testing process with ZeKraken.

## Visual context

Please provide any relevant visual context for UI changes or additions. This could be static screenshots or a loom screencast.

## Checklist:

- [X] I have performed a self-review of my own code
- [X] I have requested at least 1 review (If the PR is significant enough, use best judgement here)
- [X] I have commented my code where relevant, particularly in hard-to-understand areas
- [X] If package-lock.json has changes, it was intentional.
- [X] The base of this PR is `master` if hotfix, `develop` if not
