### PR TITLE
Hotfix: default to tokenlists for pill symbols

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.88.3",
+  "version": "1.88.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@balancer-labs/frontend-v2",
-      "version": "1.88.3",
+      "version": "1.88.4",
       "license": "MIT",
       "devDependencies": {
         "@aave/protocol-js": "^4.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.88.3",
+  "version": "1.88.4",
   "engines": {
     "node": "=16",
     "npm": ">=8"

--- a/src/components/contextual/pages/pool/PoolCompositionCard/components/TokenBreakdown.vue
+++ b/src/components/contextual/pages/pool/PoolCompositionCard/components/TokenBreakdown.vue
@@ -5,6 +5,7 @@ import { computed, toRefs } from 'vue';
 import { TokensData } from './composables/useTokenBreakdown';
 
 import { isWeightedLike, usePool } from '@/composables/usePool';
+import { useTokens } from '@/providers/tokens.provider';
 
 /**
  * TYPES
@@ -33,6 +34,7 @@ const tokenData = computed(() => props.tokensData[token.value.address]);
 const { explorerLinks } = useWeb3();
 const { isDeepPool } = usePool(rootPool);
 const isWeighted = isWeightedLike(rootPool.value.poolType);
+const { getToken } = useTokens();
 
 /**
  * COMPUTED
@@ -54,6 +56,13 @@ const nestedPaddingClass = computed(() => {
       return 'pl-4';
   }
 });
+
+/**
+ * METHODS
+ */
+function symbolFor(token: PoolToken): string {
+  return getToken(token.address)?.symbol || token.symbol || '---';
+}
 </script>
 
 <template>
@@ -79,7 +88,7 @@ const nestedPaddingClass = computed(() => {
       />
       <span
         class="group-hover:text-purple-500 dark:group-hover:text-yellow-500 transition-colors"
-        >{{ token?.symbol || '---' }}</span
+        >{{ symbolFor(token) }}</span
       >
       <BalIcon
         name="arrow-up-right"

--- a/src/components/pool/PoolPageHeader.vue
+++ b/src/components/pool/PoolPageHeader.vue
@@ -49,7 +49,7 @@ const { hasNonApprovedRateProviders } = usePool(toRef(props, 'pool'));
 const { fNum2 } = useNumbers();
 const { t } = useI18n();
 const { explorerLinks: explorer } = useWeb3();
-const { balancerTokenListTokens } = useTokens();
+const { balancerTokenListTokens, getToken } = useTokens();
 const { hasNonPrefGaugeBalance } = usePoolStaking();
 
 /**
@@ -122,6 +122,14 @@ const poolTypeLabel = computed(() => {
 
 const poolMetadata = computed(() => POOLS.Metadata[props.pool?.id]);
 const hasMetadata = computed((): boolean => !!poolMetadata.value);
+
+/**
+ * METHODS
+ */
+function symbolFor(titleTokenIndex: number): string {
+  const token = props.titleTokens[titleTokenIndex];
+  return getToken(token.address)?.symbol || token.symbol || '---';
+}
 </script>
 
 <template>
@@ -141,13 +149,13 @@ const hasMetadata = computed((): boolean => !!poolMetadata.value);
     </div>
     <div class="flex">
       <div
-        v-for="({ address, symbol, weight }, i) in titleTokens"
+        v-for="({ address, weight }, i) in titleTokens"
         :key="i"
         class="flex items-center px-2 mt-2 mr-2 h-10 bg-gray-50 dark:bg-gray-850 rounded-lg"
       >
         <BalAsset :address="address" />
         <span class="ml-2">
-          {{ symbol }}
+          {{ symbolFor(i) }}
         </span>
         <span
           v-if="!isStableLikePool"

--- a/src/components/tables/PoolsTable/TokenPills/TokenPills.vue
+++ b/src/components/tables/PoolsTable/TokenPills/TokenPills.vue
@@ -53,7 +53,7 @@ const isSelectedInPickedTokens = computed(() =>
  * METHODS
  */
 function symbolFor(token: PoolToken): string {
-  return token.symbol || getToken(token.address)?.symbol || '---';
+  return getToken(token.address)?.symbol || token.symbol || '---';
 }
 
 function weightFor(token: PoolToken): string {


### PR DESCRIPTION
# Description

The token pill symbols in pool lists were defaulting to the onchain symbol attribute and falling back to tokenlist data. This PR reverses that so that it defaults to tokenlist values.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## How should this be tested?

- [ ] Search for ankrMATIC pools on polygon, the token symbol should be ankrMATIC not aMATICc.

## Visual context

n/a

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have requested at least 1 review (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] If package-lock.json has changes, it was intentional.
- [x] The base of this PR is `master` if hotfix, `develop` if not
