### PR TITLE
Disable native asset buffer warning in pool exit form

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.86.0",
+  "version": "1.86.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@balancer-labs/frontend-v2",
-      "version": "1.86.0",
+      "version": "1.86.1",
       "license": "MIT",
       "devDependencies": {
         "@aave/protocol-js": "^4.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.86.0",
+  "version": "1.86.1",
   "engines": {
     "node": ">=14",
     "npm": ">=7"

--- a/src/components/forms/pool_actions/WithdrawForm/WithdrawFormV2.vue
+++ b/src/components/forms/pool_actions/WithdrawForm/WithdrawFormV2.vue
@@ -85,6 +85,7 @@ onBeforeMount(() => {
           :customBalance="singleAmountOut.max || '0'"
           :balanceLabel="$t('max')"
           :balanceLoading="isLoadingMax"
+          disableNativeAssetBuffer
           :excludedTokens="[veBalTokenInfo?.address, pool.address]"
           :tokenSelectProps="{ ignoreBalances: true, subsetTokens }"
           ignoreWalletBalance


### PR DESCRIPTION
# Description

Disable native asset buffer warning in pool exit form

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

Please provide instructions so we can test. Please also list any relevant details for your test configuration.

- [ ] Test A
- [ ] Test B

## Visual context

Please provide any relevant visual context for UI changes or additions. This could be static screenshots or a loom screencast.

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have requested at least 1 review (If the PR is significant enough, use best judgement here)
- [ ] I have commented my code where relevant, particularly in hard-to-understand areas
- [ ] If package-lock.json has changes, it was intentional.
- [ ] The base of this PR is `master` if hotfix, `develop` if not
