### PR TITLE
feat: remove fraction digits from pool chart current value

### DIFF
--- a/src/components/contextual/pages/pool/PoolChart.vue
+++ b/src/components/contextual/pages/pool/PoolChart.vue
@@ -400,7 +400,7 @@ function setCurrentChartValue(payload: {
 }) {
   currentChartValue.value.num = fNum(payload.chartValue, {
     style: 'currency',
-    maximumFractionDigits: 2,
+    maximumFractionDigits: 0,
     fixedFormat: true,
   });
   currentChartValue.value.isNegative = payload.chartValue < 0;


### PR DESCRIPTION
# Description
See title.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [x] Other

## How should this be tested?

Please provide instructions so we can test. Please also list any relevant details for your test configuration.

- [ ] Test A
- [ ] Test B

## Visual context
Fraction digits here are removed
![image](https://user-images.githubusercontent.com/46521087/221905184-03890207-fd9f-42be-85b4-077a736189ba.png)


## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have requested at least 1 review (If the PR is significant enough, use best judgement here)
- [ ] I have commented my code where relevant, particularly in hard-to-understand areas
- [ ] If package-lock.json has changes, it was intentional.
- [x] The base of this PR is `master` if hotfix, `develop` if not
