### PR TITLE
Hotfix: default to tokenlists for pill symbols

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.88.3",
+  "version": "1.88.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@balancer-labs/frontend-v2",
-      "version": "1.88.3",
+      "version": "1.88.4",
       "license": "MIT",
       "devDependencies": {
         "@aave/protocol-js": "^4.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.88.3",
+  "version": "1.88.4",
   "engines": {
     "node": "=16",
     "npm": ">=8"

--- a/src/components/tables/PoolsTable/TokenPills/TokenPills.vue
+++ b/src/components/tables/PoolsTable/TokenPills/TokenPills.vue
@@ -53,7 +53,7 @@ const isSelectedInPickedTokens = computed(() =>
  * METHODS
  */
 function symbolFor(token: PoolToken): string {
-  return token.symbol || getToken(token.address)?.symbol || '---';
+  return getToken(token.address)?.symbol || token.symbol || '---';
 }
 
 function weightFor(token: PoolToken): string {


### PR DESCRIPTION
# Description

The token pill symbols in pool lists were defaulting to the onchain symbol attribute and falling back to tokenlist data. This PR reverses that so that it defaults to tokenlist values.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## How should this be tested?

- [ ] Search for ankrMATIC pools on polygon, the token symbol should be ankrMATIC not aMATICc.

## Visual context

n/a

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have requested at least 1 review (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] If package-lock.json has changes, it was intentional.
- [x] The base of this PR is `master` if hotfix, `develop` if not
