### PR TITLE
Fix number format on pool creation

### DIFF
--- a/src/composables/pools/usePoolCreation.ts
+++ b/src/composables/pools/usePoolCreation.ts
@@ -389,12 +389,10 @@ export default function usePoolCreation() {
         if (!tokenInfo) return '0';
         const amount = new BigNumber(token.amount);
         const scaledAmount = scale(amount, tokenInfo.decimals);
-        console.log(`scaledAmount ${scaledAmount}}`);
         const scaledRoundedAmount = scaledAmount.toFixed(
           0,
           BigNumber.ROUND_FLOOR
         );
-        console.log(`scaledRoundedAmount ${scaledRoundedAmount}}`);
         return scaledRoundedAmount;
       }
     );

--- a/src/composables/pools/usePoolCreation.ts
+++ b/src/composables/pools/usePoolCreation.ts
@@ -389,8 +389,13 @@ export default function usePoolCreation() {
         if (!tokenInfo) return '0';
         const amount = new BigNumber(token.amount);
         const scaledAmount = scale(amount, tokenInfo.decimals);
-        const scaledRoundedAmount = scaledAmount.dp(0, BigNumber.ROUND_FLOOR);
-        return scaledRoundedAmount.toString();
+        console.log(`scaledAmount ${scaledAmount}}`);
+        const scaledRoundedAmount = scaledAmount.toFixed(
+          0,
+          BigNumber.ROUND_FLOOR
+        );
+        console.log(`scaledRoundedAmount ${scaledRoundedAmount}}`);
+        return scaledRoundedAmount;
       }
     );
     return scaledAmounts;


### PR DESCRIPTION
# Description

The scaled balances were using a bignumber toString which is bad and introduces things like 2.5e19.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## How should this be tested?

Please provide instructions so we can test. Please also list any relevant details for your test configuration.

- [ ] Test A
- [ ] Test B

## Visual context

Please provide any relevant visual context for UI changes or additions. This could be static screenshots or a loom screencast.

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have requested at least 1 review (If the PR is significant enough, use best judgement here)
- [ ] I have commented my code where relevant, particularly in hard-to-understand areas
- [ ] If package-lock.json has changes, it was intentional.
- [ ] The base of this PR is `master` if hotfix, `develop` if not
