### PR TITLE
Refactor: make summaries consistent

### DIFF
--- a/src/components/_global/BalDataList/BalDataList.vue
+++ b/src/components/_global/BalDataList/BalDataList.vue
@@ -1,0 +1,24 @@
+<script setup lang="ts">
+type Props = {
+  title: string;
+  hTag?: 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6';
+};
+
+withDefaults(defineProps<Props>(), {
+  title: 'Summary',
+  hTag: 'h6',
+});
+</script>
+
+<template>
+  <div
+    class="mt-4 rounded-lg border dark:border-gray-700 divide-y dark:divide-gray-700"
+  >
+    <component :is="hTag" class="p-2">
+      {{ title }}
+    </component>
+    <div class="flex flex-col py-2">
+      <slot />
+    </div>
+  </div>
+</template>

--- a/src/components/_global/BalDataList/BalDataListRow.vue
+++ b/src/components/_global/BalDataList/BalDataListRow.vue
@@ -1,0 +1,19 @@
+<script lang="ts" setup>
+type Props = {
+  label?: string;
+  value?: string;
+};
+
+defineProps<Props>();
+</script>
+
+<template>
+  <div class="grid grid-cols-2 py-1 px-2">
+    <div class="flex items-center">
+      <slot name="label">{{ label }}</slot>
+    </div>
+    <div class="flex justify-end items-center">
+      <slot name="value">{{ value }}</slot>
+    </div>
+  </div>
+</template>

--- a/src/components/contextual/stake/StakePreview.vue
+++ b/src/components/contextual/stake/StakePreview.vue
@@ -20,6 +20,7 @@ import { AnyPool } from '@/services/pool/types';
 import { TransactionActionInfo } from '@/types/transactions';
 import useTransactions from '@/composables/useTransactions';
 import { tokensListExclBpt, usePool } from '@/composables/usePool';
