### PR TITLE
Hotfix: missing prices alert

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.91.7",
+  "version": "1.91.8",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@balancer-labs/frontend-v2",
-      "version": "1.91.7",
+      "version": "1.91.8",
       "license": "MIT",
       "devDependencies": {
         "@aave/protocol-js": "^4.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.91.7",
+  "version": "1.91.8",
   "engines": {
     "node": "=16",
     "npm": ">=8"

--- a/src/pages/pool/_id.vue
+++ b/src/pages/pool/_id.vue
@@ -52,7 +52,7 @@ providePoolStaking(poolId);
  */
 const { t } = useI18n();
 
-const { prices } = useTokens();
+const { prices, priceQueryLoading } = useTokens();
 const { isWalletReady } = useWeb3();
 const { addAlert, removeAlert } = useAlerts();
 const _isVeBalPool = isVeBalPool(poolId);
@@ -144,7 +144,7 @@ const noInitLiquidity = computed(
 );
 
 const missingPrices = computed(() => {
-  if (pool.value && prices.value) {
+  if (pool.value && prices.value && !priceQueryLoading.value) {
     const tokensWithPrice = Object.keys(prices.value);
     const tokens = tokenTreeLeafs(pool.value.tokens);
 


### PR DESCRIPTION
# Description

Missing prices alert was appearing at the top of pool pages on reload because prices are loaded async now. This PR insures the `missingPrices` flag is only true if the price query isn't loading.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## How should this be tested?

- [ ] Go to popular pool page and hit refresh, you shouldn't see the missing prices alert.

## Visual context

n/a

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have requested at least 1 review (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] If package-lock.json has changes, it was intentional.
- [x] The base of this PR is `master` if hotfix, `develop` if not
