### PR TITLE
fix: Make injected tokens appear first

### DIFF
--- a/src/providers/tokens.provider.ts
+++ b/src/providers/tokens.provider.ts
@@ -91,8 +91,8 @@ export const tokensProvider = (
    */
   const allTokenListTokens = computed(
     (): TokenInfoMap => ({
-      ...mapTokenListTokens(Object.values(allTokenLists)),
       ...state.injectedTokens,
+      ...mapTokenListTokens(Object.values(allTokenLists)),
     })
   );
 
@@ -120,8 +120,8 @@ export const tokensProvider = (
    */
   const tokens = computed(
     (): TokenInfoMap => ({
-      ...activeTokenListTokens.value,
       ...state.injectedTokens,
+      ...activeTokenListTokens.value,
     })
   );
 

--- a/src/providers/tokens.provider.ts
+++ b/src/providers/tokens.provider.ts
@@ -71,9 +71,7 @@ export const tokensProvider = (
 
   const state: TokensProviderState = reactive({
     loading: true,
-    injectedTokens: {
-      [networkConfig.nativeAsset.address]: nativeAsset,
-    },
+    injectedTokens: {},
     allowanceContracts: compact([
       networkConfig.addresses.vault,
       networkConfig.addresses.wstETH,
@@ -91,8 +89,9 @@ export const tokensProvider = (
    */
   const allTokenListTokens = computed(
     (): TokenInfoMap => ({
-      ...state.injectedTokens,
+      [networkConfig.nativeAsset.address]: nativeAsset,
       ...mapTokenListTokens(Object.values(allTokenLists)),
+      ...state.injectedTokens,
     })
   );
 
@@ -120,8 +119,9 @@ export const tokensProvider = (
    */
   const tokens = computed(
     (): TokenInfoMap => ({
-      ...state.injectedTokens,
+      [networkConfig.nativeAsset.address]: nativeAsset,
       ...activeTokenListTokens.value,
+      ...state.injectedTokens,
     })
   );
 


### PR DESCRIPTION
# Description

When searching for ETH on mainnet it always appeared at the bottom of the list, even when searching for 'ETH'. This was because we were injecting ETH into the tokens registry after the tokenlist tokens. Since we only inject ETH on app load we can simply place injected tokens at the top of the list instead.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## How should this be tested?

- [ ] On mainnet go to the swap page and ensure neither input is already ETH, then open the model to search for it. It should appear at the top of the list.

## Visual context

n/a

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have requested at least 1 review (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] If package-lock.json has changes, it was intentional.
- [x] The base of this PR is `master` if hotfix, `develop` if not
