### PR TITLE
fix: Catch all user rejected tx errors

### DIFF
--- a/src/composables/useTransactionErrors.ts
+++ b/src/composables/useTransactionErrors.ts
@@ -33,11 +33,20 @@ export default function useTranasactionErrors() {
     };
   }
 
+  function isUserRejected(error): boolean {
+    return (
+      (error?.code && error.code === 4001) ||
+      (error?.message && error.message.includes('user rejected transaction')) ||
+      (error?.cause &&
+        error.cause.message.includes('user rejected transaction'))
+    );
+  }
+
   /**
    * METHODS
    */
   function parseError(error): TransactionError | null {
-    if (error?.code && error.code === 4001) return null; // User rejected transaction
+    if (isUserRejected(error)) return null; // User rejected transaction
     if (error?.code && error.code === 'UNPREDICTABLE_GAS_LIMIT')
       return cannotEstimateGasError;
 
@@ -53,5 +62,6 @@ export default function useTranasactionErrors() {
 
   return {
     parseError,
+    isUserRejected,
   };
 }


### PR DESCRIPTION
# Description

Currently we are showing an error message after a user cancels a transaction in any BalActionSteps (e.g. join/withdraw/stake/unstak/etc). This PR ensures we parse all error types so that we don't render errors or submit them to Sentry in the UI in this case.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## How should this be tested?

- [ ] Try a join transaction and cancel it, you should not see any error message. Try this on production and you will.

## Visual context

n/a

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have requested at least 1 review (If the PR is significant enough, use best judgement here)
- [ ] I have commented my code where relevant, particularly in hard-to-understand areas
- [ ] If package-lock.json has changes, it was intentional.
- [ ] The base of this PR is `master` if hotfix, `develop` if not
