### PR TITLE
Hotfix: Fix nonsensical values in pool stat cards

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.89.16",
+  "version": "1.89.17",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@balancer-labs/frontend-v2",
-      "version": "1.89.16",
+      "version": "1.89.17",
       "license": "MIT",
       "devDependencies": {
         "@aave/protocol-js": "^4.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.89.16",
+  "version": "1.89.17",
   "engines": {
     "node": "=16",
     "npm": ">=8"

--- a/src/components/contextual/pages/pool/PoolStatCards.vue
+++ b/src/components/contextual/pages/pool/PoolStatCards.vue
@@ -5,7 +5,7 @@ import { useI18n } from 'vue-i18n';
 import APRTooltip from '@/components/tooltips/APRTooltip/APRTooltip.vue';
 import useNumbers, { FNumFormats } from '@/composables/useNumbers';
 import { isLBP, totalAprLabel } from '@/composables/usePool';
-import { APR_THRESHOLD } from '@/constants/pools';
+import { APR_THRESHOLD, VOLUME_THRESHOLD } from '@/constants/pools';
 import { Pool } from '@/services/pool/types';
 import { AprBreakdown } from '@balancer-labs/sdk';
 
@@ -45,6 +45,8 @@ const aprLabel = computed((): string => {
 });
 
 const stats = computed(() => {
+  const volumeSnapshot = Number(props.pool?.volumeSnapshot || '0');
+  const feesSnapshot = Number(props.pool?.feesSnapshot || '0');
   return [
     {
       id: 'poolValue',
@@ -55,13 +57,19 @@ const stats = computed(() => {
     {
       id: 'volumeTime',
       label: t('volumeTime', ['24h']),
-      value: fNum2(props.pool?.volumeSnapshot || '0', FNumFormats.fiat),
+      value: fNum2(
+        volumeSnapshot > VOLUME_THRESHOLD ? '-' : volumeSnapshot,
+        FNumFormats.fiat
+      ),
       loading: props.loading,
     },
     {
       id: 'feesTime',
       label: t('feesTime', ['24h']),
-      value: fNum2(props.pool?.feesSnapshot || '0', FNumFormats.fiat),
+      value: fNum2(
+        feesSnapshot > VOLUME_THRESHOLD ? '-' : feesSnapshot,
+        FNumFormats.fiat
+      ),
       loading: props.loading,
     },
     {


### PR DESCRIPTION
Similar to #2847 this hides nonsensical values in pool stat cards. 