### PR TITLE
Remove wrapLeafToken parameter from generalisedJoin

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "devDependencies": {
         "@aave/protocol-js": "^4.3.0",
         "@balancer-labs/assets": "github:balancer-labs/assets#master",
-        "@balancer-labs/sdk": "^1.0.0-beta.16",
+        "@balancer-labs/sdk": "^1.0.1-beta.4",
         "@balancer-labs/typechain": "^1.0.0",
         "@cowprotocol/contracts": "^1.3.1",
         "@ensdomains/content-hash": "^2.5.3",
@@ -806,9 +806,9 @@
       }
     },
     "node_modules/@balancer-labs/sdk": {
-      "version": "1.0.0-beta.16",
-      "resolved": "https://registry.npmjs.org/@balancer-labs/sdk/-/sdk-1.0.0-beta.16.tgz",
-      "integrity": "sha512-+bokFb0QWWWOVWaczz/zuadCQNkBEJYATu11R9DDi5ZjRACBzn1P752WTV8U8Jzgdamlg2CyRp6wLPLdZYmBsA==",
+      "version": "1.0.1-beta.4",
+      "resolved": "https://registry.npmjs.org/@balancer-labs/sdk/-/sdk-1.0.1-beta.4.tgz",
+      "integrity": "sha512-mrAOwCB9P0bJ9SC5JM7vh6wmOKncmFLEj33pScrQyJzAnMzuIh4cMc3Me/XMHSN+I8DMZwyU3oJg8PIpUVvY3A==",
       "dev": true,
       "dependencies": {
         "@balancer-labs/sor": "^4.1.1-beta.3",
@@ -19577,9 +19577,9 @@
       }
     },
     "@balancer-labs/sdk": {
-      "version": "1.0.0-beta.16",
-      "resolved": "https://registry.npmjs.org/@balancer-labs/sdk/-/sdk-1.0.0-beta.16.tgz",
-      "integrity": "sha512-+bokFb0QWWWOVWaczz/zuadCQNkBEJYATu11R9DDi5ZjRACBzn1P752WTV8U8Jzgdamlg2CyRp6wLPLdZYmBsA==",
+      "version": "1.0.1-beta.4",
+      "resolved": "https://registry.npmjs.org/@balancer-labs/sdk/-/sdk-1.0.1-beta.4.tgz",
+      "integrity": "sha512-mrAOwCB9P0bJ9SC5JM7vh6wmOKncmFLEj33pScrQyJzAnMzuIh4cMc3Me/XMHSN+I8DMZwyU3oJg8PIpUVvY3A==",
       "dev": true,
       "requires": {
         "@balancer-labs/sor": "^4.1.1-beta.3",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   "devDependencies": {
     "@aave/protocol-js": "^4.3.0",
     "@balancer-labs/assets": "github:balancer-labs/assets#master",
-    "@balancer-labs/sdk": "^1.0.0-beta.16",
+    "@balancer-labs/sdk": "^1.0.1-beta.4",
     "@balancer-labs/typechain": "^1.0.0",
     "@cowprotocol/contracts": "^1.3.1",
     "@ensdomains/content-hash": "^2.5.3",

--- a/src/services/balancer/pools/joins/handlers/generalised-join.handler.ts
+++ b/src/services/balancer/pools/joins/handlers/generalised-join.handler.ts
@@ -55,7 +55,6 @@ export class GeneralisedJoinHandler implements JoinPoolHandler {
 
     const tokenAddresses: string[] = amountsIn.map(({ address }) => address);
     const signerAddress = await signer.getAddress();
-    const wrapLeafTokens = false;
     const slippage = slippageBsp.toString();
     const poolId = this.pool.value.id;
 
@@ -64,7 +63,6 @@ export class GeneralisedJoinHandler implements JoinPoolHandler {
       tokenAddresses,
       evmAmountsIn,
       signerAddress,
-      wrapLeafTokens,
       slippage,
       signer,
       SimulationType.Tenderly, // TODO: update to use VaultModel + Static (see SDK example for more details)


### PR DESCRIPTION
# Description

Update generalised-join handler to support SDK update that removes unused `wrapLeafTokens` parameter

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have requested at least 1 review (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] If package-lock.json has changes, it was intentional.
- [x] The base of this PR is `master` if hotfix, `develop` if not
