### PR TITLE
Add drip to locale

### DIFF
--- a/src/locales/default.json
+++ b/src/locales/default.json
@@ -1307,6 +1307,7 @@
     "approve": "Approve",
     "claim": "Claim",
     "createPool": "Create pool",
+    "drip": "Drip",
     "fundPool": "Fund pool",
     "migratePool": "Migrate pool",
     "invest": "Add liquidity",


### PR DESCRIPTION
# Description

We were missing locale key for "drip" which is used when connected to `Goerli`:

<img width="820" alt="drip-locale-error" src="https://user-images.githubusercontent.com/1316240/212943028-96c7773a-25f6-4aec-aeee-b98a9713b5fd.png">


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## How should this be tested?

Please provide instructions so we can test. Please also list any relevant details for your test configuration.

- [ ] Test A
- [ ] Test B

## Visual context

Please provide any relevant visual context for UI changes or additions. This could be static screenshots or a loom screencast.

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have requested at least 1 review (If the PR is significant enough, use best judgement here)
- [ ] I have commented my code where relevant, particularly in hard-to-understand areas
- [ ] If package-lock.json has changes, it was intentional.
- [ ] The base of this PR is `master` if hotfix, `develop` if not
