### PR TITLE
change coingecko page size to prevent uri too long

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.89.21",
+  "version": "1.89.22",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@balancer-labs/frontend-v2",
-      "version": "1.89.21",
+      "version": "1.89.22",
       "license": "MIT",
       "devDependencies": {
         "@aave/protocol-js": "^4.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.89.21",
+  "version": "1.89.22",
   "engines": {
     "node": "=16",
     "npm": ">=8"

--- a/src/services/coingecko/api/price.service.ts
+++ b/src/services/coingecko/api/price.service.ts
@@ -67,7 +67,7 @@ export class PriceService {
    */
   async getTokens(
     addresses: string[],
-    addressesPerRequest = 100
+    addressesPerRequest = 25
   ): Promise<TokenPrices> {
     try {
       if (addresses.length / addressesPerRequest > 10)


### PR DESCRIPTION
# Description

Using 100 page size was frequently throwing 414 URI too long errors

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## How should this be tested?

Please provide instructions so we can test. Please also list any relevant details for your test configuration.

- [ ] Test A
- [ ] Test B

## Visual context

Please provide any relevant visual context for UI changes or additions. This could be static screenshots or a loom screencast.

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have requested at least 1 review (If the PR is significant enough, use best judgement here)
- [ ] I have commented my code where relevant, particularly in hard-to-understand areas
- [ ] If package-lock.json has changes, it was intentional.
- [ ] The base of this PR is `master` if hotfix, `develop` if not
