### PR TITLE
Show 0% token percentage when tokens have no balance

### DIFF
--- a/src/__mocks__/pool.ts
+++ b/src/__mocks__/pool.ts
@@ -1,6 +1,6 @@
 import { PoolMock } from './weighted-pool';
 import { BoostedPoolMock } from './boosted-pool';
-import { Pool, PoolType } from '@/services/pool/types';
+import { Pool, PoolToken, PoolType } from '@/services/pool/types';
 
 export const EmptyPoolMock: Pool = {
   protocolSwapFeeCache: '',
@@ -29,3 +29,9 @@ export const EmptyPoolMock: Pool = {
 };
 
 export { PoolMock, BoostedPoolMock };
+
+export function anEmptyPool(tokens: PoolToken[]) {
+  const pool = EmptyPoolMock;
+  pool.tokens = tokens;
+  return EmptyPoolMock;
+}

--- a/src/__mocks__/weighted-pool.ts
+++ b/src/__mocks__/weighted-pool.ts
@@ -43,7 +43,7 @@ export function aWeightedPool() {
   return poolMock;
 }
 
-export function aPoolToken(options: Partial<PoolToken>): PoolToken {
+export function aPoolToken(options?: Partial<PoolToken>): PoolToken {
   const poolToken = mock<PoolToken>();
   return Object.assign(poolToken, options);
 }

--- a/src/components/contextual/pages/pool/PoolCompositionCard/components/composables/useTokenBreakdown.spec.ts
+++ b/src/components/contextual/pages/pool/PoolCompositionCard/components/composables/useTokenBreakdown.spec.ts
@@ -1,9 +1,10 @@
 import { removeBptFrom } from '@/composables/usePool';
 import * as tokensProvider from '@/providers/tokens.provider';
 import { Pool } from '@/services/pool/types';
-import { BoostedPoolMock } from '@/__mocks__/pool';
-import { aWeightedPool } from '@/__mocks__/weighted-pool';
+import { anEmptyPool, BoostedPoolMock } from '@/__mocks__/pool';
+import { aPoolToken, aWeightedPool } from '@/__mocks__/weighted-pool';
 import { mountComposable } from '@tests/mount-helpers';
+import { zeroAddress } from 'ethereumjs-util';
 import { ref } from 'vue';
 import { useTokenBreakdown } from './useTokenBreakdown';
 
@@ -127,6 +128,20 @@ describe('Given a weighted pool (GRO-WETH)', () => {
     // (token balance / total balance) * 100
     expect(wethData.getTokenPercentageLabel()).toEqual('0.02%');
     expect(groData.getTokenPercentageLabel()).toEqual('99.98%');
+  });
+
+  it('shows 0% token percentage given a token without balance ', () => {
+    rootPool.totalLiquidity = '1900';
+    const tokenWithoutBalance = aPoolToken({
+      balance: '0',
+      address: zeroAddress(),
+    });
+    const pool = anEmptyPool([tokenWithoutBalance]);
+    const data = mountTokenBreakdown(pool);
+
+    const token = data.value[zeroAddress()];
+
+    expect(token.getTokenPercentageLabel()).toEqual('0%');
   });
 });
 

--- a/src/components/contextual/pages/pool/PoolCompositionCard/components/composables/useTokenBreakdown.ts
+++ b/src/components/contextual/pages/pool/PoolCompositionCard/components/composables/useTokenBreakdown.ts
@@ -68,6 +68,7 @@ export function useTokenBreakdown(rootPool: Ref<Pool>) {
       : fNum2(token.weight, FNumFormats.percent);
 
     function getTokenPercentageLabel() {
+      if (totalFiat === 0) return '0%';
       const tokenPercentage = Number(fiatValue) / Number(totalFiat);
       return tokenPercentage === 0
         ? ''


### PR DESCRIPTION
# Description

Show `0%` (instead of Nan) for token percentage when tokens have no balance
<img width="948" alt="Screenshot 2023-02-09 at 12 11 28" src="https://user-images.githubusercontent.com/1316240/217871234-c8093d81-aed7-4a06-9207-34b77f5e6aa2.png">


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## How should this be tested?

Please provide instructions so we can test. Please also list any relevant details for your test configuration.

- [ ] Test A
- [ ] Test B

## Visual context

Please provide any relevant visual context for UI changes or additions. This could be static screenshots or a loom screencast.

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have requested at least 1 review (If the PR is significant enough, use best judgement here)
- [ ] I have commented my code where relevant, particularly in hard-to-understand areas
- [ ] If package-lock.json has changes, it was intentional.
- [ ] The base of this PR is `master` if hotfix, `develop` if not
