### PR TITLE
fix: composition column width in pools table

### DIFF
--- a/src/components/tables/PoolsTable/PoolsTable.vue
+++ b/src/components/tables/PoolsTable/PoolsTable.vue
@@ -93,12 +93,13 @@ const router = useRouter();
 const { t } = useI18n();
 const { trackGoal, Goals } = useFathom();
 const { darkMode } = useDarkMode();
-const { upToLargeBreakpoint, upToMediumBreakpoint } = useBreakpoints();
+const { upToLargeBreakpoint, upToSmallBreakpoint } = useBreakpoints();
 const { networkSlug } = useNetwork();
 
-const wideCompositionWidth = computed(() =>
-  upToMediumBreakpoint.value ? 250 : undefined
-);
+const wideCompositionWidth = computed(() => {
+  if (upToSmallBreakpoint.value) return 250;
+  return 350;
+});
 
 /**
  * DATA


### PR DESCRIPTION
# Description
Currently on certain widths of viewport, there are bugs with pools table display. This pr fixes this.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## How should this be tested?

Please provide instructions so we can test. Please also list any relevant details for your test configuration.

- [ ] Test A
- [ ] Test B

## Visual context
Fixes this ui bugs:
<img width="1159" alt="Screenshot 2023-02-20 at 21 40 26" src="https://user-images.githubusercontent.com/46521087/220171753-9c88149b-031c-4633-8725-9a536af98a7d.png">
<img width="889" alt="Screenshot 2023-02-20 at 21 40 36" src="https://user-images.githubusercontent.com/46521087/220171754-e0792554-c334-4ab4-b7c2-9adbd1665806.png">


## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have requested at least 1 review (If the PR is significant enough, use best judgement here)
- [ ] I have commented my code where relevant, particularly in hard-to-understand areas
- [ ] If package-lock.json has changes, it was intentional.
- [x] The base of this PR is `master` if hotfix, `develop` if not
