### PR TITLE
hotfix: Pool creation flow

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.89.7",
+  "version": "1.89.8",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@balancer-labs/frontend-v2",
-      "version": "1.89.7",
+      "version": "1.89.8",
       "license": "MIT",
       "devDependencies": {
         "@aave/protocol-js": "^4.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.89.7",
+  "version": "1.89.8",
   "engines": {
     "node": "=16",
     "npm": ">=8"

--- a/src/components/cards/CreatePool/CreateActions.vue
+++ b/src/components/cards/CreatePool/CreateActions.vue
@@ -55,7 +55,7 @@ const { t } = useI18n();
 const { explorerLinks } = useWeb3();
 const { networkConfig } = useConfig();
 const { isTxConfirmed } = useEthers();
-const { tokenApprovalActions } = useTokenApprovalActions(
+const { fetchTokenApprovalActions } = useTokenApprovalActions(
   props.tokenAddresses,
   ref(props.amounts)
 );
@@ -73,8 +73,7 @@ const { networkSlug } = useNetwork();
 /**
  * COMPUTED
  */
-const actions = computed((): TransactionActionInfo[] => [
-  ...tokenApprovalActions,
+const actions = ref<TransactionActionInfo[]>([
   {
     label: t('createPool'),
     loadingLabel: t('investment.preview.loadingLabel.create'),
@@ -114,6 +113,11 @@ onBeforeMount(async () => {
     createState.isLoadingRestoredTx = false;
     createState.isRestoredTxConfirmed = isConfirmed;
   }
+
+  const approvalActions = await fetchTokenApprovalActions(
+    networkConfig.addresses.vault
+  );
+  actions.value = [...approvalActions, ...actions.value];
 });
 
 /**

--- a/src/components/cards/CreatePool/InitialLiquidity.vue
+++ b/src/components/cards/CreatePool/InitialLiquidity.vue
@@ -8,7 +8,7 @@ import useNumbers, { FNumFormats } from '@/composables/useNumbers';
 import { useTokens } from '@/providers/tokens.provider';
 import { bnum, isSameAddress } from '@/lib/utils';
 import { isGreaterThan } from '@/lib/utils/validations';
-import useWeb3 from '@/services/web3/useWeb3';
+import useNetwork from '@/composables/useNetwork';
 
 const emit = defineEmits(['update:height']);
 
@@ -21,7 +21,7 @@ const cardWrapper = ref<HTMLElement>();
 /**
  * COMPOSBALES
  */
-const { userNetworkConfig } = useWeb3();
+const { networkConfig } = useNetwork();
 const {
   balanceFor,
   priceFor,
@@ -223,9 +223,7 @@ function saveAndProceed() {
     <BalCard shadow="xl" noBorder>
       <BalStack vertical>
         <BalStack vertical spacing="xs">
-          <span class="text-xs text-secondary">{{
-            userNetworkConfig?.name
-          }}</span>
+          <span class="text-xs text-secondary">{{ networkConfig?.name }}</span>
           <BalStack horizontal spacing="xs" align="center">
             <button
               v-if="!createPoolTxHash"

--- a/src/components/cards/CreatePool/PoolFees.vue
+++ b/src/components/cards/CreatePool/PoolFees.vue
@@ -6,6 +6,7 @@ import useNumbers from '@/composables/useNumbers';
 import { isRequired, isValidAddress } from '@/lib/utils/validations';
 import useWeb3 from '@/services/web3/useWeb3';
 import { shorten } from '@/lib/utils';
+import useNetwork from '@/composables/useNetwork';
 
 const emit = defineEmits(['update:height']);
 
@@ -42,7 +43,7 @@ const {
   isLoadingSimilarPools,
 } = usePoolCreation();
 const { account } = useWeb3();
-const { userNetworkConfig } = useWeb3();
+const { networkConfig } = useNetwork();
 
 /**
  * COMPUTED
@@ -144,9 +145,7 @@ watch(fee, onCustomInput, { immediate: true });
     <BalCard shadow="xl" noBorder>
       <BalStack vertical>
         <BalStack vertical spacing="xs">
-          <span class="text-xs text-secondary">{{
-            userNetworkConfig?.name
-          }}</span>
+          <span class="text-xs text-secondary">{{ networkConfig?.name }}</span>
           <BalStack horizontal align="center" spacing="xs">
             <button
               class="flex text-blue-500 hover:text-blue-700"

--- a/src/components/cards/CreatePool/PreviewPool.vue
+++ b/src/components/cards/CreatePool/PreviewPool.vue
@@ -9,6 +9,7 @@ import useNumbers, { FNumFormats } from '@/composables/useNumbers';
 import { useTokens } from '@/providers/tokens.provider';
 import { bnum, isSameAddress, shortenLabel } from '@/lib/utils';
 import useWeb3 from '@/services/web3/useWeb3';
+import useNetwork from '@/composables/useNetwork';
 
 /**
  * PROPS & EMITS
@@ -51,7 +52,8 @@ const { getToken, priceFor, nativeAsset, wrappedNativeAsset, balanceFor } =
   useTokens();
 const { fNum2 } = useNumbers();
 const { t } = useI18n();
-const { userNetworkConfig, account } = useWeb3();
+const { account } = useWeb3();
+const { networkConfig } = useNetwork();
 
 /**
  * LIFECYCLE
@@ -171,9 +173,7 @@ function getInitialWeightHighlightClass(tokenAddress: string) {
   <BalStack vertical spacing="xs" class="mb-24">
     <BalCard shadow="xl" noBorder>
       <BalStack vertical spacing="xs">
-        <span class="text-xs text-secondary">{{
-          userNetworkConfig?.name
-        }}</span>
+        <span class="text-xs text-secondary">{{ networkConfig?.name }}</span>
       </BalStack>
       <BalStack vertical>
         <div class="flex items-center mt-2">

--- a/src/components/cards/CreatePool/SimilarPools.vue
+++ b/src/components/cards/CreatePool/SimilarPools.vue
@@ -6,11 +6,13 @@ import TokenPills from '@/components/tables/PoolsTable/TokenPills/TokenPills.vue
 import usePoolCreation from '@/composables/pools/usePoolCreation';
 import useNumbers, { FNumFormats } from '@/composables/useNumbers';
 import useWeb3 from '@/services/web3/useWeb3';
+import useNetwork from '@/composables/useNetwork';
 
 /**
  * COMPOSABLES
  */
-const { userNetworkConfig, isWalletReady } = useWeb3();
+const { isWalletReady } = useWeb3();
+const { networkConfig } = useNetwork();
 const {
   similarPools,
   isLoadingSimilarPools,
@@ -54,7 +56,7 @@ function cancel() {
         <span
           v-if="isWalletReady"
           class="text-xs text-gray-600 dark:text-gray-400"
-          >{{ userNetworkConfig?.name }}</span
+          >{{ networkConfig?.name }}</span
         >
         <BalStack align="center" horizontal spacing="xs">
           <button

--- a/src/composables/approvals/useTokenApprovalActions.ts
+++ b/src/composables/approvals/useTokenApprovalActions.ts
@@ -74,6 +74,13 @@ export default function useTokenApprovalActions(
     return getTokenApprovalActions({ spender, amount, stateMap });
   }
 
+  async function fetchTokenApprovalActions(
+    spender: string
+  ): Promise<TransactionActionInfo[]> {
+    const stateMap = await getApprovalStateMapFor(spender);
+    return getTokenApprovalActions({ stateMap });
+  }
+
   function getTokenApprovalActions(
     options: Partial<ApprovalActionOptions> = {}
   ): TransactionActionInfo[] {
@@ -105,5 +112,6 @@ export default function useTokenApprovalActions(
   return {
     tokenApprovalActions,
     getTokenApprovalActionsForSpender,
+    fetchTokenApprovalActions,
   };
 }

--- a/src/composables/pools/usePoolCreation.ts
+++ b/src/composables/pools/usePoolCreation.ts
@@ -3,8 +3,6 @@ import { TransactionResponse } from '@ethersproject/providers';
 import BigNumber from 'bignumber.js';
 import { flatten, sumBy } from 'lodash';
 import { computed, reactive, ref, toRefs } from 'vue';
-import { useI18n } from 'vue-i18n';
-
 import usePoolsQuery from '@/composables/queries/usePoolsQuery';
 import useEthers from '@/composables/useEthers';
 import useTransactions from '@/composables/useTransactions';
@@ -88,7 +86,6 @@ export default function usePoolCreation() {
   const { account, getProvider } = useWeb3();
   const { txListener } = useEthers();
   const { addTransaction } = useTransactions();
-  const { t } = useI18n();
 
   /**
    * COMPUTED
@@ -436,12 +433,12 @@ export default function usePoolCreation() {
       id: tx.hash,
       type: 'tx',
       action: 'createPool',
-      summary: t('transactionSummary.createPool'),
+      summary: poolCreationState.name,
       details: {
         name: poolCreationState.name,
       },
     });
-    1;
+
     txListener(tx, {
       onTxConfirmed: async () => {
         retrievePoolAddress(tx.hash);
@@ -481,7 +478,7 @@ export default function usePoolCreation() {
       id: tx.hash,
       type: 'tx',
       action: 'fundPool',
-      summary: t('transactionSummary.fundPool'),
+      summary: poolCreationState.name,
     });
 
     txListener(tx, {

--- a/src/composables/pools/usePoolCreation.ts
+++ b/src/composables/pools/usePoolCreation.ts
@@ -420,91 +420,80 @@ export default function usePoolCreation() {
 
   async function createPool(): Promise<TransactionResponse> {
     const provider = getProvider();
-    try {
-      const tx = await balancerService.pools.weighted.create(
-        provider,
-        poolCreationState.name,
-        poolCreationState.symbol,
-        poolCreationState.initialFee,
-        poolCreationState.seedTokens,
-        poolOwner.value
-      );
-      poolCreationState.createPoolTxHash = tx.hash;
-      saveState();
 
-      addTransaction({
-        id: tx.hash,
-        type: 'tx',
-        action: 'createPool',
-        summary: t('transactionSummary.createPool'),
-        details: {
-          name: poolCreationState.name,
-        },
-      });
-      1;
-      txListener(tx, {
-        onTxConfirmed: async () => {
-          retrievePoolAddress(tx.hash);
-        },
-        onTxFailed: () => {
-          console.log('Create failed');
-        },
-      });
+    const tx = await balancerService.pools.weighted.create(
+      provider,
+      poolCreationState.name,
+      poolCreationState.symbol,
+      poolCreationState.initialFee,
+      poolCreationState.seedTokens,
+      poolOwner.value
+    );
+    poolCreationState.createPoolTxHash = tx.hash;
+    saveState();
 
-      return tx;
-    } catch (e) {
-      console.log(e);
-      return Promise.reject('Create failed');
-    }
+    addTransaction({
+      id: tx.hash,
+      type: 'tx',
+      action: 'createPool',
+      summary: t('transactionSummary.createPool'),
+      details: {
+        name: poolCreationState.name,
+      },
+    });
+    1;
+    txListener(tx, {
+      onTxConfirmed: async () => {
+        retrievePoolAddress(tx.hash);
+      },
+      onTxFailed: () => {
+        console.log('Create failed');
+      },
+    });
+
+    return tx;
   }
 
   async function joinPool() {
     const provider = getProvider();
-    try {
-      const tokenAddresses: string[] = poolCreationState.seedTokens.map(
-        (token: PoolSeedToken) => {
-          if (
-            isSameAddress(
-              token.tokenAddress,
-              wrappedNativeAsset.value.address
-            ) &&
-            poolCreationState.useNativeAsset
-          ) {
-            return nativeAsset.address;
-          }
-          return token.tokenAddress;
+
+    const tokenAddresses: string[] = poolCreationState.seedTokens.map(
+      (token: PoolSeedToken) => {
+        if (
+          isSameAddress(token.tokenAddress, wrappedNativeAsset.value.address) &&
+          poolCreationState.useNativeAsset
+        ) {
+          return nativeAsset.address;
         }
-      );
-      const tx = await balancerService.pools.weighted.initJoin(
-        provider,
-        poolCreationState.poolId,
-        account.value,
-        account.value,
-        tokenAddresses,
-        getScaledAmounts()
-      );
+        return token.tokenAddress;
+      }
+    );
+    const tx = await balancerService.pools.weighted.initJoin(
+      provider,
+      poolCreationState.poolId,
+      account.value,
+      account.value,
+      tokenAddresses,
+      getScaledAmounts()
+    );
 
-      addTransaction({
-        id: tx.hash,
-        type: 'tx',
-        action: 'fundPool',
-        summary: t('transactionSummary.fundPool'),
-      });
+    addTransaction({
+      id: tx.hash,
+      type: 'tx',
+      action: 'fundPool',
+      summary: t('transactionSummary.fundPool'),
+    });
 
-      txListener(tx, {
-        onTxConfirmed: async () => {
-          resetState();
-        },
-        onTxFailed: () => {
-          console.log('Seed failed');
-        },
-      });
+    txListener(tx, {
+      onTxConfirmed: async () => {
+        resetState();
+      },
+      onTxFailed: () => {
+        console.log('Seed failed');
+      },
+    });
 
-      return tx;
-    } catch (e) {
-      console.log(e);
-      return Promise.reject('Join failed');
-    }
+    return tx;
   }
 
   function setActiveStep(step: number) {

--- a/src/pages/pool/create.vue
+++ b/src/pages/pool/create.vue
@@ -87,7 +87,7 @@ onBeforeMount(async () => {
   // make sure to inject any custom tokens we cannot inject
   // after tokens have finished loading as it will attempt to
   // inject 'known' tokens too, as during mount, tokens are still loading
-  injectUnknownPoolTokens();
+  await injectUnknownPoolTokens();
   isRestoring.value = false;
 });
 

--- a/src/pages/pool/create.vue
+++ b/src/pages/pool/create.vue
@@ -80,6 +80,8 @@ onBeforeMount(async () => {
     if (previouslySavedState.createPoolTxHash) {
       await retrievePoolAddress(previouslySavedState.createPoolTxHash);
     }
+  } else if (previouslySavedState === null) {
+    resetPoolCreationState();
   }
   // make sure to inject any custom tokens we cannot inject
   // after tokens have finished loading as it will attempt to

--- a/src/pages/pool/create.vue
+++ b/src/pages/pool/create.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, nextTick, onBeforeMount, onMounted, ref, watch } from 'vue';
+import { computed, nextTick, onBeforeMount, ref, watch } from 'vue';
 import { useI18n } from 'vue-i18n';
 import { useRoute } from 'vue-router';
 
@@ -30,8 +30,7 @@ import { StepState } from '@/types';
  * STATE
  */
 const isUnknownTokenModalVisible = ref(false);
-const isRestoring = ref(false);
-const allowancesLoaded = ref(false);
+const isLoading = ref(true);
 
 /**
  * COMPOSABLES
@@ -72,8 +71,6 @@ onBeforeMount(async () => {
     previouslySavedState !== null &&
     !poolCreateTx.value
   ) {
-    isRestoring.value = true;
-
     // need to make sure to inject any tokens that were chosen
     previouslySavedState = JSON.parse(previouslySavedState);
     importState(previouslySavedState);
@@ -88,7 +85,7 @@ onBeforeMount(async () => {
   // after tokens have finished loading as it will attempt to
   // inject 'known' tokens too, as during mount, tokens are still loading
   await injectUnknownPoolTokens();
-  isRestoring.value = false;
+  isLoading.value = false;
 });
 
 /**
@@ -135,8 +132,6 @@ const steps = computed(() => [
     label: 4,
   },
 ]);
-
-const isLoading = computed(() => !allowancesLoaded.value || isRestoring.value);
 
 /**
  * FUNCTIONS
@@ -206,11 +201,6 @@ watch(
     immediate: true,
   }
 );
-
-onMounted(async () => {
-  await injectUnknownPoolTokens();
-  allowancesLoaded.value = true;
-});
 </script>
 
 <template>


### PR DESCRIPTION
# Description

- Removes a lot of animations that were causing re-render bugs. Try creating a pool on Goerli production and notice how the page constantly re-renders and makes it difficult to know what's happening. This was because of AnimatePresence being triggered everytime dynamic data loaded, e.g. balances re-fetched.
- Refactors loading states so we are awaiting the right things.
- Removes unnecessary try/catch blocks for txs that are handled by BalActionSteps.
- Updates pool creation tx notification labels to be more friendly.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## How should this be tested?

- [ ] Test pool creation flow on Goerli and notice how buggy the last step is, i.e. creating and funding the pool
- [ ] Then test the flow on Goerli in this PR. Hopefully it's a lot more stable.

## Visual context

n/a

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have requested at least 1 review (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] If package-lock.json has changes, it was intentional.
- [x] The base of this PR is `master` if hotfix, `develop` if not
