### PR TITLE
fix: Use shares not fiat value

### DIFF
--- a/src/composables/useLock.ts
+++ b/src/composables/useLock.ts
@@ -56,6 +56,7 @@ export function useLock({ enabled = true }: Options = {}) {
       : '0'
   );
 
+  // Total locked shares (veBAL).
   const totalLockedShares = computed((): string =>
     lockPool.value && lock.value?.hasExistingLock
       ? lock.value.lockedAmount

--- a/src/composables/usePool.ts
+++ b/src/composables/usePool.ts
@@ -1,9 +1,4 @@
-import {
-  Network,
-  AprBreakdown,
-  PoolType,
-  APR_THRESHOLD,
-} from '@balancer-labs/sdk';
+import { Network, AprBreakdown, PoolType } from '@balancer-labs/sdk';
 import { isAddress, getAddress } from '@ethersproject/address';
 import { computed, Ref } from 'vue';
 

--- a/src/composables/useUserPoolPercentage.ts
+++ b/src/composables/useUserPoolPercentage.ts
@@ -11,20 +11,16 @@ export function useUserPoolPercentage(pool: Ref<Pool>) {
   const { balanceFor } = useTokens();
   const { stakedShares } = usePoolStaking();
 
-  const { totalLockedValue } = useLock({
+  const { totalLockedShares } = useLock({
     // Avoid lock queries when pool is not veBAL:
     enabled: isVeBalPool(pool.value.id),
   });
   const { fNum } = useNumbers();
 
-  const lockedAmount = computed(() => {
-    return totalLockedValue.value || '0';
-  });
-
   const userPoolPercentage = computed(() => {
     const bptBalance = bnum(balanceFor(pool.value.address))
       .plus(stakedShares.value)
-      .plus(lockedAmount.value);
+      .plus(totalLockedShares.value);
     return bptBalance.div(bnum(pool.value.totalShares)).multipliedBy(100);
   });
 


### PR DESCRIPTION
# Description

In the user share percentage calc we were using the lock fiat value in the sum of all the user's shares (i.e. BPT). We should be using the total locked shares amount instead.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## How should this be tested?

- [ ] Test that a locked veBAL position my share pool composition table looks correct.

## Visual context

n/a

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have requested at least 1 review (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] If package-lock.json has changes, it was intentional.
- [x] The base of this PR is `master` if hotfix, `develop` if not