+import StakeSummary from './StakeSummary.vue';
 
 export type StakeAction = 'stake' | 'unstake' | 'restake';
 type Props = {
@@ -199,7 +200,9 @@ function handleClose() {
       </BalCircle>
       <h4>{{ $t(`${action}`) }} {{ $t('lpTokens') }}</h4>
     </BalStack>
-    <BalCard shadow="none" noPad class="py-2 px-4">
+    <div
+      class="py-2 px-4 rounded-lg border dark:border-gray-700 divide-y dark:divide-gray-700"
+    >
       <BalStack horizontal justify="between" align="center">
         <BalStack vertical spacing="none">
           <h5>{{ fNum2(currentShares) }} {{ $t('lpTokens') }}</h5>
@@ -213,51 +216,12 @@ function handleClose() {
           :size="32"
         />
       </BalStack>
-    </BalCard>
-    <BalCard shadow="none" noPad>
-      <div class="p-2 border-b dark:border-gray-900">
-        <h6 class="text-sm">
-          {{ $t('summary') }}
-        </h6>
-      </div>
-      <BalStack vertical spacing="xs" class="p-3">
-        <BalStack horizontal justify="between">
-          <span class="text-sm">
-            {{ $t('totalValueTo') }}
-            <span class="lowercase">
-              {{ action === 'stake' ? $t('stake') : $t('unstake') }}:
-            </span>
-          </span>
-          <BalStack horizontal spacing="base">
-            <span class="text-sm capitalize">
-              ~{{ fNum2(fiatValueOfModifiedShares, FNumFormats.fiat) }}
-            </span>
-            <BalTooltip
-              :text="
-                action === 'stake'
-                  ? $t('staking.stakeValueTooltip')
-                  : $t('staking.unstakeValueTooltip')
-              "
-              width="40"
-              textAlign="center"
-            />
-          </BalStack>
-        </BalStack>
-        <BalStack horizontal justify="between">
-          <span class="text-sm">{{ $t('staking.newTotalShare') }}:</span>
-          <BalStack horizontal spacing="base">
-            <span class="text-sm capitalize">
-              ~{{ fNum2(totalUserPoolSharePct, FNumFormats.percent) }}
-            </span>
-            <BalTooltip
-              :text="$t('staking.totalShareTooltip')"
-              width="40"
-              textAlign="center"
-            />
-          </BalStack>
-        </BalStack>
-      </BalStack>
-    </BalCard>
+    </div>
+    <StakeSummary
+      :action="action"
+      :fiatValue="fiatValueOfModifiedShares"
+      :sharePercentage="totalUserPoolSharePct"
+    />
     <BalActionSteps
       v-if="!isActionConfirmed"
       :actions="stakeActions"

--- a/src/components/contextual/stake/StakeSummary.vue
+++ b/src/components/contextual/stake/StakeSummary.vue
@@ -1,0 +1,61 @@
+<script lang="ts" setup>
+import useNumbers, { FNumFormats } from '@/composables/useNumbers';
+import { StakeAction } from './StakePreview.vue';
+
+/**
+ * PROPS
+ */
+type Props = {
+  action: StakeAction;
+  fiatValue: string;
+  sharePercentage: string;
+};
+
+defineProps<Props>();
+
+/**
+ * COMPOSABLES
+ */
+const { fNum2 } = useNumbers();
+</script>
+
+<template>
+  <BalDataList :title="$t('summary')">
+    <BalDataListRow>
+      <template #label>
+        {{ $t('totalValueTo') }}
+        <span class="lowercase">
+          {{ action === 'stake' ? $t('stake') : $t('unstake') }}:
+        </span>
+      </template>
+      <template #value>
+        <span class="capitalize">
+          {{ fNum2(fiatValue, FNumFormats.fiat) }}
+        </span>
+        <BalTooltip
+          :text="
+            action === 'stake'
+              ? $t('staking.stakeValueTooltip')
+              : $t('staking.unstakeValueTooltip')
+          "
+          width="40"
+          textAlign="center"
+          class="ml-2"
+        />
+      </template>
+    </BalDataListRow>
+    <BalDataListRow :label="$t('staking.newTotalShare')">
+      <template #value>
+        <span class="capitalize">
+          {{ fNum2(sharePercentage, FNumFormats.percent) }}
+        </span>
+        <BalTooltip
+          :text="$t('staking.totalShareTooltip')"
+          width="40"
+          textAlign="center"
+          class="ml-2"
+        />
+      </template>
+    </BalDataListRow>
+  </BalDataList>
+</template>

--- a/src/components/forms/pool_actions/InvestForm/components/InvestPreviewModal/components/InvestSummary.vue
+++ b/src/components/forms/pool_actions/InvestForm/components/InvestPreviewModal/components/InvestSummary.vue
@@ -32,71 +32,40 @@ const { currency } = useUserSettings();
 </script>
 
 <template>
-  <div class="summary-table">
-    <div class="flex flex-col py-2">
-      <div class="summary-table-row">
-        <div class="summary-table-label">
-          {{ $t('investment.preview.summary.total') }}
-        </div>
-        <div class="summary-table-number">
-          {{ fNum2(fiatTotal, FNumFormats.fiat) }}
+  <BalDataList :title="$t('summary')">
+    <BalDataListRow :label="$t('investment.preview.summary.total')">
+      <template #value>
+        {{ fNum2(fiatTotal, FNumFormats.fiat) }}
+        <BalTooltip
+          :text="$t('tooltips.addLiquidity.total', [currency.toUpperCase()])"
+          iconSize="sm"
+          class="ml-2"
+        />
+      </template>
+    </BalDataListRow>
+    <BalDataListRow
+      :label="$t('priceImpact')"
+      :class="{
+        'bg-red-50 dark:bg-red-500 text-red-500 dark:text-white':
+          highPriceImpact,
+      }"
+    >
+      <template #value>
+        <BalLoadingBlock v-if="isLoadingPriceImpact" class="w-10 h-6" />
+        <template v-else>
+          {{ fNum2(priceImpact, FNumFormats.percent) }}
           <BalTooltip
-            :text="$t('tooltips.addLiquidity.total', [currency.toUpperCase()])"
+            :text="$t('tooltips.addLiquidity.priceImpact')"
             iconSize="sm"
+            :iconName="highPriceImpact ? 'alert-triangle' : 'info'"
+            :iconClass="
+              highPriceImpact ? 'text-red-500 dark:text-white' : 'text-gray-300'
+            "
+            width="72"
             class="ml-2"
           />
-        </div>
-      </div>
-      <div
-        :class="[
-          'summary-table-row',
-          {
-            'bg-red-50 dark:bg-red-500 text-red-500 dark:text-white':
-              highPriceImpact,
-          },
-        ]"
-      >
-        <div class="summary-table-label">
-          {{ $t('priceImpact') }}
-        </div>
-        <div class="summary-table-number">
-          <BalLoadingBlock v-if="isLoadingPriceImpact" class="w-10 h-6" />
-          <template v-else>
-            {{ fNum2(priceImpact, FNumFormats.percent) }}
-            <BalTooltip
-              :text="$t('tooltips.addLiquidity.priceImpact')"
-              iconSize="sm"
-              :iconName="highPriceImpact ? 'alert-triangle' : 'info'"
-              :iconClass="
-                highPriceImpact
-                  ? 'text-red-500 dark:text-white'
-                  : 'text-gray-300'
-              "
-              width="72"
-              class="ml-2"
-            />
-          </template>
-        </div>
-      </div>
-    </div>
-  </div>
+        </template>
+      </template>
+    </BalDataListRow>
+  </BalDataList>
 </template>
-
-<style scoped>
-.summary-table {
-  @apply border dark:border-gray-700 divide-y dark:divide-gray-700 rounded-lg mt-4 bg-gray-50 dark:bg-gray-800;
-  @apply text-sm;
-}
-
-.summary-table-row {
-  @apply grid grid-cols-2 px-2 py-1;
-}
-
-.summary-table-label {
-  @apply flex items-center;
-}
-
-.summary-table-number {
-  @apply flex items-center justify-end;
-}
-</style>

--- a/src/components/forms/pool_actions/WithdrawForm/components/WithdrawPreviewModal/components/WithdrawSummary.vue
+++ b/src/components/forms/pool_actions/WithdrawForm/components/WithdrawPreviewModal/components/WithdrawSummary.vue
@@ -25,56 +25,27 @@ const { currency } = useUserSettings();
 </script>
 
 <template>
-  <div class="summary-table">
-    <h6 class="p-2">
-      {{ $t('summary') }}
-    </h6>
-    <div class="flex flex-col py-2">
-      <div class="summary-table-row">
-        <div class="summary-table-label">
-          {{ $t('total') }}
-        </div>
-        <div class="summary-table-number">
-          {{ fNum2(fiatTotal, FNumFormats.fiat) }}
-          <BalTooltip
-            :text="$t('tooltips.withdraw.total', [currency.toUpperCase()])"
-            iconSize="sm"
-            class="ml-2"
-          />
-        </div>
-      </div>
-      <div class="summary-table-row">
-        <div class="summary-table-label">
-          {{ $t('priceImpact') }}
-        </div>
-        <div class="summary-table-number">
-          {{ fNum2(priceImpact, FNumFormats.percent) }}
-          <BalTooltip
-            :text="$t('tooltips.withdraw.priceImpact')"
-            iconSize="sm"
-            width="72"
-            class="ml-2"
-          />
-        </div>
-      </div>
-    </div>
-  </div>
+  <BalDataList :title="$t('summary')">
+    <BalDataListRow :label="$t('total')">
+      <template #value>
+        {{ fNum2(fiatTotal, FNumFormats.fiat) }}
+        <BalTooltip
+          :text="$t('tooltips.withdraw.total', [currency.toUpperCase()])"
+          iconSize="sm"
+          class="ml-2"
+        />
+      </template>
+    </BalDataListRow>
+    <BalDataListRow :label="$t('priceImpact')">
+      <template #value>
+        {{ fNum2(priceImpact, FNumFormats.percent) }}
+        <BalTooltip
+          :text="$t('tooltips.withdraw.priceImpact')"
+          iconSize="sm"
+          width="72"
+          class="ml-2"
+        />
+      </template>
+    </BalDataListRow>
+  </BalDataList>
 </template>
-
-<style scoped>
-.summary-table {
-  @apply border dark:border-gray-700 divide-y dark:divide-gray-700 rounded-lg mt-4;
-}
-
-.summary-table-row {
-  @apply grid grid-cols-2 px-2 py-1;
-}
-
-.summary-table-label {
-  @apply flex items-center;
-}
-
-.summary-table-number {
-  @apply flex items-center justify-end;
-}
-</style>

--- a/src/types/global-components.d.ts
+++ b/src/types/global-components.d.ts
@@ -14,6 +14,8 @@ import BalCard from '@/components/_global/BalCard/BalCard.vue';
 import BalChart from '@/components/_global/BalChart/BalChart.vue';
 import BalCheckbox from '@/components/_global/BalCheckbox/BalCheckbox.vue';
 import BalChip from '@/components/_global/BalChip/BalChip.vue';
+import BalDataList from '@/components/_global/BalDataList/BalDataList.vue';
+import BalDataListRow from '@/components/_global/BalDataList/BalDataListRow.vue';
 import BalDetailsTable from '@/components/_global/BalDetailsTable/BalDetailsTable.vue';
 import BalDropdown from '@/components/_global/BalDropdown/BalDropdown.vue';
 import BalFlexGrid from '@/components/_global/BalFlexGrid/BalFlexGrid.vue';
@@ -81,6 +83,8 @@ declare module '@vue/runtime-core' {
     BalChart: typeof BalChart;
     BalCheckbox: typeof BalCheckbox;
     BalChip: typeof BalChip;
+    BalDataList: typeof BalDataList;
+    BalDataListRow: typeof BalDataListRow;
     BalDetailsTable: typeof BalDetailsTable;
     BalDropdown: typeof BalDropdown;
     BalFlexGrid: typeof BalFlexGrid;


### PR DESCRIPTION
# Description

The summary section of the preview modals for join/exit/stake/unstake all had minor differences which made it all feel inconsistent. This PR creates a BalDataList component and has each of the flows use it so that styling is the same in all.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [x] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## How should this be tested?

- [ ] Test join/exit/stake/unstake flows, all the summaries should look the same.

## Visual context

Inconsistent styles in each flow, text size, missing title, background color and border color on dark mode.
<img width="527" alt="Screenshot 2023-01-16 at 14 46 50" src="https://user-images.githubusercontent.com/2406506/212716341-384d165e-4bef-4516-a9fd-145894e2ba07.png">
<img width="544" alt="Screenshot 2023-01-16 at 14 47 08" src="https://user-images.githubusercontent.com/2406506/212716347-aeffe456-09cf-4ab9-8968-2956fc9c158e.png">
<img width="518" alt="Screenshot 2023-01-16 at 14 47 34" src="https://user-images.githubusercontent.com/2406506/212716351-87da82d3-8588-4a3a-8b89-b8160bfbf387.png">
<img width="479" alt="Screenshot 2023-01-16 at 14 48 27" src="https://user-images.githubusercontent.com/2406506/212716355-809d3841-04f4-4147-9788-75dd3cf0ded8.png">

Now each flow should look exactly like the Withdrawal Preview version.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have requested at least 1 review (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] If package-lock.json has changes, it was intentional.
- [x] The base of this PR is `master` if hotfix, `develop` if not
