### PR TITLE
Hotfix: my pool share values

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.89.12",
+  "version": "1.89.13",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@balancer-labs/frontend-v2",
-      "version": "1.89.12",
+      "version": "1.89.13",
       "license": "MIT",
       "devDependencies": {
         "@aave/protocol-js": "^4.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.89.12",
+  "version": "1.89.13",
   "engines": {
     "node": "=16",
     "npm": ">=8"

--- a/src/components/contextual/pages/pools/VeBalPoolTable.vue
+++ b/src/components/contextual/pages/pools/VeBalPoolTable.vue
@@ -4,7 +4,7 @@ import { computed } from 'vue';
 import PoolsTable from '@/components/tables/PoolsTable/PoolsTable.vue';
 import { useLock } from '@/composables/useLock';
 import { VeBalLockInfo } from '@/services/balancer/contracts/contracts/veBAL';
-import { Pool, PoolWithShares } from '@/services/pool/types';
+import { Pool } from '@/services/pool/types';
 
 /**
  * PROPS

--- a/src/composables/useUserPoolPercentage.spec.ts
+++ b/src/composables/useUserPoolPercentage.spec.ts
@@ -14,19 +14,19 @@ vi.mock('@/providers/tokens.provider', () => {
 });
 
 it('calculates user pool percentage', () => {
-  const pool = aPool({ totalLiquidity: '100', totalShares: '100' });
+  const pool = aPool({ totalShares: '100' });
   const { result } = mountComposable(() => useUserPoolPercentage(ref(pool)));
   expect(result.userPoolPercentage.value.toString()).toBe('15');
 });
 
 it('calculates user pool percentage label', () => {
-  const pool = aPool({ totalLiquidity: '8888888', totalShares: '100' });
+  const pool = aPool({ totalShares: '8888888' });
   const { result } = mountComposable(() => useUserPoolPercentage(ref(pool)));
   expect(result.userPoolPercentageLabel.value.toString()).toBe('0.00017%');
 });
 
 it('calculates user pool percentage label when user has a very small share', () => {
-  const pool = aPool({ totalLiquidity: '88888888888', totalShares: '100' });
+  const pool = aPool({ totalShares: '88888888888' });
   const { result } = mountComposable(() => useUserPoolPercentage(ref(pool)));
   expect(result.userPoolPercentageLabel.value.toString()).toBe('< 0.0001%');
 });

--- a/src/composables/useUserPoolPercentage.ts
+++ b/src/composables/useUserPoolPercentage.ts
@@ -14,7 +14,7 @@ export function useUserPoolPercentage(pool: Ref<Pool>) {
     const bptBalance = bnum(balanceFor(pool.value.address)).plus(
       stakedShares.value
     );
-    return bptBalance.div(bnum(pool.value.totalLiquidity)).multipliedBy(100);
+    return bptBalance.div(bnum(pool.value.totalShares)).multipliedBy(100);
   });
 
   const userPoolPercentageLabel = computed(


### PR DESCRIPTION
# Description

Calculating the user's pool share as a percentage should be done with the totalShares and the user's BPT. The calculation was mistakenly using the pool's totalLiquidity instead of totalShares, this PR fixes that.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## How should this be tested?

- [ ] Test my pool share values make sense.

## Visual context

n/a

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have requested at least 1 review (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] If package-lock.json has changes, it was intentional.
- [x] The base of this PR is `master` if hotfix, `develop` if not
