### PR TITLE
Chore: removed historic price graph extended view

### DIFF
--- a/src/components/cards/PairPriceGraph/PairPriceGraph.vue
+++ b/src/components/cards/PairPriceGraph/PairPriceGraph.vue
@@ -1,14 +1,6 @@
 <script setup lang="ts">
 import { format, fromUnixTime } from 'date-fns';
-import {
-  Dictionary,
-  mapKeys,
-  mapValues,
-  maxBy,
-  minBy,
-  pickBy,
-  toPairs,
-} from 'lodash';
+import { Dictionary, mapKeys, mapValues, pickBy, toPairs } from 'lodash';
 import { computed, reactive, ref } from 'vue';
 import { useI18n } from 'vue-i18n';
 import { useQuery } from 'vue-query';
@@ -113,13 +105,6 @@ const chartTimespans = [
   },
 ];
 
-type Props = {
-  isModal?: boolean;
-  onCloseModal?: () => void;
-  toggleModal: () => void;
-};
-
-const props = defineProps<Props>();
 const { upToLargeBreakpoint } = useBreakpoints();
 const { t } = useI18n();
 const { getToken, wrappedNativeAsset, nativeAsset } = useTokens();
@@ -127,9 +112,7 @@ const { tokenInAddress, tokenOutAddress, initialized } = useTradeState();
 const tailwind = useTailwind();
 const { chainId: userNetworkId, appNetworkConfig } = useWeb3();
 
