### PR TITLE
fix: Fixes a variety of small bugs in the join/exit flows

### DIFF
--- a/src/components/forms/pool_actions/InvestForm/components/InvestPreviewModal/components/InvestActions.vue
+++ b/src/components/forms/pool_actions/InvestForm/components/InvestPreviewModal/components/InvestActions.vue
@@ -30,6 +30,7 @@ import { TransactionActionInfo } from '@/types/transactions';
 import { InvestMathResponse } from '../../../composables/useInvestMath';
 import { Goals, trackGoal } from '@/composables/useFathom';
 import { bnum } from '@/lib/utils';
+import { useTokens } from '@/providers/tokens.provider';
 
 /**
  * TYPES
@@ -79,6 +80,7 @@ const { txListener, getTxConfirmedAt } = useEthers();
 const { lockablePoolId } = useVeBal();
 const { isPoolEligibleForStaking } = useStaking();
 const { networkSlug } = useNetwork();
+const { refetchBalances } = useTokens();
 
 const { poolWeightsLabel } = usePool(toRef(props, 'pool'));
 const {
@@ -165,6 +167,7 @@ async function handleTransaction(tx): Promise<void> {
         Goals.LiquidityAdded,
         bnum(fiatTotal.value).times(100).toNumber() || 0
       );
+      await refetchBalances.value();
     },
     onTxFailed: () => {
       console.error('Add liquidity failed');

--- a/src/components/forms/pool_actions/WithdrawForm/components/WithdrawPreviewModal/WithdrawPreviewModal.vue
+++ b/src/components/forms/pool_actions/WithdrawForm/components/WithdrawPreviewModal/WithdrawPreviewModal.vue
@@ -40,11 +40,6 @@ const emit = defineEmits<{
 }>();
 
 /**
- * STATE
- */
-const withdrawalConfirmed = ref(false);
-
-/**
  * COMPOSABLES
  */
 const { t } = useI18n();
@@ -55,6 +50,15 @@ const { tokensOut, maxSlider, resetTxState } = useWithdrawalState(
   toRef(props, 'pool')
 );
 const { account } = useWeb3();
+
+/**
+ * STATE
+ */
+const withdrawalConfirmed = ref(false);
+// Internal priceImpact - priceImpact from useWithdrawMaths can be dependent on
+// bptBalance which is updated when a tx is successful. This can result in
+// priceImpact becoming NaN. So in the preview modal we want it to be static.
+const _priceImpact = ref(priceImpact.value);
 
 /**
  * COMPUTED
@@ -146,7 +150,7 @@ watch(account, () => emit('close'));
     <WithdrawSummary
       :pool="pool"
       :fiatTotal="fiatTotal"
-      :priceImpact="priceImpact"
+      :priceImpact="_priceImpact"
     />
 
     <WithdrawActions

--- a/src/components/forms/pool_actions/WithdrawForm/components/WithdrawPreviewModal/components/WithdrawActions.vue
+++ b/src/components/forms/pool_actions/WithdrawForm/components/WithdrawPreviewModal/components/WithdrawActions.vue
@@ -28,6 +28,7 @@ import { WithdrawMathResponse } from '../../../composables/useWithdrawMath';
 import router from '@/plugins/router';
 import { Goals, trackGoal } from '@/composables/useFathom';
 import { bnum } from '@/lib/utils';
+import { useTokens } from '@/providers/tokens.provider';
 
 /**
  * TYPES
@@ -64,6 +65,7 @@ const {
   resetTxState,
 } = useWithdrawalState(toRef(props, 'pool'));
 const { networkSlug } = useNetwork();
+const { refetchBalances } = useTokens();
 
 const {
   bptIn,
@@ -125,6 +127,7 @@ async function handleTransaction(tx): Promise<void> {
         Goals.Withdrawal,
         bnum(fiatTotal.value).times(100).toNumber() || 0
       );
+      await refetchBalances.value();
     },
     onTxFailed: () => {
       txState.value.confirming = false;


### PR DESCRIPTION
# Description

- Force balances to be refetched after tx success
  - https://github.com/balancer-labs/frontend-v2/commit/85fc3c7c185f5547dfbbb59e808f53b9722c04a2
  - https://github.com/balancer-labs/frontend-v2/commit/0e8abb8b97bdd9ae45b546afc93adbc0bc4f3499
- [Fetch latest onchain pool data before calc](https://github.com/balancer-labs/frontend-v2/commit/38911fc1b416263f39dba6e68e6732ab7c36b025)
- [Make priceImpact static in preview](https://github.com/balancer-labs/frontend-v2/commit/dc263db620d329ac6cf0788f3b12607a82205ba0)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## How should this be tested?

Please provide instructions so we can test. Please also list any relevant details for your test configuration.

- [ ] Test join/exit flow works as expected
- [ ] Test after join, if you choose to stake from the preview modal the BPT balance should be updated and not zero when the stake modal shows up.
- [ ] Test after join or exit that your balance on the pool page reflects that change in state.

## Visual context

n/a

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have requested at least 1 review (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] If package-lock.json has changes, it was intentional.
- [x] The base of this PR is `master` if hotfix, `develop` if not
