### PR TITLE
Hotfix: gnosis zero trade value handle

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.85.1",
+  "version": "1.85.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@balancer-labs/frontend-v2",
-      "version": "1.85.1",
+      "version": "1.85.2",
       "license": "MIT",
       "devDependencies": {
         "@aave/protocol-js": "^4.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.85.1",
+  "version": "1.85.2",
   "engines": {
     "node": "14.x",
     "npm": ">=7"

--- a/src/composables/trade/useGnosis.ts
+++ b/src/composables/trade/useGnosis.ts
@@ -285,6 +285,10 @@ export default function useGnosis({
       return;
     }
 
+    const inputAmount = exactIn.value
+      ? tokenInAmountInput.value
+      : tokenOutAmountInput.value;
+
     const amountToExchange = exactIn.value
       ? tokenInAmountScaled.value
       : tokenOutAmountScaled.value;
@@ -293,7 +297,8 @@ export default function useGnosis({
       return;
     }
 
-    if (amountToExchange.isZero()) {
+    const zeroValueTrade = inputAmount === '' || inputAmount === '0';
+    if (zeroValueTrade) {
       tokenInAmountInput.value = '0';
       tokenOutAmountInput.value = '0';
       return;

--- a/src/composables/trade/useGnosis.ts
+++ b/src/composables/trade/useGnosis.ts
@@ -285,10 +285,6 @@ export default function useGnosis({
       return;
     }
 
-    const inputAmount = exactIn.value
-      ? tokenInAmountInput.value
-      : tokenOutAmountInput.value;
-
     const amountToExchange = exactIn.value
       ? tokenInAmountScaled.value
       : tokenOutAmountScaled.value;
@@ -297,13 +293,12 @@ export default function useGnosis({
       return;
     }
 
-    const zeroValueTrade = inputAmount === '' || inputAmount === '0';
-    if (zeroValueTrade) {
-      tokenInAmountInput.value = '0';
-      tokenOutAmountInput.value = '0';
+    if (amountToExchange.isZero()) {
+      exactIn.value
+        ? (tokenOutAmountInput.value = '0')
+        : (tokenInAmountInput.value = '0');
       return;
     }
-
     updatingQuotes.value = true;
     state.validationError = null;
 


### PR DESCRIPTION
# Description
This pr fixes the bug on swap page, when user tries to input, e.g. `0.01` in `gnosis` trade flow. Now this value will automatically set to 0. 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## How should this be tested?

Please provide instructions so we can test. Please also list any relevant details for your test configuration.

- [ ] Test A
- [ ] Test B

## Visual context

Please provide any relevant visual context for UI changes or additions. This could be static screenshots or a loom screencast.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have requested at least 1 review (If the PR is significant enough, use best judgement here)
- [ ] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] If package-lock.json has changes, it was intentional.
- [x] The base of this PR is `master` if hotfix, `develop` if not
