### PR TITLE
Fix: cowswap preview modal showing incorrect estimate

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.87.2",
+  "version": "1.87.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@balancer-labs/frontend-v2",
-      "version": "1.87.2",
+      "version": "1.87.3",
       "license": "MIT",
       "devDependencies": {
         "@aave/protocol-js": "^4.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.87.2",
+  "version": "1.87.3",
   "engines": {
     "node": "=16",
     "npm": ">=8"

--- a/src/composables/trade/useCowswap.ts
+++ b/src/composables/trade/useCowswap.ts
@@ -109,10 +109,12 @@ export default function useCowswap({
   // METHODS
   function getFeeAmount() {
     const feeAmountInToken = feeQuote.value ?? '0';
-    const feeAmountOutToken = tokenOutAmountScaled.value
-      .mul(feeAmountInToken)
-      .div(tokenInAmountScaled.value)
-      .toString();
+    const feeAmountOutToken = tokenInAmountScaled.value.isZero()
+      ? '0'
+      : tokenOutAmountScaled.value
+          .mul(feeAmountInToken)
+          .div(tokenInAmountScaled.value)
+          .toString();
 
     return {
       feeAmountInToken,
@@ -289,10 +291,9 @@ export default function useCowswap({
         toDecimals: tokenOut.value.decimals,
         from: account.value || AddressZero,
         receiver: account.value || AddressZero,
-        [exactIn.value ? 'sellAmountBeforeFee' : 'buyAmountAfterFee']:
+        [exactIn.value ? 'sellAmountAfterFee' : 'buyAmountAfterFee']:
           amountToExchange.toString(),
         partiallyFillable: false, // Always fill or kill,
-        sellTokenBalance: OrderBalance.EXTERNAL,
       };
 
       const priceQuote = await cowswapProtocolService.getPriceQuote(


### PR DESCRIPTION
# Description

Cowswap "ExactIn" swap was showing incorrect predicted swap outcome as it was using "beforeFee" rather than "afterFee" option when getting a quote.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## How should this be tested?

Please provide instructions so we can test. Please also list any relevant details for your test configuration.

- [ ] Test A
- [ ] Test B

## Visual context

Please provide any relevant visual context for UI changes or additions. This could be static screenshots or a loom screencast.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have requested at least 1 review (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] If package-lock.json has changes, it was intentional.
- [x] The base of this PR is `master` if hotfix, `develop` if not
