### PR TITLE
fix: joinExit mount logic

### DIFF
--- a/src/composables/trade/useJoinExit.ts
+++ b/src/composables/trade/useJoinExit.ts
@@ -295,11 +295,10 @@ export default function useJoinExit({
       unknownAssets.push(tokenOutAddressInput.value);
     }
     await injectTokens(unknownAssets);
-    await handleAmountChange();
   });
 
-  watch(pools, () => {
-    handleAmountChange();
+  watch(pools, async () => {
+    await getSwapInfo();
   });
 
   return {


### PR DESCRIPTION
# Description

When loading swap page, joinExit composable needs to check if a swap is joinExit. This was done with function handleAmountChange(). It can be simplified by only using function getSwapInfo()

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## How should this be tested?

Please provide instructions so we can test. Please also list any relevant details for your test configuration.

- [ ] Test A
- [ ] Test B

## Visual context

Please provide any relevant visual context for UI changes or additions. This could be static screenshots or a loom screencast.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have requested at least 1 review (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] If package-lock.json has changes, it was intentional.
- [x] The base of this PR is `master` if hotfix, `develop` if not
