### PR TITLE
Hotfix: exclude euler linear, add bb-e-usd label

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.89.24",
+  "version": "1.89.25",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@balancer-labs/frontend-v2",
-      "version": "1.89.24",
+      "version": "1.89.25",
       "license": "MIT",
       "devDependencies": {
         "@aave/protocol-js": "^4.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.89.24",
+  "version": "1.89.25",
   "engines": {
     "node": "=16",
     "npm": ">=8"

--- a/src/constants/pools.ts
+++ b/src/constants/pools.ts
@@ -109,6 +109,7 @@ const POOLS_GOERLI: Pools = {
   ExcludedPoolTypes: [
     'Element',
     'AaveLinear',
+    'EulerLinear',
     'Linear',
     'ERC4626Linear',
     'FX',
@@ -185,6 +186,7 @@ const POOLS_MAINNET: Pools = {
   ExcludedPoolTypes: [
     'Element',
     'AaveLinear',
+    'EulerLinear',
     'Linear',
     'ERC4626Linear',
     'Gyro2',
@@ -362,6 +364,10 @@ const POOLS_MAINNET: Pools = {
       name: 'Balancer Boosted Aave USD',
       hasIcon: true,
     },
+    '0x50cf90b954958480b8df7958a9e965752f62712400000000000000000000046f': {
+      name: 'Balancer Boosted Euler USD',
+      hasIcon: true,
+    },
     '0x06df3b2bbb68adc8b0e302443692037ed9f91b42000000000000000000000063': {
       name: 'Balancer Stable USD',
       hasIcon: true,
@@ -409,6 +415,7 @@ const POOLS_POLYGON: Pools = {
   ExcludedPoolTypes: [
     'Element',
     'AaveLinear',
+    'EulerLinear',
     'Linear',
     'ERC4626Linear',
     'Gyro2',
@@ -551,6 +558,7 @@ const POOLS_ARBITRUM: Pools = {
   ExcludedPoolTypes: [
     'Element',
     'AaveLinear',
+    'EulerLinear',
     'Linear',
     'ERC4626Linear',
     'FX',
@@ -640,6 +648,7 @@ const POOLS_GENERIC: Pools = {
   ExcludedPoolTypes: [
     'Element',
     'AaveLinear',
+    'EulerLinear',
     'Linear',
     'ERC4626Linear',
     'FX',


### PR DESCRIPTION
# Description

Exclue Euler linear pools from displaying in tables. Adds label to bb-e-usd pool

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## How should this be tested?

Please provide instructions so we can test. Please also list any relevant details for your test configuration.

- [ ] Test A
- [ ] Test B

## Visual context

Please provide any relevant visual context for UI changes or additions. This could be static screenshots or a loom screencast.

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have requested at least 1 review (If the PR is significant enough, use best judgement here)
- [ ] I have commented my code where relevant, particularly in hard-to-understand areas
- [ ] If package-lock.json has changes, it was intentional.
- [ ] The base of this PR is `master` if hotfix, `develop` if not
