### PR TITLE
chore: Set default slippage to 0.5%

### DIFF
--- a/src/providers/user-settings.provider.ts
+++ b/src/providers/user-settings.provider.ts
@@ -18,7 +18,7 @@ export interface UserSettingsState {
  * SETUP
  */
 const lsCurrency = lsGet(LS_KEYS.UserSettings.Currency, FiatCurrency.usd);
-const lsSlippage = lsGet(LS_KEYS.App.SwapSlippage, '0.005');
+const lsSlippage = lsGet(LS_KEYS.App.SwapSlippage, '0.005'); // Defaults to 0.5%
 
 /**
  * STATE

--- a/src/providers/user-settings.provider.ts
+++ b/src/providers/user-settings.provider.ts
@@ -18,7 +18,7 @@ export interface UserSettingsState {
  * SETUP
  */
 const lsCurrency = lsGet(LS_KEYS.UserSettings.Currency, FiatCurrency.usd);
-const lsSlippage = lsGet(LS_KEYS.App.SwapSlippage, '0.01');
+const lsSlippage = lsGet(LS_KEYS.App.SwapSlippage, '0.005');
 
 /**
  * STATE


### PR DESCRIPTION
# Description

To help protect users we're going to test setting the default slippage to 0.5% instead of 1%.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [x] Other

## How should this be tested?

n/a

## Visual context

n/a

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have requested at least 1 review (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] If package-lock.json has changes, it was intentional.
- [x] The base of this PR is `master` if hotfix, `develop` if not
