### PR TITLE
Hotfix: handle swap errors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.89.0",
+  "version": "1.89.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@balancer-labs/frontend-v2",
-      "version": "1.89.0",
+      "version": "1.89.1",
       "license": "MIT",
       "devDependencies": {
         "@aave/protocol-js": "^4.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.89.0",
+  "version": "1.89.1",
   "engines": {
     "node": "=16",
     "npm": ">=8"

--- a/src/composables/swap/useCowswap.ts
+++ b/src/composables/swap/useCowswap.ts
@@ -242,8 +242,8 @@ export default function useCowswap({
       confirming.value = false;
       trackGoal(Goals.CowswapSwap);
     } catch (error) {
-      console.trace(error);
       if (!isUserRejected(error)) {
+        console.trace(error);
         state.submissionError = t('swapException', ['Cowswap']);
         captureException(new Error(state.submissionError, { cause: error }));
       }

--- a/src/composables/swap/useJoinExit.spec.ts
+++ b/src/composables/swap/useJoinExit.spec.ts
@@ -1,20 +1,10 @@
 import { BigNumber, parseFixed } from '@ethersproject/bignumber';
-import { mount } from '@tests/mount-composable-tester';
 import { computed, ref } from 'vue';
 
 import { initBalancerWithDefaultMocks } from '@/dependencies/balancer-sdk.mocks';
 import useJoinExit from '@/composables/swap/useJoinExit';
 import { noop } from 'lodash';
-
-vi.mock('vue-i18n');
-vi.mock('vuex');
-vi.mock('@/composables/useEthereumTxType');
-vi.mock('@/composables/useEthers');
-vi.mock('@/composables/useTransactions');
-vi.mock('@/locales');
-vi.mock('@/services/web3/useWeb3');
-vi.mock('@/services/rpc-provider/rpc-provider.service');
-vi.mock('@/composables/queries/useRelayerApprovalQuery');
+import { mountComposable } from '@tests/mount-helpers';
 
 vi.mock('@/providers/tokens.provider', () => ({
   useTokens: () => {
@@ -24,17 +14,6 @@ vi.mock('@/providers/tokens.provider', () => ({
       useTokens: vi.fn(noop),
       getToken: vi.fn(noop),
     };
-  },
-}));
-
-vi.mock('@/composables/approvals/useRelayerApproval', () => ({
-  __esModule: true,
-  default: () =>
-    vi.fn().mockImplementation(() => ({
-      relayerSignature: '-',
-    })),
-  RelayerType: {
-    BATCH_V4: 'BATCH_V4',
   },
 }));
 
@@ -104,12 +83,12 @@ describe('useJoinExit', () => {
 
   it('Should load', () => {
     vi.spyOn(console, 'time').mockImplementation(noop);
-    const { result } = mount(() => useJoinExit(mockProps));
+    const { result } = mountComposable(() => useJoinExit(mockProps));
     expect(result).toBeTruthy();
   });
 
   it('Should return an available joinExit swap', async () => {
-    const { result: joinExit } = mount(() => useJoinExit(mockProps));
+    const { result: joinExit } = mountComposable(() => useJoinExit(mockProps));
     await joinExit.handleAmountChange();
     expect(Number((await joinExit).swapInfo.value?.returnAmount)).toBe(
       Number(mockAmount)

--- a/src/composables/swap/useJoinExit.ts
+++ b/src/composables/swap/useJoinExit.ts
@@ -253,8 +253,8 @@ export default function useJoinExit({
         },
       });
     } catch (error) {
-      console.trace(error);
       if (!isUserRejected(error)) {
+        console.trace(error);
         state.submissionError = t('swapException', ['Relayer']);
         captureException(new Error(state.submissionError, { cause: error }));
       }

--- a/src/composables/swap/useSor.ts
+++ b/src/composables/swap/useSor.ts
@@ -735,8 +735,8 @@ export default function useSor({
   }
 
   function handleSwapException(error: Error) {
-    console.trace(error);
     if (!isUserRejected(error)) {
+      console.trace(error);
       state.submissionError = t('swapException', ['Balancer']);
       captureException(new Error(state.submissionError, { cause: error }));
     }

--- a/src/composables/swap/useSor.ts
+++ b/src/composables/swap/useSor.ts
@@ -734,9 +734,6 @@ export default function useSor({
     return amount;
   }
 
-  /**
-   * Handles swap exceptions and returns a message to display to the user.
-   */
   function handleSwapException(error: Error) {
     console.trace(error);
     if (!isUserRejected(error)) {

--- a/src/locales/default.json
+++ b/src/locales/default.json
@@ -858,6 +858,7 @@
   "swapFeeManager": "Swap fee manager",
   "swapper": "Swapper",
   "swapRoute": "Swap route",
+  "swapException": "Failed to submit ({0}) swap transaction.",
   "switchNetwork": "Switch network",
   "symbol": "Symbol",
   "veBAL": {


### PR DESCRIPTION
# Description

We were logging error contents to the UI in the swap card, even for user cancelled transactions, which results in a huge error message. This PR makes the error message shown to the user more friendly and prevents errors being shown in the case where a user rejects the transaction.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## How should this be tested?

- [ ] Try cancelling a swap tx in production and then in this branch, you will notice that the error message isn't shown.

## Visual context

n/a

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have requested at least 1 review (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] If package-lock.json has changes, it was intentional.
- [x] The base of this PR is `master` if hotfix, `develop` if not
