### PR TITLE
Fix: ensure onchain values uptodate in join/exit flows

### DIFF
--- a/src/composables/contextual/pool-transfers/usePoolTransfers.ts
+++ b/src/composables/contextual/pool-transfers/usePoolTransfers.ts
@@ -8,6 +8,7 @@ import { useTokens } from '@/providers/tokens.provider';
 import { includesAddress } from '@/lib/utils';
 import { Pool } from '@/services/pool/types';
 import { isQueryLoading } from '@/composables/queries/useQueryHelpers';
+import usePoolDecorationQuery from '@/composables/queries/usePoolDecorationQuery';
 
 /**
  * STATE
@@ -32,22 +33,28 @@ export default function usePoolTransfers() {
   /**
    * COMPUTED
    */
-  const pool = computed((): Pool | undefined => {
+  const initialPool = computed((): Pool | undefined => {
     return poolQuery.data.value;
   });
+
+  const poolDecorationQuery = usePoolDecorationQuery(initialPool);
 
   const poolQueryLoading = computed((): boolean => isQueryLoading(poolQuery));
 
   const loadingPool = computed(
-    (): boolean => poolQueryLoading.value || !pool.value
+    (): boolean => poolQueryLoading.value || !initialPool.value
   );
 
+  const pool = computed((): Pool | undefined => {
+    return poolDecorationQuery.data.value || initialPool.value;
+  });
+
   const tokenAddresses = computed(() => {
-    if (pool.value) {
-      if (isDeep(pool.value)) {
-        return pool.value.mainTokens || [];
+    if (initialPool.value) {
+      if (isDeep(initialPool.value)) {
+        return initialPool.value.mainTokens || [];
       }
-      return tokensListExclBpt(pool.value);
+      return tokensListExclBpt(initialPool.value);
     }
     return [];
   });
@@ -62,6 +69,7 @@ export default function usePoolTransfers() {
   return {
     pool,
     poolQuery,
+    poolDecorationQuery,
     loadingPool,
     useNativeAsset,
     missingPrices,

--- a/src/composables/queries/usePoolDecorationQuery.ts
+++ b/src/composables/queries/usePoolDecorationQuery.ts
@@ -1,0 +1,61 @@
+import { reactive } from 'vue';
+import { useQuery, UseQueryOptions } from '@tanstack/vue-query';
+import { Pool } from '@/services/pool/types';
+import QUERY_KEYS from '@/constants/queryKeys';
+import { PoolDecorator } from '@/services/pool/decorators/pool.decorator';
+import { useTokens } from '@/providers/tokens.provider';
+
+/**
+ * TYPES
+ */
+type QueryResponse = Pool | undefined;
+type QueryOptions = UseQueryOptions<QueryResponse>;
+
+/**
+ * Given a pool, uses PoolDecorator to fetch onchain attributes such as token
+ * balances and totalSupply to make sure they're as up to date as possible and
+ * returns a decorated pool object with those live values.
+ */
+export default function usePoolDecorationQuery(
+  pool: Ref<Pool | undefined>,
+  options: QueryOptions = {}
+) {
+  /**
+   * COMPOSABLES
+   */
+  const { tokens } = useTokens();
+
+  /**
+   * COMPUTED
+   */
+  const poolId = computed((): string | undefined => pool.value?.id);
+
+  const queryKey = reactive(QUERY_KEYS.Pool.Decorated(poolId));
+
+  const enabled = computed((): boolean => !!pool.value);
+
+  /**
+   * QUERY FUNCTION
+   */
+  const queryFn = async () => {
+    if (!pool.value) return undefined;
+    const poolDecorator = new PoolDecorator([pool.value]);
+    // Decorate pool updating only the onchain attributes.
+    const [decoratedPool] = await poolDecorator.decorate(tokens.value, false);
+    return decoratedPool;
+  };
+
+  /**
+   * QUERY OPTIONS
+   */
+  const queryOptions = reactive({
+    enabled,
+    ...options,
+  });
+
+  return useQuery<QueryResponse>(
+    queryKey,
+    queryFn,
+    queryOptions as QueryOptions
+  );
+}

--- a/src/constants/queryKeys.ts
+++ b/src/constants/queryKeys.ts
@@ -124,6 +124,11 @@ const QUERY_KEYS = {
       'gauges',
       { poolAddress },
     ],
+    Decorated: (poolId: Ref<string | undefined>) => [
+      'pool',
+      'decorated',
+      { poolId },
+    ],
   },
   User: {
     Pool: {

--- a/src/pages/pool/invest.vue
+++ b/src/pages/pool/invest.vue
@@ -2,7 +2,7 @@
 import usePoolTransfers from '@/composables/contextual/pool-transfers/usePoolTransfers';
 import InvestPage from '@/components/contextual/pages/pool/invest/InvestPage.vue';
 import { useIntervalFn } from '@vueuse/core';
-import { oneMinInMs } from '@/composables/useTime';
+import { oneSecondInMs } from '@/composables/useTime';
 import { providePoolStaking } from '@/providers/local/pool-staking.provider';
 import { useRoute } from 'vue-router';
 import usePoolTransfersGuard from '@/composables/contextual/pool-transfers/usePoolTransfersGuard';
@@ -24,7 +24,8 @@ usePoolTransfersGuard();
 /**
  * COMPOSABLES
  */
-const { pool, poolQuery, loadingPool, transfersAllowed } = usePoolTransfers();
+const { pool, poolDecorationQuery, loadingPool, transfersAllowed } =
+  usePoolTransfers();
 const { isDeepPool } = usePool(pool);
 
 /**
@@ -40,11 +41,9 @@ const isLoading = computed(
     loadingPool.value && !transfersAllowed.value && isLoadingSor.value
 );
 
-// Instead of refetching pool data on every block, we refetch every minute to prevent
-// overfetching a heavy request on short blocktime networks like Polygon.
-// TODO: Don't refetch whole pool, only update balances and weights with
-// onchain calls. i.e. only refetch what's required to be up to date for joins/exits.
-useIntervalFn(poolQuery.refetch, oneMinInMs);
+// Instead of refetching pool data on every block, we refetch every 20s to prevent
+// overfetching a request on short blocktime networks like Polygon.
+useIntervalFn(poolDecorationQuery.refetch, oneSecondInMs * 20);
 </script>
 
 <template>

--- a/src/pages/pool/withdraw.vue
+++ b/src/pages/pool/withdraw.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import usePoolTransfers from '@/composables/contextual/pool-transfers/usePoolTransfers';
 import { usePool } from '@/composables/usePool';
-import { oneMinInMs } from '@/composables/useTime';
+import { oneSecondInMs } from '@/composables/useTime';
 import { useIntervalFn } from '@vueuse/core';
 import { computed } from 'vue';
 import { hasFetchedPoolsForSor } from '@/lib/balancer.sdk';
@@ -12,16 +12,15 @@ import usePoolTransfersGuard from '@/composables/contextual/pool-transfers/usePo
 /**
  * COMPOSABLES
  */
-const { pool, poolQuery, loadingPool, transfersAllowed } = usePoolTransfers();
+const { pool, poolDecorationQuery, loadingPool, transfersAllowed } =
+  usePoolTransfers();
 const { isDeepPool } = usePool(pool);
 const { balanceQueryLoading } = useTokens();
 usePoolTransfersGuard();
 
-// Instead of refetching pool data on every block, we refetch every minute to prevent
-// overfetching a heavy request on short blocktime networks like Polygon.
-// TODO: Don't refetch whole pool, only update balances and weights with
-// onchain calls. i.e. only refetch what's required to be up to date for joins/exits.
-useIntervalFn(poolQuery.refetch, oneMinInMs);
+// Instead of refetching pool data on every block, we refetch every 20s to prevent
+// overfetching a request on short blocktime networks like Polygon.
+useIntervalFn(poolDecorationQuery.refetch, oneSecondInMs * 20);
 
 /**
  * COMPUTED

--- a/src/services/pool/decorators/pool.decorator.ts
+++ b/src/services/pool/decorators/pool.decorator.ts
@@ -18,7 +18,7 @@ export class PoolDecorator {
 
   public async decorate(
     tokens: TokenInfoMap,
-    decorateAll = true
+    fullDecoration = true
   ): Promise<Pool[]> {
     const processedPools = this.pools.map(pool => {
       const poolService = new this.poolServiceClass(pool);
@@ -28,7 +28,7 @@ export class PoolDecorator {
     const poolMulticaller = new PoolMulticaller(processedPools);
 
     const [poolSnapshots, rawOnchainDataMap] = await Promise.all([
-      decorateAll ? this.getSnapshots() : [],
+      fullDecoration ? this.getSnapshots() : [],
       poolMulticaller.fetch(),
     ]);
 
@@ -39,7 +39,7 @@ export class PoolDecorator {
 
       // All of the following are pre-cached by the Balancer API so we can skip
       // decoration of them if the pool came from the API.
-      if (decorateAll) {
+      if (fullDecoration) {
         const poolSnapshot = poolSnapshots.find(p => p.id === pool.id);
         poolService.setFeesSnapshot(poolSnapshot);
         poolService.setVolumeSnapshot(poolSnapshot);

--- a/src/services/pool/decorators/pool.multicaller.ts
+++ b/src/services/pool/decorators/pool.multicaller.ts
@@ -45,7 +45,7 @@ export class PoolMulticaller {
   ) {}
 
   public async fetch(): Promise<RawOnchainPoolDataMap> {
-    let result = <RawOnchainPoolDataMap>{};
+    const result = <RawOnchainPoolDataMap>{};
     const multicaller = new this.MulticallerClass();
 
     this.pools.forEach(pool => {
@@ -67,6 +67,13 @@ export class PoolMulticaller {
           address: pool.address,
           function: 'getSwapFeePercentage',
           abi: PoolTypeABIs,
+        })
+        .call({
+          key: `${pool.id}.poolTokens`,
+          address: this.vaultAddress,
+          function: 'getPoolTokens',
+          abi: Vault__factory.abi,
+          params: [pool.id],
         });
 
       if (isWeightedLike(pool.poolType)) {
@@ -111,18 +118,6 @@ export class PoolMulticaller {
           }
         }
       }
-    });
-
-    result = await multicaller.execute();
-
-    this.pools.forEach(pool => {
-      multicaller.call({
-        key: `${pool.id}.poolTokens`,
-        address: this.vaultAddress,
-        function: 'getPoolTokens',
-        abi: Vault__factory.abi,
-        params: [pool.id],
-      });
     });
 
     return await multicaller.execute(result);


### PR DESCRIPTION
# Description

We were refetching the pool query every 1 minute in the join/exit flows. This was using the API, but the API pool data can be up to 5 mins old. This PR replaces that query in the join exit flows for a pool decoration query which takes the existing pool object and simply fetches and updates the onchain values every 20s.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## How should this be tested?

Quite difficult to test without logging out the pool object everytime the query runs and looking for updated onchain values.

## Visual context

n/a

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have requested at least 1 review (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] If package-lock.json has changes, it was intentional.
- [x] The base of this PR is `master` if hotfix, `develop` if not
