### PR TITLE
Hotfix: Use swapFee APR for threshold

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.91.6",
+  "version": "1.91.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@balancer-labs/frontend-v2",
-      "version": "1.91.6",
+      "version": "1.91.7",
       "license": "MIT",
       "devDependencies": {
         "@aave/protocol-js": "^4.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.91.6",
+  "version": "1.91.7",
   "engines": {
     "node": "=16",
     "npm": ">=8"

--- a/src/components/contextual/pages/pool/PoolStatCards.vue
+++ b/src/components/contextual/pages/pool/PoolStatCards.vue
@@ -76,7 +76,7 @@ const stats = computed(() => {
       id: 'apr',
       label: 'APR',
       value:
-        Number(props.poolApr?.min || '0') > APR_THRESHOLD
+        Number(props.poolApr?.swapFees || '0') > APR_THRESHOLD
           ? '-'
           : aprLabel.value,
       loading: props.loadingApr,

--- a/src/components/tables/PoolsTable/PoolsTable.vue
+++ b/src/components/tables/PoolsTable/PoolsTable.vue
@@ -191,7 +191,9 @@ const columns = computed<ColumnDefinition<Pool>[]>(() => [
         apr = Number(absMaxApr(pool.apr, pool.boost));
       }
 
-      return isFinite(apr) && apr < APR_THRESHOLD ? apr : 0;
+      return isFinite(apr) && (pool.apr?.swapFees || 0) < APR_THRESHOLD
+        ? apr
+        : 0;
     },
     width: 220,
   },

--- a/src/components/tooltips/APRTooltip/APRTooltip.vue
+++ b/src/components/tooltips/APRTooltip/APRTooltip.vue
@@ -37,7 +37,9 @@ const { fNum } = useNumbers();
 const apr = computed<AprBreakdown | undefined>(
   () => props.pool?.apr || props.poolApr
 );
-const validAPR = computed(() => Number(apr.value?.min || 0) <= APR_THRESHOLD);
+const validAPR = computed(
+  () => Number(apr.value?.swapFees || 0) <= APR_THRESHOLD
+);
 
 const hasYieldAPR = computed(() => {
   return bnum(apr.value?.tokenAprs.total || '0').gt(0);

--- a/src/composables/usePool.ts
+++ b/src/composables/usePool.ts
@@ -269,7 +269,7 @@ export function absMaxApr(aprs: AprBreakdown, boost?: string): string {
  * @summary Returns total APR label, whether range or single value.
  */
 export function totalAprLabel(aprs: AprBreakdown, boost?: string): string {
-  if (aprs.min > APR_THRESHOLD || aprs.max > APR_THRESHOLD) {
+  if (aprs.swapFees > APR_THRESHOLD) {
     return '-';
   }
   if (boost) {


### PR DESCRIPTION
# Description

When deciding if an APR is valid we should only check the swapFee APR against the threshold because that is part of an APR that can be unrealistic, if any reward APR results in a number above the threshold it has to be accurate.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## How should this be tested?

- [ ] Test a pool with an extremely high (> 10K%) reward APR, it should render as expected.
- [ ] Test a pool with an extremely high swap fee APR, it should hide the total because it's not realistic.

## Visual context

n/a

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have requested at least 1 review (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] If package-lock.json has changes, it was intentional.
- [x] The base of this PR is `master` if hotfix, `develop` if not