-const chartHeight = ref(
-  upToLargeBreakpoint ? (props.isModal ? 250 : 75) : props.isModal ? 250 : 100
-);
+const chartHeight = ref(upToLargeBreakpoint ? 75 : 100);
 const activeTimespan = ref(chartTimespans[0]);
 
 const inputSym = computed(() => {
@@ -139,14 +122,6 @@ const inputSym = computed(() => {
 const outputSym = computed(() => {
   if (tokenOutAddress.value === '') return 'Unknown';
   return getToken(tokenOutAddress.value)?.symbol;
-});
-
-const dataMin = computed(() => {
-  return (minBy(priceData.value || [], v => v[1]) || [])[1] || 0;
-});
-
-const dataMax = computed(() => {
-  return (maxBy(priceData.value || [], v => v[1]) || [])[1] || 0;
 });
 
 const {
@@ -179,10 +154,6 @@ const {
     refetchOnWindowFocus: false,
   })
 );
-
-const toggle = () => {
-  props.toggleModal();
-};
 
 const equivalentTokenPairs = [
   [appNetworkConfig.addresses.weth, appNetworkConfig.nativeAsset.address],
@@ -244,22 +215,8 @@ const chartGrid = computed(() => {
 </script>
 
 <template>
-  <div
-    :class="[
-      '',
-      {
-        'h-40 lg:h-56': !isModal,
-        'h-full lg:h-full': isModal,
-      },
-    ]"
-  >
-    <BalLoadingBlock
-      v-if="isLoadingPriceData"
-      :class="{
-        'h-56': !isModal,
-        'h-112': isModal,
-      }"
-    />
+  <div class="h-40 lg:h-56">
+    <BalLoadingBlock v-if="isLoadingPriceData" class="h-56" />
     <BalCard
       v-else
       :square="upToLargeBreakpoint"
@@ -267,17 +224,9 @@ const chartGrid = computed(() => {
       hFull
       growContent
       noPad
-      :noBorder="upToLargeBreakpoint || isModal"
+      :noBorder="upToLargeBreakpoint"
     >
       <div class="relative p-4 h-full bg-transparent">
-        <button
-          v-if="!failedToLoadPriceData && !isLoadingPriceData"
-          class="flex justify-center items-center p-2 m-4 rounded-full shadow-lg maximise"
-          @click="toggle"
-        >
-          <BalIcon v-if="!isModal" name="maximize-2" class="text-secondary" />
-          <BalIcon v-if="isModal" name="x" class="text-secondary" />
-        </button>
         <div v-if="!failedToLoadPriceData && !isLoadingPriceData" class="flex">
           <h6 class="font-medium">{{ outputSym }}/{{ inputSym }}</h6>
           <BalTooltip class="ml-2" :text="$t('coingeckoPricingTooltip')">
@@ -306,10 +255,7 @@ const chartGrid = computed(() => {
           v-if="!failedToLoadPriceData && !isLoadingPriceData"
           class="flex-col"
         >
-          <BalBlankSlate
-            v-if="chartData.length === 0"
-            :class="['mt-4', isModal ? 'h-96' : 'h-40']"
-          >
+          <BalBlankSlate v-if="chartData.length === 0" class="mt-4 h-40">
             <BalIcon name="bar-chart" />
             {{ chartBlankText }}
           </BalBlankSlate>
@@ -323,63 +269,15 @@ const chartGrid = computed(() => {
               :axisLabelFormatter="{
                 yAxis: { maximumSignificantDigits: 6, fixedFormat: true },
               }"
-              :wrapperClass="[
-                'flex flex-row lg:flex-col',
-                {
-                  'flex-row': !isModal,
-                  'flex-col': isModal,
-                },
-              ]"
-              :showTooltip="!upToLargeBreakpoint || isModal"
+              wrapperClass="flex flex-row lg:flex-col flex-row"
+              :showTooltip="!upToLargeBreakpoint"
               chartType="line"
               hideYAxis
               hideXAxis
               showHeader
               useMinMax
             />
-            <div
-              v-if="isModal"
-              :class="[
-                'w-full flex justify-between mt-6',
-                {
-                  'flex-col': isModal,
-                },
-              ]"
-            >
-              <div>
-                <button
-                  v-for="timespan in chartTimespans"
-                  :key="timespan.value"
-                  :class="[
-                    'py-1 px-2 text-sm rounded-lg mr-2',
-                    {
-                      'text-white': activeTimespan.value === timespan.value,
-                      'text-secondary': activeTimespan.value !== timespan.value,
-                      'bg-green-400':
-                        !isNegativeTrend &&
-                        activeTimespan.value === timespan.value,
-                      'bg-red-400':
-                        isNegativeTrend &&
-                        activeTimespan.value === timespan.value,
-                      'hover:bg-red-200': isNegativeTrend,
-                      'hover:bg-green-200': !isNegativeTrend,
-                    },
-                  ]"
-                  @click="activeTimespan = timespan"
-                >
-                  {{ timespan.option }}
-                </button>
-              </div>
-              <div :class="{ 'mt-4': isModal }">
-                <span class="mr-4 text-sm text-gray-500"
-                  >Low: {{ dataMin.toPrecision(6) }}</span
-                >
-                <span class="text-sm text-gray-500"
-                  >High: {{ dataMax.toPrecision(6) }}</span
-                >
-              </div>
-            </div>
-            <div v-else class="-mt-2 lg:mt-2">
+            <div class="-mt-2 lg:mt-2">
               <span class="flex justify-end w-full text-sm text-gray-500">{{
                 activeTimespan.option
               }}</span>

--- a/src/pages/trade.vue
+++ b/src/pages/trade.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, onMounted, ref } from 'vue';
+import { computed, onMounted } from 'vue';
 import MyWallet from '@/components/cards/MyWallet/MyWallet.vue';
 import PairPriceGraph from '@/components/cards/PairPriceGraph/PairPriceGraph.vue';
 import TradeCard from '@/components/cards/TradeCard/TradeCard.vue';
@@ -8,11 +8,6 @@ import usePoolFilters from '@/composables/pools/usePoolFilters';
 import useBreakpoints from '@/composables/useBreakpoints';
 import BridgeLink from '@/components/links/BridgeLink.vue';
 import { isL2 } from '@/composables/useNetwork';
-
-/**
- * STATE
- */
-const showPriceGraphModal = ref(false);
 
 /**
  * COMPOSABLES
@@ -31,17 +26,6 @@ const sections = computed(() => {
   if (isL2.value) sections.push({ title: 'Bridge assets', id: 'bridge' });
   return sections;
 });
-
-/**
- * METHODS
- */
-function onPriceGraphModalClose() {
-  showPriceGraphModal.value = false;
-}
-
-function togglePairPriceGraphModal() {
-  showPriceGraphModal.value = !showPriceGraphModal.value;
-}
 
 /**
  * CALLBACKS
@@ -70,7 +54,7 @@ onMounted(() => {
             <MyWallet />
           </template>
           <template #price-chart>
-            <PairPriceGraph :toggleModal="togglePairPriceGraphModal" />
+            <PairPriceGraph />
           </template>
           <template v-if="isL2" #bridge>
             <BridgeLink />
@@ -79,22 +63,10 @@ onMounted(() => {
       </div>
 
       <template #gutterRight>
-        <PairPriceGraph :toggleModal="togglePairPriceGraphModal" />
+        <PairPriceGraph />
         <BridgeLink v-if="isL2" class="mt-4" />
       </template>
     </Col3Layout>
-
-    <teleport to="#modal">
-      <BalModal :show="showPriceGraphModal" @close="onPriceGraphModalClose">
-        <div class="graph-modal">
-          <PairPriceGraph
-            :toggleModal="togglePairPriceGraphModal"
-            isModal
-            :onCloseModal="onPriceGraphModalClose"
-          />
-        </div>
-      </BalModal>
-    </teleport>
   </div>
 </template>
 


### PR DESCRIPTION
# Description

On swap page, in the right gutter, we display a token pair historic price chart. It's possible to extend this chart into a modal. This is now removed as it's been rarely used.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [x] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## How should this be tested?

Please provide instructions so we can test. Please also list any relevant details for your test configuration.

- [ ] Test A
- [ ] Test B

## Visual context

Please provide any relevant visual context for UI changes or additions. This could be static screenshots or a loom screencast.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have requested at least 1 review (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] If package-lock.json has changes, it was intentional.
- [x] The base of this PR is `master` if hotfix, `develop` if not
