### PR TITLE
Hotfix: Fix scaling decimals

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.86.7",
+  "version": "1.86.8",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@balancer-labs/frontend-v2",
-      "version": "1.86.7",
+      "version": "1.86.8",
       "license": "MIT",
       "devDependencies": {
         "@aave/protocol-js": "^4.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.86.7",
+  "version": "1.86.8",
   "engines": {
     "node": ">=14",
     "npm": ">=7"

--- a/src/components/forms/pool_actions/InvestForm/composables/useInvestMath.ts
+++ b/src/components/forms/pool_actions/InvestForm/composables/useInvestMath.ts
@@ -131,6 +131,7 @@ export default function useInvestMath(
           .toNumber() || 0
       );
     } catch (error) {
+      console.error(error);
       return 1;
     }
   });

--- a/src/services/pool/calculator/stable.ts
+++ b/src/services/pool/calculator/stable.ts
@@ -212,9 +212,9 @@ export default class Stable {
     // that requires balances be scaled by the token decimals and not 18
     // scaledBalances already use priceRate
     const balances = this.scaledBalances.map((balance, i) => {
-      const normalizedBalance = formatUnits(balance.toString(), 18);
+      const normalizedBalance = formatUnits(balance.toFixed(), 18);
       const denormBalance = parseUnits(
-        normalizedBalance,
+        Number(normalizedBalance).toFixed(this.calc.poolTokenDecimals[i]),
         this.calc.poolTokenDecimals[i]
       );
       return denormBalance;


### PR DESCRIPTION
# Description

In stable math we needed to limit decimal places to the token decimals before parsing units again.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## How should this be tested?

- [ ] Test that you get a reasonable price impact when joining this pool `0x34a81e8956bf20b7448b31990a2c06f96830a6e4000200000000000000000a14` on polygon. Before it was erroring and displaying 100%.

## Visual context

n/a

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have requested at least 1 review (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] If package-lock.json has changes, it was intentional.
- [x] The base of this PR is `master` if hotfix, `develop` if not
