### PR TITLE
Hotfix: vebal table balance

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.89.11",
+  "version": "1.89.12",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@balancer-labs/frontend-v2",
-      "version": "1.89.11",
+      "version": "1.89.12",
       "license": "MIT",
       "devDependencies": {
         "@aave/protocol-js": "^4.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.89.11",
+  "version": "1.89.12",
   "engines": {
     "node": "=16",
     "npm": ">=8"

--- a/src/components/contextual/pages/pool/MyPoolBalancesCard.vue
+++ b/src/components/contextual/pages/pool/MyPoolBalancesCard.vue
@@ -4,7 +4,7 @@ import { useRouter } from 'vue-router';
 
 import { POOL_MIGRATIONS_MAP } from '@/components/forms/pool_actions/MigrateForm/constants';
 import useNumbers, { FNumFormats } from '@/composables/useNumbers';
-import { fiatValueOf, usePool } from '@/composables/usePool';
+import { fiatValueOf, isVeBalPool, usePool } from '@/composables/usePool';
 import { useTokens } from '@/providers/tokens.provider';
 import useNetwork from '@/composables/useNetwork';
 import { bnum } from '@/lib/utils';
@@ -13,6 +13,7 @@ import useWeb3 from '@/services/web3/useWeb3';
 
 import PoolActionsCard from './PoolActionsCard.vue';
 import { usePoolStaking } from '@/providers/local/pool-staking.provider';
+import { useLock } from '@/composables/useLock';
 
 /**
  * TYPES
@@ -37,6 +38,7 @@ const { isMigratablePool } = usePool(toRef(props, 'pool'));
 const { stakedShares } = usePoolStaking();
 const { networkSlug } = useNetwork();
 const router = useRouter();
+const { totalLockedValue } = useLock();
 
 /**
  * COMPUTED
@@ -45,7 +47,11 @@ const bptBalance = computed((): string =>
   bnum(balanceFor(props.pool.address)).plus(stakedShares.value).toString()
 );
 
-const fiatValue = computed(() => fiatValueOf(props.pool, bptBalance.value));
+const fiatValue = computed(() => {
+  if (isVeBalPool(props.pool.id)) return totalLockedValue.value;
+
+  return fiatValueOf(props.pool, bptBalance.value);
+});
 
 const showMigrateButton = computed(
   () =>

--- a/src/components/contextual/pages/pools/VeBalPoolTable.vue
+++ b/src/components/contextual/pages/pools/VeBalPoolTable.vue
@@ -16,16 +16,14 @@ type Props = {
 const props = defineProps<Props>();
 
 /** COMPOSABLES */
-const { totalLockedValue } = useLock();
+const { totalLockedShares } = useLock();
 
 /** COMPUTED */
-const lockPools = computed<PoolWithShares[]>(() => {
+const lockPools = computed<Pool[]>(() => {
   if (props.lockPool) {
     return [
       {
         ...props.lockPool,
-        bpt: '',
-        shares: totalLockedValue.value,
         lockedEndDate:
           props.lock?.hasExistingLock && !props.lock?.isExpired
             ? props.lock?.lockedEndDate
@@ -38,7 +36,7 @@ const lockPools = computed<PoolWithShares[]>(() => {
 
 const poolShares = computed(
   (): Record<string, string> => ({
-    [props.lockPool.id]: totalLockedValue.value,
+    [props.lockPool.id]: totalLockedShares.value,
   })
 );
 

--- a/src/composables/useLock.ts
+++ b/src/composables/useLock.ts
@@ -56,6 +56,12 @@ export function useLock() {
       : '0'
   );
 
+  const totalLockedShares = computed((): string =>
+    lockPool.value && lock.value?.hasExistingLock
+      ? lock.value.lockedAmount
+      : '0'
+  );
+
   return {
     isLoadingLockPool,
     isLoadingLockInfo,
@@ -64,5 +70,6 @@ export function useLock() {
     lockPool,
     lock,
     totalLockedValue,
+    totalLockedShares,
   };
 }


### PR DESCRIPTION
# Description

We were passing the fiat value to the veBAL pool table on the portfolio page when it expected the BPT. This PR fixes that and the display of the user's lock pool balance on the actually veBAL pool page.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## How should this be tested?

- [ ] Test the my balance value on the portfolio page for locked positions matches the hero value
- [ ] Test that the my balance value on the veBAL pool page is correct.

## Visual context

n/a

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have requested at least 1 review (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] If package-lock.json has changes, it was intentional.
- [x] The base of this PR is `master` if hotfix, `develop` if not
