### PR TITLE
Chore: improve boosted UI

### DIFF
--- a/src/components/pool/PoolPageHeader.vue
+++ b/src/components/pool/PoolPageHeader.vue
@@ -158,7 +158,7 @@ function symbolFor(titleTokenIndex: number): string {
           {{ symbolFor(i) }}
         </span>
         <span
-          v-if="!isStableLikePool"
+          v-if="!isStableLikePool && !!weight && weight !== '0'"
           class="mt-px ml-1 text-xs font-medium text-gray-400"
         >
           {{

--- a/src/components/tables/PoolsTable/TokenPills/TokenPills.vue
+++ b/src/components/tables/PoolsTable/TokenPills/TokenPills.vue
@@ -63,7 +63,7 @@ function weightFor(token: PoolToken): string {
   });
 }
 
-const MAX_PILLS = 11;
+const MAX_PILLS = 8;
 </script>
 
 <template>

--- a/src/components/tables/PoolsTable/TokenPills/WeightedTokenPill.vue
+++ b/src/components/tables/PoolsTable/TokenPills/WeightedTokenPill.vue
@@ -46,7 +46,7 @@ withDefaults(defineProps<Props>(), {
         >
           {{ symbol }}
         </span>
-        <span class="pill-weight">
+        <span v-if="weight !== '0%'" class="pill-weight">
           {{ weight }}
         </span>
       </div>

--- a/src/composables/usePool.ts
+++ b/src/composables/usePool.ts
@@ -210,15 +210,13 @@ export function orderedTokenAddresses(pool: AnyPool): string[] {
   return sortedTokens.map(token => getAddress(token?.address || ''));
 }
 
-type TokenProperties = Pick<PoolToken, 'address' | 'weight'>;
-
 /**
  * @summary Orders pool tokens by weight if weighted pool
  */
-export function orderedPoolTokens<TPoolTokens extends TokenProperties>(
+export function orderedPoolTokens(
   pool: Pool,
-  tokens: TPoolTokens[]
-): TPoolTokens[] {
+  tokens: PoolToken[]
+): PoolToken[] {
   if (isDeep(pool)) {
     const leafs = tokenTreeLeafs(tokens);
     const flatTokens = flatTokenTree(pool);

--- a/src/composables/usePool.ts
+++ b/src/composables/usePool.ts
@@ -219,9 +219,14 @@ export function orderedPoolTokens<TPoolTokens extends TokenProperties>(
   pool: Pool,
   tokens: TPoolTokens[]
 ): TPoolTokens[] {
-  if (isComposableStable(pool.poolType))
+  if (isDeep(pool)) {
+    const leafs = tokenTreeLeafs(tokens);
+    const flatTokens = flatTokenTree(pool);
+    return flatTokens.filter(token => leafs.includes(token.address));
+  } else if (isComposableStable(pool.poolType)) {
     return tokens.filter(token => !isSameAddress(token.address, pool.address));
-  if (isStableLike(pool.poolType)) return tokens;
+  } else if (isStableLike(pool.poolType)) return tokens;
+
   return tokens
     .slice()
     .sort((a, b) => parseFloat(b.weight || '0') - parseFloat(a.weight || '0'));

--- a/src/composables/useVotingGauges.ts
+++ b/src/composables/useVotingGauges.ts
@@ -11,10 +11,13 @@ import useGaugeVotesQuery from './queries/useGaugeVotesQuery';
 import { isGoerli } from './useNetwork';
 import { orderedPoolTokens } from '@/composables/usePool';
 import { VotingGaugeWithVotes } from '@/services/balancer/gauges/gauge-controller.decorator';
-import { Pool } from '@/services/pool/types';
+import { Pool, PoolToken } from '@/services/pool/types';
 
 export function orderedTokenURIs(gauge: VotingGaugeWithVotes): string[] {
-  const sortedTokens = orderedPoolTokens(gauge.pool as Pool, gauge.pool.tokens);
+  const sortedTokens = orderedPoolTokens(
+    gauge.pool as Pool,
+    gauge.pool.tokens as PoolToken[]
+  );
   return sortedTokens.map(
     token => gauge.tokenLogoURIs[token?.address || ''] || ''
   );

--- a/src/pages/pool/_id.vue
+++ b/src/pages/pool/_id.vue
@@ -22,7 +22,6 @@ import useAlerts, { AlertPriority, AlertType } from '@/composables/useAlerts';
 import {
   isVeBalPool,
   preMintedBptIndex,
-  removeBptFrom,
   usePool,
   tokensListExclBpt,
   tokenTreeLeafs,

--- a/src/pages/pool/_id.vue
+++ b/src/pages/pool/_id.vue
@@ -26,6 +26,7 @@ import {
   usePool,
   tokensListExclBpt,
   tokenTreeLeafs,
+  orderedPoolTokens,
 } from '@/composables/usePool';
 import { useTokens } from '@/providers/tokens.provider';
 import { POOLS } from '@/constants/pools';
@@ -155,10 +156,8 @@ const missingPrices = computed(() => {
 
 const titleTokens = computed<PoolToken[]>(() => {
   if (!pool.value || !pool.value.tokens) return [];
-  const { tokens } = removeBptFrom(pool.value);
-  if (!tokens) return [];
 
-  return [...tokens].sort((a, b) => Number(b.weight) - Number(a.weight));
+  return orderedPoolTokens(pool.value, pool.value.tokens);
 });
 
 const isStakablePool = computed((): boolean =>


### PR DESCRIPTION
# Description

Improves information around boosted pools, by using leaf tokens in pools list and on pool page header.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## How should this be tested?

- [ ] Test boosted pools display improvements.

## Visual context

TBD

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have requested at least 1 review (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] If package-lock.json has changes, it was intentional.
- [x] The base of this PR is `master` if hotfix, `develop` if not
