### PR TITLE
Display negative values in fees chart

### DIFF
--- a/src/components/contextual/pages/pool/FxPoolWarning.vue
+++ b/src/components/contextual/pages/pool/FxPoolWarning.vue
@@ -1,0 +1,19 @@
+<template>
+  <BalAlert class="py-2 px-2.5 mb-5" type="tip" size="md" block title="">
+    <div class="flex flex-col text-sm">
+      <span>{{ $t('poolChart.fxPoolWarning') }}</span>
+      <BalLink
+        href="https://docs.xave.co/product-overview-1/amm#mechanism"
+        external
+        noStyle
+      >
+        <div class="flex items-center text-blue-600">
+          <span>
+            {{ $t('learnMore') }}
+          </span>
+          <BalIcon name="arrow-up-right" size="sm" />
+        </div>
+      </BalLink>
+    </div>
+  </BalAlert>
+</template>

--- a/src/constants/pools.ts
+++ b/src/constants/pools.ts
@@ -388,7 +388,6 @@ const POOLS_POLYGON: Pools = {
     'Gyro2',
     'Gyro3',
     'GyroE',
-    'FX',
     'HighAmpComposableStable',
   ],
   Stable: {

--- a/src/locales/default.json
+++ b/src/locales/default.json
@@ -1499,7 +1499,8 @@
       "fees": "Fees",
       "tvl": "TVL",
       "volume": "Volume"
-    }
+    },
+    "fxPoolWarning": "Under certain circumstances, FX Pools offer rebates to traders, i.e. \"negative swap fees\"."
   },
   "yes": "Yes",
   "none": "None",


### PR DESCRIPTION
# Description
There may be a case when there are negative swap fees e.g. in FX pools.
See: https://github.com/balancer-labs/balancer-subgraph-v2/issues/366
         https://docs.xave.co/product-overview-1/amm#mechanism
 
Example pool: `0x726e324c29a1e49309672b244bdc4ff62a270407000200000000000000000702`

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## How should this be tested?

Please provide instructions so we can test. Please also list any relevant details for your test configuration.

- [ ] Test A
- [ ] Test B

## Visual context

Please provide any relevant visual context for UI changes or additions. This could be static screenshots or a loom screencast.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have requested at least 1 review (If the PR is significant enough, use best judgement here)
- [ ] I have commented my code where relevant, particularly in hard-to-understand areas
- [ ] If package-lock.json has changes, it was intentional.
- [ ] The base of this PR is `master` if hotfix, `develop` if not
