### PR TITLE
Hotfix: multi choice custom input

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.89.4",
+  "version": "1.89.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@balancer-labs/frontend-v2",
-      "version": "1.89.4",
+      "version": "1.89.5",
       "license": "MIT",
       "devDependencies": {
         "@aave/protocol-js": "^4.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.89.4",
+  "version": "1.89.5",
   "engines": {
     "node": "=16",
     "npm": ">=8"

--- a/src/components/cards/CreatePool/PoolFees.vue
+++ b/src/components/cards/CreatePool/PoolFees.vue
@@ -88,7 +88,7 @@ function onFixedInput(val: string): void {
 }
 
 function onCustomInput(val: string): void {
-  if (!val) return;
+  if (val === '') return;
 
   initialFee.value = (Number(val) / 100).toString();
   isCustomFee.value = true;

--- a/src/components/cards/CreatePool/PoolFees.vue
+++ b/src/components/cards/CreatePool/PoolFees.vue
@@ -82,12 +82,15 @@ const feeOptions = FIXED_FEE_OPTIONS.map(option => {
  * FUNCTIONS
  */
 function onFixedInput(val: string): void {
+  fee.value = '';
   initialFee.value = '0';
   initialFee.value = val;
   isCustomFee.value = false;
 }
 
 function onCustomInput(val: string): void {
+  if (!val) return;
+
   initialFee.value = (Number(val) / 100).toString();
   isCustomFee.value = true;
 
@@ -133,6 +136,8 @@ async function onChangeFeeController(val: string) {
     height: cardWrapper.value?.offsetHeight || 0,
   });
 }
+
+watch(fee, onCustomInput, { immediate: true });
 </script>
 
 <template>
@@ -176,20 +181,7 @@ async function onChangeFeeController(val: string) {
                   placeholder="0.1"
                   type="number"
                   step="any"
-                  @update:modelValue="onCustomInput"
                 />
-                <!-- <BalTextInput
-              class="w-20"
-              v-model="fee"
-              placeholder="0.1"
-              size="xs"
-              type="number"
-              @input="onCustomInput"
-            >
-              <template v-slot:append>
-                %
-              </template>
-            </BalTextInput> -->
                 <div class="px-1">%</div>
               </div>
             </div>

--- a/src/components/cards/CreatePool/PoolFees.vue
+++ b/src/components/cards/CreatePool/PoolFees.vue
@@ -83,7 +83,6 @@ const feeOptions = FIXED_FEE_OPTIONS.map(option => {
  */
 function onFixedInput(val: string): void {
   fee.value = '';
-  initialFee.value = '0';
   initialFee.value = val;
   isCustomFee.value = false;
 }

--- a/src/components/forms/AppSlippageForm.vue
+++ b/src/components/forms/AppSlippageForm.vue
@@ -69,7 +69,6 @@ function onCustomInput(val: string): void {
 watch(
   slippage,
   newSlippage => {
-    console.log('newSlippage', newSlippage);
     if (isFixedSlippage.value && !state.isCustomInput) {
       state.fixedSlippage = newSlippage;
       state.customSlippage = '';

--- a/src/components/forms/AppSlippageForm.vue
+++ b/src/components/forms/AppSlippageForm.vue
@@ -4,7 +4,6 @@ import { computed, reactive, watch } from 'vue';
 import useNumbers from '@/composables/useNumbers';
 import { useUserSettings } from '@/providers/user-settings.provider';
 import { bnum } from '@/lib/utils';
-import { log } from 'console';
 
 const FIXED_OPTIONS = ['0.005', '0.01', '0.02'];
 

--- a/src/components/forms/AppSlippageForm.vue
+++ b/src/components/forms/AppSlippageForm.vue
@@ -4,6 +4,7 @@ import { computed, reactive, watch } from 'vue';
 import useNumbers from '@/composables/useNumbers';
 import { useUserSettings } from '@/providers/user-settings.provider';
 import { bnum } from '@/lib/utils';
+import { log } from 'console';
 
 const FIXED_OPTIONS = ['0.005', '0.01', '0.02'];
 
@@ -43,7 +44,7 @@ const isFixedSlippage = computed(() => {
 
 const customInputClasses = computed(() => ({
   'border border-blue-500 text-blue-500':
-    !isFixedSlippage.value || state.isCustomInput,
+    !isFixedSlippage.value && state.isCustomInput,
   'border dark:border-gray-900': isFixedSlippage.value && !state.isCustomInput,
 }));
 
@@ -57,6 +58,7 @@ function onFixedInput(val: string): void {
 }
 
 function onCustomInput(val: string): void {
+  if (!val) return;
   state.isCustomInput = true;
   val = bnum(val).div(100).toString();
   setSlippage(val);
@@ -68,6 +70,7 @@ function onCustomInput(val: string): void {
 watch(
   slippage,
   newSlippage => {
+    console.log('newSlippage', newSlippage);
     if (isFixedSlippage.value && !state.isCustomInput) {
       state.fixedSlippage = newSlippage;
       state.customSlippage = '';
@@ -78,6 +81,8 @@ watch(
   },
   { immediate: true }
 );
+
+watch(() => state.customSlippage, onCustomInput, { immediate: true });
 </script>
 
 <template>
@@ -95,7 +100,6 @@ watch(
         type="number"
         step="any"
         min="0"
-        @update:modelValue="onCustomInput"
       />
       <div class="px-2">%</div>
     </div>


### PR DESCRIPTION
# Description

The custom input in the multic choice forms were broken. When you input a custom value the onCustomInput method wasn't being triggered and therefore the value wasn't being used and the input didn't change style to suggest it had been used. This PR fixes that even trigger so that custom inputs are respected. This affects to places:|
- The slippage form in the navbar settings dropdown
- The fee selection in the pool creation UI.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## How should this be tested?

- [ ] Test the slippage form in the app settings dropdown and try to set a custom slippage amount.
- [ ] Test the fee form in the pool creation UI and try to set a custom fee.

## Visual context

n/a

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have requested at least 1 review (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] If package-lock.json has changes, it was intentional.
- [x] The base of this PR is `master` if hotfix, `develop` if not
