### PR TITLE
Fix: Set eslint max warnings back to 0

### DIFF
--- a/package.json
+++ b/package.json
@@ -144,7 +144,7 @@
     "worker-loader": "^3.0.8"
   },
   "lint-staged": {
-    "*.{js,ts,vue}": "eslint --cache --fix --max-warnings 1",
+    "*.{js,ts,vue}": "eslint --cache --fix --max-warnings 0",
     "*.{md,json,yaml,html}": "prettier --write",
     "*.{css,vue}": "stylelint --fix"
   },


### PR DESCRIPTION
## Type of change

- [x] Other

## How should this be tested?

## Visual context

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have requested at least 1 review (If the PR is significant enough, use best judgement here)
- [ ] I have commented my code where relevant, particularly in hard-to-understand areas
- [ ] If package-lock.json has changes, it was intentional.
- [ ] The base of this PR is `master` if hotfix, `develop` if not
