### PR TITLE
Move legacy claims to its own page

### DIFF
--- a/src/components/contextual/pages/claim/HeroClaim.vue
+++ b/src/components/contextual/pages/claim/HeroClaim.vue
@@ -1,4 +1,11 @@
-<script setup lang="ts"></script>
+<script setup lang="ts">
+type Props = {
+  title: string;
+  description: string;
+};
+
+defineProps<Props>();
+</script>
 
 <template>
   <div class="bg">
@@ -6,10 +13,10 @@
       <div class="hero-content">
         <div class="hero-text fade-in-slow">
           <h1 class="mb-3 text-white title text-shadow">
-            {{ $t('claimHero.title') }}
+            {{ title }}
           </h1>
           <p class="max-w-3xl body-text text-shadow">
-            {{ $t('claimHero.description') }}
+            {{ description }}
           </p>
         </div>
       </div>

--- a/src/components/contextual/pages/claim/LegacyClaims.vue
+++ b/src/components/contextual/pages/claim/LegacyClaims.vue
@@ -268,29 +268,47 @@ async function claimAvailableRewards() {
           <li class="mt-2">
             Claim BAL on other networks
             <template v-if="isArbitrum">
-              <BalLink href="https://app.balancer.fi/#/ethereum/claim" external>
+              <BalLink
+                href="https://app.balancer.fi/#/ethereum/claim/legacy"
+                external
+              >
                 Ethereum
               </BalLink>
               and
-              <BalLink href="https://app.balancer.fi/#/polygon/claim" external>
+              <BalLink
+                href="https://app.balancer.fi/#/polygon/claim/legacy"
+                external
+              >
                 Polygon </BalLink
               >.
             </template>
             <template v-else-if="isPolygon">
-              <BalLink href="https://app.balancer.fi/#/ethereum/claim" external>
+              <BalLink
+                href="https://app.balancer.fi/#/ethereum/claim/legacy"
+                external
+              >
                 Ethereum
               </BalLink>
               and
-              <BalLink href="https://app.balancer.fi/#/arbitrum/claim" external>
+              <BalLink
+                href="https://app.balancer.fi/#/arbitrum/claim/legacy"
+                external
+              >
                 Arbitrum </BalLink
               >.
             </template>
             <template v-else-if="isMainnet || isGoerli">
-              <BalLink href="https://app.balancer.fi/#/polygon/claim" external>
+              <BalLink
+                href="https://app.balancer.fi/#/polygon/claim/legacy"
+                external
+              >
                 Polygon
               </BalLink>
               and
-              <BalLink href="https://app.balancer.fi/#/arbitrum/claim" external>
+              <BalLink
+                href="https://app.balancer.fi/#/arbitrum/claim/legacy"
+                external
+              >
                 Arbitrum </BalLink
               >.
             </template>

--- a/src/composables/queries/useGaugesDecorationQuery.ts
+++ b/src/composables/queries/useGaugesDecorationQuery.ts
@@ -8,6 +8,7 @@ import { Gauge, SubgraphGauge } from '@/services/balancer/gauges/types';
 import useWeb3 from '@/services/web3/useWeb3';
 
 import useNetwork from '../useNetwork';
+import { useTokens } from '@/providers/tokens.provider';
 
 /**
  * TYPES
@@ -26,6 +27,7 @@ export default function useGaugesDecorationQuery(
    */
   const { account, isWalletReady } = useWeb3();
   const { networkId } = useNetwork();
+  const { injectTokens } = useTokens();
 
   /**
    * COMPUTED
@@ -46,7 +48,10 @@ export default function useGaugesDecorationQuery(
    */
   const queryFn = async () => {
     if (!gauges.value) return undefined;
-    return await gaugesDecorator.decorate(gauges.value, account.value);
+    const _gauges = await gaugesDecorator.decorate(gauges.value, account.value);
+    const tokens = _gauges.map(gauge => gauge.rewardTokens).flat();
+    await injectTokens(tokens);
+    return _gauges;
   };
 
   /**

--- a/src/locales/default.json
+++ b/src/locales/default.json
@@ -1479,5 +1479,6 @@
       "otherTokens": "Other tokens (higher price impact)"
     }
   },
-  "poolActivity": "Pool activity"
+  "poolActivity": "Pool activity",
+  "legacyClaims": "Legacy claims"
 }

--- a/src/locales/default.json
+++ b/src/locales/default.json
@@ -102,7 +102,9 @@
   "claim": "Claim",
   "claimHero": {
     "title": "Claim liquidity incentives",
+    "legacyTitle": "Claim legacy incentives",
     "description": "Balancer Protocol liquidity incentives are directed to pools by veBAL voters. Stake in these pools to earn incentives. Boost with veBAL for up to 2.5x extra on Mainnet pools.",
+    "legacyDescription": "Liquidity mining incentive systems before the launch of ve8020-tokenomics have been deprecated. If you provided liquidity before this change, check to see if you have any remaining claimable incentives.",
     "tipLabel": {
       "addLiquidity": "Add liquidity",
       "stake": "Stake your LP",

--- a/src/locales/default.json
+++ b/src/locales/default.json
@@ -104,7 +104,7 @@
     "title": "Claim liquidity incentives",
     "legacyTitle": "Claim legacy incentives",
     "description": "Balancer Protocol liquidity incentives are directed to pools by veBAL voters. Stake in these pools to earn incentives. Boost with veBAL for up to 2.5x extra on Mainnet pools.",
-    "legacyDescription": "Liquidity mining incentive systems before the launch of ve8020-tokenomics have been deprecated. If you provided liquidity before this change, check to see if you have any remaining claimable incentives.",
+    "legacyDescription": "Liquidity mining incentive systems before the launch of ve8020-tokenomics have been deprecated. If you provided liquidity before this change and have outstanding incentives you can claim them here.",
     "tipLabel": {
       "addLiquidity": "Add liquidity",
       "stake": "Stake your LP",

--- a/src/pages/claim/index.vue
+++ b/src/pages/claim/index.vue
@@ -4,7 +4,6 @@ import { formatUnits } from '@ethersproject/units';
 import { computed, onBeforeMount, watch } from 'vue';
 
 import HeroClaim from '@/components/contextual/pages/claim/HeroClaim.vue';
-import LegacyClaims from '@/components/contextual/pages/claim/LegacyClaims.vue';
 import BalClaimsTable, {
   RewardRow,
 } from '@/components/tables/BalClaimsTable.vue';
@@ -336,14 +335,9 @@ onBeforeMount(async () => {
           </BalFlexGrid>
         </div>
 
-        <template v-if="isWalletReady">
-          <div class="px-4 xl:px-0">
-            <h2 :class="['font-body font-semibold text-2xl mt-8']">
-              {{ $t('pages.claim.titles.legacyIncentives') }}
-            </h2>
-            <LegacyClaims />
-          </div>
-        </template>
+        <BalLink tag="router-link" to="/claim/legacy">{{
+          $t('legacyClaims')
+        }}</BalLink>
       </div>
     </div>
   </div>

--- a/src/pages/claim/index.vue
+++ b/src/pages/claim/index.vue
@@ -220,7 +220,10 @@ onBeforeMount(async () => {
 
 <template>
   <div>
-    <HeroClaim />
+    <HeroClaim
+      :title="$t('claimHero.title')"
+      :description="$t('claimHero.description')"
+    />
     <div>
       <div class="xl:container py-12 xl:px-4 xl:mx-auto">
         <h2 class="px-4 xl:px-0 font-body text-2xl font-semibold">
@@ -333,11 +336,14 @@ onBeforeMount(async () => {
               {{ $t('pages.claim.btns.claimOn') }} {{ network.name }}
             </BalBtn>
           </BalFlexGrid>
+          <BalLink
+            tag="router-link"
+            to="/claim/legacy"
+            class="flex items-center"
+            >{{ $t('legacyClaims') }}
+            <BalIcon name="arrow-right" size="sm" class="mx-1"
+          /></BalLink>
         </div>
-
-        <BalLink tag="router-link" to="/claim/legacy">{{
-          $t('legacyClaims')
-        }}</BalLink>
       </div>
     </div>
   </div>

--- a/src/pages/claim/index.vue
+++ b/src/pages/claim/index.vue
@@ -337,6 +337,7 @@ onBeforeMount(async () => {
             </BalBtn>
           </BalFlexGrid>
           <BalLink
+            v-if="isWalletReady"
             tag="router-link"
             to="/claim/legacy"
             class="flex items-center"

--- a/src/pages/claim/legacy.vue
+++ b/src/pages/claim/legacy.vue
@@ -11,11 +11,14 @@ const { isWalletReady } = useWeb3();
 
 <template>
   <div>
-    <HeroClaim />
+    <HeroClaim
+      :title="$t('claimHero.legacyTitle')"
+      :description="$t('claimHero.legacyDescription')"
+    />
     <div class="xl:container py-12 xl:px-4 xl:mx-auto">
       <template v-if="isWalletReady">
         <div class="px-4 xl:px-0">
-          <h2 :class="['font-body font-semibold text-2xl mt-8']">
+          <h2 :class="['font-body font-semibold text-2xl']">
             {{ $t('pages.claim.titles.legacyIncentives') }}
           </h2>
           <LegacyClaims />

--- a/src/pages/claim/legacy.vue
+++ b/src/pages/claim/legacy.vue
@@ -1,0 +1,26 @@
+<script lang="ts" setup>
+import HeroClaim from '@/components/contextual/pages/claim/HeroClaim.vue';
+import LegacyClaims from '@/components/contextual/pages/claim/LegacyClaims.vue';
+import useWeb3 from '@/services/web3/useWeb3';
+
+/**
+ * COMPOSABLES
+ */
+const { isWalletReady } = useWeb3();
+</script>
+
+<template>
+  <div>
+    <HeroClaim />
+    <div class="xl:container py-12 xl:px-4 xl:mx-auto">
+      <template v-if="isWalletReady">
+        <div class="px-4 xl:px-0">
+          <h2 :class="['font-body font-semibold text-2xl mt-8']">
+            {{ $t('pages.claim.titles.legacyIncentives') }}
+          </h2>
+          <LegacyClaims />
+        </div>
+      </template>
+    </div>
+  </div>
+</template>

--- a/src/plugins/router/index.ts
+++ b/src/plugins/router/index.ts
@@ -4,7 +4,9 @@ import { isGoerli } from '@/composables/useNetwork';
 import { applyNavGuards } from './nav-guards';
 
 const ClaimPage = () =>
-  import(/* webpackChunkName: "ClaimPage" */ '@/pages/claim.vue');
+  import(/* webpackChunkName: "ClaimPage" */ '@/pages/claim/index.vue');
+const LegacyClaimPage = () =>
+  import(/* webpackChunkName: "LegacyClaimPage" */ '@/pages/claim/legacy.vue');
 const CookiesPolicyPage = () =>
   import(
     /* webpackChunkName: "CookiesPolicyPage" */ '@/pages/cookies-policy.vue'
@@ -146,6 +148,11 @@ const routes: RouteRecordRaw[] = [
     path: '/:networkSlug/claim',
     name: 'claim',
     component: ClaimPage,
+  },
+  {
+    path: '/:networkSlug/claim/legacy',
+    name: 'legacy-claim',
+    component: LegacyClaimPage,
   },
   {
     path: '/:networkSlug/portfolio',


### PR DESCRIPTION
# Description

Moves legacy claims section on claims page to its own page at /claim/legacy

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [x] Other

## How should this be tested?

- [ ] Test claims page works as expected
- [ ] Test /claim/legacy renders legacy claims component.

## Visual context

n/a

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have requested at least 1 review (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] If package-lock.json has changes, it was intentional.
- [x] The base of this PR is `master` if hotfix, `develop` if not
