### PR TITLE
add check to not flash price provider warning on pool page load

### DIFF
--- a/src/pages/pool/_id.vue
+++ b/src/pages/pool/_id.vue
@@ -144,7 +144,7 @@ const noInitLiquidity = computed(
 );
 
 const missingPrices = computed(() => {
-  if (pool.value) {
+  if (pool.value && prices.value) {
     const tokensWithPrice = Object.keys(prices.value);
     const tokens = tokenTreeLeafs(pool.value.tokens);
 


### PR DESCRIPTION
# Description

When loading a pool page the price provider warning flashes and then disappears because the `prices.value` isn't loaded.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## How should this be tested?

Please provide instructions so we can test. Please also list any relevant details for your test configuration.

- [ ] Test A
- [ ] Test B

## Visual context

Please provide any relevant visual context for UI changes or additions. This could be static screenshots or a loom screencast.

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have requested at least 1 review (If the PR is significant enough, use best judgement here)
- [ ] I have commented my code where relevant, particularly in hard-to-understand areas
- [ ] If package-lock.json has changes, it was intentional.
- [ ] The base of this PR is `master` if hotfix, `develop` if not
