### PR TITLE
Hotfix: Reduce the number of Tenderly API calls

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.85.5",
+  "version": "1.85.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@balancer-labs/frontend-v2",
-      "version": "1.85.5",
+      "version": "1.85.6",
       "license": "MIT",
       "devDependencies": {
         "@aave/protocol-js": "^4.3.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.85.6",
+  "version": "1.85.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@balancer-labs/frontend-v2",
-      "version": "1.85.6",
+      "version": "1.85.7",
       "license": "MIT",
       "devDependencies": {
         "@aave/protocol-js": "^4.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.85.6",
+  "version": "1.85.7",
   "engines": {
     "node": "14.x",
     "npm": ">=7"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.85.5",
+  "version": "1.85.6",
   "engines": {
     "node": "14.x",
     "npm": ">=7"

--- a/src/components/forms/pool_actions/InvestForm/InvestFormV2.vue
+++ b/src/components/forms/pool_actions/InvestForm/InvestFormV2.vue
@@ -20,6 +20,7 @@ import InvestFormTotalsV2 from './components/InvestFormTotalsV2.vue';
 import useMyWalletTokens from '@/composables/useMyWalletTokens';
 import MissingPoolTokensAlert from './components/MissingPoolTokensAlert.vue';
 import { useTokens } from '@/providers/tokens.provider';
+import { isEqual } from 'lodash';
 
 /**
  * TYPES
@@ -97,13 +98,26 @@ onBeforeMount(() => {
 /**
  * WATCHERS
  */
-watch([isSingleAssetJoin, poolTokensWithBalance], ([isSingleAsset]) => {
-  // Initialize token form if token balances change (ie. After investing, transaction confirmed or when account changes)
-  // only if preview modal is not open
-  if (!showInvestPreview.value) {
-    initializeTokensForm(isSingleAsset);
+watch(
+  [isSingleAssetJoin, poolTokensWithBalance],
+  (
+    [isSingleAsset, newPoolTokensWithBalance],
+    [prevIsSingleAsset, prevPoolTokensWithBalance]
+  ) => {
+    // Initialize token form if token balances change (ie. After investing, transaction confirmed or when account changes)
+    // only if preview modal is not open
+    if (!showInvestPreview.value) {
+      const hasTabChanged = prevIsSingleAsset !== isSingleAsset;
+      const hasUserTokensChanged = !isEqual(
+        prevPoolTokensWithBalance,
+        newPoolTokensWithBalance
+      );
+      if (hasUserTokensChanged || hasTabChanged) {
+        initializeTokensForm(isSingleAsset);
+      }
+    }
   }
-});
+);
 </script>
 
 <template>

--- a/src/composables/useMyWalletTokens.ts
+++ b/src/composables/useMyWalletTokens.ts
@@ -24,7 +24,7 @@ export default function useMyWalletTokens({
 
   const {
     balances,
-    dynamicDataLoading: isLoadingBalances,
+    balanceQueryLoading: isLoadingBalances,
     nativeAsset,
   } = useTokens();
 

--- a/src/providers/local/exit-pool.provider.ts
+++ b/src/providers/local/exit-pool.provider.ts
@@ -105,7 +105,7 @@ const provider = (props: Props) => {
   );
   const queryClient = useQueryClient();
 
-  const debounceQueryExit = debounce(queryExit, 1000, { leading: true });
+  const debounceQueryExit = debounce(queryExit, 1000);
   const debounceGetSingleAssetMax = debounce(getSingleAssetMax, 1000, {
     leading: true,
   });
@@ -122,7 +122,7 @@ const provider = (props: Props) => {
       singleAmountOut
     ),
     debounceQueryExit,
-    reactive({ enabled: queriesEnabled })
+    reactive({ enabled: queriesEnabled, refetchOnWindowFocus: false })
   );
 
   const singleAssetMaxQuery = useQuery<void, Error>(
@@ -132,7 +132,7 @@ const provider = (props: Props) => {
       toRef(singleAmountOut, 'address')
     ),
     debounceGetSingleAssetMax,
-    reactive({ enabled: queriesEnabled })
+    reactive({ enabled: queriesEnabled, refetchOnWindowFocus: false })
   );
 
   /**

--- a/src/providers/local/join-pool.provider.ts
+++ b/src/providers/local/join-pool.provider.ts
@@ -72,7 +72,7 @@ const provider = (props: Props) => {
   const highPriceImpactAccepted = ref<boolean>(false);
   const txError = ref<string>('');
 
-  const debounceQueryJoin = debounce(queryJoin, 1000, { leading: true });
+  const debounceQueryJoin = debounce(queryJoin, 1000);
 
   const queryEnabled = computed(
     (): boolean => isMounted.value && !txInProgress.value
@@ -88,7 +88,7 @@ const provider = (props: Props) => {
       isSingleAssetJoin
     ),
     debounceQueryJoin,
-    reactive({ enabled: queryEnabled })
+    reactive({ enabled: queryEnabled, refetchOnWindowFocus: false })
   );
 
   /**

--- a/src/providers/tokens.provider.ts
+++ b/src/providers/tokens.provider.ts
@@ -449,6 +449,7 @@ export const tokensProvider = (
     prices,
     balances,
     allowances,
+    balanceQueryLoading,
     dynamicDataLoaded,
     dynamicDataLoading,
     priceQueryError,


### PR DESCRIPTION
# Description

Call queryExit and queryJoin less often to reduce the nmbr of calls to Tenderly api

1. When user is changing input amounts queries are debounced, but first query will not fire immediately (`leading` is off)
2. `refetchOnWindowFocus` for queries is disabled, but queries still refetch in the background if Preview Modal is open.
3. Prevent invest form rerender if user tokens array hasn't changed

## Type of change

- [x] Other

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have requested at least 1 review (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] If package-lock.json has changes, it was intentional.
- [x] The base of this PR is `master` if hotfix, `develop` if not
