### PR TITLE
Hotfix: old mainnet pool urls

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.91.8",
+  "version": "1.91.9",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@balancer-labs/frontend-v2",
-      "version": "1.91.8",
+      "version": "1.91.9",
       "license": "MIT",
       "devDependencies": {
         "@aave/protocol-js": "^4.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.91.8",
+  "version": "1.91.9",
   "engines": {
     "node": "=16",
     "npm": ">=8"

--- a/src/plugins/router/index.ts
+++ b/src/plugins/router/index.ts
@@ -112,6 +112,16 @@ const routes: RouteRecordRaw[] = [
     component: PoolPage,
   },
   {
+    path: '/pool/:id',
+    name: 'pool-redirect',
+    redirect: to => {
+      // Redirect old pool URLs to new structure. Only for mainnet, other
+      // networks handled in nav guards.
+      // e.g. app.balancer.fi/#/pool/0x... -> app.balancer.fi/#/ethereum/pool/0x...
+      return `/ethereum/pool/${to.params.id}`;
+    },
+  },
+  {
     path: '/:networkSlug/pool/:id/invest',
     name: 'invest',
     component: PoolInvestPage,


### PR DESCRIPTION
# Description

Backlinks to old mainnet pool URLs are broken, e.g `app.balancer.fi/#/pool/0x...` doesn't currently redirect to `app.balancer.fi/#/ethereum/pool/0x...`. This PR adds a route to the router to handle this redirect.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## How should this be tested?

Hard to test without pushing to production.

- [ ] Test a pool URL like app.balancer.fi/#/pool/0x... redirects to the correct pool on ethereum.
- [ ] Test a pool URL like polygon.balancer/fi/#/pool/0x... redirects to the correct pool on polygon. 

## Visual context

n/a

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have requested at least 1 review (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] If package-lock.json has changes, it was intentional.
- [x] The base of this PR is `master` if hotfix, `develop` if not
