### PR TITLE
chore: Remove loggingRpc from config

### DIFF
--- a/src/lib/config/arbitrum.json
+++ b/src/lib/config/arbitrum.json
@@ -10,7 +10,6 @@
   "rpc": "https://arbitrum-mainnet.infura.io/v3/{{INFURA_KEY}}",
   "ws": "wss://arb-mainnet.g.alchemy.com/v2/{{ALCHEMY_KEY}}",
   "publicRpc": "https://arb1.arbitrum.io/rpc",
-  "loggingRpc": "https://arb-mainnet.g.alchemy.com/v2/{{ALCHEMY_KEY}}",
   "explorer": "https://arbiscan.io",
   "explorerName": "Arbiscan",
   "subgraph": "https://api.thegraph.com/subgraphs/name/balancer-labs/balancer-arbitrum-v2",

--- a/src/lib/config/docker.json
+++ b/src/lib/config/docker.json
@@ -9,7 +9,6 @@
   "unknown": false,
   "rpc": "http://localhost:8545",
   "ws": "ws://localhost:8546",
-  "loggingRpc": "http://localhost:8545",
   "explorer": "",
   "explorerName": "",
   "subgraph": "http://localhost:8000/subgraphs/name/balancer-labs/balancer-v2",

--- a/src/lib/config/goerli.json
+++ b/src/lib/config/goerli.json
@@ -9,7 +9,6 @@
   "unknown": false,
   "rpc": "https://goerli.infura.io/v3/{{INFURA_KEY}}",
   "ws": "wss://goerli.infura.io/ws/v3/{{INFURA_KEY}}",
-  "loggingRpc": "https://eth-goerli.alchemyapi.io/v2/{{ALCHEMY_KEY}}",
   "explorer": "https://goerli.etherscan.io",
   "explorerName": "Etherscan",
   "subgraph": "https://api.thegraph.com/subgraphs/name/balancer-labs/balancer-goerli-v2",

--- a/src/lib/config/homestead.json
+++ b/src/lib/config/homestead.json
@@ -9,7 +9,6 @@
   "unknown": false,
   "rpc": "https://mainnet.infura.io/v3/{{INFURA_KEY}}",
   "ws": "wss://mainnet.infura.io/ws/v3/{{INFURA_KEY}}",
-  "loggingRpc": "https://eth-mainnet.alchemyapi.io/v2/{{ALCHEMY_KEY}}",
   "explorer": "https://etherscan.io",
   "explorerName": "Etherscan",
   "subgraph": "https://api.thegraph.com/subgraphs/name/balancer-labs/balancer-v2",

--- a/src/lib/config/index.ts
+++ b/src/lib/config/index.ts
@@ -20,7 +20,6 @@ export interface Config {
   rpc: string;
   publicRpc?: string;
   ws: string;
-  loggingRpc: string;
   explorer: string;
   explorerName: string;
   subgraph: string;

--- a/src/lib/config/optimism.json
+++ b/src/lib/config/optimism.json
@@ -9,7 +9,6 @@
   "unknown": false,
   "rpc": "https://mainnet.optimism.io",
   "ws": "wss://ws-mainnet.optimism.io",
-  "loggingRpc": "",
   "blockTime": 13,
   "explorer": "https://optimistic.etherscan.io/",
   "explorerName": "The Optimism Explorer",

--- a/src/lib/config/polygon.json
+++ b/src/lib/config/polygon.json
@@ -9,7 +9,6 @@
   "unknown": false,
   "rpc": "https://polygon-mainnet.infura.io/v3/{{INFURA_KEY}}",
   "ws": "wss://polygon-mainnet.g.alchemy.com/v2/{{ALCHEMY_KEY}}",
-  "loggingRpc": "https://polygon-mainnet.g.alchemy.com/v2/{{ALCHEMY_KEY}}",
   "publicRpc": "https://polygon-rpc.com",
   "explorer": "https://polygonscan.com",
   "explorerName": "Polygonscan",

--- a/src/lib/config/test.json
+++ b/src/lib/config/test.json
@@ -9,7 +9,6 @@
   "unknown": false,
   "rpc": "https://mainnet.infura.io/v3/{{INFURA_KEY}}",
   "ws": "ws://balancer.fi:1234",
-  "loggingRpc": "https://eth-mainnet.alchemyapi.io/v2/{{ALCHEMY_KEY}}",
   "explorer": "https://etherscan.io",
   "explorerName": "Etherscan",
   "subgraph": "https://api.thegraph.com/subgraphs/name/balancer-labs/balancer-v2",

--- a/src/services/config/config.service.ts
+++ b/src/services/config/config.service.ts
@@ -90,13 +90,6 @@ export default class ConfigService {
       ALCHEMY_KEY: this.env.ALCHEMY_KEY,
     });
   }
-
-  public get loggingRpc(): string {
-    return template(this.network.loggingRpc, {
-      INFURA_KEY: this.env.INFURA_PROJECT_ID,
-      ALCHEMY_KEY: this.env.ALCHEMY_KEY,
-    });
-  }
 }
 
 export const configService = new ConfigService();

--- a/src/services/rpc-provider/rpc-provider.service.spec.ts
+++ b/src/services/rpc-provider/rpc-provider.service.spec.ts
@@ -41,7 +41,7 @@ describe('RPC provider service', () => {
   it('Calls the JsonProvider constructor', () => {
     new RpcProviderService();
     // Expect 2 calls since logging provider is also a JSON provider
-    expect(JsonRpcBatchProvider).toHaveBeenCalledTimes(2);
+    expect(JsonRpcBatchProvider).toHaveBeenCalledTimes(1);
   });
 
   it('Calls the WebSocketProvider', () => {

--- a/src/services/rpc-provider/rpc-provider.service.ts
+++ b/src/services/rpc-provider/rpc-provider.service.ts
@@ -12,10 +12,7 @@ export default class RpcProviderService {
   constructor(
     private readonly config = configService,
     public readonly network = config.network.shortName,
-    public readonly jsonProvider = new StaticJsonRpcBatchProvider(config.rpc),
-    public readonly loggingProvider = new StaticJsonRpcBatchProvider(
-      config.loggingRpc
-    )
+    public readonly jsonProvider = new StaticJsonRpcBatchProvider(config.rpc)
   ) {}
 
   public initBlockListener(newBlockHandler: NewBlockHandler): void {


### PR DESCRIPTION
# Description

loggingRpc is a legacy thing we don't use anymore, removing from config.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [x] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## How should this be tested?

n/a

## Visual context

n/a

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have requested at least 1 review (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] If package-lock.json has changes, it was intentional.
- [x] The base of this PR is `master` if hotfix, `develop` if not
