### PR TITLE
Hotfix: preminted injection

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.85.0",
+  "version": "1.85.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@balancer-labs/frontend-v2",
-      "version": "1.85.0",
+      "version": "1.85.1",
       "license": "MIT",
       "devDependencies": {
         "@aave/protocol-js": "^4.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.85.0",
+  "version": "1.85.1",
   "engines": {
     "node": "14.x",
     "npm": ">=7"

--- a/src/components/forms/pool_actions/InvestForm/composables/useInvestMath.ts
+++ b/src/components/forms/pool_actions/InvestForm/composables/useInvestMath.ts
@@ -267,6 +267,7 @@ export default function useInvestMath(
    */
   async function getQueryBptOut() {
     if (!isShallowComposableStablePool.value) return;
+    if (!hasAmounts.value) return;
 
     try {
       loadingData.value = true;

--- a/src/services/pool/exchange/serializers/JoinParams.ts
+++ b/src/services/pool/exchange/serializers/JoinParams.ts
@@ -9,7 +9,7 @@ import {
   isManaged,
   isStableLike,
 } from '@/composables/usePool';
-import { isSameAddress } from '@/lib/utils';
+import { includesAddress, isSameAddress } from '@/lib/utils';
 import { encodeJoinStablePool } from '@/lib/utils/balancer/stablePoolEncoding';
 import { encodeJoinWeightedPool } from '@/lib/utils/balancer/weightedPoolEncoding';
 import ConfigService from '@/services/config/config.service';
@@ -116,21 +116,18 @@ export default class JoinParams {
   private parseTokensIn(tokensIn: string[]): string[] {
     const nativeAsset = this.config.network.nativeAsset;
     const poolTokenItselfIndex = preMintedBptIndex(this.pool.value);
-    const tokensInProcessed = tokensIn.map(address =>
+    const newTokensIn = tokensIn.map(address =>
       isSameAddress(address, nativeAsset.address) ? AddressZero : address
     );
 
     if (
       isComposableStable(this.pool.value.poolType) &&
-      poolTokenItselfIndex !== undefined
+      poolTokenItselfIndex !== undefined &&
+      !includesAddress(newTokensIn, this.pool.value.address)
     ) {
-      tokensInProcessed.splice(
-        poolTokenItselfIndex,
-        0,
-        this.pool.value.address
-      );
+      newTokensIn.splice(poolTokenItselfIndex, 0, this.pool.value.address);
     }
-    return tokensInProcessed;
+    return newTokensIn;
   }
 
   private txData(amountsIn: BigNumberish[], minimumBPT: BigNumberish): string {


### PR DESCRIPTION
# Description

A conditional for join params was injecting pre-minted BPT to the assets array for pools that required it. Since we changed tokensList to always include pre-minted BPT this logic needed to be changed to only inject if it wasn't already there.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## How should this be tested?

- [ ] Test joins on this pool (0x02d2e2d7a89d6c5cb3681cfcb6f7dac02a55eda400000000000000000000088f) on polygon in production, price impact will never stop loading because of the exception. Then test in the preview URL.

## Visual context

n/a

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have requested at least 1 review (If the PR is significant enough, use best judgement here)
- [ ] I have commented my code where relevant, particularly in hard-to-understand areas
- [ ] If package-lock.json has changes, it was intentional.
- [ ] The base of this PR is `master` if hotfix, `develop` if not
