### PR TITLE
Hotfix: Pool redirect for l2s

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.91.9",
+  "version": "1.91.10",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@balancer-labs/frontend-v2",
-      "version": "1.91.9",
+      "version": "1.91.10",
       "license": "MIT",
       "devDependencies": {
         "@aave/protocol-js": "^4.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@balancer-labs/frontend-v2",
-  "version": "1.91.9",
+  "version": "1.91.10",
   "engines": {
     "node": "=16",
     "npm": ">=8"

--- a/src/plugins/router/index.ts
+++ b/src/plugins/router/index.ts
@@ -112,16 +112,6 @@ const routes: RouteRecordRaw[] = [
     component: PoolPage,
   },
   {
-    path: '/pool/:id',
-    name: 'pool-redirect',
-    redirect: to => {
-      // Redirect old pool URLs to new structure. Only for mainnet, other
-      // networks handled in nav guards.
-      // e.g. app.balancer.fi/#/pool/0x... -> app.balancer.fi/#/ethereum/pool/0x...
-      return `/ethereum/pool/${to.params.id}`;
-    },
-  },
-  {
     path: '/:networkSlug/pool/:id/invest',
     name: 'invest',
     component: PoolInvestPage,

--- a/src/plugins/router/nav-guards.ts
+++ b/src/plugins/router/nav-guards.ts
@@ -102,6 +102,12 @@ function applyNetworkPathRedirects(router: Router): Router {
         ];
         const routerHandledRedirects = ['not-found', 'trade-redirect'];
         if (
+          to.redirectedFrom?.fullPath &&
+          to.redirectedFrom?.fullPath.includes('/pool')
+        ) {
+          const newPath = to.redirectedFrom?.fullPath ?? to.fullPath;
+          router.push({ path: `/${config[Network.MAINNET].slug}${newPath}` });
+        } else if (
           !to.redirectedFrom ||
           routerHandledRedirects.includes(to.redirectedFrom?.name as string) ||
           networkAgnosticRoutes.includes(to.fullPath)


### PR DESCRIPTION
# Description

Previous hotfix #2951 broke L2 redirects, e.g. polygon.balancer.fi/#/pool/0x... -> app.balancer.fi/#/polygon/pool/0x... This PR reverts that fix and implements a new one which should handle mainnet without breaking L2s.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## How should this be tested?

Can't test in preview, has to be tested in production.

## Visual context

n/a

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have requested at least 1 review (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] If package-lock.json has changes, it was intentional.
- [x] The base of this PR is `master` if hotfix, `develop` if not
