### PR TITLE
Hotfix: Show a dash instead of 0 for nonsensical values

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.89.18",
+  "version": "1.89.19",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@balancer-labs/frontend-v2",
-      "version": "1.89.18",
+      "version": "1.89.19",
       "license": "MIT",
       "devDependencies": {
         "@aave/protocol-js": "^4.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.89.18",
+  "version": "1.89.19",
   "engines": {
     "node": "=16",
     "npm": ">=8"

--- a/src/components/tables/PoolsTable/PoolsTable.vue
+++ b/src/components/tables/PoolsTable/PoolsTable.vue
@@ -344,7 +344,7 @@ function iconAddresses(pool: Pool) {
               fNum2(
                 pool?.volumeSnapshot < VOLUME_THRESHOLD
                   ? pool?.volumeSnapshot
-                  : 0,
+                  : '-',
                 {
                   style: 'currency',
                   maximumFractionDigits: 0,

--- a/src/composables/usePool.ts
+++ b/src/composables/usePool.ts
@@ -268,7 +268,7 @@ export function absMaxApr(aprs: AprBreakdown, boost?: string): string {
  */
 export function totalAprLabel(aprs: AprBreakdown, boost?: string): string {
   if (aprs.min > APR_THRESHOLD || aprs.max > APR_THRESHOLD) {
-    return numF(0, FNumFormats.bp);
+    return '-';
   }
   if (boost) {
     numF(absMaxApr(aprs, boost), FNumFormats.bp);


### PR DESCRIPTION
Show a dash for nonsensical values instead of $0 / 0%. This is more clear to users that the number is missing / broken. 