### PR TITLE
Hotfix/my shares

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.90.4",
+  "version": "1.90.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@balancer-labs/frontend-v2",
-      "version": "1.90.4",
+      "version": "1.90.5",
       "license": "MIT",
       "devDependencies": {
         "@aave/protocol-js": "^4.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.90.4",
+  "version": "1.90.5",
   "engines": {
     "node": "=16",
     "npm": ">=8"

--- a/src/composables/useUserPoolPercentage.ts
+++ b/src/composables/useUserPoolPercentage.ts
@@ -11,16 +11,21 @@ export function useUserPoolPercentage(pool: Ref<Pool>) {
   const { balanceFor } = useTokens();
   const { stakedShares } = usePoolStaking();
 
+  const isVeBal = computed(() => isVeBalPool(pool.value.id));
+
   const { totalLockedShares } = useLock({
     // Avoid lock queries when pool is not veBAL:
-    enabled: isVeBalPool(pool.value.id),
+    enabled: isVeBal.value,
   });
   const { fNum } = useNumbers();
 
   const userPoolPercentage = computed(() => {
-    const bptBalance = bnum(balanceFor(pool.value.address))
-      .plus(stakedShares.value)
-      .plus(totalLockedShares.value);
+    let bptBalance = bnum(balanceFor(pool.value.address)).plus(
+      stakedShares.value
+    );
+    if (isVeBal.value && totalLockedShares.value) {
+      bptBalance = bptBalance.plus(totalLockedShares.value);
+    }
     return bptBalance.div(bnum(pool.value.totalShares)).multipliedBy(100);
   });
 


### PR DESCRIPTION
# Description

`totalLockedShares` were added to all pools when calculating `userPoolPercentage`.

This PR adds a condition to only adding the value when the current pool is veBAL.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## How should this be tested?

Please provide instructions so we can test. Please also list any relevant details for your test configuration.

- [ ] Test A
- [ ] Test B

## Visual context

Please provide any relevant visual context for UI changes or additions. This could be static screenshots or a loom screencast.

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have requested at least 1 review (If the PR is significant enough, use best judgement here)
- [ ] I have commented my code where relevant, particularly in hard-to-understand areas
- [ ] If package-lock.json has changes, it was intentional.
- [ ] The base of this PR is `master` if hotfix, `develop` if not
