### PR TITLE
fix: Render FX pools like stable pools

### DIFF
--- a/src/composables/usePool.ts
+++ b/src/composables/usePool.ts
@@ -59,6 +59,10 @@ export function isComposableStableLike(poolType: PoolType): boolean {
   return isStablePhantom(poolType) || isComposableStable(poolType);
 }
 
+export function isFx(poolType: PoolType | string): boolean {
+  return poolType === 'FX';
+}
+
 export function isPreMintedBptType(poolType: PoolType): boolean {
   // Currently equivalent to isComposableStableLike but will be extended later
   // with managed and composable weighted pools.
@@ -119,7 +123,8 @@ export function isStableLike(poolType: PoolType): boolean {
     isStable(poolType) ||
     isMetaStable(poolType) ||
     isStablePhantom(poolType) ||
-    isComposableStable(poolType)
+    isComposableStable(poolType) ||
+    isFx(poolType)
   );
 }
 
@@ -485,7 +490,8 @@ export function findTokenInTree(
  */
 export function isBlocked(pool: Pool, account: string): boolean {
   const requiresAllowlisting =
-    isStableLike(pool.poolType) || isManaged(pool.poolType);
+    (isStableLike(pool.poolType) && !isFx(pool.poolType)) ||
+    isManaged(pool.poolType);
   const isOwnedByUser =
     pool.owner && isAddress(account) && isSameAddress(pool.owner, account);
   const isAllowlisted =

--- a/src/locales/default.json
+++ b/src/locales/default.json
@@ -387,6 +387,7 @@
   "fundPool": "Fund pool",
   "fundPoolTooltip": "Add the initial liquidity for this pool.",
   "forum": "Forum",
+  "fx": "FX pool",
   "gaugeFilter": {
     "gaugeDisplay": "Pool gauge display",
     "showExpired": "Show expired pools",


### PR DESCRIPTION
# Description

Sorry, I missed this in the review. We need to add a label for factory keys so the title of the pool page is correct. Also, FX pools are more like stable pools in that they don't seem to have weights, so let's treat them like stables.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [x] Other

## How should this be tested?

- [ ] Test the title of FX pool pages is "FX Pool"
- [ ] Test the token pills in the pool page title don't include weights.

## Visual context

n/a

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have requested at least 1 review (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] If package-lock.json has changes, it was intentional.
- [x] The base of this PR is `master` if hotfix, `develop` if not
