### PR TITLE
feat: Add new GHA to automate develop merge PRs

### DIFF
--- a/.github/workflows/develop-merge.yml
+++ b/.github/workflows/develop-merge.yml
@@ -1,0 +1,40 @@
+name: Create develop Pull Request
+
+on:
+  pull_request:
+    types: [closed]
+    branches:
+      - master
+
+jobs:
+  create_pr:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v2
+
+    - name: Create new branch
+      run: |
+        git checkout -b develop-update
+
+    - name: Cherry-pick changes
+      run: |
+        git cherry-pick ${{github.event.pull_request.head.sha}}
+
+    - name: Push changes to new branch
+      run: |
+        git push origin develop-update
+
+    - name: Create new Pull Request
+      uses: peter-evans/create-pull-request@v2
+      with:
+        commit-message: "Update develop branch with changes from ${{github.event.pull_request.head.ref}}"
+        branch: develop-update
+        title: "Update develop branch with changes from ${{github.event.pull_request.head.ref}}"
+        body: |
+          This pull request updates the develop branch with changes from the ${{github.event.pull_request.head.ref}} branch.
+
+        token: ${{ secrets.GITHUB_TOKEN }}
+        repository: ${{ github.repository }}
+        base: develop


### PR DESCRIPTION
# Description

Adds a Github action that is triggered on PR merge into the develop branch and auto-creates the develop merge PR.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## How should this be tested?

n/a

## Visual context

n/a

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have requested at least 1 review (If the PR is significant enough, use best judgement here)
- [ ] I have commented my code where relevant, particularly in hard-to-understand areas
- [ ] If package-lock.json has changes, it was intentional.
- [ ] The base of this PR is `master` if hotfix, `develop` if not
