### PR TITLE
Hotfix: price alert notification

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.91.3",
+  "version": "1.91.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@balancer-labs/frontend-v2",
-      "version": "1.91.3",
+      "version": "1.91.4",
       "license": "MIT",
       "devDependencies": {
         "@aave/protocol-js": "^4.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.91.3",
+  "version": "1.91.4",
   "engines": {
     "node": "=16",
     "npm": ">=8"

--- a/src/pages/pool/_id.vue
+++ b/src/pages/pool/_id.vue
@@ -144,7 +144,7 @@ const noInitLiquidity = computed(
 );
 
 const missingPrices = computed(() => {
-  if (pool.value) {
+  if (pool.value && prices.value) {
     const tokensWithPrice = Object.keys(prices.value);
     const tokens = tokenTreeLeafs(pool.value.tokens);
 


### PR DESCRIPTION
# Description

When loading a pool page the price provider warning flashes and then disappears because the prices.value isn't loaded.

Replaces #2930 as hotfix.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## How should this be tested?

- [ ] Test missing prices notification doesn't appear on pool page.

## Visual context

n/a

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have requested at least 1 review (If the PR is significant enough, use best judgement here)
- [ ] I have commented my code where relevant, particularly in hard-to-understand areas
- [ ] If package-lock.json has changes, it was intentional.
- [ ] The base of this PR is `master` if hotfix, `develop` if not
