### PR TITLE
Hotfix: Re-enable balancer api on Polygon and Arbitrum

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.86.9",
+  "version": "1.86.10",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@balancer-labs/frontend-v2",
-      "version": "1.86.9",
+      "version": "1.86.10",
       "license": "MIT",
       "devDependencies": {
         "@aave/protocol-js": "^4.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.86.9",
+  "version": "1.86.10",
   "engines": {
     "node": ">=14",
     "npm": ">=7"

--- a/src/lib/config/arbitrum.json
+++ b/src/lib/config/arbitrum.json
@@ -13,7 +13,7 @@
   "explorer": "https://arbiscan.io",
   "explorerName": "Arbiscan",
   "subgraph": "https://api.thegraph.com/subgraphs/name/balancer-labs/balancer-arbitrum-v2",
-  "balancerApi": "",
+  "balancerApi": "https://api.balancer.fi",
   "poolsUrlV1": "",
   "poolsUrlV2": "",
   "subgraphs": {

--- a/src/lib/config/polygon.json
+++ b/src/lib/config/polygon.json
@@ -13,7 +13,7 @@
   "explorer": "https://polygonscan.com",
   "explorerName": "Polygonscan",
   "subgraph": "https://api.thegraph.com/subgraphs/name/balancer-labs/balancer-polygon-prune-v2",
-  "balancerApi": "",
+  "balancerApi": "https://api.balancer.fi",
   "poolsUrlV2": "",
   "subgraphs": {
     "main": [


### PR DESCRIPTION
# Description

These two endpoints were removed in #2717 and #2720 because the API was returning bad data. 

The API was returning bad data because we use alchemy to notify the API to update the pools when a transaction is made with the Balancer vault. This notification was disabled by someone for Polygon and Arbitrum on the weekend, so the pools hadn't been updated since then. I've re-enabled it and pools are up to date again. 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)


## How should this be tested?

- Ensure that Polygon and Arbitrum pools are being fetched from the API and have sane volumes and APR's (no negative numbers or 0's)

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have requested at least 1 review (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] If package-lock.json has changes, it was intentional.
- [x] The base of this PR is `master` if hotfix, `develop` if not
