### PR TITLE
Fix: change url when using old format 'trade' route

### DIFF
--- a/src/plugins/router/index.ts
+++ b/src/plugins/router/index.ts
@@ -95,13 +95,9 @@ const routes: RouteRecordRaw[] = [
   },
   {
     path: '/:networkSlug/trade/:assetIn?/:assetOut?',
-    name: 'trade',
-    component: SwapPage,
-  },
-  {
-    path: '/:networkSlug/swap/:assetIn?/:assetOut?',
+    name: 'trade-redirect',
     redirect: to => {
-      return `/swap${to.path.split('/swap')[1]}`;
+      return `/${to.params.networkSlug}/swap${to.path.split('/trade')[1]}`;
     },
   },
   {

--- a/src/plugins/router/nav-guards.ts
+++ b/src/plugins/router/nav-guards.ts
@@ -94,20 +94,25 @@ function applyNetworkPathRedirects(router: Router): Router {
           networkChangeCallback
         );
       } else {
-        const nonNetworkedRoutes = [
+        const networkAgnosticRoutes = [
           '/',
           '/terms-of-use',
           '/privacy-policy',
           '/cookies-policy',
         ];
-        if (to.redirectedFrom || !nonNetworkedRoutes.includes(to.fullPath)) {
+        const routerHandledRedirects = ['not-found', 'trade-redirect'];
+        if (
+          !to.redirectedFrom ||
+          routerHandledRedirects.includes(to.redirectedFrom?.name as string) ||
+          networkAgnosticRoutes.includes(to.fullPath)
+        ) {
+          next();
+        } else {
           const newPath = to.redirectedFrom?.fullPath ?? to.fullPath;
           const newNetwork = newPath.includes('/pool')
             ? config[Network.MAINNET].slug
             : networkSlug;
           router.push({ path: `/${newNetwork}${newPath}` });
-        } else {
-          next();
         }
       }
     }


### PR DESCRIPTION
# Description

Instead of simply rendering the swap page, also update the url to say 'swap' instead of 'trade'. Also included fix to a problem of 'not-found' route getting stuck in a loop.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## How should this be tested?

Please provide instructions so we can test. Please also list any relevant details for your test configuration.

- [ ] Test A
- [ ] Test B

## Visual context

Please provide any relevant visual context for UI changes or additions. This could be static screenshots or a loom screencast.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have requested at least 1 review (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] If package-lock.json has changes, it was intentional.
- [x] The base of this PR is `master` if hotfix, `develop` if not
