### PR TITLE
Hotfix: increase gauge pool query limit

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.86.8",
+  "version": "1.86.9",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@balancer-labs/frontend-v2",
-      "version": "1.86.8",
+      "version": "1.86.9",
       "license": "MIT",
       "devDependencies": {
         "@aave/protocol-js": "^4.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.86.8",
+  "version": "1.86.9",
   "engines": {
     "node": ">=14",
     "npm": ">=7"

--- a/src/composables/useClaimsData.ts
+++ b/src/composables/useClaimsData.ts
@@ -56,6 +56,7 @@ export function useClaimsData() {
       pools: {
         __args: {
           where: { id_in: gaugePoolIds.value },
+          first: 1000,
         },
         id: true,
         address: true,


### PR DESCRIPTION
# Description

We perform a pool query to fetch the pools that correspond to the gauges for the claims page. The number of gauges has past 100 but the default limit for the pools query was 100 so for some gauges we didn't have pool information and so didn't display the claimable balance on the claims page. This PR increases the pool fetch limit to 1000 which fixes the problem for the foreseeable future.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## How should this be tested?

n/a

## Visual context

n/a

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have requested at least 1 review (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] If package-lock.json has changes, it was intentional.
- [x] The base of this PR is `master` if hotfix, `develop` if not
