### PR TITLE
Hotfix: Fix Euler proportional withdrawals

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "devDependencies": {
         "@aave/protocol-js": "^4.3.0",
         "@balancer-labs/assets": "github:balancer-labs/assets#master",
-        "@balancer-labs/sdk": "^1.0.0-beta.11",
+        "@balancer-labs/sdk": "^1.0.0-beta.14",
         "@balancer-labs/typechain": "^1.0.0",
         "@cowprotocol/contracts": "^1.3.1",
         "@ensdomains/content-hash": "^2.5.3",
@@ -806,12 +806,12 @@
       }
     },
     "node_modules/@balancer-labs/sdk": {
-      "version": "1.0.0-beta.11",
-      "resolved": "https://registry.npmjs.org/@balancer-labs/sdk/-/sdk-1.0.0-beta.11.tgz",
-      "integrity": "sha512-G8Rj4O1lzcc94uY3Mh0d63Jk88m5Nvf7mxeVl+YCkyNBrzWyhcLk1VkgZCHKecdYmWrwgpurxlPpBcj8x5kOlg==",
+      "version": "1.0.0-beta.14",
+      "resolved": "https://registry.npmjs.org/@balancer-labs/sdk/-/sdk-1.0.0-beta.14.tgz",
+      "integrity": "sha512-u9up1xUQLA8xuiepB/I0d9Lp0i7E/y65E82zcwMYV0nQF+w6S6gSz41ELNbz+4nKh73zSDVr92Lwg+GW5wjkCQ==",
       "dev": true,
       "dependencies": {
-        "@balancer-labs/sor": "^4.1.1-beta.1",
+        "@balancer-labs/sor": "^4.1.1-beta.2",
         "@balancer-labs/typechain": "^1.0.0",
         "@ethersproject/abi": "^5.4.0",
         "@ethersproject/abstract-signer": "^5.4.0",
@@ -858,9 +858,9 @@
       }
     },
     "node_modules/@balancer-labs/sor": {
-      "version": "4.1.1-beta.1",
-      "resolved": "https://registry.npmjs.org/@balancer-labs/sor/-/sor-4.1.1-beta.1.tgz",
-      "integrity": "sha512-lBJRa5EwMjOzxHrH8QSZ8RaszhZu4XCwMEpS57eCGv5gvkgADXBaMseZhV/ofCKaagxa4FOBvXY1DlUZtfyMJg==",
+      "version": "4.1.1-beta.2",
+      "resolved": "https://registry.npmjs.org/@balancer-labs/sor/-/sor-4.1.1-beta.2.tgz",
+      "integrity": "sha512-NNy6/Vm6Rk1waKu9EYolJdTRuoUwUddXPAmeByb+ELQlJ8ZMoCxMb0ZFHjoBeIuHXC7xFky5XWiOfgRHBMcRVg==",
       "dev": true,
       "dependencies": {
         "isomorphic-fetch": "^2.2.1"
@@ -19653,12 +19653,12 @@
       }
     },
     "@balancer-labs/sdk": {
-      "version": "1.0.0-beta.11",
-      "resolved": "https://registry.npmjs.org/@balancer-labs/sdk/-/sdk-1.0.0-beta.11.tgz",
-      "integrity": "sha512-G8Rj4O1lzcc94uY3Mh0d63Jk88m5Nvf7mxeVl+YCkyNBrzWyhcLk1VkgZCHKecdYmWrwgpurxlPpBcj8x5kOlg==",
+      "version": "1.0.0-beta.14",
+      "resolved": "https://registry.npmjs.org/@balancer-labs/sdk/-/sdk-1.0.0-beta.14.tgz",
+      "integrity": "sha512-u9up1xUQLA8xuiepB/I0d9Lp0i7E/y65E82zcwMYV0nQF+w6S6gSz41ELNbz+4nKh73zSDVr92Lwg+GW5wjkCQ==",
       "dev": true,
       "requires": {
-        "@balancer-labs/sor": "^4.1.1-beta.1",
+        "@balancer-labs/sor": "^4.1.1-beta.2",
         "@balancer-labs/typechain": "^1.0.0",
         "@ethersproject/abi": "^5.4.0",
         "@ethersproject/abstract-signer": "^5.4.0",
@@ -19697,9 +19697,9 @@
       }
     },
     "@balancer-labs/sor": {
-      "version": "4.1.1-beta.1",
-      "resolved": "https://registry.npmjs.org/@balancer-labs/sor/-/sor-4.1.1-beta.1.tgz",
-      "integrity": "sha512-lBJRa5EwMjOzxHrH8QSZ8RaszhZu4XCwMEpS57eCGv5gvkgADXBaMseZhV/ofCKaagxa4FOBvXY1DlUZtfyMJg==",
+      "version": "4.1.1-beta.2",
+      "resolved": "https://registry.npmjs.org/@balancer-labs/sor/-/sor-4.1.1-beta.2.tgz",
+      "integrity": "sha512-NNy6/Vm6Rk1waKu9EYolJdTRuoUwUddXPAmeByb+ELQlJ8ZMoCxMb0ZFHjoBeIuHXC7xFky5XWiOfgRHBMcRVg==",
       "dev": true,
       "requires": {
         "isomorphic-fetch": "^2.2.1"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.89.23",
+  "version": "1.89.24",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@balancer-labs/frontend-v2",
-      "version": "1.89.23",
+      "version": "1.89.24",
       "license": "MIT",
       "devDependencies": {
         "@aave/protocol-js": "^4.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.89.23",
+  "version": "1.89.24",
   "engines": {
     "node": "=16",
     "npm": ">=8"

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "devDependencies": {
     "@aave/protocol-js": "^4.3.0",
     "@balancer-labs/assets": "github:balancer-labs/assets#master",
-    "@balancer-labs/sdk": "^1.0.0-beta.11",
+    "@balancer-labs/sdk": "^1.0.0-beta.14",
     "@balancer-labs/typechain": "^1.0.0",
     "@cowprotocol/contracts": "^1.3.1",
     "@ensdomains/content-hash": "^2.5.3",

--- a/src/composables/usePool.ts
+++ b/src/composables/usePool.ts
@@ -35,7 +35,9 @@ export function addressFor(poolId: string): string {
 
 export function isLinear(poolType: PoolType): boolean {
   return (
-    poolType === PoolType.AaveLinear || poolType === PoolType.ERC4626Linear
+    poolType === PoolType.AaveLinear ||
+    poolType === PoolType.ERC4626Linear ||
+    poolType === PoolType.EulerLinear
   );
 }
 


### PR DESCRIPTION
# Description

Euler linear pool tokens needed to be returned from the subgraph ordered by index. A fix for this has been included in the SDK and the API, this update just ensures that the fallback will also work. We were also missing the detection of EulerLinear pools in the isLinearPool conditional which has been fixed too.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## How should this be tested?

- [ ] Test proportional withdrawals from bb-e-USD.

## Visual context

n/a

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have requested at least 1 review (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] If package-lock.json has changes, it was intentional.
- [x] The base of this PR is `master` if hotfix, `develop` if not
