### PR TITLE
fix: Redirect if on gnosis safe and wrong network

### DIFF
--- a/src/composables/useGnosisSafeApp.ts
+++ b/src/composables/useGnosisSafeApp.ts
@@ -33,7 +33,7 @@ export default function useGnosisSafeApp() {
     // connect to the provided safe.
     isGnosisSafeApp.value = await checkIfGnosisSafeApp();
     console.log('isGnosisSafeApp.value', isGnosisSafeApp.value);
-    if (!isGnosisSafeApp.value) {
+    if (isGnosisSafeApp.value) {
       await connectWallet('gnosis');
       console.log('chainId.value', chainId.value);
       console.log('networkId.value', networkId.value);

--- a/src/composables/useGnosisSafeApp.ts
+++ b/src/composables/useGnosisSafeApp.ts
@@ -33,13 +33,14 @@ export default function useGnosisSafeApp() {
     isGnosisSafeApp.value = await checkIfGnosisSafeApp();
     console.log('isGnosisSafeApp.value', isGnosisSafeApp.value);
     if (isGnosisSafeApp.value) {
-      window.location.href = `https://app.balancer.fi/#/arbitrum`;
       await connectWallet('gnosis');
       console.log('chainId.value', chainId.value);
       console.log('networkId.value', networkId.value);
       if (chainId.value !== networkId.value) {
         console.log(`/#/${getNetworkSlug(chainId.value)}`);
+        console.log(window.location.href);
         window.location.href = `/#/${getNetworkSlug(chainId.value)}`;
+        console.log(window.location.href);
       }
       // Disable darkmode by default
       if (darkMode) toggleDarkMode();

--- a/src/composables/useGnosisSafeApp.ts
+++ b/src/composables/useGnosisSafeApp.ts
@@ -31,7 +31,7 @@ export default function useGnosisSafeApp() {
     // If we're running as a Safe App we want to automatically
     // connect to the provided safe.
     isGnosisSafeApp.value = await checkIfGnosisSafeApp();
-    if (!isGnosisSafeApp.value) {
+    if (isGnosisSafeApp.value) {
       await connectWallet('gnosis');
       if (chainId.value !== networkId.value) {
         window.location.href = `/#/${getNetworkSlug(chainId.value)}`;

--- a/src/composables/useGnosisSafeApp.ts
+++ b/src/composables/useGnosisSafeApp.ts
@@ -32,17 +32,10 @@ export default function useGnosisSafeApp() {
     // If we're running as a Safe App we want to automatically
     // connect to the provided safe.
     isGnosisSafeApp.value = await checkIfGnosisSafeApp();
-    console.log('isGnosisSafeApp.value', isGnosisSafeApp.value);
     if (isGnosisSafeApp.value) {
       await connectWallet('gnosis');
-      console.log('chainId.value', chainId.value);
-      console.log('networkId.value', networkId.value);
       if (chainId.value !== networkId.value) {
-        console.log(`/#/${getNetworkSlug(chainId.value)}`);
-        console.log(window.location.href);
         hardRedirectTo(`/#/${getNetworkSlug(chainId.value)}`);
-        // window.location.href = `/#/${getNetworkSlug(chainId.value)}`;
-        console.log(window.location.href);
       }
       // Disable darkmode by default
       if (darkMode) toggleDarkMode();

--- a/src/composables/useGnosisSafeApp.ts
+++ b/src/composables/useGnosisSafeApp.ts
@@ -33,6 +33,7 @@ export default function useGnosisSafeApp() {
     isGnosisSafeApp.value = await checkIfGnosisSafeApp();
     console.log('isGnosisSafeApp.value', isGnosisSafeApp.value);
     if (isGnosisSafeApp.value) {
+      window.location.href = `https://app.balancer.fi/#/arbitrum`;
       await connectWallet('gnosis');
       console.log('chainId.value', chainId.value);
       console.log('networkId.value', networkId.value);

--- a/src/composables/useGnosisSafeApp.ts
+++ b/src/composables/useGnosisSafeApp.ts
@@ -5,6 +5,7 @@ import useDarkMode from '@/composables/useDarkMode';
 import useNetwork from '@/composables/useNetwork';
 import { tryPromiseWithTimeout } from '@/lib/utils/promise';
 import useWeb3 from '@/services/web3/useWeb3';
+import { hardRedirectTo } from '@/plugins/router/nav-guards';
 
 export const isGnosisSafeApp = ref(false);
 
@@ -32,14 +33,15 @@ export default function useGnosisSafeApp() {
     // connect to the provided safe.
     isGnosisSafeApp.value = await checkIfGnosisSafeApp();
     console.log('isGnosisSafeApp.value', isGnosisSafeApp.value);
-    if (isGnosisSafeApp.value) {
+    if (!isGnosisSafeApp.value) {
       await connectWallet('gnosis');
       console.log('chainId.value', chainId.value);
       console.log('networkId.value', networkId.value);
       if (chainId.value !== networkId.value) {
         console.log(`/#/${getNetworkSlug(chainId.value)}`);
         console.log(window.location.href);
-        window.location.href = `/#/${getNetworkSlug(chainId.value)}`;
+        hardRedirectTo(`/#/${getNetworkSlug(chainId.value)}`);
+        // window.location.href = `/#/${getNetworkSlug(chainId.value)}`;
         console.log(window.location.href);
       }
       // Disable darkmode by default

--- a/src/composables/useGnosisSafeApp.ts
+++ b/src/composables/useGnosisSafeApp.ts
@@ -2,6 +2,7 @@ import SafeAppsSDK from '@gnosis.pm/safe-apps-sdk';
 import { onBeforeMount, ref } from 'vue';
 
 import useDarkMode from '@/composables/useDarkMode';
+import useNetwork from '@/composables/useNetwork';
 import { tryPromiseWithTimeout } from '@/lib/utils/promise';
 import useWeb3 from '@/services/web3/useWeb3';
 
@@ -22,15 +23,19 @@ async function checkIfGnosisSafeApp(): Promise<boolean> {
 }
 
 export default function useGnosisSafeApp() {
-  const { connectWallet } = useWeb3();
+  const { connectWallet, chainId } = useWeb3();
   const { darkMode, toggleDarkMode } = useDarkMode();
+  const { networkId, getNetworkSlug } = useNetwork();
 
   onBeforeMount(async () => {
     // If we're running as a Safe App we want to automatically
     // connect to the provided safe.
     isGnosisSafeApp.value = await checkIfGnosisSafeApp();
-    if (isGnosisSafeApp.value) {
+    if (!isGnosisSafeApp.value) {
       await connectWallet('gnosis');
+      if (chainId.value !== networkId.value) {
+        window.location.href = `/#/${getNetworkSlug(chainId.value)}`;
+      }
       // Disable darkmode by default
       if (darkMode) toggleDarkMode();
     }

--- a/src/composables/useGnosisSafeApp.ts
+++ b/src/composables/useGnosisSafeApp.ts
@@ -31,9 +31,13 @@ export default function useGnosisSafeApp() {
     // If we're running as a Safe App we want to automatically
     // connect to the provided safe.
     isGnosisSafeApp.value = await checkIfGnosisSafeApp();
+    console.log('isGnosisSafeApp.value', isGnosisSafeApp.value);
     if (isGnosisSafeApp.value) {
       await connectWallet('gnosis');
+      console.log('chainId.value', chainId.value);
+      console.log('networkId.value', networkId.value);
       if (chainId.value !== networkId.value) {
+        console.log(`/#/${getNetworkSlug(chainId.value)}`);
         window.location.href = `/#/${getNetworkSlug(chainId.value)}`;
       }
       // Disable darkmode by default

--- a/src/composables/useNetwork.ts
+++ b/src/composables/useNetwork.ts
@@ -162,6 +162,7 @@ export default function useNetwork() {
     networkId,
     networkConfig,
     networkSlug,
+    getNetworkSlug,
     getSubdomain,
     handleNetworkSlug,
     networkLabelMap,


### PR DESCRIPTION
# Description

Gnosis safe always loads our app with root url '/'. This prevents loading correct network. Added chainId check so that it automatically switches to correct network url.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## How should this be tested?

Please provide instructions so we can test. Please also list any relevant details for your test configuration.

- [ ] Test A
- [ ] Test B

## Visual context

Please provide any relevant visual context for UI changes or additions. This could be static screenshots or a loom screencast.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have requested at least 1 review (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] If package-lock.json has changes, it was intentional.
- [x] The base of this PR is `master` if hotfix, `develop` if not
